### PR TITLE
Add unit tests for Trace_ELBO.loss_and_grads()

### DIFF
--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -68,7 +68,7 @@ class Trace_ELBO(object):
         loss = -elbo
         return loss
 
-    def _compute_loss_and_grads(self, traces):
+    def _compute_loss_and_grads(self, traces, use_reparam_trick=True):
         """
         :args: an iterable of traces
         :returns: returns an estimate of the ELBO
@@ -95,7 +95,7 @@ class Trace_ELBO(object):
                     else:
                         lp_lq = model_trace.nodes[name]["log_pdf"] - guide_trace.nodes[name]["log_pdf"]
                         elbo_particle += lp_lq
-                        if model_trace.nodes[name]["fn"].reparameterized:
+                        if model_trace.nodes[name]["fn"].reparameterized and use_reparam_trick:
                             surrogate_elbo_particle += lp_lq
                         else:
                             # XXX should the user be able to control inclusion of the -logq term below?


### PR DESCRIPTION
Needed for testing #256 

This PR adds unit tests that check that `.loss()` agrees with `.loss_and_grads()`.

## Why?

These tests intend to be faster and more general than Normal-Normal-Normal tests. Specifically, they should include discrete latent variables to cover the case of `enum_discrete=True`. These tests will be extended in #256 to cover the batched version of summing out latent variables.

## How?

This PR factors out helpers `Trace_ELBO._loss(traces)`, and `._loss_and_grads(traces)` to allow independent testing of trace generation and loss computation. Specifically, the new tests check agreement between `._loss(traces)` and `._loss_and_grads(traces)` on a common set of traces. This also refactors to compute a differentiable loss in `._loss()`, which is cast to a `float` only later in the `.loss()` wrapper.

This also renames `._get_traces()` to `._iter_traces()` to indicate that the result is an iterator that must be wrapped in `list(...)` if it is used twice (as it is in these tests).