### PR TITLE
Scrub output and metadata of ipynb files for git commits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ipynb filter=nbstripout
+*.ipynb diff=ipynb

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,6 @@
+[filter "nbstripout"]
+    clean = "python -m nbstripout"
+    smudge = cat
+    required = true
+[diff "ipynb"]
+    textconv = nbstripout -t

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,20 @@
 # Development
 For consistency, please adhere to the established coding style including variable names, module imports, and function definitions.  The Pyro codebase uses the PEP8 style guide.
 
+# Setup
+
+Install all the dev dependencies for Pyro.
+
+```sh
+pip install -e .[dev]
+```
+
+Add the repository's git configuration to your local project `.gitconfig` file.
+
+```sh
+git config --local include.path ../.gitconfig
+```
+
 # Testing
 
 Before submitting a pull request, please ensure that linting and unit tests pass locally

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             'pytest-xdist',
             'nbval',
             'yapf',
+            'nbstripout',
             'sphinx',
             'sphinx_rtd_theme',
         ],

--- a/tutorial/bayesian_regression.ipynb
+++ b/tutorial/bayesian_regression.ipynb
@@ -23,10 +23,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -51,10 +49,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "N = 100  # size of toy data\n",
@@ -78,10 +74,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "class RegressionModel(nn.Module):\n",
@@ -105,33 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "105.713066101\n",
-      "102.354705811\n",
-      "102.354682922\n",
-      "102.354660034\n",
-      "102.354660034\n",
-      "102.354660034\n",
-      "102.354660034\n",
-      "102.354660034\n",
-      "102.354660034\n",
-      "102.354660034\n",
-      "Parameters: [('linear.weight', Parameter containing:\n",
-      " 2.9949\n",
-      "[torch.FloatTensor of size 1x1]\n",
-      "), ('linear.bias', Parameter containing:\n",
-      " 1.0565\n",
-      "[torch.FloatTensor of size 1]\n",
-      ")]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "loss_fn = torch.nn.MSELoss(size_average=False)\n",
     "optim = torch.optim.Adam(regression_model.parameters(), lr=0.01)\n",
@@ -175,10 +145,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "mu = Variable(torch.zeros(1, 1))\n",
@@ -203,10 +171,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def model(data):\n",
@@ -256,26 +222,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "epoch avg loss 1.53375732422\n",
-      "epoch avg loss 1.55264312744\n",
-      "epoch avg loss 1.54637115479\n",
-      "epoch avg loss 1.56145004272\n",
-      "epoch avg loss 1.55594955444\n",
-      "epoch avg loss 1.55865844727\n",
-      "epoch avg loss 1.55234939575\n",
-      "epoch avg loss 1.55432601929\n",
-      "epoch avg loss 1.55954589844\n",
-      "epoch avg loss 1.55867294312\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "optim = Adam({\"lr\": 0.01})\n",
     "svi = SVI(model, guide, optim, loss=\"ELBO\")\n",
@@ -303,29 +252,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'guide_log_sigma_bias': Variable containing:\n",
-      "-2.2687\n",
-      "[torch.FloatTensor of size 1]\n",
-      ", 'guide_log_sigma_weight': Variable containing:\n",
-      "-3.5816\n",
-      "[torch.FloatTensor of size 1x1]\n",
-      ", 'guide_mean_weight': Variable containing:\n",
-      " 2.9820\n",
-      "[torch.FloatTensor of size 1x1]\n",
-      ", 'guide_mean_bias': Variable containing:\n",
-      " 1.2036\n",
-      "[torch.FloatTensor of size 1]\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print pyro.get_param_store()._params"
    ]
@@ -346,21 +275,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Variable containing:\n",
-      "1.00000e-04 *\n",
-      "  5.8031\n",
-      "[torch.FloatTensor of size 1]\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "X = np.linspace(8, 12, num=20)\n",
     "y = 3 * X + 1\n",

--- a/tutorial/dmm/dmm_tutorial.ipynb
+++ b/tutorial/dmm/dmm_tutorial.ipynb
@@ -59,9 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Emitter(nn.Module):\n",
@@ -106,9 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class GatedTransition(nn.Module):\n",
@@ -176,9 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def model(...):\n",
@@ -217,9 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def model(self, mini_batch, mini_batch_reversed, mini_batch_mask,\n",
@@ -319,9 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Combiner(nn.Module):\n",
@@ -369,9 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def guide(self, mini_batch, mini_batch_reversed, mini_batch_mask,\n",
@@ -427,9 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class DMM(nn.Module):\n",
@@ -495,9 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the dmm\n",
@@ -521,9 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# setup inference algorithm\n",
@@ -544,9 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "svi.step(mini_batch, ...)"
@@ -600,9 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "jsb_file_loc = join(dirname(__file__), \"jsb_processed.pkl\")\n",
@@ -621,9 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "For this dataset we will typically use a `mini_batch_size` of 20, so that there will be 12 mini-batches per epoch. Next we define the function `process_minibatch` which prepares a mini-batch for training and takes a gradient step:"
    ]
@@ -631,9 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def process_minibatch(epoch, which_mini_batch, shuffled_indices):\n",
@@ -681,9 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "times = [time.time()]\n",
@@ -724,9 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val_loss = svi.evaluate_loss(val_batch, ..., num_particles=5)"
@@ -742,9 +712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# package repeated copies of val/test data for faster evaluation\n",
@@ -773,9 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def do_evaluation():\n",
@@ -840,9 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "iafs = [InverseAutoregressiveFlow(z_dim, iaf_dim) for _ in range(num_iafs)]\n",
@@ -859,9 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "if self.iafs.__len__() > 0:\n",
@@ -877,9 +839,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Checkpointing\n",
     "\n",
@@ -893,9 +853,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "    # saves the model and optimizer states to disk\n",

--- a/tutorial/svi_part_i.ipynb
+++ b/tutorial/svi_part_i.ipynb
@@ -242,9 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",

--- a/tutorial/svi_part_ii.ipynb
+++ b/tutorial/svi_part_ii.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "# SVI Part II: Conditional Independence, Subsampling, and Amortization\n",
     "\n",
@@ -93,9 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Subsampling\n",
     "\n",

--- a/tutorial/svi_part_iii.ipynb
+++ b/tutorial/svi_part_iii.ipynb
@@ -342,9 +342,7 @@
   },
   {
    "cell_type": "raw",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "Doing inference with use_decaying_avg_baseline=True\n",
     "...........\n",


### PR DESCRIPTION
Addresses #397. 
 - Adds `nbstripout` to scrub output and certain execution metadata from jupyter notebooks when generating the commit. Note that this is implemented as a filter, and has no effect on the local file (i.e. the output will be stored locally on disk as is), but simply the generated commit. We can generate the full fledged html output separately.
 - I ran the script on the existing tutorials to scrub out metadata and output. We can add `{ "keep_output": true,}` to a cell to commit its output to git, if needed later.
 - This adds a `.gitattributes` and `.gitconfig` files to the repo for the filter. The config file will need to be manually added to the local git config for the repo by the user by running `git config --local include.path ../.gitconfig` (added in CONTRIBUTING.md). Not adding it will not result in any adverse action - it will simply skip this script, but we can catch that during PR review.


