### PR TITLE
Memoize Trace.log_pdf()

### DIFF
--- a/pyro/infer/tracegraph_kl_qp.py
+++ b/pyro/infer/tracegraph_kl_qp.py
@@ -84,8 +84,10 @@ class TraceGraph_KL_QP(object):
 
         # have the trace compute all the individual (batch) log pdf terms
         # so that they are available below
-        guide_trace.log_pdf(vec_batch_nodes_dict=guide_vec_batch_nodes_dict)
-        model_trace.log_pdf(vec_batch_nodes_dict=model_vec_batch_nodes_dict)
+        guide_trace.batch_log_pdf(site_filter=lambda name, site: name in guide_vec_batch_nodes_dict)
+        guide_trace.log_pdf()
+        model_trace.batch_log_pdf(site_filter=lambda name, site: name in model_vec_batch_nodes_dict)
+        model_trace.log_pdf()
 
         # prepare a list of all the cost nodes, each of which is +- log_pdf
         cost_nodes = []

--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -91,35 +91,41 @@ class Trace(dict):
         """
         return Trace(self)
 
-    def log_pdf(self, vec_batch_nodes_dict={}):
+    def log_pdf(self, site_filter=lambda name, site: True):
         """
         Compute the local and overall log-probabilities of the trace.
+
+        The local computation is memoized.
         """
         log_p = 0.0
         for name, site in self.items():
-            if site["type"] in ("observe", "sample"):
-                args, kwargs = site["args"]
-                if name not in vec_batch_nodes_dict:
+            if site["type"] in ("observe", "sample") and site_filter(name, site):
+                try:
+                    log_p += site["log_pdf"]
+                except KeyError:
+                    args, kwargs = site["args"]
                     site["log_pdf"] = site["fn"].log_pdf(
                         site["value"], *args, **kwargs) * site["scale"]
                     log_p += site["log_pdf"]
-                else:
-                    site["batch_log_pdf"] = site["fn"].batch_log_pdf(
-                        site["value"], *args, **kwargs) * site["scale"]
-                    log_p += site["batch_log_pdf"].sum()
         return log_p
 
-    def batch_log_pdf(self):
+    def batch_log_pdf(self, site_filter=lambda name, site: True):
         """
         Compute the batched local and overall log-probabilities of the trace.
+
+        The local computation is memoized, and also stores the local `.log_pdf()`.
         """
         log_p = 0.0
         for name, site in self.items():
-            if site["type"] in ("observe", "sample"):
-                args, kwargs = site["args"]
-                site["batch_log_pdf"] = site["fn"].batch_log_pdf(
-                    site["value"], *args, **kwargs) * site["scale"]
-                log_p += site["batch_log_pdf"]
+            if site["type"] in ("observe", "sample") and site_filter(name, site):
+                try:
+                    log_p += site["batch_log_pdf"]
+                except KeyError:
+                    args, kwargs = site["args"]
+                    site["batch_log_pdf"] = site["fn"].batch_log_pdf(
+                        site["value"], *args, **kwargs) * site["scale"]
+                    site["log_pdf"] = site["batch_log_pdf"].sum()
+                    log_p += site["batch_log_pdf"]
         return log_p
 
 


### PR DESCRIPTION
Addresses: #220

This changes `Trace.log_pdf()` and `Trace.batch_log_pdf()` to:
1. accept a `site_filter` argument.
2. use memoized values by default.

Note that this does not incur any extra memory overhead, since we were already saving the computed `log_pdf` values at each site, we just weren't reusing them at the next call to `.log_pdf()`.

## Why?

This generalizes @martinjankowiak's `vec_batch_nodes_dict` behavior so that it can also be used to compute the discrete part of the `log_pdf()` or `batch_log_pdf()`. The `site_filter` argument now solves both our problems.

## New Behavior

- The first time each function is called, they compute `site["log_pdf"]` or `site["batch_log_pdf"]`, respectively. Subsequent calls always use values cached at each site.
- The new functions take a `site_filter` function which is useful for (1) precomputing only some sites (as in @martinjankowiak's clever tracegraph kl_qp), and (2) in computing discrete-only costs when summing over discrete latent states.

## Old Behavior

- Each call to `log_pdf` or `batch_log_pdf` recomputes the `site["log_pdf"]` or `site["batch_log_pdf"]` fields.
- To reuse these fields, users must access sites directly `site["log_pdf"]`

## Example Usage

In #206, we need to evaluate `batch_log_prob` of only the discrete choices in a trace (these are used to weight traces for aggregation in KL_QP). After this PR, we can

```py
def is_discrete(name, site):
    return getattr(site["fn"], "enumerable", False)

discrete_log_q = guide_trace.batch_log_pdf(site_filter=is_discrete)
```