### PR TITLE
Move .flake8, pytest.ini into setup.cfg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 120
-exclude = docs/src, examples/storyboard

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    error

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 120
+exclude = docs/src, examples/storyboard
+
+[isort]
+force_single_line = true
+
+[pytest]
+filterwarnings = error
+
+[yapf]
+based_on_style = google


### PR DESCRIPTION
This combines our configuration files `.flake8` and `pytest.ini` into the standard `setup.cfg` combined file. This also adds stubs for sections to configure `yapf` and `isort`.

## Why?

As we configure more tools (linting, testing, formatting, code coverage, ...), it's nice avoid a profusion of config files littering our root directory. The standard solution is to collect configuration settings into a single `setup.cfg` file.