### PR TITLE
Support cuda tensors in iarange

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -142,7 +142,7 @@ class _Subsample(Distribution):
     def batch_log_pdf(self, x):
         # This is zero so that iarange can provide an unbiased estimate of
         # the non-subsampled batch_log_pdf.
-        return Variable(torch.zeros(0))
+        return 0.0  # Works with cpu and cuda tensors.
 
 
 @contextlib.contextmanager
@@ -251,6 +251,8 @@ def map_data(name, data, fn, batch_size=0, batch_dim=0):
     if isinstance(data, (torch.Tensor, Variable)):
         size = data.size(batch_dim)
         with iarange(name, size, batch_size) as batch:
+            if data.is_cuda:
+                batch = batch.cuda()
             return fn(batch, data.index_select(batch_dim, batch))
     else:
         size = len(data)


### PR DESCRIPTION
Fixes #267 
Simplifies #259 

## Why?

`iarange`, `irange` and `map_data` do not work for cuda tensors for two reasons:
1. `iarange` adds a `Variable(torch.zeros(1))` to the `log_pdf` term, which may be a cuda tensor, and
2. `iarange` and `_Subsample` return always cpu tensor.

## How?

This PR fixes both problems:
1. Make `iarange` add a `float` 0.0 to the `log_pdf` (which works with cpu and gpu tensors)
2. Fixes `map_data` to convert the `iarange` batch to cuda if `data.is_cuda`

The author favors keeping a `use_cuda` argument out of the `iarange` interface, since it is more transparent to simply write `batch = batch.cuda()` in user code.

## Tests

TODO I'll add cuda tests Monday morning