### PR TITLE
Epsilon-scaled clipped versions of Softmax and Sigmoid as utilities

### DIFF
--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
 from .auto_reg_nn import AutoRegressiveNN, MaskedLinear  # noqa: F401
+
+from .clipped_nn import ClippedSoftmax, ClippedSigmoid

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
 
 from .auto_reg_nn import AutoRegressiveNN, MaskedLinear  # noqa: F401
-
-from .clipped_nn import ClippedSoftmax, ClippedSigmoid   # noqa: F401
+from .clipped_nn import ClippedSigmoid, ClippedSoftmax  # noqa: F401

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import, division, print_function
 
 from .auto_reg_nn import AutoRegressiveNN, MaskedLinear  # noqa: F401
 
-from .clipped_nn import ClippedSoftmax, ClippedSigmoid
+from .clipped_nn import ClippedSoftmax, ClippedSigmoid   # noqa: F401

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -13,7 +13,7 @@ class ClippedSoftmax(nn.Softmax):
 
     def forward(self, val):
         rval = super(ClippedSoftmax, self).forward(val)
-        n = rval.shape(getattr(self, "dim", -1))
+        n = rval.shape[getattr(self, "dim", -1)]
         return (rval * (1.0 - n * self.epsilon)) + self.epsilon
 
 

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import torch.nn as nn
 
 

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -1,0 +1,30 @@
+
+import torch
+import torch.nn as nn
+
+class ClippedSoftmax(nn.Softmax):
+    """
+        a wrapper around nn.Softmax that scales its output
+        from [0,1] to [epsilon,1-epsilon]
+    """
+    def __init__(self, epsilon, *args, **kwargs):
+        self.epsilon = epsilon
+        super(ClippedSoftmax, self).__init__(*args, **kwargs)
+
+    def forward(self, val):
+        rval = super(ClippedSoftmax, self).forward(val)
+        return (rval * (1.0 - 2 * self.epsilon)) + self.epsilon
+
+
+class ClippedSigmoid(nn.Sigmoid):
+    """
+        a wrapper around nn.Sigmoid that scales its output
+        from [0,1] to [epsilon,1-epsilon]
+    """
+    def __init__(self, epsilon, *args, **kwargs):
+        self.epsilon = epsilon
+        super(ClippedSigmoid, self).__init__(*args, **kwargs)
+
+    def forward(self, val):
+        rval = super(ClippedSigmoid, self).forward(val)
+        return (rval * (1.0 - 2 * self.epsilon)) + self.epsilon

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -13,7 +13,7 @@ class ClippedSoftmax(nn.Softmax):
 
     def forward(self, val):
         rval = super(ClippedSoftmax, self).forward(val)
-        n = rval.shape[getattr(self, "dim", -1)]
+        n = rval.size(getattr(self, "dim", -1))
         return (rval * (1.0 - n * self.epsilon)) + self.epsilon
 
 

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -3,8 +3,9 @@ import torch.nn as nn
 
 class ClippedSoftmax(nn.Softmax):
     """
-        a wrapper around nn.Softmax that scales its output
-        from [0,1] to [epsilon,1-epsilon]
+    a wrapper around `nn.Softmax` that scales its output
+    from `[0,1]` to `[epsilon,1-(n-1)*epsilon]`
+    where n is the output dimension of Softmax
     """
     def __init__(self, epsilon, *args, **kwargs):
         self.epsilon = epsilon
@@ -18,8 +19,8 @@ class ClippedSoftmax(nn.Softmax):
 
 class ClippedSigmoid(nn.Sigmoid):
     """
-        a wrapper around nn.Sigmoid that scales its output
-        from [0,1] to [epsilon,1-epsilon]
+    a wrapper around `nn.Sigmoid` that scales its output
+    from `[0,1]` to `[epsilon,1-epsilon]`
     """
     def __init__(self, epsilon, *args, **kwargs):
         self.epsilon = epsilon

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -12,7 +12,7 @@ class ClippedSoftmax(nn.Softmax):
 
     def forward(self, val):
         rval = super(ClippedSoftmax, self).forward(val)
-        n = rval.shape(self.dim)
+        n = rval.shape(getattr(self, "dim", -1))
         return (rval * (1.0 - n * self.epsilon)) + self.epsilon
 
 

--- a/pyro/nn/clipped_nn.py
+++ b/pyro/nn/clipped_nn.py
@@ -1,6 +1,5 @@
-
-import torch
 import torch.nn as nn
+
 
 class ClippedSoftmax(nn.Softmax):
     """
@@ -13,7 +12,8 @@ class ClippedSoftmax(nn.Softmax):
 
     def forward(self, val):
         rval = super(ClippedSoftmax, self).forward(val)
-        return (rval * (1.0 - 2 * self.epsilon)) + self.epsilon
+        n = rval.shape(self.dim)
+        return (rval * (1.0 - n * self.epsilon)) + self.epsilon
 
 
 class ClippedSigmoid(nn.Sigmoid):

--- a/tests/nn/__init__.py
+++ b/tests/nn/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import, division, print_function

--- a/tests/nn/test_clipped_nn.py
+++ b/tests/nn/test_clipped_nn.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+import torch
+from torch.autograd import Variable
+
+from pyro.nn.clipped_nn import ClippedSigmoid, ClippedSoftmax
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize('Tensor', [torch.FloatTensor, torch.DoubleTensor])
+def test_clipped_softmax(Tensor):
+    epsilon = 1e-5
+    clipped_softmax = ClippedSoftmax(epsilon)
+    ps = Variable(Tensor([[0, 1]]))
+    softmax_ps = clipped_softmax(ps)
+    print("epsilon = {}".format(epsilon))
+    print("softmax_ps = {}".format(softmax_ps))
+    assert (softmax_ps.data >= epsilon).all()
+    assert (softmax_ps.data <= 1 - epsilon).all()
+    assert_equal(softmax_ps.data.sum(), 1.0)
+
+
+@pytest.mark.parametrize('Tensor', [torch.FloatTensor, torch.DoubleTensor])
+def test_clipped_sigmoid(Tensor):
+    epsilon = 1e-5
+    clipped_softmax = ClippedSigmoid(epsilon)
+    ps = Variable(Tensor([0, 1]))
+    softmax_ps = clipped_softmax(ps)
+    print("epsilon = {}".format(epsilon))
+    print("softmax_ps = {}".format(softmax_ps))
+    assert (softmax_ps.data >= epsilon).all()
+    assert (softmax_ps.data <= 1 - epsilon).all()


### PR DESCRIPTION
Blocking #107 

Epsilon-scaled clipped versions of Softmax and Sigmoid as utilities that can be used to avoid numerical unstability with Pytorch.nn Softmax and Sigmoid operations

## Tested

Added simple tests for both new classes.