### PR TITLE
Remove subsample_size arg from model in AIR example

### DIFF
--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -97,7 +97,7 @@ class AIR(nn.Module):
 
     def model(self, data, batch_size, **kwargs):
         pyro.module("decode", self.decode)
-        with pyro.iarange('data', data.size(0), subsample_size=batch_size, use_cuda=self.use_cuda) as ix:
+        with pyro.iarange('data', data.size(0), use_cuda=self.use_cuda) as ix:
             return self.local_model(batch_size, data[ix], **kwargs)
 
     def local_model(self, n, batch=None, **kwargs):

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -199,7 +199,7 @@ for i in range(args.num_steps):
             loss / X_size))
 
     if args.viz and (i + 1) % args.viz_every == 0:
-        trace = poutine.trace(air.guide).get_trace(examples_to_viz, 0)
+        trace = poutine.trace(air.guide).get_trace(examples_to_viz, None)
         z, recons = poutine.replay(air.prior, trace)(examples_to_viz.size(0))
         z_wheres = post_process_latents(z)
 


### PR DESCRIPTION
Since #347, we only need specify `subsample_size` in the guide. (Rather than in the guide and the model.) This PR updates the AIR example accordingly.