### PR TITLE
Add test discovery of examples supporting a --cuda flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ run_outputs*
 data
 examples/processed
 examples/raw
+examples/dmm/*.pkl
 processed
 raw
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ format: FORCE
 test: lint FORCE
 	pytest -vx -n auto --stage unit
 
+test-examples: lint FORCE
+	pytest -vx -n auto --stage test_examples
+
 integration-test: lint FORCE
 	pytest -vx -n auto --stage integration
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,20 +1,33 @@
 import os
-import glob
 import sys
 from subprocess import check_call
 
-from tests.common import EXAMPLES_DIR
+from tests.common import EXAMPLES_DIR, requires_cuda
 import pytest
 
-EXAMPLES = [
-    os.path.basename(f)
-    for f in glob.glob(os.path.join(EXAMPLES_DIR, '*.py'))
-    if not f.endswith('__init__.py')
-]
+
+def find_examples_matching(*substrings):
+    for root, dirs, files in os.walk(EXAMPLES_DIR):
+        for basename in files:
+            if not basename.endswith('.py'):
+                continue
+            path = os.path.join(root, basename)
+            with open(path) as f:
+                text = f.read()
+            if all(s in text for s in substrings):
+                yield os.path.relpath(path, EXAMPLES_DIR)
 
 
 @pytest.mark.stage("test_examples")
-@pytest.mark.parametrize('example', EXAMPLES)
-def test_example(example):
+@pytest.mark.parametrize('example', find_examples_matching('--num-epochs'))
+def test_cpu(example):
     example = os.path.join(EXAMPLES_DIR, example)
     check_call([sys.executable, example, '--num-epochs', '1'])
+
+
+@requires_cuda
+@pytest.mark.stage("test_examples")
+@pytest.mark.parametrize('example', find_examples_matching('--num-epochs', '--cuda'))
+def test_cuda(example):
+    example = os.path.join(EXAMPLES_DIR, example)
+    check_call([sys.executable, example, '--num-epochs', '1', '--cuda'])


### PR DESCRIPTION
Addresses #296 

This adds discoverability to test all examples that support a `--cuda` flag (currently only `dmm.py`). Cuda tests are not run on travis, but are run locally via `pytest --stage test_examples` or simply `make test-examples`.

This also fixes two problems with previous discovery:
- `examples/dmm/dmm.py` is now tested
- `examples/util.py` will not be tested (from #281)

## Test results

```
[gw12] PASSED tests/test_examples.py::test_cpu[bayesian_regression.py]
[gw55] PASSED tests/test_examples.py::test_cpu[inclined_plane.py]
[gw35] PASSED tests/test_examples.py::test_cpu[mnist_classification.py]
[gw18] PASSED tests/test_examples.py::test_cpu[vae.py]
[gw54] PASSED tests/test_examples.py::test_cpu[vae_bernoulli_labeling_fun.py]
[gw45] PASSED tests/test_examples.py::test_cpu[vae_bernoulli_multimodal.py]
[gw37] PASSED tests/test_examples.py::test_cpu[vae_bernoulli_ss.py]
[gw16] PASSED tests/test_examples.py::test_cuda[dmm/dmm.py]
[gw6] PASSED tests/test_examples.py::test_cpu[dmm/dmm.py]
[gw17] PASSED tests/test_examples.py::test_cpu[vae_bernoulli.py]
[gw53] PASSED tests/test_examples.py::test_cpu[gaussian_bernoulli_factor_analysis.py]
[gw9] PASSED tests/test_examples.py::test_cpu[categorical_bmm.py]
```