### PR TITLE
Rename .support() -> .enumerate_support()

### DIFF
--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -61,7 +61,7 @@ class Bernoulli(Distribution):
         batch_log_pdf_shape = self.batch_shape(x) + (1,)
         return torch.sum(logsum, -1).contiguous().view(batch_log_pdf_shape)
 
-    def support(self):
+    def enumerate_support(self):
         """
         Returns the Bernoulli distribution's support, as a tensor along the first dimension.
 

--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -141,7 +141,7 @@ class Categorical(Distribution):
             batch_log_pdf = batch_log_pdf * scaling_mask
         return batch_log_pdf
 
-    def support(self):
+    def enumerate_support(self):
         """
         Returns the categorical distribution's support, as a tensor along the first dimension.
 

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -49,7 +49,7 @@ class Delta(Distribution):
             v = v.expand_as(x)
         return torch.sum(torch.eq(x, v).float().log(), -1)
 
-    def support(self, v=None):
+    def enumerate_support(self, v=None):
         """
         Returns the delta distribution's support, as a tensor along the first dimension.
 

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -68,7 +68,7 @@ class Distribution(object):
 
     Derived classes must implement the following methods: `.sample()`,
     `.batch_log_pdf()`, `.batch_shape()`, and `.event_shape()`, .
-    Discrete classes may also implement the `.support()` method to improve
+    Discrete classes may also implement the `.enumerate_support()` method to improve
     gradient estimates and set `.enumerable = True`.
 
     **Examples**:
@@ -179,7 +179,7 @@ class Distribution(object):
         """
         raise NotImplementedError
 
-    def support(self, *args, **kwargs):
+    def enumerate_support(self, *args, **kwargs):
         """
         Returns a representation of the parametrized distribution's support.
 

--- a/pyro/distributions/random_primitive.py
+++ b/pyro/distributions/random_primitive.py
@@ -42,8 +42,8 @@ class RandomPrimitive(Distribution):
     def batch_log_pdf(self, x, *args, **kwargs):
         return self.dist_class(*args, **kwargs).batch_log_pdf(x)
 
-    def support(self, *args, **kwargs):
-        return self.dist_class(*args, **kwargs).support()
+    def enumerate_support(self, *args, **kwargs):
+        return self.dist_class(*args, **kwargs).enumerate_support()
 
     def analytic_mean(self, *args, **kwargs):
         return self.dist_class(*args, **kwargs).analytic_mean()

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -49,8 +49,8 @@ class Histogram(pyro.distributions.Distribution):
     def batch_log_pdf(self, val, *args, **kwargs):
         return poutine.block(self._dist)(*args, **kwargs).batch_log_pdf([val])
 
-    def support(self, *args, **kwargs):
-        return poutine.block(self._dist)(*args, **kwargs).support()
+    def enumerate_support(self, *args, **kwargs):
+        return poutine.block(self._dist)(*args, **kwargs).enumerate_support()
 
 
 class Marginal(Histogram):

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -263,7 +263,7 @@ def enum_extend(trace, msg, num_samples=None):
         num_samples = -1
 
     extended_traces = []
-    for i, s in enumerate(msg["fn"].support(*msg["args"], **msg["kwargs"])):
+    for i, s in enumerate(msg["fn"].enumerate_support(*msg["args"], **msg["kwargs"])):
         if i > num_samples and num_samples >= 0:
             break
         msg_copy = msg.copy()

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -79,33 +79,33 @@ class TestCategorical(TestCase):
         self.assertEqual(log_px_torch2, log_px_np2, prec=1e-4)
 
     def test_one_hot_support_non_vectorized(self):
-        s = dist.categorical.support(self.d_ps[0].squeeze(0))
+        s = dist.categorical.enumerate_support(self.d_ps[0].squeeze(0))
         assert_equal(s.data, self.support_one_hot_non_vec)
 
     def test_one_hot_support(self):
-        s = dist.categorical.support(self.d_ps)
+        s = dist.categorical.enumerate_support(self.d_ps)
         assert_equal(s.data, self.support_one_hot)
 
     def test_discrete_support_non_vectorized(self):
-        s = dist.categorical.support(self.d_ps[0].squeeze(0), self.d_vs[0].squeeze(0))
+        s = dist.categorical.enumerate_support(self.d_ps[0].squeeze(0), self.d_vs[0].squeeze(0))
         assert_equal(s.data, self.discrete_support_non_vec)
 
     def test_discrete_support(self):
-        s = dist.categorical.support(self.d_ps, self.d_vs)
+        s = dist.categorical.enumerate_support(self.d_ps, self.d_vs)
         assert_equal(s.data, self.discrete_support)
 
     def test_discrete_arr_support_non_vectorized(self):
-        s = dist.categorical.support(self.d_ps[0].squeeze(0), self.d_vs_arr[0]).tolist()
+        s = dist.categorical.enumerate_support(self.d_ps[0].squeeze(0), self.d_vs_arr[0]).tolist()
         assert_equal(s, self.discrete_arr_support_non_vec)
 
     def test_discrete_arr_support(self):
-        s = dist.categorical.support(self.d_ps, self.d_vs_arr).tolist()
+        s = dist.categorical.enumerate_support(self.d_ps, self.d_vs_arr).tolist()
         assert_equal(s, self.discrete_arr_support)
 
     def test_support_non_vectorized(self):
-        s = dist.categorical.support(self.batch_ps[0].squeeze(0), one_hot=False)
+        s = dist.categorical.enumerate_support(self.batch_ps[0].squeeze(0), one_hot=False)
         assert_equal(s.data, self.support_non_vec)
 
     def test_support(self):
-        s = dist.categorical.support(self.batch_ps, one_hot=False)
+        s = dist.categorical.enumerate_support(self.batch_ps, one_hot=False)
         assert_equal(s.data, self.support)

--- a/tests/distributions/test_categorical_dimensions.py
+++ b/tests/distributions/test_categorical_dimensions.py
@@ -55,7 +55,7 @@ def modify_params_using_dims(ps, vs, dim):
 
 def test_support_dims(dim, vs, one_hot, ps):
     ps, vs = modify_params_using_dims(ps, vs, dim)
-    support = dist.categorical.support(ps, vs, one_hot=one_hot)
+    support = dist.categorical.enumerate_support(ps, vs, one_hot=one_hot)
     for s in support:
         assert_correct_dimensions(s, ps, vs, one_hot)
 
@@ -70,6 +70,6 @@ def test_batch_log_dims(dim, vs, one_hot, ps):
     batch_pdf_shape = (3,) + (1,) * dim
     expected_log_pdf = np.array(wrap_nested(list(np.log(ps)), dim-1)).reshape(*batch_pdf_shape)
     ps, vs = modify_params_using_dims(ps, vs, dim)
-    support = dist.categorical.support(ps, vs, one_hot=one_hot)
+    support = dist.categorical.enumerate_support(ps, vs, one_hot=one_hot)
     batch_log_pdf = dist.categorical.batch_log_pdf(support, ps, vs, one_hot=one_hot)
     assert_equal(batch_log_pdf.data.cpu().numpy(), expected_log_pdf)

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -38,7 +38,7 @@ class TestDelta(TestCase):
         self.assertEqual(torch_var, self.analytic_var)
 
     def test_support(self):
-        actual_support = dist.delta.support(self.vs)
-        actual_support_non_vec = dist.delta.support(self.v)
+        actual_support = dist.delta.enumerate_support(self.vs)
+        actual_support_non_vec = dist.delta.enumerate_support(self.v)
         assert_equal(actual_support.data, torch.Tensor(self.expected_support))
         assert_equal(actual_support_non_vec.data, torch.Tensor(self.expected_support_non_vec))

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -107,13 +107,15 @@ def test_mean_and_variance(dist):
 
 # Distributions tests - discrete distributions
 
-def test_support(discrete_dist):
+def test_enumerate_support(discrete_dist):
     expected_support = discrete_dist.expected_support
     expected_support_non_vec = discrete_dist.expected_support_non_vec
     if not expected_support:
-        pytest.skip("Support not tested for distribution")
-    actual_support_non_vec = discrete_dist.pyro_dist.support(**discrete_dist.get_dist_params(SINGLE_TEST_DATUM_IDX))
-    actual_support = discrete_dist.pyro_dist.support(**discrete_dist.get_dist_params(BATCH_TEST_DATA_IDX))
+        pytest.skip("enumerate_support not tested for distribution")
+    actual_support_non_vec = discrete_dist.pyro_dist.enumerate_support(
+        **discrete_dist.get_dist_params(SINGLE_TEST_DATUM_IDX))
+    actual_support = discrete_dist.pyro_dist.enumerate_support(
+        **discrete_dist.get_dist_params(BATCH_TEST_DATA_IDX))
     assert_equal(actual_support.data, torch.Tensor(expected_support))
     assert_equal(actual_support_non_vec.data, torch.Tensor(expected_support_non_vec))
 


### PR DESCRIPTION
Addresses #159 

## Why?

Both @fritzo and @dustinvtran were confused by the name `.support()` which suggests that it returns a representation of the support for a possibly-constrained probability distribution (e.g. R for `Cauchy` or a half-line for `HalfCauchy`). The renaming to `.enumerate_support()` makes it clear that this method is intended only for distributions with enumerable support, and matches the naming of the `.enumerable` property that describes this method.