### PR TITLE
Make docs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
               - pip install -r docs/requirements.txt
           script:
               - make lint
-            # - make docs
+              - make docs
         - stage: unit test
           python: 2.7
           env: STAGE=unit

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ format: FORCE
 	yapf -i -p *.py pyro/*.py pyro/*/*.py
 	isort -i *.py pyro/*.py pyro/*/*.py
 
-test: lint FORCE
+test: lint docs FORCE
 	pytest -vx -n auto --stage unit
 
 test-examples: lint FORCE


### PR DESCRIPTION
Fixes #242 

This also adds `make docs` to the local `make test` target, to help avoid `git push` noise when docs are broken.