### PR TITLE
Read sphinx options from environment before running make docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -E -W
+SPHINXOPTS    ?= -E
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = Pyro
 SOURCEDIR     = source


### PR DESCRIPTION
Fixes #240. There is a bigger issue in that our rst files are not updated, and we are not testing for the sphinx build in travis (Refer to #242).