### PR TITLE
Add `CensoredDistribution`

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -24,6 +24,7 @@ from pyro.distributions.util import enable_validation, is_validation_enabled, va
 from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D
 from pyro.distributions.zero_inflated_poisson import ZeroInflatedPoisson
+from pyro.distributions.censored import CensoredDistribution
 
 __all__ = [
     "enable_validation",

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -49,7 +49,8 @@ __all__ = [
     "TorchDistribution",
     "VonMises",
     "VonMises3D",
-    "ZeroInflatedPoisson"
+    "ZeroInflatedPoisson",
+    "CensoredDistribution"
 ]
 
 # Import all torch distributions from `pyro.distributions.torch_distribution`

--- a/pyro/distributions/censored.py
+++ b/pyro/distributions/censored.py
@@ -1,6 +1,5 @@
 import torch
 from torch.distributions import constraints
-from torch.distributions.utils import _sum_rightmost
 
 from pyro.distributions.torch_distribution import TorchDistribution
 
@@ -9,7 +8,8 @@ class CensoredDistribution(TorchDistribution):
 
     def __init__(self, base_distribution, upper_lim=float('inf'), lower_lim=float('-inf'), validate_args=None):
         # Log-prob only computed correctly for univariate base distribution
-        assert base_distribution.event_dim == 0 or base_distribution.event_dim == 1 and base_distribution.event_shape[0] == 1
+        assert base_distribution.event_dim == 0 or (
+                base_distribution.event_dim == 1 and base_distribution.event_shape[0] == 1)
         self.base_dist = base_distribution
         self.upper_lim = upper_lim
         self.lower_lim = lower_lim
@@ -33,7 +33,6 @@ class CensoredDistribution(TorchDistribution):
         x[x > self.upper_lim] = self.upper_lim
         x[x < self.lower_lim] = self.lower_lim
 
-
     def log_prob(self, value):
         """
         Scores the sample by giving a probability density relative to a new base measure.
@@ -44,7 +43,7 @@ class CensoredDistribution(TorchDistribution):
         as for discrete distributions. `log_prob(x)` in the interior represent regular
         pdfs with respect to Lebesgue measure on R.
 
-        **Note**: `log_prob` scores from distributions with different censoring are not 
+        **Note**: `log_prob` scores from distributions with different censoring are not
         comparable.
         """
         log_prob = self.base_dist.log_prob(value)
@@ -68,4 +67,3 @@ class CensoredDistribution(TorchDistribution):
     def icdf(self, value):
         # Is this even possible?
         raise NotImplemented
-

--- a/pyro/distributions/censored.py
+++ b/pyro/distributions/censored.py
@@ -19,7 +19,7 @@ class CensoredDistribution(TorchDistribution):
 
     @constraints.dependent_property
     def support(self):
-        raise NotImplemented
+        return constraints.interval(self.lower_lim, self.upper_lim)
 
     def sample(self, sample_shape=torch.Size()):
         with torch.no_grad():

--- a/pyro/distributions/censored.py
+++ b/pyro/distributions/censored.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/censored.py
+++ b/pyro/distributions/censored.py
@@ -1,0 +1,71 @@
+import torch
+from torch.distributions import constraints
+from torch.distributions.utils import _sum_rightmost
+
+from pyro.distributions.torch_distribution import TorchDistribution
+
+
+class CensoredDistribution(TorchDistribution):
+
+    def __init__(self, base_distribution, upper_lim=float('inf'), lower_lim=float('-inf'), validate_args=None):
+        # Log-prob only computed correctly for univariate base distribution
+        assert base_distribution.event_dim == 0 or base_distribution.event_dim == 1 and base_distribution.event_shape[0] == 1
+        self.base_dist = base_distribution
+        self.upper_lim = upper_lim
+        self.lower_lim = lower_lim
+
+        super(CensoredDistribution, self).__init__(self.base_dist.batch_shape, self.base_dist.event_shape,
+                                                   validate_args=validate_args)
+
+    @constraints.dependent_property
+    def support(self):
+        raise NotImplemented
+
+    def sample(self, sample_shape=torch.Size()):
+        with torch.no_grad():
+            x = self.base_dist.sample(sample_shape)
+            x[x > self.upper_lim] = self.upper_lim
+            x[x < self.lower_lim] = self.lower_lim
+            return x
+
+    def rsample(self, sample_shape=torch.Size()):
+        x = self.base_dist.sample(sample_shape)
+        x[x > self.upper_lim] = self.upper_lim
+        x[x < self.lower_lim] = self.lower_lim
+
+
+    def log_prob(self, value):
+        """
+        Scores the sample by giving a probability density relative to a new base measure.
+        The new base measure places an atom at `self.upper_lim` and `self.lower_lim`, and
+        has Lebesgue measure on the intervening interval.
+
+        Thus, `log_prob(self.lower_lim)` and `log_prob(self.upper_lim)` represent probabilities
+        as for discrete distributions. `log_prob(x)` in the interior represent regular
+        pdfs with respect to Lebesgue measure on R.
+
+        **Note**: `log_prob` scores from distributions with different censoring are not 
+        comparable.
+        """
+        log_prob = self.base_dist.log_prob(value)
+        upper_cdf = 1. - self.base_dist.cdf(self.upper_lim)
+        lower_cdf = self.base_dist.cdf(self.lower_lim)
+
+        log_prob[value == self.upper_lim] = torch.log(upper_cdf.expand_as(log_prob)[value == self.upper_lim])
+        log_prob[value > self.upper_lim] = float('-inf')
+        log_prob[value == self.lower_lim] = torch.log(lower_cdf.expand_as(log_prob)[value == self.lower_lim])
+        log_prob[value < self.lower_lim] = float('-inf')
+
+        return log_prob
+
+    def cdf(self, value):
+        if self._validate_args:
+            self.base_dist._validate_sample(value)
+        cdf = self.base_dist.cdf(value)
+        cdf[value >= self.upper_lim] = 1.
+        cdf[value < self.lower_lim] = 0.
+
+    def icdf(self, value):
+        # Is this even possible?
+        raise NotImplemented
+


### PR DESCRIPTION
We currently have `TransformedDistribution` which works with *invertible* transformations of random variables. The new `CensoredDistribution`, added here, makes the following non-invertible transformation
```
X ~ dist
X[X >= upper_lim] = upper_lim
X[X <= lower_lim] = lower_lim
```
The new pdf uses the `log(cdf)` values at `upper_lim` and `lower_lim`, and the original pdf elsewhere. This is a valid probability density function, albeit with respect to a new base measure.

These distributions find applications in `contrib.oed` work (they make interesting OED problems because censoring leads to lower / zero information gain)