### PR TITLE
Fix (and enable) linting for examples

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-exclude = docs/src, examples/
+exclude = docs/src, examples/storyboard

--- a/examples/categorical_bmm.py
+++ b/examples/categorical_bmm.py
@@ -1,18 +1,16 @@
 import argparse
+
 import numpy as np
 import torch
-from torch.nn import Softmax
-from torch.autograd import Variable
-
-import pyro
-from pyro.distributions import DiagNormal
-from pyro.distributions import Bernoulli, Categorical
-import visdom
-
-from pyro.infer.kl_qp import KL_QP
-
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
+import visdom
+from torch.autograd import Variable
+from torch.nn import Softmax
+
+import pyro
+from pyro.distributions import Bernoulli, Categorical
+from pyro.infer.kl_qp import KL_QP
 
 mnist = dset.MNIST(
     root='./data',
@@ -87,6 +85,7 @@ all_batches = np.arange(0, mnist_size, batch_size)
 if all_batches[-1] != mnist_size:
     all_batches = list(all_batches) + [mnist_size]
 
+
 def main():
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', nargs='?', default=1000, type=int)
@@ -103,10 +102,12 @@ def main():
             batch_class = Variable(batch_class)
             epoch_loss += inference.step(ix, batch_data)
 
-           # optional  visualization!
-    #      vis.image(batch_data[0].view(28, 28).data.numpy())
-    #      vis.image(sample[0].view(28, 28).data.numpy())
-    #      vis.image(sample_mu[0].view(28, 28).data.numpy())
+            # optional  visualization!
+            #      vis.image(batch_data[0].view(28, 28).data.numpy())
+            #      vis.image(sample[0].view(28, 28).data.numpy())
+            #      vis.image(sample_mu[0].view(28, 28).data.numpy())
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
+
 if __name__ == '__main__':
     main()

--- a/examples/gaussian_bernoulli_factor_analysis.py
+++ b/examples/gaussian_bernoulli_factor_analysis.py
@@ -1,14 +1,15 @@
 import argparse
+
 import numpy as np
 import torch
+import torchvision.datasets as dset
 from torch.autograd import Variable
 
 import pyro
-from pyro.distributions import DiagNormal
 from pyro.distributions import Bernoulli
+from pyro.distributions import DiagNormal
 from pyro.infer.kl_qp import KL_QP
-import torchvision.datasets as dset
-import torchvision.transforms as transforms
+
 mnist = dset.MNIST(
     root='./',
     train=True,
@@ -36,22 +37,21 @@ def factor_analysis_model(i, data):
     def sub_model(data, weight):
         mu_latent = Variable(torch.zeros(nr_samples, dim_z))
         sigma_latent = Variable(torch.ones(mu_latent.size()))
-        z = pyro.sample("embedding_of_chunk_" +str(i),DiagNormal(mu_latent,sigma_latent))
+        z = pyro.sample("embedding_of_chunk_" + str(i), DiagNormal(mu_latent, sigma_latent))
 
         mean_observations = pyro.param("observation_mean", Variable(torch.zeros(1, dim_o), requires_grad=True))
 
         # coordinate times factors yields an activation
-        mean_beta_activation = z.mm(weight) + mean_observations.repeat(nr_samples,1)
+        mean_beta_activation = z.mm(weight) + mean_observations.repeat(nr_samples, 1)
 
         # use sigmoid as link function between the Gaussian activation and the Bernoulli variable
         beta = sigmoid(mean_beta_activation)
         # observe with the Bernoulli
         pyro.observe("obs_" + str(i), Bernoulli(beta), data)
-    nr_data = data.size(0)
 
     # global variables are sampled once
     mu_w = Variable(torch.ones(dim_z, dim_o), requires_grad=False)
-    sigma_w = Variable(torch.ones(dim_z, dim_o), requires_grad = False)
+    sigma_w = Variable(torch.ones(dim_z, dim_o), requires_grad=False)
     weight = pyro.sample("factor_weight", DiagNormal(mu_w, sigma_w))
 
     # loop over all data and sample the local variables (coordinates/embeddings) for each datum given global variable
@@ -70,22 +70,22 @@ def factor_analysis_guide(i, data):
         # parameters for approximate posteriors to the distributions of the embeddings
         guide_mu_z = pyro.param("embedding_posterior_mean_", mu_q_z)
         guide_log_sigma_q_z = pyro.param("embedding_posterior_log_sigma_", log_sigma_q_z)
-        guide_sigma_z = torch.exp(guide_log_sigma_q_z)# * 1e-5
+        guide_sigma_z = torch.exp(guide_log_sigma_q_z)  # * 1e-5
 
         # sample from approximate posteriors for embeddings
-        z_q = pyro.sample("embedding_of_chunk_" +str(i), DiagNormal(guide_mu_z, guide_sigma_z))
+        pyro.sample("embedding_of_chunk_" + str(i), DiagNormal(guide_mu_z, guide_sigma_z))  # z_q
 
     mu_q_w = Variable(torch.zeros(dim_z, dim_o), requires_grad=True)
     log_sigma_q_w = Variable(torch.zeros(dim_z, dim_o), requires_grad=True)
 
     # parameters for approximate posteriors to the distribution of the factor weights
     guide_mu_q_w = pyro.param("factor_weight_mean", mu_q_w)
-    guide_log_sigma_q_w = log_sigma_q_w - 1e5#pyro.param("factor_weight_log_sigma", log_sigma_q_w)
+    guide_log_sigma_q_w = log_sigma_q_w - 1e5  # pyro.param("factor_weight_log_sigma", log_sigma_q_w)
     guide_sigma_q_w = torch.exp(guide_log_sigma_q_w)
     guide_sigma_q_w = softplus(guide_sigma_q_w)
 
     # sample from approximate posterior for weights
-    w_q = pyro.sample("factor_weight",DiagNormal(guide_mu_q_w,guide_sigma_q_w))
+    pyro.sample("factor_weight", DiagNormal(guide_mu_q_w, guide_sigma_q_w))  # w_q
 
     # loop over all data and infer local variables
     inference_model(data)
@@ -96,7 +96,7 @@ adam_optim = pyro.optim(torch.optim.Adam, adam_params)
 
 dat = mnist.train_data
 mnist_size = dat.size(0)
-m_data= dat.view(mnist_size,-1)
+m_data = dat.view(mnist_size, -1)
 mnist_data = Variable(m_data).float() / 255.
 nr_samples = mnist_data.size(0)
 batch_size = 10
@@ -123,6 +123,7 @@ def main():
             epoch_loss += grad_step.step(ix, batch_data)
 
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -1,13 +1,16 @@
 from __future__ import print_function
+
 import argparse
+import sys
+
 import numpy as np
 import torch
+import torch.optim as optim
 from torch.autograd import Variable
+
 import pyro
 from pyro.distributions import Uniform, DiagNormal
 from pyro.infer.kl_qp import KL_QP
-import torch.optim as optim
-import sys
 
 """
 Samantha really likes physics---but she likes pyro even more. Instead of using
@@ -22,9 +25,10 @@ the little box to slide down the inclined plane as a function of mu. Using pyro,
 can reverse the simulator and infer mu from the observed descent times.
 """
 
-little_g = 9.8   # m/s/s
+little_g = 9.8  # m/s/s
 mu0 = 0.12  # actual coefficient of friction in the experiment
 time_measurement_sigma = 0.02  # observation noise in seconds (known quantity)
+
 
 # the forward simulator, which does numerical integration of the equations of motion
 # in steps of size dx, and optionally includes measurement noise
@@ -33,10 +37,10 @@ def simulate(mu, length=2.0, phi=np.pi / 6.0, dx=0.01, noise_sigma=None):
     T = Variable(torch.zeros(1))
     velocity = Variable(torch.zeros(1))
     displacement = Variable(torch.zeros(1))
-    acceleration = Variable(torch.Tensor([little_g * np.sin(phi)])) -\
-                           (Variable(torch.Tensor([little_g * np.cos(phi)])) * mu)
+    acceleration = Variable(torch.Tensor([little_g * np.sin(phi)])) - \
+        Variable(torch.Tensor([little_g * np.cos(phi)])) * mu
 
-    if acceleration.data[0] <= 0.0:         # the box doesn't slide if the friction is too large
+    if acceleration.data[0] <= 0.0:  # the box doesn't slide if the friction is too large
         return Variable(torch.Tensor([np.inf]))
 
     while displacement.data[0] < length:  # otherwise slide to the end of the inclined plane
@@ -49,6 +53,7 @@ def simulate(mu, length=2.0, phi=np.pi / 6.0, dx=0.01, noise_sigma=None):
     else:
         return T + Variable(noise_sigma * torch.randn(1))
 
+
 # analytic formula that the simulator above is computing via
 # numerical integration (no measurement noise)
 
@@ -57,12 +62,14 @@ def analytic_T(mu, length=2.0, phi=np.pi / 6.0):
     denominator = little_g * (np.sin(phi) - mu * np.cos(phi))
     return np.sqrt(numerator / denominator)
 
+
 # generate N_obs observations using simulator and the true coefficient of friction mu0
 print("generating simulated data using the true coefficient of friction %.3f" % mu0)
 N_obs = 10
 observed_data = [simulate(Variable(torch.Tensor([mu0])), noise_sigma=time_measurement_sigma)
                  for _ in range(N_obs)]
 observed_mean = np.mean([T.data[0] for T in observed_data])
+
 
 # define model with uniform prior on mu and gaussian noise on the descent time
 
@@ -73,10 +80,11 @@ def model(observed_data):
     def observe_T(T_obs, obs_name):
         T_simulated = simulate(mu)
         T_obs_dist = DiagNormal(T_simulated, Variable(torch.Tensor([time_measurement_sigma])))
-        T = pyro.observe(obs_name, T_obs_dist, T_obs)
+        pyro.observe(obs_name, T_obs_dist, T_obs)
 
     pyro.map_data("map", observed_data, lambda i, x: observe_T(x, "obs_%d" % i), batch_size=1)
     return mu
+
 
 # define a gaussian variational approximation for the posterior over mu
 
@@ -88,16 +96,19 @@ def guide(observed_data):
     pyro.map_data("map", observed_data, lambda i, x: None, batch_size=1)
     return mu
 
+
 # do variational inference using KL_QP
 print("doing inference with simulated data")
 verbose = True
 kl_optim = KL_QP(model, guide, pyro.optim(optim.Adam, {"lr": 0.003, "betas": (0.93, 0.993)}))
+
+
 def main():
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', nargs='?', default=1000, type=int)
     args = parser.parse_args()
     for step in range(args.num_epochs):
-        loss = kl_optim.step(observed_data)
+        kl_optim.step(observed_data)  # loss
         if step % 100 == 0:
             if verbose:
                 print("[epoch %d] mean_mu: %.3f" % (step, pyro.param("mean_mu").data[0]))
@@ -122,6 +133,7 @@ def main():
           simulate(pyro.param("mean_mu")).data[0])
     print("elementary calulus gives the descent time for the inferred (mean) mu as: %.4f seconds" %
           analytic_T(pyro.param("mean_mu").data[0]))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/mnist_classification.py
+++ b/examples/mnist_classification.py
@@ -1,20 +1,17 @@
 import argparse
-import torch
-import pyro
-from torch.autograd import Variable
-from pyro.infer.kl_qp import KL_QP
-from pyro.distributions import DiagNormal, Normal, Bernoulli, Categorical
-from torch import nn
 
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+import torch.optim as optim
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
-import torch.nn.functional as F
-import torch.optim as optim
-import numpy as np
 import visdom
+from torch.autograd import Variable
+
+import pyro
+from pyro.distributions import Categorical
+from pyro.infer.kl_qp import KL_QP
 
 # load mnist dataset
 root = './data'
@@ -70,12 +67,13 @@ def model_sample(data, cll):
     cll = pyro.sample('observed_class', Categorical(alpha_cat))
     return cll
 
+
 def guide(data, cll):
     return lambda foo: None
 
+
 # or alternatively
 adam_params = {"lr": .0001}
-
 
 inference_opt = KL_QP(model_obs, guide, pyro.optim(optim.Adam, adam_params))
 
@@ -84,7 +82,6 @@ mnist_labels = Variable(train_loader.dataset.train_labels)
 mnist_size = mnist_data.size(0)
 batch_size = 128  # 64
 
-
 # TODO: batches not necessarily
 all_batches = np.arange(0, mnist_size, batch_size)
 
@@ -92,6 +89,7 @@ if all_batches[-1] != mnist_size:
     all_batches = list(all_batches) + [mnist_size]
 
 vis = visdom.Visdom()
+
 
 def main():
     parser = argparse.ArgumentParser(description="parse args")
@@ -113,6 +111,7 @@ def main():
             epoch_loss += inference_opt.step(batch_data, batch_class)
 
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/vae.py
+++ b/examples/vae.py
@@ -1,21 +1,18 @@
 import argparse
-import torch
-import pyro
-from torch.autograd import Variable
-from pyro.infer.kl_qp import KL_QP
-from pyro.distributions import DiagNormal, Normal
-from pyro.util import ng_zeros, ng_ones
-from torch import nn
 
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+import torch.optim as optim
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
-import torch.nn.functional as F
-import torch.optim as optim
-import numpy as np
 import visdom
+from torch.autograd import Variable
+
+import pyro
+from pyro.distributions import DiagNormal
+from pyro.infer.kl_qp import KL_QP
+from pyro.util import ng_zeros, ng_ones
 
 # load mnist dataset
 root = './data'
@@ -40,9 +37,9 @@ test_loader = torch.utils.data.DataLoader(
     batch_size=batch_size,
     shuffle=False, **kwargs)
 
+
 # network
 class Encoder(nn.Module):
-
     def __init__(self):
         super(Encoder, self).__init__()
         self.fc1 = nn.Linear(784, 200)
@@ -111,7 +108,6 @@ def guide(data):
 
 
 def model_sample():
-
     # wrap params for use in model -- required
     decoder = pyro.module("decoder", pt_decode)
 
@@ -155,6 +151,7 @@ if all_batches[-1] != mnist_size:
 
 vis = visdom.Visdom()
 
+
 def main():
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', nargs='?', default=1000, type=int)
@@ -172,6 +169,7 @@ def main():
         vis.image(batch_data[0].contiguous().view(28, 28).data.numpy())
         vis.image(sample[0].contiguous().view(28, 28).data.numpy())
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/vae_bernoulli.py
+++ b/examples/vae_bernoulli.py
@@ -1,20 +1,17 @@
 import argparse
-import torch
-import pyro
-from torch.autograd import Variable
-from pyro.infer.kl_qp import KL_QP
-from pyro.distributions import DiagNormal, Normal, Bernoulli
-from torch import nn
 
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+import torch.optim as optim
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
-import torch.nn.functional as F
-import torch.optim as optim
-import numpy as np
 import visdom
+from torch.autograd import Variable
+
+import pyro
+from pyro.distributions import DiagNormal, Bernoulli
+from pyro.infer.kl_qp import KL_QP
 
 # load mnist dataset
 root = './data'
@@ -39,11 +36,11 @@ test_loader = torch.utils.data.DataLoader(
     batch_size=batch_size,
     shuffle=False, **kwargs)
 
+
 # network
 
 
 class Encoder(nn.Module):
-
     def __init__(self):
         super(Encoder, self).__init__()
         self.fc1 = nn.Linear(784, 200)
@@ -69,7 +66,7 @@ class Decoder(nn.Module):
         h3 = self.relu(self.fc3(z))
         rv = self.sigmoid(self.fc4(h3))
         # reshape to capture mu, sigma params for every pixel
-        rvs = rv.view(z.size(0), -1, 1)
+        # rvs = rv.view(z.size(0), -1, 1)
         # send back two params
         return rv  # rvs[:,:, 0]
 
@@ -79,7 +76,6 @@ pt_decode = Decoder()
 
 
 def model(data):
-
     # wrap params for use in model -- required
     decoder = pyro.module("decoder", pt_decode)
 
@@ -133,7 +129,7 @@ def per_param_args(name, param):
 adam_params = {"lr": .0001}
 
 kl_optim = KL_QP(model, guide, pyro.optim(optim.Adam, adam_params))
-kl_eval = KL_QP(model=model, guide=guide, optim_step_fct=pyro.optim(optim.Adam, adam_params), num_particles = 10)
+kl_eval = KL_QP(model=model, guide=guide, optim_step_fct=pyro.optim(optim.Adam, adam_params), num_particles=10)
 
 # num_steps = 1
 mnist_data = Variable(train_loader.dataset.train_data.float() / 255.)
@@ -146,10 +142,10 @@ all_batches = np.arange(0, mnist_size, batch_size)
 if all_batches[-1] != mnist_size:
     all_batches = list(all_batches) + [mnist_size]
 
-
 vis = visdom.Visdom(env='vae_mnist')
 
 loss_training = []
+
 
 def main():
     parser = argparse.ArgumentParser(description="parse args")
@@ -166,17 +162,18 @@ def main():
             batch_data = mnist_data[batch_start:batch_end]
 
             epoch_loss += kl_optim.step(batch_data)
-            
+
             epoch_eval_loss += kl_eval.eval_objective(batch_data)
 
         loss_training.append(-epoch_loss / float(mnist_size))
         sample, sample_mu = model_sample()
         vis.line(np.array(loss_training), opts=dict({'title': 'Training ELBO in nats'}))
-        #vis.image(batch_data[0].view(28, 28).data.numpy())
-        #vis.image(sample[0].view(28, 28).data.numpy())
+        # vis.image(batch_data[0].view(28, 28).data.numpy())
+        # vis.image(sample[0].view(28, 28).data.numpy())
         vis.image(sample_mu[0].view(28, 28).data.numpy())
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
         print("epoch eval loss {}".format(epoch_eval_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/vae_bernoulli_labeling_fun.py
+++ b/examples/vae_bernoulli_labeling_fun.py
@@ -1,20 +1,17 @@
 import argparse
-import torch
-import pyro
-from torch.autograd import Variable
-from pyro.infer.kl_qp import KL_QP
-from pyro.distributions import DiagNormal, Normal, Bernoulli, Categorical
-from torch import nn
 
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+import torch.optim as optim
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
-import torch.nn.functional as F
-import torch.optim as optim
-import numpy as np
 import visdom
+from torch.autograd import Variable
+
+import pyro
+from pyro.distributions import DiagNormal, Bernoulli, Categorical
+from pyro.infer.kl_qp import KL_QP
 
 # load mnist dataset
 root = './data'
@@ -39,11 +36,11 @@ test_loader = torch.utils.data.DataLoader(
     batch_size=batch_size,
     shuffle=False, **kwargs)
 
+
 # network
 
 
 class Encoder(nn.Module):
-
     def __init__(self):
         super(Encoder, self).__init__()
         self.fc1 = nn.Linear(784, 200)
@@ -60,7 +57,6 @@ class Encoder(nn.Module):
 
 
 class Encoder_xz(nn.Module):
-
     def __init__(self):
         super(Encoder_xz, self).__init__()
         self.fc1 = nn.Linear(784, 200)
@@ -84,7 +80,7 @@ class Classifier(nn.Module):
 
     def forward(self, x):
         x = x.view(-1, 784)
-        h1 = self.relu(fc1(x))
+        h1 = self.relu(self.fc1(x))
         alpha_mult = self.softmax(self.fc21(h1))
         return alpha_mult
 
@@ -100,7 +96,6 @@ class Decoder(nn.Module):
         self.relu = nn.ReLU()
 
     def forward(self, z):
-
         h3 = self.relu(self.fc3(z))
         mu_bern = self.sigmoid(self.fc4(h3))
         alpha_mult = self.softmax(self.fc5(h3))
@@ -144,7 +139,6 @@ pt_decode_xz = Decoder_xz()
 
 
 def model(data, cll):
-
     # wrap params for use in model -- required
     decoder = pyro.module("decoder", pt_decode)
 
@@ -221,7 +215,6 @@ def per_param_args(name, param):
 # or alternatively
 adam_params = {"lr": .0001}
 
-
 inference = KL_QP(model_xz, guide_latent, pyro.optim(optim.Adam, adam_params))
 inference_c = KL_QP(model_c, guide_latent, pyro.optim(optim.Adam, adam_params))
 
@@ -235,7 +228,6 @@ mnist_labels_test_raw = Variable(test_loader.dataset.test_labels)
 mnist_labels_test = torch.zeros(mnist_labels_test_raw.size(0), 10)
 mnist_labels_test.scatter_(1, mnist_labels_test_raw.data.view(-1, 1), 1)
 mnist_labels_test = Variable(mnist_labels_test)
-
 
 # TODO: batches not necessarily
 all_batches = np.arange(0, mnist_size, batch_size)
@@ -277,13 +269,14 @@ def main():
         acc_val = acc.data.numpy()[0]
         print('accuracy ' + str(acc_val))
         acc_test.append(acc_val)
-        #vis.image(batch_data[0].view(28, 28).data.numpy())
-        #vis.image(sample[0].view(28, 28).data.numpy())
+        # vis.image(batch_data[0].view(28, 28).data.numpy())
+        # vis.image(sample[0].view(28, 28).data.numpy())
         vis.image(sample_mu[0].view(28, 28).data.numpy())  # ,opts=dict({'title': str(sample_class)}))
         vis.line(np.array(acc_test), opts=dict(
             {'title': 'Test Classification Acc. given 100% Tr.-labels'}))
         # vis.image(sample_class.view(1,10).data.numpy())
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/vae_bernoulli_multimodal.py
+++ b/examples/vae_bernoulli_multimodal.py
@@ -1,20 +1,17 @@
 import argparse
-import torch
-import pyro
-from torch.autograd import Variable
-from pyro.infer.kl_qp import KL_QP
-from pyro.distributions import DiagNormal, Normal, Bernoulli, Categorical
-from torch import nn
 
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+import torch.optim as optim
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
-import torch.nn.functional as F
-import torch.optim as optim
-import numpy as np
 import visdom
+from torch.autograd import Variable
+
+import pyro
+from pyro.distributions import DiagNormal, Bernoulli, Categorical
+from pyro.infer.kl_qp import KL_QP
 
 # load mnist dataset
 root = './data'
@@ -39,11 +36,11 @@ test_loader = torch.utils.data.DataLoader(
     batch_size=batch_size,
     shuffle=False, **kwargs)
 
+
 # network
 
 
 class Encoder(nn.Module):
-
     def __init__(self):
         super(Encoder, self).__init__()
         self.fc1 = nn.Linear(784, 200)
@@ -68,7 +65,7 @@ class Classifier(nn.Module):
 
     def forward(self, x):
         x = x.view(-1, 784)
-        h1 = self.relu(fc1(x))
+        h1 = self.relu(self.fc1(x))
         alpha_mult = self.softmax(self.fc21(h1))
         return alpha_mult
 
@@ -84,7 +81,6 @@ class Decoder(nn.Module):
         self.relu = nn.ReLU()
 
     def forward(self, z):
-
         h3 = self.relu(self.fc3(z))
         mu_bern = self.sigmoid(self.fc4(h3))
         alpha_mult = self.softmax(self.fc5(h3))
@@ -96,7 +92,6 @@ pt_decode = Decoder()
 
 
 def model(data, cll):
-
     # wrap params for use in model -- required
     decoder = pyro.module("decoder", pt_decode)
 
@@ -116,7 +111,6 @@ def model(data, cll):
 
 
 def model_latent(data):
-
     # wrap params for use in model -- required
     decoder = pyro.module("decoder", pt_decode)
 
@@ -177,7 +171,6 @@ def per_param_args(name, param):
 # or alternatively
 adam_params = {"lr": .0001}
 
-
 inference = KL_QP(model, guide, pyro.optim(optim.Adam, adam_params))
 inference_latent = KL_QP(model_latent, guide, pyro.optim(optim.Adam, adam_params))
 
@@ -185,7 +178,6 @@ mnist_data = Variable(train_loader.dataset.train_data.float() / 255.)
 mnist_labels = Variable(train_loader.dataset.train_labels)
 mnist_size = mnist_data.size(0)
 batch_size = 128  # 64
-
 
 # TODO: batches not necessarily
 all_batches = np.arange(0, mnist_size, batch_size)
@@ -221,6 +213,7 @@ def main():
         vis.image(sample[0].view(28, 28).data.numpy())
         vis.image(sample_mu[0].view(28, 28).data.numpy())
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()

--- a/examples/vae_bernoulli_ss.py
+++ b/examples/vae_bernoulli_ss.py
@@ -1,20 +1,17 @@
 import argparse
-import torch
-import pyro
-from torch.autograd import Variable
-from pyro.infer.kl_qp import KL_QP
-from pyro.distributions import DiagNormal, Normal, Bernoulli, Multinomial, Categorical
-from torch import nn
 
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
+import torch.optim as optim
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
-import torch.nn.functional as F
-import torch.optim as optim
-import numpy as np
 import visdom
+from torch.autograd import Variable
+
+import pyro
+from pyro.distributions import DiagNormal, Bernoulli, Categorical
+from pyro.infer.kl_qp import KL_QP
 
 # pyro.set_cuda()
 
@@ -30,7 +27,6 @@ train_set = dset.MNIST(
     download=download)
 test_set = dset.MNIST(root=root, train=False, transform=trans)
 
-
 train_loader = torch.utils.data.DataLoader(
     dset.MNIST('../data', train=True, download=True,
                transform=transforms.Compose([
@@ -44,7 +40,6 @@ test_loader = torch.utils.data.DataLoader(
         transforms.Normalize((0.1307,), (0.3081,))
     ])),
     batch_size=128, shuffle=True)
-
 
 batch_size = 128
 kwargs = {'num_workers': 1, 'pin_memory': True}
@@ -76,7 +71,6 @@ class Encoder_c(nn.Module):
 
 
 class Encoder_o(nn.Module):
-
     def __init__(self):
         super(Encoder_o, self).__init__()
         self.fc1 = nn.Linear(784 + 10, 400)
@@ -92,6 +86,7 @@ class Encoder_o(nn.Module):
 
 
 class Decoder(nn.Module):
+
     def __init__(self):
         super(Decoder, self).__init__()
         self.fc3 = nn.Linear(20 + 10, 400)
@@ -104,7 +99,7 @@ class Decoder(nn.Module):
         h3 = self.relu(self.fc3(input_vec))
         rv = self.sigmoid(self.fc4(h3))
         # reshape to capture mu, sigma params for every pixel
-        rvs = rv.view(z.size(0), -1, 1)
+        # rvs = rv.view(z.size(0), -1, 1)
         # send back two params
         return rv  # rvs[:,:, 0]
 
@@ -160,7 +155,7 @@ def model_observed(data, cll):
 def guide_observed(data, cll):
     encoder = pyro.module("encoder_o", pt_encode_o)
     z_mu, z_sigma = encoder.forward(data, cll)
-    z = pyro.sample("latent_z", DiagNormal(z_mu, z_sigma))
+    pyro.sample("latent_z", DiagNormal(z_mu, z_sigma))
 
 
 def guide_observed2(data, cll):
@@ -170,7 +165,7 @@ def guide_observed2(data, cll):
 
     encoder = pyro.module("encoder_o", pt_encode_o)
     z_mu, z_sigma = encoder.forward(data, cll)
-    z = pyro.sample("latent_z", DiagNormal(z_mu, z_sigma))
+    pyro.sample("latent_z", DiagNormal(z_mu, z_sigma))
 
 
 def guide_latent(data):
@@ -187,7 +182,7 @@ def guide_latent2(data):
 
     encoder = pyro.module("encoder_o", pt_encode_o)
     z_mu, z_sigma = encoder.forward(data, cll)
-    z = pyro.sample("latent_z", DiagNormal(z_mu, z_sigma))
+    pyro.sample("latent_z", DiagNormal(z_mu, z_sigma))
 
 
 def model_sample(cll=None):
@@ -238,7 +233,6 @@ batch_size = 128  # 64
 mnist_data_test = Variable(test_loader.dataset.test_data.float() / 255.)
 mnist_labels_test = Variable(test_loader.dataset.test_labels)
 
-
 # TODO: batches not necessarily
 all_batches = np.arange(0, mnist_size, batch_size)
 
@@ -246,7 +240,6 @@ if all_batches[-1] != mnist_size:
     all_batches = list(all_batches) + [mnist_size]
 
 vis = visdom.Visdom(env='vae_ss_400')
-
 
 cll_clamp0 = Variable(torch.zeros(1, 10))
 cll_clamp3 = Variable(torch.zeros(1, 10))
@@ -256,8 +249,8 @@ cll_clamp0[0, 0] = 1
 cll_clamp3[0, 3] = 1
 cll_clamp9[0, 9] = 1
 
-
 loss_training = []
+
 
 def main():
     parser = argparse.ArgumentParser(description="parse args")
@@ -288,11 +281,12 @@ def main():
         sample9, sample_mu9 = model_sample(cll=cll_clamp9)
         vis.line(np.array(loss_training), opts=dict({'title': 'my title'}))
         vis.image(batch_data[0].view(28, 28).data.numpy())
-#         vis.image(sample[0].view(28, 28).data.numpy())
+        # vis.image(sample[0].view(28, 28).data.numpy())
         vis.image(sample_mu0[0].view(28, 28).data.numpy())
         vis.image(sample_mu3[0].view(28, 28).data.numpy())
         vis.image(sample_mu9[0].view(28, 28).data.numpy())
         print("epoch avg loss {}".format(epoch_loss / float(mnist_size)))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Continuation of #108. The examples folder was not addressed in that PR due to a lot of ongoing flux in that directory. This fixes the lint errors for examples and enabling the lint check for the directory (except for the `storyboard` sub solder which contains a lot of non compiling skeleton code).