### PR TITLE
Raise error in case of duplicate sample sites

### DIFF
--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -10,7 +10,7 @@ from .condition_poutine import ConditionPoutine
 from .lambda_poutine import LambdaPoutine  # noqa: F401
 from .escape_poutine import EscapePoutine
 
-# trace data structures
+import pyro
 from .trace import Trace  # noqa: F401
 from pyro import util
 
@@ -186,6 +186,8 @@ def queue(fn, queue, max_tries=None,
                                    functools.partial(escape_fn, next_trace)))
                 return ftr(*args, **kwargs)
             except util.NonlocalExit as site_container:
+                for frame in pyro._PYRO_STACK:
+                    frame._reset()
                 for tr in extend_fn(ftr.trace.copy(), site_container.site,
                                     num_samples=num_samples):
                     queue.put(tr)

--- a/pyro/poutine/poutine.py
+++ b/pyro/poutine/poutine.py
@@ -112,6 +112,14 @@ class Poutine(object):
                 for i in range(0, loc + 1):
                     pyro._PYRO_STACK.pop(0)
 
+    def _reset(self):
+        """
+        Resets the computation to the beginning, un-sampling all sample sites.
+
+        By default, does nothing, but overridden in derived classes.
+        """
+        pass
+
     def _prepare_site(self, msg):
         """
         :param msg: current message at a trace site

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -26,7 +26,7 @@ def assert_error(model, guide, **kwargs):
     Assert that inference fails with an error.
     """
     inference = SVI(model,  guide, Adam({"lr": 1e-6}), "ELBO", **kwargs)
-    with pytest.raises((NotImplementedError, UserWarning, KeyError)):
+    with pytest.raises((NotImplementedError, UserWarning, KeyError, RuntimeError)):
         inference.step()
 
 
@@ -43,7 +43,6 @@ def assert_warning(model, guide, **kwargs):
             print(warning)
 
 
-@pytest.mark.xfail(reason="Did not raise error despite x being sampled twice")
 @pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
 def test_variable_clash_in_model_error(trace_graph):
 
@@ -59,7 +58,6 @@ def test_variable_clash_in_model_error(trace_graph):
     assert_error(model, guide, trace_graph=trace_graph)
 
 
-@pytest.mark.xfail(reason="Did not raise error despite x being sampled twice")
 @pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
 def test_variable_clash_in_guide_error(trace_graph):
 
@@ -92,7 +90,6 @@ def test_irange_ok(trace_graph, subsample_size):
     assert_ok(model, guide, trace_graph=trace_graph)
 
 
-@pytest.mark.xfail(reason="Did not raise error despite x being sampled twice")
 @pytest.mark.parametrize("trace_graph", [False, True], ids=["trace", "tracegraph"])
 def test_irange_variable_clash_error(trace_graph):
 


### PR DESCRIPTION
Fixes #398 
Addresses #164 

This is a quick-and-dirty fix to ensure users are warned about duplicate sample sites that can sneak in to `irange`/`map_data` code:
```py
for i in pyro.irange("data", len(mus)):
    x = pyro.sample("x", dist.normal, mus[i], sigma)  # Should be named "x_{}".format(i)
```

## How?

This sends a `Poutine._reset()` signal to all poutines in the `_PYRO_STACK` whenever computation is aborted. The new `._reset()` method is similar to the `unsample`/`unincorporate` statements of pychurch/venture/cgpm in that it removes `sample` and `observe` statements from traces. (In the future, we could conceivable add finer-grained `.unsample()` statements for Metropolis-Hastings.) The `._reset()` method is currently only used in `poutine.queue()` when computation is aborted by an `EscapePoutine`.

We should definitely clean this up after launch, but given that this catches such a common user error, I'm inclined to merge this before launch.

## Tested

Three previously xfailing tests now pass.