### PR TITLE
Clean up travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,13 @@ before_install:
     - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
 
 install:
-    # this will be in setup.py
-    - pip install numpy scipy cloudpickle funcy graphviz networkx visdom
-    # install test dependencies
-    - pip install pytest pytest-cov flake8 nbval
     # install pytorch and its dependencies
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
           pip install http://download.pytorch.org/whl/cu75/torch-0.2.0.post2-cp27-cp27mu-manylinux1_x86_64.whl;
       else
           pip install http://download.pytorch.org/whl/cu75/torch-0.2.0.post2-cp35-cp35m-manylinux1_x86_64.whl;
       fi
-    - pip install torchvision
+    - pip install -e .[test]
     - pip freeze
 
 branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,9 @@ The Pyro codebase follows the [PEP8 style guide](https://www.python.org/dev/peps
 
 # Setup
 
-Install all the dev dependencies for Pyro.
+First install [PyTorch](http://pytorch.org/).
+
+Then, install all the dev dependencies for Pyro.
 ```sh
 make install
 ```

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,11 @@ setup(
     install_requires=[
         'numpy>=1.7',
         'scipy>=0.19.0',
-        'funcy>=1.7.5',
         'cloudpickle>=0.3.1',
         'graphviz>=0.8',
         'networkx>=2.0.0',
         'torch',
-        'six>=1.11.0',
+        'six>=1.10.0',
     ],
     extras_require={
         'notebooks': ['jupyter>=1.0.0'],
@@ -24,14 +23,22 @@ setup(
             'visdom>=0.1.4',
             'pillow',
         ],
-        'dev': [
+        'test': [
+            'pytest',
+            'pytest-cov',
+            'nbval',
+            # examples/tutorials
+            'visdom',
             'torchvision',
+        ],
+        'dev': [
+            'torchvision'
             'flake8',
+            'yapf',
             'isort',
             'pytest',
             'pytest-xdist',
             'nbval',
-            'yapf',
             'nbstripout',
             'sphinx',
             'sphinx_rtd_theme',
@@ -48,4 +55,5 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
-    ],)
+    ],
+)


### PR DESCRIPTION
 - Cleaned up unused dependency. 
 - Added `test` to `extras_require`, which is called from travis. This also ensures that our setup.py is tested.
 - Needed by #446, since we need `pyro-ppl` to be in the class path for `make docs` to read version information.