### PR TITLE
Build only PRs and commits to dev and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ install:
     - pip install torchvision
     - pip freeze
 
+branches:
+    only:
+        - master
+        - dev
+
 jobs:
     fast_finish: true
     include:


### PR DESCRIPTION
Implements one potential solution highlighted in #244, i.e. Option 2. This makes it so that we only run a single build per PR (not two builds as we are running now).

We only build the commits on `dev` and `master` branches, and skip travis builds on other remote branches. Practically speaking, this will only have an effect if you commit to a remote branch that does not have an associated PR. Travis will skip the tests on that branch. To have travis run tests on such a branch, create a PR and put a `WIP` label on it.