### PR TITLE
add get_named_parameters() to param store

### DIFF
--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -48,9 +48,9 @@ class ParamStoreDict(object):
         self._param_tags = defaultdict(lambda: set())
         self._tag_params = defaultdict(lambda: set())
 
-    def get_named_parameters(self):
+    def named_parameters(self):
         """
-        Returns a list of tuples of the form (name, parameter) for each parameter in the ParamStore
+        Returns an iterator over tuples of the form (name, parameter) for each parameter in the ParamStore
         """
         return self._params.items()
 


### PR DESCRIPTION
6 lines of code/comments. just add a get_named_parameters() method to the paramstore. will cleanup bayesian reg tutorial example code