### PR TITLE
Error if enum_discrete assumptions are not met

### DIFF
--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -8,6 +8,32 @@ from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match
 
 
+def check_enum_discrete_can_run(model_trace, guide_trace):
+    """
+    Checks whether `enum_discrete` is supported for the given (model, guide) pair.
+
+    :param Trace model: A model trace.
+    :param Trace guide: A guide trace.
+    :raises: NotImplementedError
+    """
+    # Check that all batch_log_pdf shapes are the same,
+    # since we currently do not correctly handle broadcasting.
+    model_trace.compute_batch_log_pdf()
+    guide_trace.compute_batch_log_pdf()
+    shapes = {}
+    for source, trace in [("model", model_trace), ("guide", guide_trace)]:
+        for name, site in trace.nodes.items():
+            if site["type"] == "sample":
+                shapes[site["batch_log_pdf"].size()] = (source, name)
+    if len(shapes) > 1:
+        raise NotImplementedError(
+                "enum_discrete does not support mixture of batched and un-batched variables. "
+                "Try rewriting your model to avoid batching or running with enum_discrete=False. "
+                "Found the following variables of different batch shapes:\n{}".format(
+                    "\n".join(["{} {}: shape = {}".format(source, name, tuple(shape))
+                               for shape, (source, name) in sorted(shapes.items())])))
+
+
 class Trace_ELBO(object):
     """
     A trace implementation of ELBO-based SVI
@@ -41,6 +67,7 @@ class Trace_ELBO(object):
                     check_model_guide_match(model_trace, guide_trace)
                     guide_trace = prune_subsample_sites(guide_trace)
                     model_trace = prune_subsample_sites(model_trace)
+                    check_enum_discrete_can_run(model_trace, guide_trace)
 
                     log_r = model_trace.batch_log_pdf() - guide_trace.batch_log_pdf()
                     weight = scale / self.num_particles

--- a/pyro/poutine/lambda_poutine.py
+++ b/pyro/poutine/lambda_poutine.py
@@ -10,10 +10,10 @@ class LambdaPoutine(Poutine):
     This poutine has two functions:
         (i)  handle score-rescaling
         (ii) keep track of stack of nested map_datas at each sample/observe site
-             for the benefit of TraceGraphPoutine;
+             for the benefit of TracePoutine;
              necessary information passed via map_data_stack in msg
     """
-    def __init__(self, fn, name, scale, map_data_type):
+    def __init__(self, fn, name, scale, vectorized):
         """
         Constructor: basically default, but store an extra scalar self.scale
         and a counter to keep track of which (list) map_data branch we're in
@@ -21,7 +21,7 @@ class LambdaPoutine(Poutine):
         self.name = name
         self.scale = scale
         self.counter = 0
-        self.vectorized = (map_data_type == "tensor")
+        self.vectorized = vectorized
         super(LambdaPoutine, self).__init__(fn)
 
     def __enter__(self):
@@ -33,7 +33,7 @@ class LambdaPoutine(Poutine):
 
     def _prepare_site(self, msg):
         """
-        construct the message that is consumed by TraceGraphPoutine;
+        construct the message that is consumed by TracePoutine;
         map_data_stack encodes the nested sequence of map_data branches
         that the site at name is within
         note: the map_data_stack ordering is innermost to outermost from left to right

--- a/pyro/poutine/trace_poutine.py
+++ b/pyro/poutine/trace_poutine.py
@@ -19,9 +19,7 @@ def get_vectorized_map_data_info(trace):
             continue
         if node["type"] in ("sample", "param"):
             stack = tuple(reversed(node["map_data_stack"]))
-            # remove nonvec_names, since irange is implemented in terms of iarange
-            nonvec_names = set(x.name for x in stack if not x.vectorized)
-            vec_mds = [x for x in stack if x.vectorized and x.name not in nonvec_names]
+            vec_mds = [x for x in stack if x.vectorized]
             # check for nested vectorized map datas
             if len(vec_mds) > 1:
                 vectorized_map_data_info['rao-blackwellization-condition'] = False
@@ -65,9 +63,7 @@ def get_vectorized_map_data_info(trace):
             if site_is_subsample(node):
                 continue
             if node["type"] in ("sample", "param"):
-                # remove nonvec_names, since irange is implemented in terms of iarange
-                nonvec_names = set(x.name for x in stack if not x.vectorized)
-                if any(x.vectorized and x.name not in nonvec_names for x in node["map_data_stack"]):
+                if any(x.vectorized for x in node["map_data_stack"]):
                     vectorized_map_data_info['nodes'].add(name)
 
     return vectorized_map_data_info

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -412,7 +412,6 @@ def test_iarange_enum_discrete_batch_ok():
 
 
 @segfaults_on_pytorch_020
-@pytest.mark.xfail(reason="error is not caught")
 def test_no_iarange_enum_discrete_batch_error():
 
     def model():
@@ -427,7 +426,7 @@ def test_no_iarange_enum_discrete_batch_error():
 
 
 @segfaults_on_pytorch_020
-def test_enum_discrete_global_local_ok():
+def test_enum_discrete_global_local_error():
 
     def model():
         p = Variable(torch.Tensor([0.5]))
@@ -441,4 +440,4 @@ def test_enum_discrete_global_local_ok():
         with pyro.iarange("iarange", 10, 5) as ind:
             pyro.sample("y", dist.bernoulli, p, batch_size=len(ind))
 
-    assert_ok(model, guide, enum_discrete=True)
+    assert_error(model, guide, enum_discrete=True)


### PR DESCRIPTION
Fixes #288 

**WARNING:** @rohitsingh0812 This may break SS-VAE. To fix, wrap your model in an `iarange`. All you need to do is something like
```py
def model(...):
    with pyro.iarange("independent"):  # <-------- add this line
        ...your existing code...
```

This checks two assumptions:
- If `enum_discrete` enumerates batch variables, then those must be within an `iarange`.
- `enum_discrete` does not support a mixture of batched and non-batched variables.

This PR also simplifies `irange` to use 1 (not 2) `LambdaPoutine`s. Previously `irange` was iplemented using `iarange` under the hood, adding two `LambdaPoutine`s to the `_PYRO_STACK`, one for scaling and one for independence. This duplication made it cumbersome to inspect the `map_data_stack`, and has led to bugs in the past. After this PR it is easy to check whether a site is inside an `iarange`: `any(f.vectorized for f in site['map_data_stack'])`.

## Tested

Updated `tests/infer/test_valid_models.py`