### PR TITLE
Revert "Merge pull request #310 from uber/cuda-iarange"

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -150,7 +150,7 @@ class _Subsample(Distribution):
     def batch_log_pdf(self, x):
         # This is zero so that iarange can provide an unbiased estimate of
         # the non-subsampled batch_log_pdf.
-        return 0.0  # Works with cpu and cuda tensors.
+        return Variable(torch.zeros(0))
 
 
 @contextlib.contextmanager
@@ -259,8 +259,6 @@ def map_data(name, data, fn, batch_size=0, batch_dim=0):
     if isinstance(data, (torch.Tensor, Variable)):
         size = data.size(batch_dim)
         with iarange(name, size, batch_size) as batch:
-            if data.is_cuda:
-                batch = batch.cuda()
             return fn(batch, data.index_select(batch_dim, batch))
     else:
         size = len(data)


### PR DESCRIPTION
This reverts commit dfcfc922d608d3048174957bbdad37ad3c6010ee, reversing
changes made to a3e3741a5d5d7bc0a5115f934fbaf739fa977552.  Related #312

In `test_elbo_mapdata`:
```
E TypeError: torch.sum received an invalid combination of arguments - got (float), but expected one of:
E  (torch.DoubleTensor source)
E didn't match because some of the arguments have invalid types: (float)
E  (torch.DoubleTensor source, int dim)
E  (torch.DoubleTensor source, int dim, bool keepdim)
```

as a sidenote, to avoid this, we really should not merge until tests pass, or state a reason for bypassing them, esp since the test suite is pretty reliable now.