### PR TITLE
Show all primitive distributions in Sphinx sidebar TOC

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -98,8 +98,10 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#
-# html_theme_options = {}
+
+html_theme_options = {
+    'navigation_depth': 3,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -38,6 +38,13 @@ Distributions provide the following methods:
 
 Take a look at the examples[link] to see how they interact with inference algorithms.
 
+Distribution Base Class
+^^^^^^^^^^^^^^^^^^^^^^^
+.. automodule:: pyro.distributions.distribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Primitives
 ----------
 .. include:: pyro.distributions.txt

--- a/docs/source/pyro.distributions.txt
+++ b/docs/source/pyro.distributions.txt
@@ -1,69 +1,100 @@
+
+Bernoulli
+^^^^^^^^^
 .. automodule:: pyro.distributions.bernoulli
     :members:
     :undoc-members:
     :show-inheritance:
 
+Beta
+^^^^
 .. automodule:: pyro.distributions.beta
     :members:
     :undoc-members:
     :show-inheritance:
 
+Categorical
+^^^^^^^^^^^
 .. automodule:: pyro.distributions.categorical
     :members:
     :undoc-members:
     :show-inheritance:
 
+Delta
+^^^^^
 .. automodule:: pyro.distributions.delta
     :members:
     :undoc-members:
     :show-inheritance:
 
+
+DiagNormal
+^^^^^^^^^^
 .. automodule:: pyro.distributions.diag_normal
     :members:
     :undoc-members:
     :show-inheritance:
 
+Exponential
+^^^^^^^^^^^
 .. automodule:: pyro.distributions.exponential
     :members:
     :undoc-members:
     :show-inheritance:
 
+Gamma
+^^^^^
 .. automodule:: pyro.distributions.gamma
     :members:
     :undoc-members:
     :show-inheritance:
 
+LogNormal
+^^^^^^^^^
 .. automodule:: pyro.distributions.log_normal
     :members:
     :undoc-members:
     :show-inheritance:
 
+Multinomial
+^^^^^^^^^^^
 .. automodule:: pyro.distributions.multinomial
     :members:
     :undoc-members:
     :show-inheritance:
 
+Normal
+^^^^^^
 .. automodule:: pyro.distributions.normal
     :members:
     :undoc-members:
     :show-inheritance:
 
+NormalChol
+^^^^^^^^^^
 .. automodule:: pyro.distributions.normal_chol
     :members:
     :undoc-members:
     :show-inheritance:
 
+Poisson
+^^^^^^^
 .. automodule:: pyro.distributions.poisson
     :members:
     :undoc-members:
     :show-inheritance:
 
+TransformedDistribution
+^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: pyro.distributions.transformed_distribution
     :members:
     :undoc-members:
     :show-inheritance:
 
+Uniform
+^^^^^^^
 .. automodule:: pyro.distributions.uniform
     :members:
     :undoc-members:
     :show-inheritance:
+


### PR DESCRIPTION
One of the things I love about Tensorflow's documentation (compared to Pytorch's) is that all the `tf.*` primitives show up in the sidebar toc. This really helps discoverability of operations.

This PR:
- shows all of Pyro's distributions in the sidebar TOC by adding a Sphinx subsubsection or each primitive
- adds the `Distribution` base class to the generated documentation (eventually we'll move some documentation from `docs/source/distributions.rst` into `distribution.py`, as suggested by @dustinvtran in #145 

The sidebar TOC now looks like this (after expanding the Distributions section):
```
CONTENTS:
Installation
Getting Started
Primitives
Inference
Distributions
  Distribution Base Class
  Bernoulli
  Beta
  Categorical
  Delta
  DiagNormal
  Exponential
  Gamma
  LogNormal
  Multinomial
  Normal
  NormalChol
  Poisson
  TransformedDistribution
  Uniform
Parameters
Neural Network
Optimization
```