### PR TITLE
Add assert_close to tests.common

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -169,77 +169,80 @@ def _safe_coalesce(t):
     return tg
 
 
-def assert_close(x, y, atol=1e-7, rtol=0, msg=''):
+def assert_close(actual, expected, atol=1e-7, rtol=0, msg=''):
     if not msg:
-        msg = '{} vs {}'.format(x, y)
-    if isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
-        assert x == approx(y, abs=atol, rel=rtol), msg
+        msg = '{} vs {}'.format(actual, expected)
+    if isinstance(actual, numbers.Number) and isinstance(expected, numbers.Number):
+        assert actual == approx(expected, abs=atol, rel=rtol), msg
     # Placing this as a second check allows for coercing of numeric types above;
     # this can be moved up to harden type checks.
-    elif type(x) != type(y):
-        raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
-    elif torch.is_tensor(x) and torch.is_tensor(y):
-        prec = atol + rtol * abs(y) if rtol > 0 else atol
-        assert x.is_sparse == y.is_sparse, msg
-        if x.is_sparse:
-            x = _safe_coalesce(x)
-            y = _safe_coalesce(y)
+    elif type(actual) != type(expected):
+        raise AssertionError("cannot compare {} and {}".format(type(actual),
+                                                               type(expected)))
+    elif torch.is_tensor(actual) and torch.is_tensor(expected):
+        prec = atol + rtol * abs(expected) if rtol > 0 else atol
+        assert actual.is_sparse == expected.is_sparse, msg
+        if actual.is_sparse:
+            x = _safe_coalesce(actual)
+            y = _safe_coalesce(expected)
             assert_tensors_equal(x._indices(), y._indices(), prec, msg)
             assert_tensors_equal(x._values(), y._values(), prec, msg)
         else:
-            assert_tensors_equal(x, y, prec, msg)
-    elif type(x) == np.ndarray and type(y) == np.ndarray:
-        assert_allclose(x, y, atol=atol, rtol=rtol, equal_nan=True, err_msg=msg)
-    elif isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
-        assert x == approx(y, abs=atol, rel=rtol), msg
-    elif isinstance(x, dict):
-        assert set(x.keys()) == set(y.keys())
-        for key, x_val in x.items():
-            assert_close(x_val, y[key], atol=atol, rtol=rtol,
-                         msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
-    elif is_iterable(x) and is_iterable(y):
-        assert len(x) == len(y), msg
-        for xi, yi in zip(x, y):
+            assert_tensors_equal(actual, expected, prec, msg)
+    elif type(actual) == np.ndarray and type(expected) == np.ndarray:
+        assert_allclose(actual, expected, atol=atol, rtol=rtol, equal_nan=True, err_msg=msg)
+    elif isinstance(actual, numbers.Number) and isinstance(y, numbers.Number):
+        assert actual == approx(expected, abs=atol, rel=rtol), msg
+    elif isinstance(actual, dict):
+        assert set(actual.keys()) == set(expected.keys())
+        for key, x_val in actual.items():
+            assert_close(x_val, expected[key], atol=atol, rtol=rtol,
+                         msg='At key{}: {} vs {}'.format(key, x_val, expected[key]))
+    elif is_iterable(actual) and is_iterable(expected):
+        assert len(actual) == len(expected), msg
+        for xi, yi in zip(actual, expected):
             assert_close(xi, yi, atol=atol, rtol=rtol, msg='{} vs {}'.format(xi, yi))
     else:
-        assert x == y, msg
+        assert actual == expected, msg
 
 
 # TODO: Remove `prec` arg, and move usages to assert_close
-def assert_equal(x, y, prec=1e-5, msg=''):
+def assert_equal(actual, expected, prec=1e-5, msg=''):
     if prec > 0.:
-        return assert_close(x, y, atol=prec, msg=msg)
+        return assert_close(actual, expected, atol=prec, msg=msg)
     if not msg:
-        msg = '{} vs {}'.format(x, y)
-    if isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
-        assert x == y, msg
+        msg = '{} vs {}'.format(actual, expected)
+    if isinstance(actual, numbers.Number) and isinstance(expected, numbers.Number):
+        assert actual == expected, msg
     # Placing this as a second check allows for coercing of numeric types above;
     # this can be moved up to harden type checks.
-    elif type(x) != type(y):
-        raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
-    elif torch.is_tensor(x) and torch.is_tensor(y):
-        assert x.is_sparse == y.is_sparse, msg
-        if x.is_sparse:
-            x = _safe_coalesce(x)
-            y = _safe_coalesce(y)
+    elif type(actual) != type(expected):
+        raise AssertionError("cannot compare {} and {}".format(type(actual),
+                                                               type(expected)))
+    elif torch.is_tensor(actual) and torch.is_tensor(expected):
+        assert actual.is_sparse == expected.is_sparse, msg
+        if actual.is_sparse:
+            x = _safe_coalesce(actual)
+            y = _safe_coalesce(expected)
             assert_tensors_equal(x._indices(), y._indices(), msg=msg)
             assert_tensors_equal(x._values(), y._values(), msg=msg)
         else:
-            assert_tensors_equal(x, y, msg=msg)
-    elif type(x) == np.ndarray and type(y) == np.ndarray:
-        assert (x == y).all(), msg
-    elif isinstance(x, dict):
-        assert set(x.keys()) == set(y.keys())
-        for key, x_val in x.items():
-            assert_equal(x_val, y[key], prec=0., msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
-    elif isinstance(x, str):
-        assert x == y, msg
-    elif is_iterable(x) and is_iterable(y):
-        assert len(x) == len(y), msg
-        for xi, yi in zip(x, y):
+            assert_tensors_equal(actual, expected, msg=msg)
+    elif type(actual) == np.ndarray and type(actual) == np.ndarray:
+        assert (actual == expected).all(), msg
+    elif isinstance(actual, dict):
+        assert set(actual.keys()) == set(expected.keys())
+        for key, x_val in actual.items():
+            assert_equal(x_val, expected[key], prec=0.,
+                         msg='At key{}: {} vs {}'.format(key, x_val, expected[key]))
+    elif isinstance(actual, str):
+        assert actual == expected, msg
+    elif is_iterable(actual) and is_iterable(expected):
+        assert len(actual) == len(expected), msg
+        for xi, yi in zip(actual, expected):
             assert_equal(xi, yi, prec=0., msg='{} vs {}'.format(xi, yi))
     else:
-        assert x == y, msg
+        assert actual == expected, msg
 
 
 def assert_not_equal(x, y, prec=1e-5, msg=''):

--- a/tests/common.py
+++ b/tests/common.py
@@ -198,7 +198,9 @@ def assert_close(x, y, atol=1e-7, rtol=0, msg=''):
             assert_close(x_val, y[key], atol=atol, rtol=rtol,
                          msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
     elif is_iterable(x) and is_iterable(y):
-        assert list(x) == approx(list(y), abs=atol, rel=rtol), msg
+        assert len(x) == len(y), msg
+        for xi, yi in zip(x, y):
+            assert_close(xi, yi, atol=atol, rtol=rtol, msg='{} vs {}'.format(xi, yi))
     else:
         assert x == y, msg
 
@@ -229,11 +231,11 @@ def assert_equal(x, y, prec=1e-5, msg=''):
     elif isinstance(x, dict):
         assert set(x.keys()) == set(y.keys())
         for key, x_val in x.items():
-            assert_equal(x_val, y[key], prec=prec, msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
+            assert_equal(x_val, y[key], prec=0., msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
+    elif isinstance(x, str):
+        assert x == y, msg
     elif is_iterable(x) and is_iterable(y):
-        assert len(x) == len(y), msg
-        for xi, yi in zip(x, y):
-            assert_equal(xi, yi, prec=prec, msg=msg)
+        assert list(x) == list(y), msg
     else:
         assert x == y, msg
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -121,23 +121,27 @@ def is_iterable(obj):
         return False
 
 
-def assert_tensors_equal(a, b, prec=1e-5, msg=''):
+def assert_tensors_equal(a, b, prec=0., msg=''):
     assert a.size() == b.size(), msg
-    if prec == 0:
+    if isinstance(prec, numbers.Number) and prec == 0:
         assert (a == b).all(), msg
-    elif a.numel() > 0:
-        b = b.type_as(a)
-        b = b.cuda(device=a.get_device()) if a.is_cuda else b.cpu()
-        # check that NaNs are in the same locations
-        nan_mask = a != a
-        assert torch.equal(nan_mask, b != b), msg
-        diff = a - b
-        diff[a == b] = 0  # handle inf
-        diff[nan_mask] = 0
-        if diff.is_signed():
-            diff = diff.abs()
+    if a.numel() == 0 and b.numel() == 0:
+        return
+    b = b.type_as(a)
+    b = b.cuda(device=a.get_device()) if a.is_cuda else b.cpu()
+    # check that NaNs are in the same locations
+    nan_mask = a != a
+    assert torch.equal(nan_mask, b != b), msg
+    diff = a - b
+    diff[a == b] = 0  # handle inf
+    diff[nan_mask] = 0
+    if diff.is_signed():
+        diff = diff.abs()
+    if isinstance(prec, torch.Tensor):
+        assert (diff <= prec).all(), msg
+    else:
         max_err = diff.max().item()
-        assert max_err < prec, msg
+        assert (max_err <= prec), msg
 
 
 def _safe_coalesce(t):
@@ -165,11 +169,18 @@ def _safe_coalesce(t):
     return tg
 
 
-# TODO Split this into assert_equal() and assert_close() or assert_almost_equal().
-# TODO Use atol and rtol instead of prec
-def assert_equal(x, y, prec=1e-5, msg=''):
-    if torch.is_tensor(x) and torch.is_tensor(y):
-        assert_equal(x.is_sparse, y.is_sparse, prec, msg)
+def assert_close(x, y, atol=1e-7, rtol=0, msg=''):
+    if not msg:
+        msg = '{} vs {}'.format(x, y)
+    if isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
+        assert x == approx(y, abs=atol, rel=rtol), msg
+    # Placing this as a second check allows for coercing of numeric types above;
+    # this can be moved up to harden type checks.
+    elif type(x) != type(y):
+        raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
+    elif torch.is_tensor(x) and torch.is_tensor(y):
+        prec = atol + rtol * abs(y) if rtol > 0 else atol
+        assert x.is_sparse == y.is_sparse, msg
         if x.is_sparse:
             x = _safe_coalesce(x)
             y = _safe_coalesce(y)
@@ -178,34 +189,51 @@ def assert_equal(x, y, prec=1e-5, msg=''):
         else:
             assert_tensors_equal(x, y, prec, msg)
     elif type(x) == np.ndarray and type(y) == np.ndarray:
-        if prec == 0:
-            assert (x == y).all(), msg
-        else:
-            assert_allclose(x, y, atol=prec, equal_nan=True)
+        assert_allclose(x, y, atol=atol, rtol=rtol, equal_nan=True, err_msg=msg)
     elif isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
-        if not msg:
-            msg = '{} vs {}'.format(x, y)
-        if prec == 0:
-            assert x == y, msg
-        else:
-            assert x == approx(y, abs=prec), msg
-    elif type(x) != type(y):
-        raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
-    elif isinstance(x, str):
-        assert x == y, msg
+        assert x == approx(y, abs=atol, rel=rtol), msg
     elif isinstance(x, dict):
         assert set(x.keys()) == set(y.keys())
         for key, x_val in x.items():
-            assert_equal(x_val, y[key], prec, msg='{} {}'.format(key, msg))
+            assert_close(x_val, y[key], atol=atol, rtol=rtol,
+                         msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
     elif is_iterable(x) and is_iterable(y):
-        if prec == 0:
-            assert len(x) == len(y), msg
-            for xi, yi in zip(x, y):
-                assert_equal(xi, yi, prec, msg)
+        assert list(x) == approx(list(y), abs=atol, rel=rtol), msg
+    else:
+        assert x == y, msg
+
+
+# TODO: Remove `prec` arg, and move usages to assert_close
+def assert_equal(x, y, prec=1e-5, msg=''):
+    if prec > 0.:
+        return assert_close(x, y, atol=prec, msg=msg)
+    if not msg:
+        msg = '{} vs {}'.format(x, y)
+    if isinstance(x, numbers.Number) and isinstance(y, numbers.Number):
+        assert x == y, msg
+    # Placing this as a second check allows for coercing of numeric types above;
+    # this can be moved up to harden type checks.
+    elif type(x) != type(y):
+        raise AssertionError("cannot compare {} and {}".format(type(x), type(y)))
+    elif torch.is_tensor(x) and torch.is_tensor(y):
+        assert x.is_sparse == y.is_sparse, msg
+        if x.is_sparse:
+            x = _safe_coalesce(x)
+            y = _safe_coalesce(y)
+            assert_tensors_equal(x._indices(), y._indices(), msg=msg)
+            assert_tensors_equal(x._values(), y._values(), msg=msg)
         else:
-            if not msg:
-                msg = '{} vs {}'.format(x, y)
-            assert list(x) == approx(list(y), prec), msg
+            assert_tensors_equal(x, y, msg=msg)
+    elif type(x) == np.ndarray and type(y) == np.ndarray:
+        assert (x == y).all(), msg
+    elif isinstance(x, dict):
+        assert set(x.keys()) == set(y.keys())
+        for key, x_val in x.items():
+            assert_equal(x_val, y[key], prec=prec, msg='At key{}: {} vs {}'.format(key, x_val, y[key]))
+    elif is_iterable(x) and is_iterable(y):
+        assert len(x) == len(y), msg
+        for xi, yi in zip(x, y):
+            assert_equal(xi, yi, prec=prec, msg=msg)
     else:
         assert x == y, msg
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -235,7 +235,9 @@ def assert_equal(x, y, prec=1e-5, msg=''):
     elif isinstance(x, str):
         assert x == y, msg
     elif is_iterable(x) and is_iterable(y):
-        assert list(x) == list(y), msg
+        assert len(x) == len(y), msg
+        for xi, yi in zip(x, y):
+            assert_equal(xi, yi, prec=0., msg='{} vs {}'.format(xi, yi))
     else:
         assert x == y, msg
 

--- a/tests/distributions/test_conjugate.py
+++ b/tests/distributions/test_conjugate.py
@@ -7,7 +7,7 @@ import torch
 
 import pyro.distributions as dist
 from pyro.distributions import BetaBinomial, GammaPoisson
-from tests.common import assert_equal
+from tests.common import assert_close
 
 
 @pytest.mark.parametrize("dist", [
@@ -20,7 +20,7 @@ def test_mean(dist):
     analytic_mean = dist.mean
     num_samples = 500000
     sample_mean = dist.sample((num_samples,)).mean(0)
-    assert_equal(sample_mean, analytic_mean, prec=0.01)
+    assert_close(sample_mean, analytic_mean, atol=0.01)
 
 
 @pytest.mark.parametrize("dist", [
@@ -33,7 +33,7 @@ def test_variance(dist):
     analytic_var = dist.variance
     num_samples = 500000
     sample_var = dist.sample((num_samples,)).var(0)
-    assert_equal(sample_var, analytic_var, prec=0.01)
+    assert_close(sample_var, analytic_var, atol=0.01)
 
 
 @pytest.mark.parametrize("dist, values", [
@@ -46,7 +46,7 @@ def test_log_prob_support(dist, values):
     if values is None:
         values = dist.enumerate_support()
     log_probs = dist.log_prob(values)
-    assert_equal(log_probs.logsumexp(0), torch.tensor(0.), prec=0.01)
+    assert_close(log_probs.logsumexp(0), torch.tensor(0.), atol=0.01)
 
 
 @pytest.mark.parametrize("total_count", [1, 2, 3, 10])
@@ -62,7 +62,7 @@ def test_beta_binomial_log_prob(total_count, shape):
     expected = log_probs.logsumexp(0) - math.log(num_samples)
 
     actual = BetaBinomial(concentration1, concentration0, total_count).log_prob(value)
-    assert_equal(actual, expected, prec=0.05)
+    assert_close(actual, expected, atol=0.05)
 
 
 @pytest.mark.parametrize("shape", [(1,), (3, 1), (2, 3, 1)])
@@ -76,5 +76,4 @@ def test_gamma_poisson_log_prob(shape):
     log_probs = dist.Poisson(poisson_rate).log_prob(value)
     expected = log_probs.logsumexp(0) - math.log(num_samples)
     actual = GammaPoisson(gamma_conc, gamma_rate).log_prob(value)
-    err = (expected - actual) / expected
-    assert_equal(err, torch.zeros(expected.shape), prec=0.05)
+    assert_close(actual, expected, rtol=0.05)

--- a/tests/distributions/test_zip.py
+++ b/tests/distributions/test_zip.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from pyro.distributions import ZeroInflatedPoisson, Poisson, Delta
-from tests.common import assert_tensors_equal
+from tests.common import assert_close
 
 
 @pytest.mark.parametrize('rate', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
@@ -15,7 +15,7 @@ def test_zip_0_gate(rate):
     s = pois.sample((20,))
     zip_prob = zip_.log_prob(s)
     pois_prob = pois.log_prob(s)
-    assert_tensors_equal(zip_prob, pois_prob)
+    assert_close(zip_prob, pois_prob)
 
 
 @pytest.mark.parametrize('rate', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
@@ -26,7 +26,7 @@ def test_zip_1_gate(rate):
     s = torch.tensor([0., 1.])
     zip_prob = zip_.log_prob(s)
     delta_prob = delta.log_prob(s)
-    assert_tensors_equal(zip_prob, delta_prob)
+    assert_close(zip_prob, delta_prob)
 
 
 @pytest.mark.parametrize('gate', [0.0, 0.25, 0.5, 0.75, 1.0])
@@ -39,5 +39,5 @@ def test_zip_mean_variance(gate, rate):
     estimated_mean = s.mean()
     expected_std = zip_.stddev
     estimated_std = s.std()
-    assert_tensors_equal(expected_mean, estimated_mean, prec=1e-02)
-    assert_tensors_equal(expected_std, estimated_std, prec=1e-02)
+    assert_close(expected_mean, estimated_mean, atol=1e-02)
+    assert_close(expected_std, estimated_std, atol=1e-02)


### PR DESCRIPTION
Minor refactoring of testing utilities to:
 - introduce `assert_close` that takes in `atol`, `rtol` params like `numpy.allclose`.
 - refactor `assert_equal` to defer to `assert_close` with `prec > 0`, but do strict equality checks otherwise. This argument can be later removed once all tests that require equality testing within a certain precision threshold have been changed to use `assert_close` instead.