### PR TITLE
fix typo/nan in vae.py

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -120,7 +120,7 @@ class VAE(nn.Module):
         # use the encoder to get the parameters used to define q(z|x)
         z_mu, z_sigma = self.encoder(x)
         # sample the latent code z
-        z=pyro.sample("latent", dist.normal, z_mu, z_sigma)
+        pyro.sample("latent", dist.normal, z_mu, z_sigma)
 
     # define a helper function for reconstructing images
     def reconstruct_img(self, x):


### PR DESCRIPTION
don't make the mistake i did: 

the correct incantation is

`pyro.observe("obs", dist.normal, datapoint, mu, sigma)`