### PR TITLE
Mark Distribution.sample() and .batch_log_pdf() as abstract

### DIFF
--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -1,6 +1,10 @@
+from six import add_metaclass
+from abc import ABCMeta, abstractmethod
+
 import torch
 
 
+@add_metaclass(ABCMeta)
 class Distribution(object):
     """
     Base class for parametrized probability distributions.
@@ -133,6 +137,7 @@ class Distribution(object):
         """
         return self.sample(*args, **kwargs)
 
+    @abstractmethod
     def sample(self, *args, **kwargs):
         """
         Samples a random value.
@@ -156,6 +161,7 @@ class Distribution(object):
         """
         return torch.sum(self.batch_log_pdf(x, *args, **kwargs))
 
+    @abstractmethod
     def batch_log_pdf(self, x, *args, **kwargs):
         """
         Evaluates log probability densities for each of a batch of samples.

--- a/pyro/distributions/transformed_distribution.py
+++ b/pyro/distributions/transformed_distribution.py
@@ -73,6 +73,9 @@ class TransformedDistribution(Distribution):
             log_det_jacobian += bijector.log_det_jacobian(inverse, *args, **kwargs)
         return log_pdf_base - log_det_jacobian
 
+    def batch_log_pdf(self, y, *args, **kwargs):
+        raise NotImplementedError("https://github.com/uber/pyro/issues/293")
+
 
 class Bijector(nn.Module):
     def __init__(self, *args, **kwargs):

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -46,6 +46,9 @@ class Histogram(pyro.distributions.Distribution):
     def log_pdf(self, val, *args, **kwargs):
         return poutine.block(self._dist)(*args, **kwargs).log_pdf([val])
 
+    def batch_log_pdf(self, val, *args, **kwargs):
+        return poutine.block(self._dist)(*args, **kwargs).batch_log_pdf([val])
+
     def support(self, *args, **kwargs):
         return poutine.block(self._dist)(*args, **kwargs).support()
 


### PR DESCRIPTION
Later we may also want to mark `batch_shape` and `event_shape` as abstract.