### PR TITLE
Block AD through Bernoulli sampler.

### DIFF
--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -36,10 +36,10 @@ class Bernoulli(Distribution):
 
     def sample(self, ps=None, *args, **kwargs):
         """
-        Reparameterized Bernoulli sampler.
+        Bernoulli sampler.
         """
         _ps = self._sanitize_input(ps)
-        return torch.bernoulli(_ps).type_as(_ps)
+        return Variable(torch.bernoulli(_ps.data).type_as(_ps.data))
 
     def log_pdf(self, x, ps=None, batch_size=1, *args, **kwargs):
         """


### PR DESCRIPTION
Without this, I'm seeing "RuntimeError: differentiating stochastic functions requires providing a reward" when attempting VI on a Bernoulli latent choice. This fixes that.