### PR TITLE
Allow log pdf mask broadcasting for Categorical

### DIFF
--- a/pyro/distributions/categorical.py
+++ b/pyro/distributions/categorical.py
@@ -137,8 +137,7 @@ class Categorical(Distribution):
         batch_pdf_shape = self.batch_shape(x) + (1,)
         batch_log_pdf = torch.log(self.ps.masked_select(boolean_mask.byte())).contiguous().view(batch_pdf_shape)
         if self.log_pdf_mask is not None:
-            scaling_mask = self.log_pdf_mask.contiguous().view(batch_pdf_shape)
-            batch_log_pdf = batch_log_pdf * scaling_mask
+            batch_log_pdf = batch_log_pdf * self.log_pdf_mask
         return batch_log_pdf
 
     def enumerate_support(self):

--- a/pyro/distributions/random_primitive.py
+++ b/pyro/distributions/random_primitive.py
@@ -19,7 +19,7 @@ class RandomPrimitive(Distribution):
     def reparameterized(self):
         return self.dist_class.reparameterized
 
-    def batch_shape(self, x, *args, **kwargs):
+    def batch_shape(self, x=None, *args, **kwargs):
         return self.dist_class(*args, **kwargs).batch_shape(x)
 
     def event_shape(self, *args, **kwargs):
@@ -28,7 +28,7 @@ class RandomPrimitive(Distribution):
     def event_dim(self, *args, **kwargs):
         return self.dist_class(*args, **kwargs).event_dim()
 
-    def shape(self, x, *args, **kwargs):
+    def shape(self, x=None, *args, **kwargs):
         return self.dist_class(*args, **kwargs).shape(x)
 
     def sample(self, *args, **kwargs):

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -70,23 +70,24 @@ def test_batch_log_pdf_shape(dist):
 
 
 def test_batch_log_pdf_mask(dist):
-    if dist.pyro_dist.__class__.__name__ not in ('Normal', 'Bernoulli', 'Categorical'):
+    if dist.get_test_distribution_name() not in ('Normal', 'Bernoulli', 'Categorical'):
         pytest.skip('Batch pdf masking not supported for the distribution.')
     d = dist.pyro_dist
     for idx in range(dist.get_num_test_data()):
         dist_params = dist.get_dist_params(idx)
         x = dist.get_test_data(idx)
         with xfail_if_not_implemented():
-            batch_pdf_shape = get_batch_pdf_shape(dist, x, dist_params)
-            zeros_mask = ng_zeros(batch_pdf_shape)
-            ones_mask = ng_ones(batch_pdf_shape)
-            half_mask = ng_ones(batch_pdf_shape) * 0.5
+            batch_pdf_shape = d.batch_shape(**dist_params) + (1,)
+            batch_pdf_shape_broadcasted = get_batch_pdf_shape(dist, x, dist_params)
+            zeros_mask = ng_zeros(1)  # should be broadcasted to data dims
+            ones_mask = ng_ones(batch_pdf_shape)  # should be broadcasted to data dims
+            half_mask = ng_ones(1) * 0.5
             batch_log_pdf = d.batch_log_pdf(x, **dist_params)
             batch_log_pdf_zeros_mask = d.batch_log_pdf(x, log_pdf_mask=zeros_mask, **dist_params)
             batch_log_pdf_ones_mask = d.batch_log_pdf(x, log_pdf_mask=ones_mask, **dist_params)
             batch_log_pdf_half_mask = d.batch_log_pdf(x, log_pdf_mask=half_mask, **dist_params)
             assert_equal(batch_log_pdf_ones_mask, batch_log_pdf)
-            assert_equal(batch_log_pdf_zeros_mask, ng_zeros(batch_pdf_shape))
+            assert_equal(batch_log_pdf_zeros_mask, ng_zeros(batch_pdf_shape_broadcasted))
             assert_equal(batch_log_pdf_half_mask, 0.5 * batch_log_pdf)
 
 


### PR DESCRIPTION
This enables the categorical pdf mask to correctly broadcast to the batch dimensions during scoring. Modified the log pdf mask tests to ensure that the broadcasting is happening correctly. 

Needed for SS-VAE.