### PR TITLE
Use make lint rather than flake8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
           python: "2.7"
           addons: true
           install: pip install flake8
-          script: flake8
+          script: make lint
         - stage: unit test
           python: 2.7
           env: STAGE=unit


### PR DESCRIPTION
This has the desired side-effect of also linting our Makefile to avoid breakages.