### PR TITLE
Resolve failing VAE example

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -1,16 +1,18 @@
 import argparse
+
 import numpy as np
 import torch
-from torch.autograd import Variable
 import torch.nn as nn
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
 import visdom
+from torch.autograd import Variable
+
 import pyro
-from pyro.distributions import Normal
-from pyro.util import ng_zeros, ng_ones
+import pyro.distributions as dist
 from pyro.infer import SVI
 from pyro.optim import Adam
+from pyro.util import ng_zeros, ng_ones
 
 
 # for loading and batching MNIST dataset
@@ -126,7 +128,7 @@ class VAE(nn.Module):
         # encode image x
         z_mu, z_sigma = self.encoder(x)
         # sample in latent space
-        z = dist.normal(z_mu, z_sigma).sample()
+        z = dist.normal(z_mu, z_sigma)
         # decode the image (note we don't sample in image space)
         mu_img, sigma_img = self.decoder(z)
         return mu_img


### PR DESCRIPTION
The example seems to be failing the dev build with:

```
./examples/vae.py:10:1: F401 'pyro.distributions.Normal' imported but unused
./examples/vae.py:108:35: F821 undefined name 'dist'
./examples/vae.py:113:29: F821 undefined name 'dist'
```

This fixes the build. There is a separate issue in that we are seeing `nans` in test losses. cc. @martinjankowiak.