### PR TITLE
fix bug in kl_qp

### DIFF
--- a/pyro/infer/kl_qp.py
+++ b/pyro/infer/kl_qp.py
@@ -125,7 +125,8 @@ class KL_QP(object):
                         elbo_particle += model_trace[name]["log_pdf"]
                         elbo_particle -= guide_trace[name]["log_pdf"]
                     else:
-                        elbo_particle += Variable(log_r.data) * guide_trace[name]["log_pdf"]
+                        elbo_particle += Variable(log_r.data) * guide_trace[name]["log_pdf"] +\
+                                         model_trace[name]["log_pdf"]
                 else:
                     pass
             elbo += elbo_particle / self.num_particles


### PR DESCRIPTION
in the process of refactoring the optimization interface i realized there's a bug in kl_qp. basically the surrogate loss is missing the term log p(z) in the case that z is non-reparameterizable. the reason we never caught this is because all the tests for vanilla kl_qp that have non-reparameterizable z have fixed (parameterless) priors. i think this could have probably been caught by one of the subtests of the normal-normal-normal test (where there should be non-zero gradients for this term), but afaik that's only ever been run for the tracegraph_klqp (in part because the variance would probably make any such test somewhat flaky).

yikes