### PR TITLE
Fix warnings invocation in pyro/__init__.py

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -71,7 +71,7 @@ def sample(name, fn, *args, **kwargs):
     if len(_PYRO_STACK) == 0:
         if obs is not None:
             warnings.warn("trying to observe a value outside of inference at " + name,
-                          warnings.RuntimeWarning)
+                          RuntimeWarning)
         return fn(*args, **kwargs)
     # if stack not empty, apply everything in the stack?
     else:


### PR DESCRIPTION
This fixes:
```
        if len(_PYRO_STACK) == 0:
            if obs is not None:
                warnings.warn("trying to observe a value outside of inference at " + name,
>                             warnings.RuntimeWarning)
E               AttributeError: 'module' object has no attribute 'RuntimeWarning'
```