### PR TITLE
Raise NotImplementedError for unsupported uses of iarange

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -165,6 +165,22 @@ class _Subsample(Distribution):
         return result.cuda() if self.use_cuda else result
 
 
+def _check_for_notimplemented_iarange_behavior(name):
+    conflicts = {"tensor": set(), "list": set()}
+    for frame in _PYRO_STACK:
+        if isinstance(frame, poutine.LambdaPoutine):
+            conflicts[frame.map_data_type].add(frame.name)
+        elif isinstance(frame, poutine.TracePoutine):
+            if frame.graph_type != "dense":
+                return  # Only TraceGraph_ELBO has this issue; Trace_ELBO is fine.
+    conflicts["tensor"] -= conflicts["list"]  # irange is implemented via iarange.
+    if conflicts["tensor"]:
+        raise NotImplementedError(
+                "TraceGraph_ELBO does not support irange/iarange nested inside iarange. "
+                "Found {} inside {}. "
+                "See https://github.com/uber/pyro/issues/370".format(name, conflicts["tensor"]))
+
+
 @contextlib.contextmanager
 def iarange(name, size=None, subsample_size=None, subsample=None, use_cuda=False):
     """
@@ -226,6 +242,7 @@ def iarange(name, size=None, subsample_size=None, subsample=None, use_cuda=False
     if len(_PYRO_STACK) == 0:
         yield subsample
     else:
+        _check_for_notimplemented_iarange_behavior(name)
         # Wrap computation in a scaling context.
         scale = size / subsample_size
         with LambdaPoutine(None, name, scale, 'tensor', 0, subsample_size):

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -129,7 +129,6 @@ def test_irange_in_guide_not_model_error(trace_graph, subsample_size):
     assert_error(model, guide, trace_graph=trace_graph)
 
 
-@pytest.mark.xfail(reason="NotImplementedError is not raised")
 def test_iarange_irange_error():
 
     def model():
@@ -165,8 +164,24 @@ def test_irange_iarange_ok(trace_graph):
     assert_ok(model, guide, trace_graph=trace_graph)
 
 
-@pytest.mark.xfail(reason="error is not caught")
-def test_iarange_iarange_error():
+def test_iarange_iarange_no_trace_graph_ok():
+
+    def model():
+        p = Variable(torch.Tensor([0.5]))
+        with pyro.iarange("iarange_0", 10, 5) as ind1:
+            with pyro.iarange("iarange_1", 10, 5) as ind2:
+                pyro.sample("x", dist.bernoulli, p, batch_size=len(ind1) * len(ind2))
+
+    def guide():
+        p = pyro.param("p", Variable(torch.Tensor([0.5]), requires_grad=True))
+        with pyro.iarange("iarange_0", 10, 5) as ind1:
+            with pyro.iarange("iarange_1", 10, 5) as ind2:
+                pyro.sample("x", dist.bernoulli, p, batch_size=len(ind1) * len(ind2))
+
+    assert_ok(model, guide, trace_graph=False)
+
+
+def test_iarange_iarange_trace_graph_error():
 
     def model():
         p = Variable(torch.Tensor([0.5]))


### PR DESCRIPTION
This raises an error and points users to #370 

The new check is not elegant, but we hope to remove it soon.