### PR TITLE
Reinstate informative cell output in AIR tutorial.

### DIFF
--- a/tutorial/source/air.ipynb
+++ b/tutorial/source/air.ipynb
@@ -14,9 +14,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
    "source": [
     "%pylab inline\n",
     "import os\n",
@@ -47,11 +55,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "keep_output": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAABvCAYAAADfcqgvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAFEBJREFUeJzt3X10z+Ufx/Hn1+ZmTYxtNoStECtsKtF9utUpKqEbpcahU2ed6oRyDkkqR1mpIznRoqJQ6iRJOW5S6hRRqrmpjSG3KTOWbPv98fld76EpZd/v5/vdXo9/Vttsl8tne3+v9/W+3legrKwMERER8U8NvwcgIiJS3SkYi4iI+EzBWERExGcKxiIiIj5TMBYREfGZgrGIiIjPFIxFRER8pmAsIiLiMwVjERERn0WH8psFAgG1+/qXysrKAv/1z2q+/70TmW/QnP8XesZDS/MdWsc731oZi4iI+EzBWERExGcKxiIiIj5TMBYREfGZgrGIiIjPFIxFRER8pmAsIiLis5CeMxaRypWens6mTZsA+PXXX30ejUj4O/XUUwG4+OKLmTNnDgCHDh0iLS0NgE6dOgFQs2ZN9u/fD8Dq1avZsWMHABs3bqSkpKTSx6VgLBKBatWqBcDAgQN5/vnngSODcb169bj//vsBmDt3LitXrgz9IEXCUN26dQFITk4mJSUFgDvvvJMrrrgCgKZNmwLw559/sm/fPgDy8/M5cOAAALNmzSInJ6fSx6U0tYiIiM+0MhaJQC7VlpaWRmlp6V8+3rlzZ7p16wbA5MmTQzo2kXD2ww8/APDbb7/x3HPPAdClSxe++eYbACZNmgTAypUr2bx5MwAZGRkkJycDUFxcHJRxKRiLRKBzzz0XgKioKLZt2/aXj7dt25aTTjoJgN9//z2kYxMJZ4cOHQK8n5HzzjsPgEWLFnHPPfcAsGfPHvvc888/H4Ds7GyysrIAb9snGJSmFhER8ZlWxiIRqF27dgBER0ezd+9ee78r7GrWrBk1a9YEoKxMF+2I/J06depw8sknA1jRVkZGBuPGjQOgsLCQrVu3BnUMER2Mo6KiAIiNjSU62vurFBcXW06/or00karABdoaNY5MbsXExADQokULS18fOnTIUtYJCQmAt192eBAXqW7y8/NZvHgxAFdddRWPP/44AB988AEAWVlZpKamApCZmRn0EwlKU4uIiPgsIlfGgYB3V7NL1T3yyCM0btwYgK+++spe7Xz33XeWWjh48GDoByoSJH/++Sfg/Sy4rFBpaamtjGvWrGnVnyNHjqRt27YA9rnZ2dksWrQo1MMWCRtr167l4YcfBryfi969ewNw6aWXApCYmMjo0aMBLKYEU0QHY/eL5eeff7YuRCkpKTz77LMAbNiwwSrf5s6dy8aNGwHtoUnkW7FiBQDXXXcdffr0AbwtmgsuuADwqq1dc4MzzzzTUmy5ubkArFu3LtRDFgk7Libk5ORw9tlnAxAfHw94+8gbNmwAoKioKOhjUZpaRETEZ4FQrhIDgUClfrPDV8juvxs2bMjpp58OwNVXX22ND7Zt28bUqVMBmDdvXsScvSwrKwv81z9b2fPtWseddtpptG/fHvAO0K9atQqA7du3V+a388WJzDdU/pwfy2mnnQZ4z3Lz5s0B2Lt3L1u2bAEgNTWVL7/8EoCbb77ZnvdwzAqF0zNeHWi+y7kK6kcffZQmTZoA3vYmwKBBg+znqUePHuzates/fY/jnW+tjEVERHwWkXvGjnuV74pZwFsBuxXaypUrWbJkCeA11B85ciQA55xzjrVBKygoCMvVQqhFR0cTFxcHeEfG3Jy2b9+eQYMGAViZf1JSEklJSYC3Gv7xxx8BePHFF/noo4+AI/9NpPLl5eUB0KtXL+rVqwfA/v377Zzx+PHjWbhwIeAdYxKRv7r22msBuOaaa6wD1xdffAF4nbjcZStnnXWW/W4LlogOxsfigmthYSELFiwAYP369fTq1QuAfv36WfX1I488Uq0Lu9w51bPPPpunn34a8KoICwoKAK8HsrtGzJ1bLSgosNR0amoqiYmJgHfziUvxuDmV4HBn6L/99tsj3l+/fn0ANm3aFDFbMSJ+SElJsQCcm5vL999/D5T3nn7ppZfIzMwEoGPHjkEPxkpTi4iI+KxKroydQCBgK7+NGzcyYcIEwGt3Nnz4cAD69+/PmDFjgNCUr4ebli1bAjBixAg7FgNYGnrs2LGWXVi7di1Q3i7uaHFxcdVyDsOJ68xVu3ZtdaAT+Rvt27e3LZ7hw4ezc+fOIz6ekpJihcEuUxhMVTIYu32ztLQ0MjIyAK/phzubOXv2bNv/7Nmzp+0rf/LJJz6M1l/9+vUD4MILL+T1118HYMKECbbPuGnTJktT/xPtTfrPNfpISUmx699E5K+6dOliTaGWLVtmfSvcAqVfv362demuXQwmpalFRER8ViVXxp06dQK8FKvrpnLyySeTn58PeCu/iRMnAt7NHHfddRdQPVfGp5xyCuAVr7lq6hYtWlinpuNdFUt4cMV0TZs2DfotMyKRrHbt2nbZUGZmprVXdvGjUaNGPProowBBvyQCqmAwrlWrFldddRXgBZIhQ4YA3m027ojOkCFDGDp0KOBVWbvKanezTXUKQG+++Sbg/d27du0KeGX87rjS4sWLrWL3008/Bbx0tPYjw5M7UrZmzRrdyiTyN6ZNm0bPnj0BuP32262aetasWQB8/vnnfP311yEbj9LUIiIiPovodpgVadCgAdnZ2YB3z/GAAQMArwK4devWALz88su28isqKrIiL1fMFE5nZIPdus5V38bGxlqj9AEDBthcNWjQwCoOXapmwoQJfPzxx0DVq0CPlHaYVYnaM4aW5ju0jne+q1yauqioiJ9++gnAelSD1yTB3ez02WefccsttwDwyy+/sHv3bsDruFLduLTmb7/9ZnvmS5Yssd7H7du3p3///kD5XkpOTo7tpUyZMqXKBWQRkVBTmlpERMRnVW5lfPDgQTug3alTJ2sPuHfvXlsFbty40aqIGzZsSE5Ojn2OeC0yD7/3dunSpQC0adMG8KrUR40aBXjZBFcEpn7UkcU1xImLi7Ptij179nDw4EH7eExMDAAlJSXWJlBEKl+VC8aAVcUNGDCAvn37AjBjxgxq164NQLNmzewXUUFBAdOmTfNnoGGqa9eudixm9erV1pPavX3ggQesQUh2djY///wz4KX/JXK4BiGTJk2iVatWAEyePJnFixcD3iXrV199NQCrVq2yn5Pq2MNdJNiUphYREfFZlVwZr1mzBoD33nuPu+++G4DLL7/cDninpaVZKm7atGn2+eIpLi5mxIgRgHer1fr16wFs/goLC60/dcOGDa3YSyvjyBEVFcU111wDeDd2uXZ/w4YNIysrC/Aa5TRo0ACAcePG+TNQkWqiSgZjt7eVk5Nj/XnT0tJsT/OLL76wAPLhhx9qL+woa9eutT6tI0eO5J133gG8X84At912m+0f5+fnW29viRz16tWjW7dugLdPfO+99wLeFo47aXDrrbfaz8/cuXOVnhYJIqWpRUREfFYlV8bO7t27mT17NuA1t3Cv7AOBgN3spDOyf7V161YGDx4MwPTp06093OFcY5Ts7Gy2b98e0vHJievcuTOXXnop4F2i7s7g5+bmWlvY66+/nilTpgDw5Zdf+jNQkf87/Pd2cnKyFeTGxMTQsGFDAMvo7d+/39r4FhYW+jDaf08rYxEREZ9VuXaYVY3frevatGnDbbfdBmBntj/77DO7G7qgoIA//vjjRL9N2Kjq7TCbN28OwKuvvsqpp54KQN++ffn8888Bry7AHVurX78+AwcOBLw6gmD9rvD7Ga9uImG+3ao3OTnZ6lMSExPtCF6nTp2sTW9cXJzdT+/+XH5+Pn369AEI6WUPFam27TClcuXm5jJ8+PAT+ho1a9bksssuA7zir9jYWKC80G7mzJm8++67JzZQOS6ucDE+Pp7x48cD3lly92/y0EMPWcC+//77WbduHaCzxRJ8gYAXs5o3b24V/eeffz5JSUmAd7OcWxC4JjUAf/zxh/VF+OabbwDvtrm8vLyQjb0yKE0tIiLiM62Mj8EVCjRp0oSUlBTAezW2c+dOwFsx6kjU8alVqxYdOnQAoHv37tStWxcob5+ZkJBg8z1v3jw7wyyVb/Xq1QAMHjyY5cuXA14Ro7sDfODAgTzzzDMALF26VPdWS8jUqVMHgKFDh1rnxJiYGDtel5eXZwW36enpxMXFAfDOO+8wZswYALZs2QLAgQMHrJdEpFAwrkBUVJRdJzhq1Ci6dOkCeGkSl7YbOXKkna/duXMniYmJAOzYsQOAQ4cOhXrYYauoqIiFCxcCcMYZZ9CyZUsA2rVrB3jtN5s2bQp4t0ctWLDAn4FWA7/++isACxYssJaw6enpPPHEE/Z+16u9pKTEn0FKteRekKelpdne79dff83YsWMBWLFiBQcOHAC8AJyeng54lf6uBXIkU5paRETEZ1oZV6Bu3brWRrNr1672/tLSUlvVPfXUU3z11VcAbN682W6BckUDixYtYtmyZYC3Mqzu6T5X0XjHHXdYdeSMGTMA785kl15y510luKKiosjIyABgzJgxtnUwadIkWz2LhJIrEjxw4ICdDX777beZP38+4BV4uer+1q1b2wU1K1eu9GG0lU/BuALp6elccskl9v9u72H9+vWWjm7RogVNmjQBvCDtUn4uPX3HHXcwb948AIYPH27BRrCmEu6AfmlpKT/99BNAxFVARqpzzjmHiRMnAtCoUSMeeughAJYvX17tXziKP9x+8IwZM+jYsSPgtWR1KeiioiL69+8PePvL7gjeqlWrKvx6rjo7NjaW/fv3A4T1s600tYiIiM+0Mq5At27dbAUM5bcRvfzyy9ZQPykpyVZ2h3Pvq1OnDt27dwdgypQpWhn/X1xcnM1L48aNAe/ijjfeeAMor7CW4HBZiV69etG6dWvAS1O///77gIq2xD/u2Zs/fz4XXXQRAH369LHq/q1bt9oW17p165gzZw6ArXqP5s7OX3vttfZ8h3P7YwVjsBSz20Pr0qWLBdWioiJLh3z77bdHpDlc56k5c+bwyy+/AF56GrymCuIJBAJ2FV9mZiaZmZlAecpo+vTpdswmnNNIVYE7wnTTTTcxc+ZMACZOnKjjZBI2du3aZQG4Ro0a3HjjjQCcfvrpRwTsbdu2/e3Xcc1rLr/8ctsyDGdKU4uIiPhMK2PK7+m98847AW9lHBUVBcCyZctYtGgRAPv27bMVXIcOHazyd+zYsbYydv1+e/ToEbLxh7vExEQGDRoEQFZWlrWye+WVVwCvYEPp0eCpUaMG5513HoA1R8jLy+Oxxx4DvJWISLgoLS21fg6jRo2ibdu2gFd06Cquk5OTrRnTmjVrKvw6rimIexvuFIwpr7o7usoXvFS0q6betWsXzz77rH2u+0fetm2bpaUbNWoUsnGHu5iYGAD69+9ve+3x8fF89NFHALzwwgsA/P777/4MsJqoVasWV155JVB+2cd9991Hfn6+j6MSOTa3XZWQkGDH7g6/QvGGG26wxdCIESMqrDVxX6OwsDAieqsrTS0iIuIzrYwP41bI7u3R/w2wfft2AEaPHm0r6R07dljLTFftFwgErI91OFfwBZO7evHuu+8mISEB8M5qv/baawCW2o+EV62R7ODBg0yfPh3AtlzcdotIOHJZtR49ethNY5s3b2bt2rUAdO7cmQsuuADwTmVU1CzI9S4YN27cMSuuw4lWxiIiIj7TyvgwboV2+ErtWKs2dyEEeHvMrhuX29MoLi5m9uzZAGzYsCEo4w1nKSkpdiQhKSmJH3/8EYAnn3yS9957Dyg/GibBVVpaSm5uLoC9FQlnLpOWnp5ul0Zs3brVjiidccYZJCcnA9CqVasKV8YuI7lnz56IyL4pGP+DVq1aWTXf9u3bj6j6dYVeXbt2tbOz7sGZN2+eNbKIhBRJZcvIyLB5Ky4u5q233gLg/fffr5bzISLHr6KFUWpqql2t2KBBA3sx706+HM3dI3DLLbcwevRoILy3DJWmFhER8ZlWxpS3YFy/fj3gpTVcx6g2bdrYq6qhQ4daU/KoqCg7uzlq1Cg6dOgAlF8qsWTJEis2iIQUSWUrLCy0FfApp5zChRdeCHhnitXtSUT+jit+/fTTT61QKyEhwdLXRUVFrF69GsDOJB9tz549gJfejoTfwYFQDjIQCITljLiKabcH8eCDD9oVirGxsXYT0w8//GABNjo62nr7tm3b1tLXS5YsAWDw4MH2sJyIsrKywD9/VsX8nO/ExEQGDBgAwLBhwywAz5o1y1LW7lrFcNo7PpH5hvB9xsNZpD7jkSqS5js+Pp6srCzAa/rhzg4vXLjQelMXFBRU2EbXtTmuXbs2xcXFgD8Lo+Odb6WpRUREfKaVcQWaNm1qxVcdO3a0DjCHCwQC9iqrpKTEzm8OGzYM8C68roxLDyLpVezRWrRoAcDUqVNp1qwZ4LWm27x5M4BVQJaUlLB3714AJk+ezNKlS30YrUcr49CL5Gc8Emm+Q+t451vBuALR0dG2B9y3b1969+4NeGlsl9Let2+fNQD55JNPyMnJAWDFihVA5V1FF8k/OC5NFB8fT2pqKgA9e/a0KxRda8aysjJ74TJkyBBmzJjhw2hxY1EwDrFIfsYjkeY7tJSmFhERiRBaGR+DWwE3atTI7jkeNGiQtcB844037LaQvLw8u+ygsu/jrWqvYuvUqWM3Wu3evRvwsghXXHEF4J3PXrZsmW/j08o49KraMx7uNN+hpTR1FaEfnNBSMA49PeOhpfkOLaWpRUREIoSCsYiIiM8UjEVERHymYCwiIuIzBWMRERGfKRiLiIj4TMFYRETEZyE9ZywiIiJ/pZWxiIiIzxSMRUREfKZgLCIi4jMFYxEREZ8pGIuIiPhMwVhERMRnCsYiIiI+UzAWERHxmYKxiIiIzxSMRUREfKZgLCIi4jMFYxEREZ8pGIuIiPhMwVhERMRnCsYiIiI+UzAWERHxmYKxiIiIzxSMRUREfKZgLCIi4jMFYxEREZ8pGIuIiPhMwVhERMRnCsYiIiI++x9GRfeHJefNbwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1055f1f60>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "inpath = '../../examples/air/data'\n",
     "(X_np, _), _ = multi_mnist(inpath, max_digits=2, canvas_size=50, seed=42)\n",
@@ -115,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,11 +223,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "keep_output": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAABvCAYAAADfcqgvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAFHNJREFUeJzt3UlzG1X3BvBHrVZLljUklmVbHjMQgu1AEiigCqqANQULiiVLvgYfABZs+QYUX4AVLIAqoKAYk0pCgBASO3iOHI2WNfW76DqPJfi/4Y3545ad57eJSpYUqTWcPueee2/E932IiIhIeJywn4CIiMjDTsFYREQkZArGIiIiIVMwFhERCZmCsYiISMgUjEVEREKmYCwiIhIyBWMREZGQKRiLiIiEzD3I/ywSiWi5rwfk+35kv/fV8X5w/+R4Azrm+6HP+MHS8T5Y/+vxVmYsIiISMgVjERGRkCkYi4iIhEzBWEREJGQH2sAlInIYJBIJPPvsswCATCaDer0OAGi322g0GgCAZDLZd59oNAoA6HQ6GB4eBgBsbGwAAI4dO4ZWq8XbZrNZAMC9e/fw6aef/nsvRA4NBWMRkT85fvw43nrrLQDA7OwsA3Cj0UCpVAIQBFgLuolEApubmwCA4eFhBub19XUAQeB2XZeXPc8DAFy+fFnBWACoTC0iIhI6ZcYiIn8SjUYxPj4OICgpd7tdAEA+n0cikQAAuK6LmZkZAEClUuFtisUipqamAABnz54FACwtLcH3ff7dStypVOqAXpEMOgVjEZE/cRyHQbfZbPL67e1tVKtVAMDY2BjL12tra8jn8wCA5eVl3Lt3DwAwNDQEAIjH4xgZGeFjt9ttAMDq6uoBvBo5DFSmFhERCZkyYxGRP2k2m/jpp58AAKdOnWKjVjKZxNWrVwEAIyMj7JDO5/NsyhofH0c6nQYAXL9+HQDgeR47sl3X5eXjx48f0CuSQadgLCLyJ/F4HI888ggAoFQqsZw8PT3NwFytVlGr1Xj5zJkzAICdnR2Wp+0xqtUqlpaWAATl7bm5OQD9JXB5uKlMLSIiEjJlxiIheumllwAAL774IuehtlotVCoVAODc1enpac5vTSQSiMVivK118bqui8nJSQBArVZjo1Gr1eJjf/zxxwCAH3/88d9+aYdau91mE1YymWQ5OZvN4umnnwYQHGM79vF4nLfPZDI89seOHQMQdFAvLCwAAMrlMu7cuQMAePzxxw/oFcmgUzAWCdELL7wAAHj99dcxOjoKALhz5w4ymQwA4ObNmwCAXC7HkmahUGCwdhwHW1tbAIJpMp1OBwAwMzPD27fbbezu7gIAbty4AUDB+O84zl7RsFQq8URod3cX09PTAIC7d+8iEgl2x7OuaiB4H2zMeHt7GwBw+vRpvge+77Pz+sqVK//yK5HDQmVqERGRkCkzFgmRZcNbW1ssJafTaZZF7d+dnR2cPn0aQFAetdumUik2Bp06dYqZ9NbWFrt7NzY2mMHZ/eT+fN9nlSESifBYxuNxdkL3lqZjsRg7q8vlMteeLhQKAIIs2niex/fD5h6L6JspEqLff/8dQDBmbD/+7Xab6xWfPHkSQDBObD/cQ0NDHHMsl8t4+eWXAQD1ep3Xp9NplrpLpRJ2dnb42PL3HMfhClxDQ0MMntFolCc0pVIJExMTAMBhAyB4r2z6k91vamqqL/DeunULABjMRVSmFhERCZkyY5EQWZna8zyWNr/77ju89tprAPZ2/QGCjlwgKDXb2sa7u7v4/vvv+RjWvbu9vc0mrRMnTjArsy5sub92u80qw9jYGCsYzWYT58+fBxBUJaziEIlEeOyTySTfy5WVFQDA7du38ccffwAIMufFxUUAe1ssiigzFhERCZkyYxk4thdsOp3um2Ji42/dbpfX2zxPx3H4997re0UiEe6cA+xNR7GGnDDYc+h2u8ycpqam8PPPPwPYm2cci8Vw7tw5AMGmBDae+dFHH/Fyb3OW53m4ePEigGBcOh6P8/+Rv+c4DqsItVqNuzBVq1VuIJFOp5HL5QAE48c2Rr+zs8PGO+sDyOfzzJZ/+uknTnOy+4soGMvAsaal9957r6+8aj+OKysr7FK1MuHY2Bgvx2Ixzr3tdDoMUolEgh2vjuPggw8+AAC88847B/Gy/k9Wei6VSvyRT6VSbACy5RR938d3330HAJifn2cJ9fz58wzo9+7d4yIS6+vrnBt7/PhxnuBYeVvuz3VdPProowCC42od651Ohydv7Xab71+32+X1u7u7uH37NgBwTvL29jbfD8/z+uaGiwAqU4uIiIROmbEMHJvTOTc3x9JzpVJhZuw4DrNgyzyAvZJvs9nkQv31ep3Zy/j4OB9jY2ODpdtBUK/XmbVWq1Vm/lZWbjabfL5ra2ucojQ5OYnl5WUAwfGyjMx1XZTLZQDB8oyWdfeW8uX+rJRsQwUAuBkE0L8cpg0VAEHGbCtw2WcvGo3y/fA8j59VNdSJUTCWgdUbVKvVKpd3zGazLDeber3OzuQbN25w/G5iYoLjdr7v940TW+k2TL1zT+01ua7LQGCvKZ/PY21tDUBwYmKBu1KpMCDMzs5yR6ErV66wBNrtdlkitX/l/trtNndqSqVSPN6xWIzXA+Cylq7r9p3c2WfO/i2Xyzwh6h3bfxiD8RtvvIF3330XwN787Lm5OQ7N3L17l2P03W6X3/upqSl2p/u+zzH4aDT6l5OfYrGI559/HgD+8lsxqFSmFhERCZkyYxk4vdmEnRWPjIywgzoWi3HlIvt7IpFg6TqVSjEDLJfL7KCOx+N8jNHR0YEo2drz9zyP5XnLhoG9s/pGo8EsKpvN8rnX63Uer83NTT5ep9Ppe2wth/lgWq0Wl7C8cOECqw+NRoOXc7kcS89DQ0PcqclxHFZ0end1Mqurq9xdyz6zD5PepUPtu3n16lUeo2QyyYx5cXGRjXHXr1/n8Uyn0/zcLy8vsyJkx3NjY6Nv5sRhoG+mDJzeL5F9KXtLUeVyue/HEQh+PO0HMJVKscxbqVQ4nreyssJO7Rs3bgzExu72gwKApfV2u80FJOwHPhaL8fUnEgluat9qtVj+TCaT+OGHHwAEwcGCSS6XYzncbiv3l06nOTXs119/ZUl0eHgY8/PzAIBLly71lVN7A6t1wduiHjdv3uTnc2pqimP+vT0PD4ve4SELtI1GA7OzswCC7nVbh31zc5O3LxQKPJnu3SVrcXGR5Wt7n1qt1kCcbD8IlalFRERCpsxYBpbneSyrTk9PMxvMZDIs2fZmzpb13b17l5lxJBJhduJ5Hn799VcAQYZoZeFB4Ps+n3/vnGM708/lctyLuLchJRaLMePKZDLMtE+ePMnXqrnFD65er3Ne99DQEIc9fvjhB2Zt169fxy+//MLbWDXD8zy+V7aQy+joKJuLZmdn+fm1xV0eJo7jsCpl+z2n02nO5XYch1WdTCbDEvTS0hKPWywW4216Z0bYbQ9jY5yCsQwcK0VFo1EGktXVVQbjyclJ/rBZuS8ej7OkOz09zSDuui7LVbu7u3y8zc3NUFfeMvaa0uk0L09NTXFdaVt44ssvv2Sp+ebNmzh16hQfw37EisUiXnnlFQDAZ599xlJpvV7n2Kb9H3J/KysrePXVV8N+GkeS7/s8EbYVyGq1GsvR9+7d4xSyn3/+GY899hiA4ITnq6++AgA89dRTfduLWmC234PeMvZhoTK1iIhIyJQZy8Cx5qydnZ2+cq1luyMjI8z0LOvtdDpscLLSFxCUq2x+bj6f52PMz8/j2rVrB/Bq7s/mAruuy/mrnU6HjT22I1OxWGQZ1HVddpPPzMzgySefBBBkEZZRR6NRXLlyBQDwxBNP8DgN0kIn8nCqVCrcBcuGWM6dO8eS/gsvvMBhpkKhwMpPNpvFhQsXeD8rdTuOw6EDW/RmcnLy0DVwKRjLwLHxnuPHj3MMtFQq9Y0PW5nLbttqtViCvnv3Li9vbGz0TTmxYFwsFvuCdlisrLa1tcUAXKlUWJ62DutkMtnXbW0nLMVikaXnaDSKsbExAEG3uJW1b9++3ddlKhKmVCrFk0L7Dq6urjIwX7t2jUNI8Xgct27dAgAsLCxwTLjT6fBzXygU+Di2ct3W1tahm9qkMrWIiEjIlBnLwLES1cbGBkuzm5ubnNO5vr7OM2DLFre3t5n1Tk1Nsfu12+2yXLW8vIy5uTkAQUdr7+IaYbGz+94qQDqdZqOKvb5yucxqwLlz5/q2XrTMv16v45tvvgEQHEObt1mr1TjXepA6yOXh1LsIjWXDkUiEn+N4PM6GrEQiwQVSfN9nJalQKHCoxsrYwN6iH73z9w8LBWMZOFbCisVi7JoeGxtjYPI8j12YNvaUSqVYqmq1WuzIHh4e5vrBw8PDfLzV1VUG/TDZ66hWqyyt12o1/ujY2Hgul+MPV7FY5BZ8o6OjDMzRaJQnKY1Gg2Vqz/P4WtVNLWHrdDr8nNq4bzKZ5MId0WiUvRSLi4u4dOkSgGCoyoZnlpeXsb6+DiAIzFaStu99b8A/LFSmFhERCZkyYxk4VmIaGhpiWbXdbrP0nMlk2NRhmW48HudtK5UKG5Zc12XTUqlU6itfDcKZs1UBHnnkkb61pG0xiZmZGQBB5v/bb78BCF5/73KZ1nEejUZZqt/Y2GAX+YkTJ5QRy8Co1+us7Nj3tFqt8nIqlWLWWy6X+T3N5/OcizwxMcGtLVdWVnj92bNnARzORkVlxiIiIiFTZiwDx8ZLi8UipzJ4nsex306nwwzXVuHp3aWo0+lwfHVnZ4e3XVlZYdNWvV4fiBW4PvzwQwDBsom98ybtrN8aryqVChtWstksj1Hv5Xa7zepA77hzKpVi5nD58uWDeFki/1WpVMLNmzcBAM888wyA4HtqvQ/NZpPf9WvXrnG6nu/7rCStra1hYmICQFA9suYvy6jte3OYKBjLwOltvrIGp96g2u12/7Lrzfr6Orutd3d3+7qNe7cetEYPz/PYEBamb7/9tu9fkaPO8zwu0mHDMdYxDQTB2E6U0+k0mw8TiQSHpWKxGBYWFgAA33zzDZ544gkAe1uE3rp1S/OMRURE5MEoM5aBY+XaarXKsnIkEuHcQ8dx+kpXQDD16c6dOwD6S9bVapUlr2w2y+lPMzMz+OKLLw7oFYmI8TyP30PbX7xWq+HEiRMAguEk+17X63VO+btz5w5L06lUiruxtdttLiXb26x52CgYy8CxOYanT5/mPNtoNMqO4Hw+zy+dlbQ7nQ7HRYeGhvgFzmazfQsBPPvsswCCnY8GYcxY5GFk33GbCdBqtfj9Xltb4/XdbpcBOBqNckncRqPBoSrHcdhxbWPGmUxmIGZLPAiVqUVEREKmzFgGjnUNf/LJJ5xnu7u7y7PicrnMzdstQ/5ztmzdlZOTk+xMTiQS+Prrr/l4NtdRRA5Oo9HgLAnbZSmZTHIP4263yzn1Fy9e5JoCa2treO655wAAV69eZSm6UCiwgmZNmb7vH7oGLgVjGTg29vvmm2+G/ExE5P+b67p9HdJAMHPio48+AhAshGNjyZ9//jmnKZ44cYIL2czPzzMY907psyVgi8WiytQiIiLyYI58Znz+/HkAQWnEzpSi0SjPzBzH4TzU3r/3ljx7GwXssuu6XLR8c3OTnb4iIvLf/fHHH1zsxtYJ+P3339l06fs+s2Tf9zlz4tKlS2zQSiQSvP3S0hIX+bAmzng8zt/nwyJykHX1SCRy4EV829VnZWWF011mZmb4pna7XaTTaQB7HX6e5/FNrdVqHKuMRCJceCKVSjEwv/3223j//ff/lefv+/6+ay1hHO/D7p8cb0DHfD/0GT9YOt4H63893ipTi4iIhOzIl6ktA87lcuyqjcfj7NK9ceMGB/2tTO26LrtxXddlGXtra4tz3kZHR9lMoA3bRUTknzjywdg68azUDAQBenZ2FkAQgC3w2qowrusyQMdiMQbbiYkJLhRRq9WwtLTUdz8REZH9UJlaREQkZEc+M7ZJ4L1rnLquiytXrgAArwP6N3K3yeiRSISTx13X5ZZ99Xqdax7bTiEiIiL7ocxYREQkZEc+pbMmq1wux+lK0WgUZ8+eBYC+uWi28pPnebzfc889xz00a7Uab/P444/zfodtpRcRERksRz4YW3PV1NQUF/Ko1+sMoO12m+uk2tJs2WyW1zWbzb7FQKxMbTuMAHtLsImIiOyHytQiIiIhO/KZce8cYJvmdOzYMW5MPTw8zKlNtlvQ6uoqFhcXAQQNXpYFr6+vY2FhAUCwab2VuG3HEBERkf048sHY1jWtVCooFAoAgo3lbSGPRqPRN6cYCLbXswVCHMfhMpkjIyPczD6ZTHJ9a/u7iIjIfqhMLSIiErIjnxlbCXpiYoIb0pfLZUxOTgIIdlyyzNjmEzebTTQaDQDBjiA2j3h8fJwZc7lcZkasecYiIvJPHPkoYgE4nU6zK3p0dJSd1WfPnuXCIBaMk8kkx4HT6TRvm0gkEI/HAQA7OzvsvhYREfknVKYWEREJ2ZHPjG3z6t3dXXY/53I57ubUaDS4qId1Xg8PD7ODOplMsgu70+kwM/Z9n81ctnmEiIjIfhz5YGwd1AA43uu6LtLpNICgy3p8fBxAUHoGgoVA2u0272dBulgsotls8jobj+5dxUtERORBqUwtIiISsiOfGfeWkC1LTiQSbOa6fPkyy9BWmk4kEmzgOnPmDH777TcAwXxiK01XKhXOM7YlMkVERPbjoQnGhUKBpedr165x7HdoaIgbSFhX9ejoKLa2tnh/m7pUqVQ4DSqbzbI83btOtYiIyINSmVpERCRkRz4ztky2dwvFnZ0dJJNJAMF61NlsFsDeAiHr6+uYmZkB0N9B7TgOy9SO4zCTtutERET248gHY9v8IZPJcJoTAHZQe57HhUGsm9p1XXZQNxoN5PN5AMF0JhsnPnPmDEvZtliIiIjIfiilExERCVlEWZ2IiEi4lBmLiIiETMFYREQkZArGIiIiIVMwFhERCZmCsYiISMgUjEVEREKmYCwiIhIyBWMREZGQKRiLiIiETMFYREQkZArGIiIiIVMwFhERCZmCsYiISMgUjEVEREKmYCwiIhIyBWMREZGQKRiLiIiETMFYREQkZArGIiIiIVMwFhERCZmCsYiISMgUjEVEREKmYCwiIhKy/wDmgSdm2uGlvAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1165c9c18>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "pyro.set_rng_seed(0)\n",
     "samples = [prior_step_sketch(0)[0] for _ in range(5)]\n",
@@ -226,11 +256,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "keep_output": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sampled 2\n",
+      "sampled 3\n",
+      "sampled 0\n",
+      "sampled 1\n",
+      "sampled 0\n"
+     ]
+    }
+   ],
    "source": [
     "pyro.set_rng_seed(0)\n",
     "def geom(num_trials=0):\n",
@@ -257,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,13 +322,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "keep_output": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAABvCAYAAADfcqgvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAF0ZJREFUeJzt3UtvG+f1BvBnhsM7RUqU5EhmIl8UKZFrtzCatsiiCJou+pH6Fboq0FV3/QDdFF0UAYoCBVqg7aIB4sJJHCcq5YtkS5F1I8XrDNnF4Dx6Jxb+/ziRNaH8/DZRaF7EGYpnznnP+77eeDyGiIiIpMdP+xcQERF51SkYi4iIpEzBWEREJGUKxiIiIilTMBYREUmZgrGIiEjKFIxFRERSpmAsIiKSMgVjERGRlAXn+WKe52m5rxc0Ho+9b/pYHe8X922ON6Bj/k3oM36+dLzP19c93sqMRUREUqZgLCIikjIFYxERkZQpGIuIiKRMwVhERCRlCsYiIiIpUzAWERFJmYKxiIhIyhSMRUREUqZgLCIikrJzXQ5TJofnxSu4BUEA34+v2cbjceK/dj/3/097jvF4zJ/dx49GIwBAFEVn/NuLiEwWBWM51fvvvw8A+NWvfoVGowEA6Pf7AIC7d+8ik8kAABqNBobDIQAgn88zwO7u7mJ1dRUAsLm5iXq9DgDwfR/Hx8cAgN/97ncAgN/85jfn8ZZERL6zVKYWERFJmTJjOdXMzAwAoFAoYGNjAwCwuLgIIM6G9/b2AACVSgVBcPIxarfbAIByuYzd3V0AQK/Xw9bWFm+/fPkyACCbzb78NyIiMgEUjOVUNo7rjvf+97//BQBMT0/ztkwmg1wuByAuTR8cHAAAVldX8fDhQwBAGIa8z9OnT9HtdgEAR0dH5/RuLp58Pg8AePfddzkG7/s+hwn6/T56vR4AYHZ2lsfcxv+HwyGfwzUYDHhxFQQBBoMBgHio4cGDBy/xHYm82lSmFhERSZkyYzmVZUfT09OoVqsAgFarxdssc/7444/x1ltvAQCmpqaYgT1+/JiNWvV6nRnZ7du38fTpUwDAG2+8cU7v5uKxykS1WuXP7XYbpVKJt3c6HQDxUEKlUgFwkhmHYYgwDHmbDRl0Oh025xUKBQ47nJZFi8jZUTCWU1kwfvDgAUufxv3C/vnPf46PPvoIQBxcC4UCgHiceGFhAUBc+iyXywCADz74AGtrawDALmz55qIo4rnK5XIcDhiPxwzMtVqNQwIWoH3f57kKw5Cd8oPBALOzswDigG9B3J5XRF4OlalFRERSpsxYTvXll18CAB49esRyspUqy+Uys+V//OMfnIf87NkzZltRFLH5p9PpMHtbW1tj2Vulz2/P87xEtmtNW/l8nmXoVqvFUraVo4vFIkvQQRDwvGWzWWbJYRg+VxURkZdDmbGIiEjKlBnLqWq1GoC4iceafsz8/DyazSaAuJlrZ2cHQNwoZNNslpeXmRnfuXOHmfHh4SFu3rwJABx3lhfnLldqzXTZbJbHP4oinrcoip5bstQa7b76czabTWTJX50SJSIvh4KxnMoart5++21+2U9PTwMAms0mm3w+/vhjXLp0CQCwtbWFlZUVAPGc5Pn5eQBxY5cF47t37+LPf/4zAODJkyfn9G4uHnd9b7uoGY1GPM7u/PBMJpMoXwPJOcRBEPA52u02S9nj8Zg/KxiLvFz6CxMREUmZMmM5lWVSnucxI7b5wYuLi1yN6fbt2ygWiwDiRi2brlQoFPD48WMA8XQZawir1+t47bXXAIBTb+TFWWY8GAx4/MfjMTNct2mu1+txapI7NGA/R1HEJrBSqcSMGQCbwETk5VIwllPZ2tP379/Hu+++C+CkdL2xsYGpqSkAcaeuBd033niDZdBOp8OfW60Wd21qtVoscVsQkRfnlqDdLSjtmLrjxKPRiAuw2Hiw53m8bzabZTn6+PiYgTubzfLiyg3QInL2VKYWERFJmTJjOZV1U7/55pv47LPPAJyswhSGITeB6Pf7LGMPh0NmYG4GvLy8zLmrr732Gp/HzeguCiv91mq1RGOVzdcNwzDRIOVu8mDZrv0bcJIB+77P4+V5XuL57Ge3+7nb7SY2fLD72L8XCgVmvWEY8nV6vR5X3er1erzd/d1E5OwpGMuprCx5eHiIR48eAThZS3plZYXjx+vr6wzcT5484a5NpVKJ48Tz8/MM0jdv3mQX9UXcBcgWNHnvvfcYdHu9HgPp4eEhL1KA5AWJlfWHwyG7l91Aaxc02WwW6+vrAOLpZBZUe70ex35rtVoikNsFkwXoMAx53zAM+drFYpEB2+3UftWC8V/+8hf2NozHY67L/sknn/Cc3Lp1K1HGt4vMer2Of/3rX/wZABYWFvg3c/36dV5svf/++/ybkVebytQiIiIpU2Ysp7LsrVwuc1cm4y51+bOf/YxX9oPBAFevXgUQl7Stsevw8JCZ1wcffMCfl5eXX/r7OG+WSWazWXakZ7NZZrruIiqFQoEZVxAEie5ny5wse3V3Z3JL09vb2ywrAyfnLQxDdqvv7e3x+ey/buna8zz+rsPhkPeZmZlhw9er1vm+srKCu3fvAogrC3NzcwCAd955h5tuZLNZrK6uAojn2Nu5fPz4Mc+DnZvRaMT77uzssNqkbnUxCsZyqsPDQwDxl7MFgddffx1AvAa1leT+85//4MaNGwDiwGFd2Kurq/j8888BxOVXWwDkhz/8IcebL+K6x/aehsNhYmzcbi+Xy4lpSfZlPB6PeZ9cLvfcIhtBEPDL3vM8Ps5K4UB8nO1xmUyGr1MulxlAbIEWz/N4UTQajfg4z/MS5XX7ndxdnuzzMBqN+LO7yIh7H3d1r0ny8OFDXlju7u7yvedyOR7Ld955B//85z8BxOfbhhzcLSvNYDDghVW9Xk90w4sAKlOLiIikTpmxnMpKpqPRiPNRLVsOgiCxiIRlw/v7+8wOisUi16AuFApsOLJ/Ay7m3FU3o7UMKp/PMwvt9/vMWPP5fGKurzUDZTIZHhvbWanX6zFjzWQyieN/2l7Do9GI2XMURSwz25zx+fl5Zr3tdpuZ2nA4ZBOau9/0+vo6G5rsPboLi4xGI/4enufx+f7whz987WP3XRKGIc9BLpfD7u4ugPhvwBoZP/30UzbVBUHA41IsFvk3Yee6UqnwHPi+zyGcizijQL4ZBWM5lX2ZNhoNBuGPPvoIQNwZ+uzZMwDxF9XGxgbvax2jd+7cYWm61WrxS7vdbmN/fx8A+EV2kVgA63a7LEH6vs9u8vF4zKDV7XYTpWm3E93thAbiL3h3swf7Es9kMnzN0WiEmZkZAHFwt7K26/LlywDic2iPOzw8ZBkWQGK7Rbug6Ha7HFe2IOV2W7sl8u3t7Ylfd3x6eprHr9vtYnFxEUB8fq3cfOPGDX726/U6j8twOOR5cI+VfQZyuRz/NrTmtxh9EkRERFKmzFhO9fvf/z7xX3kx7jrRg8GAJcooiph5ug1cwMkcZbcxyl04xG2ssp/DMOQypZ7nMWMeDofM7Obm5nj/H//4xwDirmsrpfq+z6y72+2yHD0ajZjhvvnmm4llMgHg4OCA82jtvdnvZ3PMJ1WxWOS56ff7zIYXFxdZUXjy5Akb4vr9fqKZzpodrby9t7fHZrbPP/8ct27dAnAyHCSiT4LIGXK7kt0vc7cT+bTS5GAwSDzWgqMF42KxyC/2Wq3G5y4UConpVO44r3X0jsfj516z2+0mgoc75cluj6KIgX5vb4/vwZ2aZcMS9Xqd498XofT64YcfYmlpCUA8bGDHtdlscl32Tz/9FN/73vcAxFuGvv322wCApaUl/P3vfwdwspJdo9HA9vY2gPjiyKY2acxYzOT/1YiIiEw4ZcYiZ+i0NahnZmYS5WjrrHbv7y62kcvlEtsbAnHnsi1pCZzsvuSWr925rkByARIrs1rTXLFY5O9RrVbZtd1qtXj7YDDg63S7XWa87rrZ1qi0t7fH38/3/YmfP3vjxg2W5dfX1/k+r1y5wiGEWq3GbLdYLLKZCwB+8pOf8HYA+NOf/oS1tTX+ux1vtylPXm3KjEVERFKmzFgAxFmUNRm5Y5buylDufd2Vl9xMyb2v24Tk3n6RswLLHt09goMgYGZcLpc5tSubzbKB5/j4mBlpFEWJ8WYgzoRtapG741KhUGA2PB6P+XOhUOBjh8MhM1V7vUwmw9dwd2oKgoDT1vL5PJvKPM9jQ5iNmeZyOZ7LhYUF/v7lcpn3mWQ2FWlpaYnH8uDggI1vlUqFGfMnn3zCFbu2trZ4DO0zfuvWLd736OiIVYRJryDI2VEwFgDxbkq//e1vAcRfMvZF3W63ubuSfWEvLy+z/NbpdBgYoijivFS3+WdtbY0NK+PxGL/4xS8AYOI7bk9jwTAMQx6vTqeTKPfasev3+wyO1WqVjx0MBrzdAlyr1eKXubtV5dddVMNKru+99x6AuMTqBnS7ELNytr0Xuz2Xy3G9ZXc+rf37cDhkt/Bpi5BMmt3dXZ6D/f19BtWpqSmev3q9zgukq1evJi547CLFjnGlUklcKF2EYyRnS2VqERGRlCkzFgBxFmRX/4eHh4nyo82ltCwom80mllq0f3/69Cl/fvz4MVeU2tnZOXWe7UXkluYtK/I8L7EXsWVQ/X6f5ftqtcryZ6FQYFZmZe/p6Wlmnu7UocuXL+P73/8+gDgLs2z88PAwsRey3f7Tn/4UwMk82K8+DjjJ7qMo4ufgb3/7G7NAy9DL5TKzZLdpazQaTfwevVtbW9ypyd2kY3Z2NrFcqFvxsGNRKBRYprfzvrS0xGOZz+cv5CYp8u0oGAuA5DhwPp/nF3KpVOL4lgWLlZUVrq07Ho+5XGY+n2cwPjo64tjoYDDgc1/kQAycBMqvblHoBlf7UnYXfBgOh4l5xvazWxI+bZcl97z5vs8y88zMDINnqVTi/S2QtFot/lwul/k7hWGY6MK2uc1RFDFg2/BCNptN7OpkZexutzvxi1lcv36dpeSjo6PEBactjdloNLgoyvz8PBYWFgDEZW07LnaB22w2+XzD4ZBDOCJGZWoREZGUTfblq5yZfr/PTLZarfIqfjwe8+rfukW73S7Lzl/tiLbHuXNioyhKPN9F7KI2bhe6O1fYMqHj4+PEjkvm+PiY2WQURaxMuMteuptNWOaVyWQSOydZ2dSd15zNZpk9W7a8uLiYyMQt693d3WU5vFarYXl5GQDw73//m1m6/U7ZbJbNTDs7O3yc53kT3yW8ubnJMvXOzg53u3r06BH/HmZmZngsBoMB/vrXvwKIm7zs82/Vh/v373Pp0Ewmw0ZHlavFKBgLgHic69q1awDiL3v7stjc3MTKygqAk5Jpp9PB/fv3AcRjlvbFUywW+eXUbrcTY48WMNyS6UVk783tli2VSjx2BwcHDJhuwK5Wqwygg8GA97exynq9zpJxtVpNjM/a43K5HF/f3dJwOBwyaLrlU3uOMAwZSKemphILirjjw1YCtyUe3e0zc7kcy9fuGtmTqtFo8DNbr9exubkJIH5vdkHz7NkzfPHFFwCA1dVVLvQxGAz492HlfyvhA/F4vjuNUARQmVpERCR1yowFQJwpWTbmbmxQLpefa0YJggA3btwAkMziOp0Os4bhcMjbB4MBMy/bmP2ismPlbsTgzt21jAiIsyI7LsPhkN3XmUyGx9Gy22q1yjJ1EASJPYwtG+50OsxkW61WYiGPnZ0dAEgsPmJZbalUYiZbqVQSWbc9bjQaMSO21+71evyc9Pt97tHb7/cnfh5tr9djxSebzXKYYXt7m7taZbNZvPXWWwDi42lz6WdnZ9nwtbW1BSB5/C5dusTPhjJjMQrGAiAes7xz5w6AuPRsnaEHBwecpmEBIooijoVtbGzgypUrAOJAa18+1Wo1MeZmxuPxK/EF5E5h8n2fQev4+DjxRWyl0EKhwEAeBEEiEADxeXB3YbJg1+12E9Op7P6VSoXP3e12n+veDcOQF0uZTIa/n5VV7TnsAsz3fV44uAuV2Gfi4OCAFwVHR0cTPxYahmFiKpd7IWrnxvM8TuH68ssvE+PENq5sf0e9Xo/Hr1qt8sLlIg/ZyIvRJ0FERCRlyowFQJyZ2UIQ7prDV65c4c40VmLe2NhgMxFwMu/02rVrzKL39vbYnb22tsby6EXImv4vlv189tlniS5ne8+5XI73iaKImZHv+4n7u3sNA3GmZvOMwzDk8Xf3M3bXqXabqNw5zHZbu91mdm3NXUBc6rZServdZkn6+PiY3cC2kMXu7i6z60ajwd9pb29v4s9xs9nkUIy75Ovc3BybuVqtFjPcYrHI83f37t1ERQGIKwfXr1/nbTZEMOnHSc6OgrEASC7Y4Y4fN5tNlqGbzSaAeIzRgkWxWGTn9cbGBoNxsVhkkNje3mbJr1arXegytQUq66Z92RqNRmIalB3br37J28XQ5cuXAcQXBRZgyuUyL7jcADMajXg+G40Gn8sCTK/X4+fk3r17vO/MzAzHTyfVL3/5y8RwggVXd4ON0WiUmMJlx95dZc49H+5CKPZ8k75SmZwdlalFRERSpsxYAMRX85a9ViqVxAITdrtd5VcqlcR2epZB9Pt9ZludTofZWavVYgNRt9tVae4MudszBkGQ6JC2LD2Xy7HEbUMKs7OzvG1/f5/Z7qVLl9j9HQQBlzptNps8h3aO2+02G/lqtRqz5HK5PPHd1Pb5FjkvyoxFRERSpsxYAMSZ7NOnTwHE44ruXrc2JmzTNNxxsyiKmD15nsest9/vc3zS8zyuQPSqTG06L+70KM/z2Izl+z6z1m63yyzYqhj1ep23HR0d8XxmMhlWRWZnZ/l8xWKRc5jNzMwMG/36/T6z6263m9gFSkT+fwrGAiAuZVqTTqVSYUNPPp/n/EnrIr1+/ToDwOHhIf99bm4u0eVrjUWzs7P8gp/08uV3jbvoSjabZWPQaDTiBRXwfNn14OCAgdntcC+VSgzMm5ubiW017T42bNHr9XjfqampxJKf9vkRka9HZWoREZGUKTMWAHEGbNM07t27x6X7bt++zTL0actehmHIDOz+/fvMkvP5PB4+fAggzrasxLm9va0GrjOUy+Wea6wy7t7KluH++te/BhCfH8tq3f2Tu90uPwe9Xo+l7D/+8Y/PzZ11X9N9jX6/z7nUIvL1KBgLgOTOSq+//npivWMrPduX9GAwYKdupVLhuOHS0hKD+GAwYNm72WxyqU139xr59txdm4bDIQOiu8uSGzxtIRbgZO6x7/uJ8+1ucWljv+7jROTsqUwtIiKSMmXGAiDOkqzpplwuc2eara0tNm5Zw8+1a9dw8+ZNPtbmrpZKJdy7dw9AXOK05f/m5+eZpS0sLEz8xvPfJUEQsJTsZsYAEvOPrbPahhqiKEosnWnnxx2usKEIEXn5FIwFQPyFbSVmd5P6UqmEq1evAgAXlPB9H8+ePQOQHGM8Pj5mMPjBD36ABw8eAIiDsQVmdzEQ+faGwyE7pXO5HKciudOL3GUr3ZK27dTU6/W4lKXneYnubAVkkfOhMrWIiEjKlBkLgDgztuaqQqHAkvTGxgZ+9KMfAQC++OILAHFmbPu1ep7HRTwKhQKzLcu0gLjxy0qp1vglZ8P3fe6yBJzMJ/Z9P7G5gbuDExCXo91mL6t6uNl1EASJ5xaRl8dzx5he+ot53vm92AUxHo+/8XJVL3K8a7Uabt26BSD+IrfFOfb39zE3NwcAXLjD3Xjd7g8ktwqsVquJMUu7z2AwwIcffgjg+ak43wXf5ngD5/8Zr1arXBnNLf/7vp8IwHZx5U5PsvuHYcj7BkHArnp3tbT19fWX9h7O6zMuMR3v8/V1j7fK1CIiIilTZvwdp6vY8zVpmfFFoM/4+dLxPl/KjEVERCaEgrGIiEjKFIxFRERSpmAsIiKSMgVjERGRlJ1rN7WIiIg8T5mxiIhIyhSMRUREUqZgLCIikjIFYxERkZQpGIuIiKRMwVhERCRlCsYiIiIpUzAWERFJmYKxiIhIyhSMRUREUqZgLCIikjIFYxERkZQpGIuIiKRMwVhERCRlCsYiIiIpUzAWERFJmYKxiIhIyhSMRUREUqZgLCIikjIFYxERkZQpGIuIiKRMwVhERCRlCsYiIiIp+x9N6ru6GFvI9AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1164aeb38>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "pyro.set_rng_seed(13)\n",
+    "pyro.set_rng_seed(4)\n",
     "x_empty = torch.zeros(1, 50, 50)\n",
     "samples = [geom_prior(x_empty)[0] for _ in range(5)]\n",
     "show_images(samples)"
@@ -322,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,13 +440,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "keep_output": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeMAAABvCAYAAADfcqgvAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAGI1JREFUeJzt3VtvG9fVBuB3eBZFiiIlSpZsST6nTl2khhugLdoCRX9BUfQm6L/or+llbwoUvSrQqwK9CJCicIPYhuG4bWIrsa0zRYnnM4ffxWC92hMHHxJH1kjW+9xIoChSIoezZq299t7eZDKBiIiIRCcW9R8gIiJy3ikYi4iIREzBWEREJGIKxiIiIhFTMBYREYmYgrGIiEjEFIxFREQipmAsIiISMQVjERGRiCVO8sk8z9NyX9/SZDLxXvd39Xp/e9/l9Qb0mr8OHeMnS6/3yfqmr7cyYxERkYgpGIuIiERMwVhERCRiCsYiIiIRUzAWERGJmIKxiIhIxBSMRUREIqZgLCIiErETXfTjuP3yl78EAMTjcdRqNQBAPp/HcDgEACSTSUwmwRz1wWCAQqHA28fjMQCg3W7D84I52YlE8HIcHh4in88DAFKpFLa3twEAjx49Ool/S0REzhllxiIiIhHzLHM8kSc75qXUPvzwQwDAwsICNjY2AACrq6uoVqsAgGKxiG63y/u/++67AICXL18iHo8DAOr1OrNny4ZfvHiBy5cvAwA6nQ7+/ve/AwB+//vfH+ef/41o6bqTpeUwT56O8ZOl1/tkfdPX+0yXqa2svLS0hHa7DQBIp9NIp9MAgnJ0MpkEACwuLqLX6/H2g4MDAEAul2NgPjw8BBAE5ZmZGQDA/v4++v3+Cf1HIiJyHqlMLSIiErEznRnPzc0BALa2tliOHgwGbMj64osv8MMf/hAA0Ov1mAEXi0XU63UAQRZsme/U1BTva3zfZ9YtIiLyJpzpYGzBs1KpMOgOBgOOAfu+z8BcqVQ4Dux5Hi5dugQAqFar6HQ6AIALFy4AADY3N/kcCwsLLIeLiIi8CSpTi4iIROxMp3yffvopgKAJ6z//+Q8AYDKZMOut1+vMnhuNBj777DMAwM2bN7G3twcAoaz3448/BgD0+33e3u/3sbCwcAL/jYiInFdnOhjbWO+NGzcQiwVJ/vz8PDulS6USdnd3AQB37tzB+vo6AGA0GjHY9no9jj2/fPmSj7G0tAQAmJ6exr17907oPxIRkfNIZWoREZGInenM2ErQCwsLnE88Go3YNe37Pr788ksAwN7eHorFIgDgyZMneO+99wAAz58/Z4n79u3bAIBms8mFQz7//HNUKpWT+YdERORY3L17F0AwLFkulwEEw5ij0YjfW3V1ZmaGSyTb116vx1k6c3NzjAlra2u8fTgc4h//+AcAcBj0dSkzFhERidiZzoxLpRKAIANuNBoAgo0dbDx4bm6O84nX19eRzWYBAJlMhg1c5XIZmUwGADi+vLS0xDHoTCbD1bhERORssGmthUKBmwfFYjGe73u9HjcPSqfTzJJ3dnYAgNk0ALRaLeRyOT6uLZ3c6/WYaX9XZzoYWzkhFosxGI9GI74JzWYT09PTAICrV6+ytDA1NcWdmJaWlvhG2eM9ffqU61g3Gg0+hoiInA2pVApAMIxp5/v5+Xku6tTpdBiYB4MBf8+ad+PxOIN1v99nfOh2uxwi9X2fz/NdqUwtIiISsTOdGVsGfHBwwCuV3d1dlqlnZmbY2FUoFFiyLhQKvMqZnZ3llCcrQ9RqNZaxV1dXQ+UKERE5/WyosdlsMj40m02u0JjNZtnsO5lMGCtqtRofw2LM9PQ0Y0a73eaqjY1GQ2VqICgRAMD//vc//PjHPwYQlBOsrOz7PssQT58+xZ07dwAEHdQ23hyPx7moh5Ubbt68iYcPHwIIdm3a398/of9IRESOgw0/DodDBtrhcMiSdDabZcDu9/u8j8WPWq3Gn8diMcabbrfL+8zNzalMLSIi8rY405nx4uIigOAK5tGjRwCCsrMN1ufzec4RPjg4YFd0NpvFs2fPAAQD+nZFZB1yg8EA77zzDoAg67bmMBERORusxDwej0OlabdZy77PZDKsopr5+Xme+0ulEkvT2WyWWXc8Hn/l917XmQ7GVu+/dOkSg+v09DQD6dTUFO+Tz+f5wrZaLT7GaDRiMP7iiy8ABJO37QV2O+pERORssPP8eDxmWblarXJYcjQasbM6n89jY2MDQJDQAcG5337eaDSYzFUqFQbxVCrFseTvSmVqERGRiJ3pzPjw8BBA0AW9trYGAMxyAeCf//wnfvKTnwAAHj58iJs3bwIIrmysbJHJZJgx2zzk+fl5TgBfWFjgkpoiInI2WDbszqpJJBLsrO52u7y9UqmwK9oadsvlMve4HwwGnHWzsrLCpTF93z+2zPhMB2MrIczOzoZWR7HbC4UCA+0vfvELliFyuRyDbb1eZznDtl5stVpIp9N8HuuoEzlOxWKRQyrxeJxdmY1Gg2NSdlwPBgMOuXiexxNHOp3m8e7enkgkeMFZrVZ1QSnnjgXJwWDAAJxOp9FsNgEEnxe7Tz6f5+599vN6vc79DIbDIYP7ZDLh5zOVSqmbWkRE5G1xpjNjKyt3u12WE9y1Qi9dusT77OzshJbPtCXPut0uMw4blJ+bm2O2kcvlQqVvkeOyvLyMn//85wCCbNgy2WQyyeNvfn4eQHgd3d3dXTYYFgoFbG1tAQiGXOwYd3eZuX//vjJjiZzbFGvVRjvm7SsQlH6tE9rzPP7Mnesbi8V4rHuex/vbfbvdLu+bTCb5vZvVptNpLhDV7/dZIbVMN51O8/eAoyrVzs4OK6eJRCJ0n+/iTAdjC6jum1GtVlluGI/HXHWr0WjwBZydneWmEJ7n8Xa7byqVYnnCShYixy0ej/NCcH9/nz0Nvu+j3W4DAIdZyuUyLyxTqRQvHA8PDxmk3ZNYtVplWc26Q0Wi9Nvf/hZAcKHobrQABOtEu8M09n0mk+GUomKxGDpH22ckmUzy/nbbn//8Zz721tYWLl++zOdzV190n9P+Jku+fN/ncOZ4PA7NqrEAPBqNjm0FLpWpRUREInamM2O70kokEiw39Ho9Xu3EYjFmE8DRFU8sFmNm4fs+f9ctddhjjEaj0FqlIsfFXeM2n8/zOKvVaq9c6afTaR6/U1NT/N7zPJajXYlEgtWfWq2G69evAziamz8ej0ObrFu24H6W3LLg15XiPM8LZRH2+el0Onj58uVrvirytnKHXKwkbNvaAkdrQq+urjIDdvX7fZaKt7e3+XjA1x+f9tjlchmbm5sAws1crVaLx2wikeBnzTLgfD7Pz4jbMT07O8uK6WQyObYG3zMdjB8/fhz1nyDy2jzP4/jV1NQUT1DlcpnDJFamjsViDJKDwYAXme6JIJfLsTSXSCRYni6VSvjd734HAPjNb34DIFyu8zyPY8qLi4uhmQl2UVCr1VjGs/uWSiWe8FqtFm7fvg0AuHfvHteKFzEW2HK5XChJAoJgasH4xo0bPI5nZmYYHJPJJI/BfD6PixcvAgguMC042sXh/fv3Oa313XffZbl5ZmaG37sLQdlnyx4PCI5pW+Xx6dOn3Oe4UCgwoFerVf6t35XK1CIiIhE705mxyNui1+uFysN2xW6Zs1vOy+fzeP78Ob+3BsRut8vhl36/z6v3yWTCq33LINyyXr/fZ8nvwoUL/DtyuRz++9//AgiyhYODAwBHa8K7Xd2xWAz//ve/AQTLyYp8lR17rVaLFRc7Rufn53lbp9NhdSabzbKU3G63Wb5+//33OfQCILSIExBUTe/evQsA+OlPf8oKUrfbDX3O3GEWy9bts+b7PpfAXFxcxF//+lf+HZbF5/N5zTMWERF5WygzFomI2zjlbl7ueR4zWWvw6vf7oSYrWy0OQGgXGruPu4D94uIim7zsqr/T6XBcut1uMxPvdDqcMri5ucn7p1KpUHYOBONzlrkvLCy88hwiLsuMb9y4waWM3bUiLOtNJBKh3ge3mcuOsTt37nAseWtri/0RVvFZWFgIrdBo49WlUolZ7WQyYUY9Pz/PHf5sSuDBwQE/F6PRiPeNx+Oh51MDl8gZl0gk+EEeDAY8SZRKJd7HSmDJZJKNJy9evMDKygrvYyeg4XDIkrW7ofr29jZLdqZUKvFE2Ol02Ekai8V4MpqammJAH4/HvEBwdz+zny8tLTGI2+5nIi47lg8PD3nM2rE+Go1YEm40GrxQnJ2dDTVULS8vAwiGU2yxm/39/Vfm1KfTaX62ZmZmQg1e9rloNBqhwGtrUltZPBaLhWY72EXB4uIiA7Pnece26IfK1CIiIhFTZiwSkX6/H9rUxLKE8XjMLNkaXJrNJq/AO50Of55IJJgxd7tdlMtlAEG2bI89GAxemZbk7jyTSqXY1HLx4kXuDT6ZTPD9738fAPDJJ5/g2rVrAMJzla1E/vDhQ658ZxmOiMuOm0wmw+Nmb28PQLAqlx3fjUaDQx3r6+usuKTTaT7G5uYm3nvvPQDBZ8SyWcuou90uh3JisVhodS2bc+xuGuH7Plfpss9TPB5n9u37PqtO6+vruHXrFoBgyt9xrcClYCwSkUwmw5MHcFRuTiQS7Ca1k8/s7CxPEqlUigt6ZDIZluY8z+Nc5Uqlws7S6elpnlR+8IMfAAhOZhZo3R2h9vf38b3vfQ9AcOKyoH/lyhX+fTa/s9vthsbirMxnJzURl9u5bN+7607bMegG5kwmw2MwFosxIF66dIll46WlJR57Ftzj8Tg++ugjAMGx/uDBAwBBedsuBNyu7Vwux3FsuwDudDq8KNjY2MBf/vKXY35FwlSmFhERiZgyY5GIdDodlpKnp6fZRDUej1l2syv3er3O5pVkMslS8GAwYKNKr9djw8mNGzeYafR6PTZrWSaytLTEecOWQRvLMizLBoJs127/17/+xb95YWEBQNAktra2BgBaClO+lh1n2WyWx6E1dXmeF5rfbkajUWi4xTqo3eUwK5UK577bY7grxm1vb3NOslvNcf8Od4cme75MJsPPjfs3vSkKxiIRSaVSnBrkbis3MzPDkpm7HOb29jaAYBqGnTAmkwlPcsvLy+xurlarLF/H43GW3iyIj0YjLu9XLBYZ6O1nQHgdX+Coy9RObAcHB6ExN/u9ry51eJr8+te/BhCUQt31hr9ufW878bdaLXbdep7H92FxcZEn/GazyfchkUjgD3/4w5v7J84oKzdns1ke93Z8x+Nx9kz0+/3QdCF3LWl7z3Z3d7G6ugogCJpWnrZx4lQqxds6nQ4vFN1jenp6mhekm5ubfP6nT58CALflPSkqU4uIiERMmbFIRNz9jPf29r527qJlwPl8nrf1+32WjEulEjPSVqsVKsFZ9tFqtZgRWyl8eXmZTTSpVIoLHvR6PWaEiUSCj/HgwQNmHdbU0u/3mS0fHh6GFm04rT744AMAwN27d9nI02g0mO3a65ROp5kZbWxs8P9053vncrnQDnHuBvbKjF9lx/fOzg6zWneRGjvWSqUSGw7L5TIz1k6nw/cslUrhnXfeARC8P1ahcBepsTJ2o9Fgw2OhUGAFYzQahZocrRplv3dwcMDyt/3sTTq9nxqRt5y7MEcul+NJvlAo8CRlJyh3ndxarcYStLtjjJ3sgCA4WHAcDAYsx1m51fd9XgjE43E+z9zcHANMLpdjkHbHzOyxKpVKaFqHuy3paWX/x7Nnz/h6zszM8H2wBUtu3brF9+PatWt8HXzf53szmUwYxNvtNt8Td2s/OWLH1crKCodI3J/Z8Ear1QoFbjvGfN/n7Wtra7xAun37NoPl559/DiDcSxGLxRjQ3SmCbld3u93m89hsgVgsxuc7iel6KlOLiIhETJmxSETcuZXj8ZiNJTs7Oyy3WfltPB7zSn91dZVl6slkwsYY3/f5e1tbW5zvu7W1xQYld71eK91NJhNmzNlsllnL8vIyy3TVapVlassSL168yIzafYzjWqv3TbD/+datW8zkt7a2mAVbdjQ3N8fXYX19nf/75cuXeftHH33EOdmVSoWZmi2sImHurk2WkbrNgvZ+5HI5HleZTIavK3BU1m40Gsykd3d3X2lQXF5e5vuQy+VCi4K4603b4/m+z2PAqh2ZTIafl5M4phWMRSKSSCR4kpiamuJYa6FQ4MnIDAYDnnz29vZYaovH4zyJlctllkrdxfXH4zGuXr0K4OikUq/XGeir1SrHkt1NJxqNBst7nueFyt5AcGKzRUs8zwv9faeVvW6xWIwdttVqleVI97V0O33dMujNmzcBBO/TkydP+L1duNiYu4TZxVoikeBFox0z7kYp8/PzvMAsFAqhFebs89LpdEKlbnfDB/u5lcVHo1HootE+Z+l0mo/XaDRCMweAoHRuUwWPa5Wt/8/pvYQVERE5J5QZi0TEbRAZDofMFnq9HrMB+zo9Pc0r+nw+H9og3dbu7XQ6LAVeuXKFJfBUKsWM2K7+d3d3mdVmMhlmdfV6ndnC9vZ2aMvFrzZouU1nqVSKzTNuI9lpY+VR4KhD1l3cxDK158+fY2NjA0BQjrdhAeCoVHrt2jWWvePxOB/nJBaIOIvcY9qyVnd4wDqbe70eX+Nms8lj2q0CZbNZHtOJRIKPZ++Zu767e5wmk0ne1x36KRaLoe+B4Di23/u6eejHTZmxiIhIxJQZi0SkUqng4cOHAILM0h0PswzOnVpki+S7Swe6Y13JZJLjnMVikWO8jUYDv/rVrwAcjSVfvnyZzSnz8/PcyWYwGPB50uk073PhwgV+b9nC4eEhx6gfPHjAv/k0zzO2jKvb7XI80PM8ZrM2rvnpp5/iRz/6EYAgO7PqQ71eD42JWzYXj8dZRbCKhIRZxrmyssKqhL3utVqNfQtTU1OsUHiex8/F9PQ0V4rL5/Ohfb+N9UHs7u7y/ajVaqHpdvYeDwYDHtOpVIrP7y5Fa5+FkzimT++nRuQtV6lU8OGHH57oc9rJyj0RdTodnoC63S63SrQTERB0CNuJ006k7gkqkUjw5Hia5xlbAC6Xy2wAGg6HvKCxDvRGoxHqQLdAMh6PeZIvl8v47LPPAAQB2E7ybilcjthF3JMnT0JDK0B4nvH9+/e5KEitVuNx2Gg0OASSzWb52nc6HS7QYl9XV1d5Iesue5lMJkNlb/dC1u3UBoJZDSc5M0BlahERkYgpMxY5B9wmJSDILCyT6/V6zBzm5uZC8y3n5uYAhLMIyz7a7TankvR6PZYQ19fX3/B/8/pWVlYABFmaO4fbsmD738bjMV+H9fV1TldqNpt4//33AQCPHj3iak0zMzOcPnMSqzWdRX/84x+P7bE+/vhjzvEGjhrv3M0drOkunU6HdnWyilCtVuNnADha7c7NxN2pUm+agrHIOWLl1l6vx67SyWTCAFKv19mRmslkGJB6vR7Hm23bRHf8dGVlhWVrdzek08YWgrh+/TrL8V9++SVPuu4axlZuX15e5sm+WCxyycypqSme8JvNJi9W3M5reTPcvopSqRQKsEBwbNqFEnB03D979oy35XK50K5oVgK3C69ut6sytYiIyHmizFjkHPjTn/4EIOh6BoJynXX99vt9dgW7yzpa5gwETVlW6rYO6vF4zIykUCgwi7Bs+jSyeaoHBwfM8Pv9PkuUbuneMuPZ2VlmvYlEgv+nuyJUrVYLraAmb5a7el29Xg/tNAYE2bLbHPbixQsAQVXHMuB+v8+mw1wux4qGVXbW1ta4e5RVTN7o//TGn0FEIvf48ePQ1/PKgurq6ioXKfF9/5ULiUwmwyUQu90uL1xarRaD+MzMDH8vk8nwJO6upSxvRqvVYrd0NptFuVwGcLRsZbFYZNf0cDhk53y73eZF5mAwCO1cZn0T9hjz8/O8SP26aVTHTWVqERGRiCkzFpFz48qVKwCCrPbevXsAgnKkNbBZdru1tcUMKhaLscHL930ukFIsFvn9ysoKH8MyNnlzHj9+/NZVeRSMReTcePnyJQBgc3MT169fBxCMKdr4sJUor169ik8++QRAMGZs44yTyYTfV6tVTv2qVCosc9o0GpFvQ2VqERGRiCkzFpFzw5Zh3N3dZfNVKpXiHGrrxu10OlzcI5lMhtbjtsVCpqen2YHr7pl7mudZy+mlYCwi54YtaPKzn/2M3bbdbpdd1lam9n2f3+/u7nJxk6WlJW4osLy8zNWaDg8PuXb3V1c7E/kmVKYWERGJmDJjETk3bN5oOp3mcoru0opWjh4Oh+yU7vV6XAwklUqFtl58/vw5gKDj2pZctHK1yLehYCwi54ZtVvC3v/2NCz64wdM6pYfDIYOu7/ucthSLxUL7QNvKTOl0mgFbwVheh8rUIiIiEfPsSlBERESiocxYREQkYgrGIiIiEVMwFhERiZiCsYiISMQUjEVERCKmYCwiIhIxBWMREZGIKRiLiIhETMFYREQkYgrGIiIiEVMwFhERiZiCsYiISMQUjEVERCKmYCwiIhIxBWMREZGIKRiLiIhETMFYREQkYgrGIiIiEVMwFhERiZiCsYiISMQUjEVERCKmYCwiIhIxBWMREZGI/R8nQmNyVYqNZwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x114de2048>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "pyro.set_rng_seed(87678)\n",
+    "pyro.set_rng_seed(121)\n",
     "show_images(prior(5))"
    ]
   },
@@ -410,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,7 +728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -734,9 +798,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "i=0, elbo=2806.79\n",
+      "i=1, elbo=3656.81\n",
+      "i=2, elbo=3222.37\n",
+      "i=3, elbo=3872.77\n",
+      "i=4, elbo=2818.27\n"
+     ]
+    }
+   ],
    "source": [
     "data = mnist.view(-1, 50 * 50)\n",
     "\n",


### PR DESCRIPTION
The output from some of the cells in the AIR notebook is integral to the flow of the tutorial. These cells have the `keep_output` flag set so that their output is not removed by `nbstripout`. Despite this, some of these outputs have disappeared, so this PR adds them back. For the most part I just opened the notebook, ran all the cells, saved the notebook, and ran `nbstripout`.

One other thing I did was hand tune the random seed to ensure that the pictures are illustrative of the point been made.