### PR TITLE
Add sphinx dependencies to dev dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
             'pytest',
             'pytest-xdist',
             'yapf',
+            'sphinx',
+            'sphinx_rtd_theme',
         ],
     },
     tests_require=['flake8', 'pytest'],


### PR DESCRIPTION
Since we are running `make docs` as part of tests, we should include the sphinx dependencies in `setup.py`.