### PR TITLE
Fix sphinx errors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,7 +106,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/pyro/infer/search.py
+++ b/pyro/infer/search.py
@@ -6,14 +6,17 @@ from pyro.infer import TracePosterior
 
 class Search(TracePosterior):
     """
-    :param model: probabilistic model defined as a function
-    :param max_tries: the maximum number of times to try completing a trace from the queue.
-    :type max_tries: int
-    New Trace and Poutine-based implementation of systematic search
+    Trace and Poutine-based implementation of systematic search.
+
+    :param callable model: Probabilistic model defined as a function.
+    :param int max_tries: The maximum number of times to try completing a trace from the queue.
     """
     def __init__(self, model, max_tries=1e6):
         """
-        Constructor. Default max_tries to something sensible - 1e6.
+        Constructor. Default `max_tries` to something sensible - 1e6.
+
+        :param callable model: Probabilistic model defined as a function.
+        :param int max_tries: The maximum number of times to try completing a trace from the queue.
         """
         self.model = model
         self.max_tries = int(max_tries)
@@ -21,9 +24,11 @@ class Search(TracePosterior):
     def _traces(self, *args, **kwargs):
         """
         algorithm entered here
-        Returns traces from the posterior
         Running until the queue is empty and collecting the marginal histogram
         is performing exact inference
+
+        :returns: Iterator of traces from the posterior.
+        :rtype: Geneator[:class:`pyro.Trace`]
         """
         # currently only using the standard library queue
         self.queue = Queue()
@@ -37,7 +42,7 @@ class Search(TracePosterior):
 
     def log_z(self, *args, **kwargs):
         """
-        harmonic mean log-evidence estimator
+        Harmonic mean log-evidence estimator.
         """
         log_z = 0.0
         n = 0


### PR DESCRIPTION
This fixes errors when running sphinx to generate documentation:
```
make -C docs html   # This now has no errors.
```