### PR TITLE
Fix spacing lint issues with latest version of flake8

### DIFF
--- a/pyro/util.py
+++ b/pyro/util.py
@@ -63,7 +63,7 @@ def warn_if_inf(value, msg="", allow_posinf=False, allow_neginf=False):
     also works with numbers.
     """
     if torch.is_tensor(value) and value.requires_grad:
-            value.register_hook(lambda x: warn_if_inf(x, msg, allow_posinf, allow_neginf))
+        value.register_hook(lambda x: warn_if_inf(x, msg, allow_posinf, allow_neginf))
     if (not allow_posinf) and (value == float('inf') if isinstance(value, numbers.Number)
                                else (value == float('inf')).any()):
         warnings.warn("Encountered +inf{}".format((': ' if msg else '.') + msg), stacklevel=2)

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -64,8 +64,8 @@ def test_expand(sample_shape, batch_shape, event_shape):
         with pytest.raises(ValueError):
             base_dist.to_event(len(event_shape)).expand(batch_shape)
     else:
-            expanded = base_dist.to_event(len(event_shape)).expand(batch_shape)
-            assert expanded.batch_shape == batch_shape
-            assert expanded.event_shape == (base_dist.batch_shape[len(base_dist.batch_shape) -
-                                                                  expanded.reinterpreted_batch_ndims:] +
-                                            base_dist.event_shape)
+        expanded = base_dist.to_event(len(event_shape)).expand(batch_shape)
+        assert expanded.batch_shape == batch_shape
+        assert expanded.event_shape == (base_dist.batch_shape[len(base_dist.batch_shape) -
+                                                              expanded.reinterpreted_batch_ndims:] +
+                                        base_dist.event_shape)

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -28,13 +28,13 @@ BERN_PROBS = [
 
 @pytest.mark.parametrize('probs', ONEHOT_PROBS)
 def test_onehot_shapes(probs):
-        temperature = torch.tensor(0.5)
-        probs = torch.tensor(probs, requires_grad=True)
-        d = RelaxedOneHotCategoricalStraightThrough(temperature, probs=probs)
-        sample = d.rsample()
-        log_prob = d.log_prob(sample)
-        grad_probs = grad(log_prob.sum(), [probs])[0]
-        assert grad_probs.shape == probs.shape
+    temperature = torch.tensor(0.5)
+    probs = torch.tensor(probs, requires_grad=True)
+    d = RelaxedOneHotCategoricalStraightThrough(temperature, probs=probs)
+    sample = d.rsample()
+    log_prob = d.log_prob(sample)
+    grad_probs = grad(log_prob.sum(), [probs])[0]
+    assert grad_probs.shape == probs.shape
 
 
 @pytest.mark.parametrize('temp', [0.3, 0.5, 1.0])
@@ -79,13 +79,13 @@ def test_onehot_svi_usage():
 
 @pytest.mark.parametrize('probs', BERN_PROBS)
 def test_bernoulli_shapes(probs):
-        temperature = torch.tensor(0.5)
-        probs = torch.tensor(probs, requires_grad=True)
-        d = RelaxedBernoulliStraightThrough(temperature, probs=probs)
-        sample = d.rsample()
-        log_prob = d.log_prob(sample)
-        grad_probs = grad(log_prob.sum(), [probs])[0]
-        assert grad_probs.shape == probs.shape
+    temperature = torch.tensor(0.5)
+    probs = torch.tensor(probs, requires_grad=True)
+    d = RelaxedBernoulliStraightThrough(temperature, probs=probs)
+    sample = d.rsample()
+    log_prob = d.log_prob(sample)
+    grad_probs = grad(log_prob.sum(), [probs])[0]
+    assert grad_probs.shape == probs.shape
 
 
 @pytest.mark.parametrize('temp', [0.5, 1.0])


### PR DESCRIPTION
Our lint tests started failing with the recent update of flake8 which catches some space related formatting issues (all legit). All PRs are blocked until this fix is merged into dev.