### PR TITLE
Adding support for logits in Bernoulli and Categorical

### DIFF
--- a/pyro/distributions/bernoulli.py
+++ b/pyro/distributions/bernoulli.py
@@ -1,7 +1,9 @@
 import torch
+import torch.nn.functional as F
 from torch.autograd import Variable
 
 from pyro.distributions.distribution import Distribution
+from pyro.distributions.util import get_probs_and_logits
 
 
 class Bernoulli(Distribution):
@@ -16,14 +18,26 @@ class Bernoulli(Distribution):
 
     :param torch.autograd.Variable ps: Probabilities. Should lie in the
         interval `[0,1]`.
+    :param logits: Log odds, i.e. log (p / (1 - p)). Either `ps` or `logits`
+        should be specified, but not both.
+    :param batch_size: The number of elements in the batch used to generate
+        a sample. The batch dimension will be the leftmost dimension in the
+        generated sample.
+    :param log_pdf_mask: Tensor that is applied to the batch log pdf values
+        as a multiplier. The most common use case is supplying a boolean
+        tensor mask to mask out certain batch sites in the log pdf computation.
     """
     enumerable = True
 
-    def __init__(self, ps, batch_size=None, log_pdf_mask=None, *args, **kwargs):
-        self.ps = ps
+    def __init__(self, ps=None, logits=None, batch_size=None, log_pdf_mask=None, *args, **kwargs):
+        if (ps is None) == (logits is None):
+            raise ValueError("Got ps={}, logits={}. Either `ps` or `logits` must be specified, "
+                             "but not both.".format(ps, logits))
+        self.ps, self.logits = get_probs_and_logits(ps=ps, logits=logits, is_multidimensional=False)
         self.log_pdf_mask = log_pdf_mask
-        if ps.dim() == 1 and batch_size is not None:
-            self.ps = ps.expand(batch_size, ps.size(0))
+        if self.ps.dim() == 1 and batch_size is not None:
+            self.ps = self.ps.expand(batch_size, self.ps.size(0))
+            self.logits = self.logits.expand(batch_size, self.logits.size(0))
             if log_pdf_mask is not None and log_pdf_mask.dim() == 1:
                 self.log_pdf_mask = log_pdf_mask.expand(batch_size, log_pdf_mask.size(0))
         super(Bernoulli, self).__init__(*args, **kwargs)
@@ -31,8 +45,17 @@ class Bernoulli(Distribution):
     def batch_shape(self, x=None):
         event_dim = 1
         ps = self.ps
-        if x is not None and x.size() != self.ps.size():
-            ps = self.ps.expand_as(x)
+        if x is not None:
+            if x is not None:
+                if x.size()[-event_dim] != ps.size()[-event_dim]:
+                    raise ValueError("The event size for the data and distribution parameters must match.\n"
+                                     "Expected x.size()[-1] == self.ps.size()[-1], but got {} vs {}"
+                                     .format(x.size(-1), ps.size(-1)))
+                try:
+                    ps = self.ps.expand_as(x)
+                except RuntimeError as e:
+                    raise ValueError("Parameter `ps` with shape {} is not broadcastable to "
+                                     "the data shape {}. \nError: {}".format(ps.size(), x.size(), str(e)))
         return ps.size()[:-event_dim]
 
     def event_shape(self):
@@ -46,23 +69,16 @@ class Bernoulli(Distribution):
         return Variable(torch.bernoulli(self.ps.data))
 
     def batch_log_pdf(self, x):
-        ps = self.ps
-        ps = ps.expand(self.shape(x))
-        x_1 = x - 1
-        ps_1 = ps - 1
-        x = x.type_as(ps)
-        x_1 = x_1.type_as(x_1)
-        xmul = torch.mul(x, ps)
-        xmul_1 = torch.mul(x_1, ps_1)
-        logsum = torch.log(torch.add(xmul, xmul_1))
-
+        batch_log_pdf_shape = self.batch_shape(x) + (1,)
+        log_prob_1 = F.sigmoid(self.logits)
+        log_prob_0 = F.sigmoid(-self.logits)
+        log_prob = torch.log(x * log_prob_1 + (1 - x) * log_prob_0)
         # XXX this allows for the user to mask out certain parts of the score, for example
         # when the data is a ragged tensor. also useful for KL annealing. this entire logic
         # will likely be done in a better/cleaner way in the future
         if self.log_pdf_mask is not None:
-            logsum = logsum * self.log_pdf_mask
-        batch_log_pdf_shape = self.batch_shape(x) + (1,)
-        return torch.sum(logsum, -1).contiguous().view(batch_log_pdf_shape)
+            log_prob = log_prob * self.log_pdf_mask
+        return torch.sum(log_prob, -1).contiguous().view(batch_log_pdf_shape)
 
     def enumerate_support(self):
         """

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 from torch.autograd import Variable
 
 
@@ -108,3 +109,54 @@ def torch_multinomial(input, num_samples, replacement=False):
         return torch_multinomial(input.cpu(), num_samples, replacement).cuda()
     else:
         return torch.multinomial(input, num_samples, replacement)
+
+
+def softmax(x, dim=-1):
+    """
+    TODO: change to use the default pyTorch implementation when available
+    Source: https://discuss.pytorch.org/t/why-softmax-function-cant-specify-the-dimension-to-operate/2637
+    :param x: tensor
+    :param dim: Dimension to apply the softmax function to. The elements of the tensor in this
+        dimension must sum to 1.
+    :return: tensor having the same dimension as `x` rescaled along dim
+    """
+    input_size = x.size()
+
+    trans_input = x.transpose(dim, len(input_size) - 1)
+    trans_size = trans_input.size()
+
+    input_2d = trans_input.contiguous().view(-1, trans_size[-1])
+
+    soft_max_2d = F.softmax(input_2d)
+
+    soft_max_nd = soft_max_2d.view(*trans_size)
+    return soft_max_nd.transpose(dim, len(input_size) - 1)
+
+
+def get_probs_and_logits(ps=None, logits=None, is_multidimensional=True):
+    """
+    Convert probability values to logits, or vice-versa. Either `ps` or
+    `logits` should be specified, but not both.
+
+    :param ps: tensor of probabilities. Should be in the interval *[0, 1]*.
+        If, `is_multidimensional = True`, then must be normalized along
+        axis -1.
+    :param logits: tensor of logit values.
+    :param is_multidimensional: determines the computation of ps from logits,
+        and vice-versa. For the multi-dimensional case, logit values are
+        assumed to be non-normalized log probabilities, whereas for the uni-
+        dimensional case, it specifically refers to log odds.
+    :return: tuple containing raw probabilities and logits as tensors
+    """
+    assert (ps is None) != (logits is None)
+    if is_multidimensional:
+        if ps is None:
+            ps = softmax(logits, -1)
+        else:
+            logits = torch.log(ps)
+    else:
+        if ps is None:
+            ps = F.sigmoid(logits)
+        else:
+            logits = torch.log(ps) - torch.log1p(-ps)
+    return ps, logits

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pytest
 import scipy.stats as sp
@@ -139,12 +141,21 @@ discrete_dists = [
             examples=[
                 {'ps': [0.25],
                  'test_data': [1]},
-                {'ps': [0.25],
+                {'ps': [0.25, 0.25],
                  'test_data': [[[0, 1]], [[1, 0]], [[0, 0]]]},
+                {'logits': [math.log(p / (1 - p)) for p in (0.25, 0.25)],
+                 'test_data': [[[0, 1]], [[1, 0]], [[0, 0]]]},
+                {'logits': [-float('inf'), 0],
+                 'test_data': [[0, 1], [0, 1], [0, 1]]},
+                {'logits': [[math.log(p / (1 - p)) for p in (0.25, 0.25)],
+                            [math.log(p / (1 - p)) for p in (0.3, 0.3)]],
+                 'test_data': [[1, 1], [0, 0]]},
                 {'ps': [[0.25, 0.25], [0.3, 0.3]],
                  'test_data': [[1, 1], [0, 0]]}
             ],
-            scipy_arg_fn=lambda ps: ((), {'p': ps}),
+            test_data_indices=[0, 1, 2, 3],
+            batch_data_indices=[-1, -2],
+            scipy_arg_fn=lambda **kwargs: ((), {'p': kwargs['ps']}),
             prec=0.01,
             min_samples=10000,
             is_discrete=True,
@@ -170,9 +181,19 @@ discrete_dists = [
     Fixture(pyro_dist=(dist.categorical, Categorical),
             scipy_dist=sp.multinomial,
             examples=[
-                {'ps': [0.1, 0.6, 0.3], 'test_data': [0, 0, 1]},
-                {'ps': [[0.1, 0.6, 0.3], [0.2, 0.4, 0.4]], 'test_data': [[0, 0, 1], [1, 0, 0]]}
+                {'ps': [0.1, 0.6, 0.3],
+                 'test_data': [0, 0, 1]},
+                {'logits': list(map(math.log, [0.1, 0.6, 0.3])),
+                 'test_data': [0, 0, 1]},
+                {'logits': [list(map(math.log, [0.1, 0.6, 0.3])),
+                            list(map(math.log, [0.2, 0.4, 0.4]))],
+                 'test_data': [[0, 0, 1], [1, 0, 0]]},
+                {'ps': [[0.1, 0.6, 0.3],
+                        [0.2, 0.4, 0.4]],
+                 'test_data': [[0, 0, 1], [1, 0, 0]]}
             ],
+            test_data_indices=[0, 1, 2],
+            batch_data_indices=[-1, -2],
             scipy_arg_fn=lambda ps: ((1, np.array(ps)), {}),
             prec=0.05,
             min_samples=10000,

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -4,7 +4,10 @@ import numpy as np
 import torch
 from torch.autograd import Variable
 
-from tests.common import assert_equal
+from pyro.distributions.util import get_probs_and_logits
+
+SINGLE_TEST_DATUM_IDX = [0]
+BATCH_TEST_DATA_IDX = [-1]
 
 
 class Fixture(object):
@@ -17,7 +20,9 @@ class Fixture(object):
                  min_samples=None,
                  is_discrete=False,
                  expected_support_non_vec=None,
-                 expected_support=None):
+                 expected_support=None,
+                 test_data_indices=None,
+                 batch_data_indices=None):
         self.pyro_dist, self.pyro_dist_obj = pyro_dist
         self.scipy_dist = scipy_dist
         self.dist_params, self.test_data = self._extract_fixture_data(examples)
@@ -27,6 +32,18 @@ class Fixture(object):
         self.is_discrete = is_discrete
         self.expected_support_non_vec = expected_support_non_vec
         self.expected_support = expected_support
+        self.test_data_indices = test_data_indices
+        self.batch_data_indices = batch_data_indices
+
+    def get_batch_data_indices(self):
+        if not self.batch_data_indices:
+            return BATCH_TEST_DATA_IDX
+        return self.batch_data_indices
+
+    def get_test_data_indices(self):
+        if not self.test_data_indices:
+            return SINGLE_TEST_DATUM_IDX
+        return self.test_data_indices
 
     def _extract_fixture_data(self, examples):
         dist_params, test_data = [], []
@@ -51,10 +68,20 @@ class Fixture(object):
             return self.dist_params[idx]
         return tensor_wrap(**self.dist_params[idx])
 
+    def _convert_logits_to_ps(self, dist_params):
+        if 'logits' in dist_params:
+            logits = torch.Tensor(dist_params.pop('logits'))
+            is_multidimensional = self.get_test_distribution_name() != 'Bernoulli'
+            ps, _ = get_probs_and_logits(logits=logits, is_multidimensional=is_multidimensional)
+            dist_params['ps'] = list(ps.data.cpu().numpy())
+        return dist_params
+
     def get_scipy_logpdf(self, idx):
         if not self.scipy_arg_fn:
             return
-        args, kwargs = self.scipy_arg_fn(**self.get_dist_params(idx, wrap_tensor=False))
+        dist_params = self.get_dist_params(idx, wrap_tensor=False)
+        dist_params = self._convert_logits_to_ps(dist_params)
+        args, kwargs = self.scipy_arg_fn(**dist_params)
         if self.is_discrete:
             log_pdf = self.scipy_dist.logpmf(self.get_test_data(idx, wrap_tensor=False), *args, **kwargs)
         else:
@@ -66,6 +93,7 @@ class Fixture(object):
             return
         dist_params = self.get_dist_params(idx, wrap_tensor=False)
         dist_params_wrapped = self.get_dist_params(idx)
+        dist_params = self._convert_logits_to_ps(dist_params)
         test_data = self.get_test_data(idx, wrap_tensor=False)
         test_data_wrapped = self.get_test_data(idx)
         shape = self.pyro_dist.shape(test_data_wrapped, **dist_params_wrapped)
@@ -85,18 +113,6 @@ class Fixture(object):
                                                             *args,
                                                             **kwargs))
         return batch_log_pdf
-
-    def get_pyro_logpdf(self, idx):
-        dist_function_return = self.pyro_dist.log_pdf(self.get_test_data(idx), **self.get_dist_params(idx))
-        dist_object_return = self.pyro_dist_obj(**self.get_dist_params(idx)).log_pdf(self.get_test_data(idx))
-        assert_equal(dist_function_return, dist_object_return)
-        return dist_function_return
-
-    def get_pyro_batch_logpdf(self, idx):
-        dist_function_return = self.pyro_dist.batch_log_pdf(self.get_test_data(idx), **self.get_dist_params(idx))
-        dist_object_return = self.pyro_dist_obj(**self.get_dist_params(idx)).batch_log_pdf(self.get_test_data(idx))
-        assert_equal(dist_function_return, dist_object_return)
-        return dist_function_return
 
     def get_num_samples(self, idx):
         """
@@ -132,9 +148,12 @@ class Fixture(object):
 def tensor_wrap(*args, **kwargs):
     tensor_list, tensor_map = [], {}
     for arg in args:
-        tensor_list.append(Variable(torch.Tensor(arg)))
+        wrapped_arg = Variable(torch.Tensor(arg)) if isinstance(arg, list) else arg
+        tensor_list.append(wrapped_arg)
     for k in kwargs:
-        tensor_map[k] = Variable(torch.Tensor(kwargs[k]))
+        kwarg = kwargs[k]
+        wrapped_kwarg = Variable(torch.Tensor(kwarg)) if isinstance(kwarg, list) else kwarg
+        tensor_map[k] = wrapped_kwarg
     if args and not kwargs:
         return tensor_list
     if kwargs and not args:

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -6,9 +6,6 @@ from pyro.distributions import RandomPrimitive
 from pyro.util import ng_ones, ng_zeros
 from tests.common import assert_equal, xfail_if_not_implemented
 
-SINGLE_TEST_DATUM_IDX = 0
-BATCH_TEST_DATA_IDX = -1
-
 
 def unwrap_variable(x):
     return x.data.cpu().numpy()
@@ -16,26 +13,32 @@ def unwrap_variable(x):
 
 # Distribution tests - all distributions
 
-
 def test_log_pdf(dist):
-    pyro_log_pdf = unwrap_variable(dist.get_pyro_logpdf(SINGLE_TEST_DATUM_IDX))[0]
-    scipy_log_pdf = dist.get_scipy_logpdf(SINGLE_TEST_DATUM_IDX)
-    assert_equal(pyro_log_pdf, scipy_log_pdf)
+    d = dist.pyro_dist
+    for idx in dist.get_test_data_indices():
+        dist_params = dist.get_dist_params(idx)
+        test_data = dist.get_test_data(idx)
+        pyro_log_pdf = unwrap_variable(d.log_pdf(test_data, **dist_params))[0]
+        scipy_log_pdf = dist.get_scipy_logpdf(idx)
+        assert_equal(pyro_log_pdf, scipy_log_pdf)
 
 
 def test_batch_log_pdf(dist):
-    logpdf_sum_pyro = unwrap_variable(torch.sum(dist.get_pyro_batch_logpdf(BATCH_TEST_DATA_IDX)))[0]
-    logpdf_sum_np = np.sum(dist.get_scipy_batch_logpdf(-1))
-    assert_equal(logpdf_sum_pyro, logpdf_sum_np)
+    d = dist.pyro_dist
+    for idx in dist.get_batch_data_indices():
+        dist_params = dist.get_dist_params(idx)
+        test_data = dist.get_test_data(idx)
+        logpdf_sum_pyro = unwrap_variable(torch.sum(d.batch_log_pdf(test_data, **dist_params)))[0]
+        logpdf_sum_np = np.sum(dist.get_scipy_batch_logpdf(-1))
+        assert_equal(logpdf_sum_pyro, logpdf_sum_np)
 
 
 def test_shape(dist):
-    if isinstance(dist.pyro_dist, RandomPrimitive):
-        pytest.skip('FIXME: https://github.com/uber/pyro/issues/323')
     d = dist.pyro_dist
-    dist_params = dist.get_dist_params(SINGLE_TEST_DATUM_IDX)
-    with xfail_if_not_implemented():
-        assert d.shape(**dist_params) == d.batch_shape(**dist_params) + d.event_shape(**dist_params)
+    for idx in dist.get_test_data_indices():
+        dist_params = dist.get_dist_params(idx)
+        with xfail_if_not_implemented():
+            assert d.shape(**dist_params) == d.batch_shape(**dist_params) + d.event_shape(**dist_params)
 
 
 def test_sample_shape(dist):
@@ -46,11 +49,7 @@ def test_sample_shape(dist):
         x_obj = dist.pyro_dist_obj(**dist_params).sample()
         assert_equal(x_obj.size(), x_func.size())
         with xfail_if_not_implemented():
-            # TODO remove once #323 is resolved
-            if isinstance(dist.pyro_dist, RandomPrimitive):
-                assert(x_func.size() == d.shape(x_func, **dist_params))
-                return
-            assert x_func.size() == d.shape(**dist_params)
+            assert(x_func.size() == d.shape(x_func, **dist_params))
 
 
 def test_batch_log_pdf_shape(dist):
@@ -60,7 +59,7 @@ def test_batch_log_pdf_shape(dist):
         x = dist.get_test_data(idx)
         with xfail_if_not_implemented():
             # Get batch pdf shape after broadcasting.
-            expected_shape = get_batch_pdf_shape(dist, x, dist_params)
+            expected_shape = d.batch_shape(x, **dist_params) + (1,)
             log_p_func = d.batch_log_pdf(x, **dist_params)
             log_p_obj = dist.pyro_dist_obj(**dist_params).batch_log_pdf(x)
             # assert that the functional and object forms return
@@ -78,7 +77,7 @@ def test_batch_log_pdf_mask(dist):
         x = dist.get_test_data(idx)
         with xfail_if_not_implemented():
             batch_pdf_shape = d.batch_shape(**dist_params) + (1,)
-            batch_pdf_shape_broadcasted = get_batch_pdf_shape(dist, x, dist_params)
+            batch_pdf_shape_broadcasted = d.batch_shape(x, **dist_params) + (1,)
             zeros_mask = ng_zeros(1)  # should be broadcasted to data dims
             ones_mask = ng_ones(batch_pdf_shape)  # should be broadcasted to data dims
             half_mask = ng_ones(1) * 0.5
@@ -92,40 +91,39 @@ def test_batch_log_pdf_mask(dist):
 
 
 def test_mean_and_variance(dist):
-    num_samples = dist.get_num_samples(SINGLE_TEST_DATUM_IDX)
-    dist_params = dist.get_dist_params(SINGLE_TEST_DATUM_IDX)
-    torch_samples = dist.get_samples(num_samples, **dist_params)
-    sample_mean = torch_samples.float().mean(0)
-    sample_var = torch_samples.float().var(0)
-    try:
-        analytic_mean = dist.pyro_dist.analytic_mean(**dist_params)
-        analytic_var = dist.pyro_dist.analytic_var(**dist_params)
-        assert_equal(sample_mean, analytic_mean, prec=dist.prec)
-        assert_equal(sample_var, analytic_var, prec=dist.prec)
-    except (NotImplementedError, ValueError):
-        pytest.skip('analytic mean and variance are not available')
+    for idx in dist.get_test_data_indices():
+        num_samples = dist.get_num_samples(idx)
+        dist_params = dist.get_dist_params(idx)
+        torch_samples = dist.get_samples(num_samples, **dist_params)
+        sample_mean = torch_samples.float().mean(0)
+        sample_var = torch_samples.float().var(0)
+        try:
+            analytic_mean = dist.pyro_dist.analytic_mean(**dist_params)
+            analytic_var = dist.pyro_dist.analytic_var(**dist_params)
+            assert_equal(sample_mean, analytic_mean, prec=dist.prec)
+            assert_equal(sample_var, analytic_var, prec=dist.prec)
+        except (NotImplementedError, ValueError):
+            pytest.skip('analytic mean and variance are not available')
 
 
 def test_score_errors_event_dim_mismatch(dist):
-    if dist.get_test_distribution_name() in ('Bernoulli', 'Categorical'):
-        pytest.skip('TODO: after https://github.com/uber/pyro/issues/415')
     d = dist.pyro_dist
-    dist_params = dist.get_dist_params(BATCH_TEST_DATA_IDX)
-    test_data_wrong_dims = torch.ones(d.shape(**dist_params) + (1,))
-    with pytest.raises(ValueError):
-        d.batch_log_pdf(test_data_wrong_dims, **dist_params)
+    for idx in dist.get_batch_data_indices():
+        dist_params = dist.get_dist_params(idx)
+        test_data_wrong_dims = ng_ones(d.shape(**dist_params) + (1,))
+        with pytest.raises(ValueError):
+            d.batch_log_pdf(test_data_wrong_dims, **dist_params)
 
 
 def test_score_errors_non_broadcastable_data_shape(dist):
-    if dist.get_test_distribution_name() in ('Bernoulli', 'Categorical'):
-        pytest.skip('TODO: after https://github.com/uber/pyro/issues/415')
     d = dist.pyro_dist
-    dist_params = dist.get_dist_params(BATCH_TEST_DATA_IDX)
-    shape = d.shape(**dist_params)
-    non_broadcastable_shape = (shape[0] + 1,) + shape[1:]
-    test_data_non_broadcastable = torch.ones(non_broadcastable_shape)
-    with pytest.raises(ValueError):
-        d.batch_log_pdf(test_data_non_broadcastable, **dist_params)
+    for idx in dist.get_batch_data_indices():
+        dist_params = dist.get_dist_params(idx)
+        shape = d.shape(**dist_params)
+        non_broadcastable_shape = (shape[0] + 1,) + shape[1:]
+        test_data_non_broadcastable = ng_ones(non_broadcastable_shape)
+        with pytest.raises(ValueError):
+            d.batch_log_pdf(test_data_non_broadcastable, **dist_params)
 
 
 # Distributions tests - discrete distributions
@@ -136,23 +134,14 @@ def test_enumerate_support(discrete_dist):
     if not expected_support:
         pytest.skip("enumerate_support not tested for distribution")
     actual_support_non_vec = discrete_dist.pyro_dist.enumerate_support(
-        **discrete_dist.get_dist_params(SINGLE_TEST_DATUM_IDX))
+        **discrete_dist.get_dist_params(0))
     actual_support = discrete_dist.pyro_dist.enumerate_support(
-        **discrete_dist.get_dist_params(BATCH_TEST_DATA_IDX))
+        **discrete_dist.get_dist_params(-1))
     assert_equal(actual_support.data, torch.Tensor(expected_support))
     assert_equal(actual_support_non_vec.data, torch.Tensor(expected_support_non_vec))
 
 
 def get_batch_pdf_shape(dist, data, dist_params):
     d = dist.pyro_dist
-    broadcasted_params = {}
-    # TODO remove once https://github.com/uber/pyro/issues/323 is resolved
     if isinstance(dist.pyro_dist, RandomPrimitive):
         return d.batch_shape(data, **dist_params) + (1,)
-    for p in dist_params:
-        if dist_params[p].dim() < data.dim():
-            broadcasted_params[p] = dist_params[p].expand_as(data)
-        else:
-            broadcasted_params[p] = dist_params[p]
-    with xfail_if_not_implemented():
-        return d.batch_shape(**broadcasted_params) + (1,)


### PR DESCRIPTION
Addresses #415. 
 - Adds support for specifying logits in Categorical and Bernoulli. This does not handle all the corner cases, but is a start.
 - Had to refactor the distribution tests so that all test methods could test multiple non-vectorized or vectorized test cases.