### PR TITLE
Patch Trace.batch_log_pdf() to handle tensor shape mismatch

### DIFF
--- a/pyro/poutine/trace.py
+++ b/pyro/poutine/trace.py
@@ -85,6 +85,12 @@ class Trace(networkx.DiGraph):
                     args, kwargs = site["args"], site["kwargs"]
                     site_log_p = site["fn"].batch_log_pdf(
                         site["value"], *args, **kwargs) * site["scale"]
+
+                    # The following line is a quick fix for size mismatch issues,
+                    # and should be reverted after this issue is fixed:
+                    # https://github.com/uber/pyro/issues/278
+                    site_log_p = site_log_p.squeeze()
+
                     site["batch_log_pdf"] = site_log_p
                     site["log_pdf"] = site_log_p.sum()
                 # Here log_p may be broadcast to a larger tensor:


### PR DESCRIPTION
This quick-fix may be reverted after #278 is merged.