### PR TITLE
Do not capture stdout from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - pip install torchvision
 
 script:
-    - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=pyro
+    - PYTHONPATH=$PWD:$PYTHONPATH pytest -s --cov=pyro
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
Pytest captures the stdout from tests, by default. As such, any tests taking a long time to complete (currently more than 10 mins), are considered a stalled build and failed by travis CI with the exception:
```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```

Refer to #84. This should give a signal to travis-ci that the tests are running. Long term, we should invest in making these tests faster though (10 mins a long time for a single test!).
