### PR TITLE
make TransformedDistribution more pytorchy

### DIFF
--- a/pyro/distributions/transformed_distribution.py
+++ b/pyro/distributions/transformed_distribution.py
@@ -32,7 +32,7 @@ class TransformedDistribution(Distribution):
         elif isinstance(bijectors, nn.ModuleList):
             for bijector in bijectors:
                 assert isinstance(bijector, Bijector), \
-                    "bijectors must be a Bijector or a ListModule of Bijectors"
+                    "bijectors must be a Bijector or a nn.ModuleList of Bijectors"
             self.bijectors = bijectors
 
     def sample(self, *args, **kwargs):


### PR DESCRIPTION
currently TransformedDistribution takes either a single Bijector or a list of Bijectors as arguments.

now, instead, it takes a single Bijector or a sequence of Bijectors _wrapped in a nn.ModuleList_, which is the right way to do things. ensures that pytorch module logic applies to the sequence, etc.

so a very minor change