### PR TITLE
Allow arbitrary iterables as args to .expand()

### DIFF
--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -26,6 +26,7 @@ class Beta(torch.distributions.Beta, TorchDistributionMixin):
 
 class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
     def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('validate_args')
         if 'probs' in self.__dict__:
             probs = self.probs.expand(batch_shape + self.probs.shape[-1:])
@@ -52,6 +53,7 @@ class Chi2(torch.distributions.Chi2, TorchDistributionMixin):
 
 class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
     def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('validate_args')
         concentration = self.concentration.expand(batch_shape + self.event_shape)
         return Dirichlet(concentration, validate_args=validate_args)
@@ -93,6 +95,7 @@ class Gumbel(torch.distributions.Gumbel, TorchDistributionMixin):
 
 class Independent(torch.distributions.Independent, TorchDistributionMixin):
     def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('validate_args')
         extra_shape = self.base_dist.event_shape[:self.reinterpreted_batch_ndims]
         base_dist = self.base_dist.expand(batch_shape + extra_shape)
@@ -117,6 +120,7 @@ class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
 
 class Multinomial(torch.distributions.Multinomial, TorchDistributionMixin):
     def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('validate_args')
         if 'probs' in self.__dict__:
             probs = self.probs.expand(batch_shape + self.event_shape)
@@ -152,6 +156,7 @@ class Normal(torch.distributions.Normal, TorchDistributionMixin):
 
 class OneHotCategorical(torch.distributions.OneHotCategorical, TorchDistributionMixin):
     def expand(self, batch_shape):
+        batch_shape = torch.Size(batch_shape)
         validate_args = self.__dict__.get('validate_args')
         if 'probs' in self.__dict__:
             probs = self.probs.expand(batch_shape + self.event_shape)

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -113,24 +113,27 @@ def check_sample_shapes(small, large):
 
 
 @pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])
-def test_expand_by(dist, sample_shape):
+@pytest.mark.parametrize('shape_type', [torch.Size, tuple, list])
+def test_expand_by(dist, sample_shape, shape_type):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
-        large = small.expand_by(sample_shape)
+        large = small.expand_by(shape_type(sample_shape))
         assert large.batch_shape == sample_shape + small.batch_shape
         check_sample_shapes(small, large)
 
 
 @pytest.mark.parametrize('sample_shape', [(), (2,), (2, 3)])
-def test_expand_new_dim(dist, sample_shape):
+@pytest.mark.parametrize('shape_type', [torch.Size, tuple, list])
+def test_expand_new_dim(dist, sample_shape, shape_type):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
-        large = small.expand(sample_shape + small.batch_shape)
+        large = small.expand(shape_type(sample_shape + small.batch_shape))
         assert large.batch_shape == sample_shape + small.batch_shape
         check_sample_shapes(small, large)
 
 
-def test_expand_existing_dim(dist):
+@pytest.mark.parametrize('shape_type', [torch.Size, tuple, list])
+def test_expand_existing_dim(dist, shape_type):
     for idx in range(dist.get_num_test_data()):
         small = dist.pyro_dist(**dist.get_dist_params(idx))
         for dim, size in enumerate(small.batch_shape):
@@ -140,7 +143,7 @@ def test_expand_existing_dim(dist):
             batch_shape[dim] = 5
             batch_shape = torch.Size(batch_shape)
             with xfail_if_not_implemented():
-                large = small.expand(batch_shape)
+                large = small.expand(shape_type(batch_shape))
             assert large.batch_shape == batch_shape
             check_sample_shapes(small, large)
 


### PR DESCRIPTION
This fixes a type coverage error in `TorchDistribution.expand()` whereby for a few distributions, `.expand()` did not work for `list` or `tuple` args (as is allowed by `torch.Tensor.expand()` and `TorchDistribution.expand_by()`. Previously, passing in lists would result in an error
```
TypeError: can only concatenate list (not "torch.Size") to list
```

## Tested

- added regression tests to test_distributions.py