### PR TITLE
Reorganizing doc table of contents and sidebar

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -1,9 +1,10 @@
 Distributions
 =============
 
-.. automodule:: pyro.distributions.distribution
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. toctree::
+   :glob:
+   :maxdepth: 2
+   :caption: Contents:
 
-.. include:: pyro.distributions.txt
+   primitive_dist
+   transformed_dist

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Pyro Documentation
 
 .. toctree::
    :glob:
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Contents:
 
    installation

--- a/docs/source/primitive_dist.rst
+++ b/docs/source/primitive_dist.rst
@@ -1,0 +1,9 @@
+Primitive Distributions
+=======================
+
+.. automodule:: pyro.distributions.distribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. include:: pyro.distributions.txt

--- a/docs/source/pyro.distributions.transformed_distribution.txt
+++ b/docs/source/pyro.distributions.transformed_distribution.txt
@@ -1,0 +1,20 @@
+TransformedDistribution
+-----------------------
+.. autoclass:: pyro.distributions.transformed_distribution.TransformedDistribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Bijector
+--------
+.. autoclass:: pyro.distributions.transformed_distribution.Bijector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+InverseAutoRegressiveFlow
+-------------------------
+.. autoclass:: pyro.distributions.transformed_distribution.InverseAutoregressiveFlow
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pyro.distributions.txt
+++ b/docs/source/pyro.distributions.txt
@@ -85,13 +85,6 @@ Poisson
     :undoc-members:
     :show-inheritance:
 
-TransformedDistribution
------------------------
-.. automodule:: pyro.distributions.transformed_distribution
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 Uniform
 -------
 .. automodule:: pyro.distributions.uniform

--- a/docs/source/transformed_dist.rst
+++ b/docs/source/transformed_dist.rst
@@ -1,0 +1,4 @@
+Transformed Distribution
+========================
+
+.. include:: pyro.distributions.transformed_distribution.txt


### PR DESCRIPTION
Changes the doc reorganization in the index page and the search bar:
 - Primitive and transformed distribution falls under Distribution.
 - Reduced the depth in the index page to remove clutter.
