### PR TITLE
Remove the home logo from sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,6 +105,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 html_theme_options = {
     'navigation_depth': 3,
+    'logo_only': True,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
This makes sure that the pesky home logo in our sphinx docs does not show any more.