### PR TITLE
Implement sampling for von Mises distribution based on Best-Fisher algorithm

### DIFF
--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -126,13 +126,13 @@ class VonMises(TorchDistribution):
     @property
     def mean(self):
         """
-        The provided mean is the :attr:`circular` one.
+        The provided mean is the circular one.
         """
         return self.loc
 
     @property
     def variance(self):
         """
-        The provided variance is the :attr:`circular` one.
+        The provided variance is the circular one.
         """
         return self._variance

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -70,7 +70,7 @@ def _fit_params_from_samples(samples, n_iter=50):
 
     def bfgs_closure():
         bfgs.zero_grad()
-        obj = (_log_modified_bessel_fn(kappa, order=1) 
+        obj = (_log_modified_bessel_fn(kappa, order=1)
                - _log_modified_bessel_fn(kappa, order=0)).exp()
         obj = (obj - samples_r).abs()
         obj.backward()

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -66,7 +66,7 @@ class VonMises(TorchDistribution):
         event_shape = torch.Size()
 
         # Parameters for sampling
-        tau = 1 + (1 + 4 * self.concentration ** 2).sqrt() 
+        tau = 1 + (1 + 4 * self.concentration ** 2).sqrt()
         rho = (tau - (2 * tau).sqrt()) / (2 * self.concentration)
         self._proposal_r = (1 + rho ** 2) / (2 * rho)
 
@@ -96,7 +96,6 @@ class VonMises(TorchDistribution):
                 x[accept] = torch.sign(u3[accept] - 0.5) * torch.acos(f[accept])
                 done |= accept
         return (x + math.pi + self.loc) % (2 * math.pi) - math.pi
-
 
     def expand(self, batch_shape):
         try:

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -94,9 +94,11 @@ class VonMises(TorchDistribution):
 
     @torch.no_grad()
     def sample(self, sample_shape=torch.Size()):
-        # Based on:
-        # Best, D. J., and Nicholas I. Fisher.
-        # "Efficient simulation of the von Mises distribution." Applied Statistics (1979): 152-157.
+        """
+        The sampling algorithm for the von Mises distribution is based on the following paper:
+        Best, D. J., and Nicholas I. Fisher.
+        "Efficient simulation of the von Mises distribution." Applied Statistics (1979): 152-157.
+        """
         shape = self._extended_shape(sample_shape)
         x = torch.empty(shape, dtype=self.loc.dtype, device=self.loc.device)
         done = torch.zeros(shape, dtype=self.loc.dtype, device=self.loc.device).byte()

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import math
 
 import torch
+from torch import optim
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all
 
@@ -24,6 +25,9 @@ _I1_COEF_SMALL = [0.5, 0.87890594, 0.51498869, 0.15084934, 0.2658733e-1, 0.30153
 _I1_COEF_LARGE = [0.39894228, -0.3988024e-1, -0.362018e-2, 0.163801e-2, -0.1031555e-1,
                   0.2282967e-1, -0.2895312e-1, 0.1787654e-1, -0.420059e-2]
 
+_COEF_SMALL = [_I0_COEF_SMALL, _I1_COEF_SMALL]
+_COEF_LARGE = [_I0_COEF_LARGE, _I1_COEF_LARGE]
+
 
 def _log_modified_bessel_fn(x, order=0):
     """
@@ -32,22 +36,49 @@ def _log_modified_bessel_fn(x, order=0):
     """
     assert order == 0 or order == 1
 
-    small_coeff = [_I0_COEF_SMALL, _I1_COEF_SMALL]
-    large_coeff = [_I0_COEF_LARGE, _I1_COEF_LARGE]
-
     # compute small solution
     y = (x / 3.75).pow(2)
-    small = _eval_poly(y, small_coeff[order]).log()
+    small = _eval_poly(y, _COEF_SMALL[order]).log()
 
     # compute large solution
     y = 3.75 / x
-    large = x - 0.5 * x.log() + _eval_poly(y, large_coeff[order]).log()
+    large = x - 0.5 * x.log() + _eval_poly(y, _COEF_LARGE[order]).log()
 
     mask = (x < 3.75)
     result = large
     if mask.any():
         result[mask] = small[mask]
     return result
+
+
+def _fit_params_from_samples(samples, n_iter=50):
+    assert samples.dim() == 1
+    samples_count = samples.size(0)
+    samples_cs = samples.cos().sum()
+    samples_ss = samples.sin().sum()
+    mu = torch.atan2(samples_ss / samples_count, samples_cs / samples_count)
+    samples_r = (samples_cs ** 2 + samples_ss ** 2).sqrt() / samples_count
+    # From Banerjee, Arindam, et al.
+    # "Clustering on the unit hypersphere using von Mises-Fisher distributions."
+    # Journal of Machine Learning Research 6.Sep (2005): 1345-1382.
+    # By mic (https://stats.stackexchange.com/users/67168/mic),
+    # Estimating kappa of von Mises distribution, URL (version: 2015-06-12):
+    # https://stats.stackexchange.com/q/156692
+    kappa = (samples_r * 2 - samples_r ** 3) / (1 - samples_r ** 2)
+    kappa.requires_grad = True
+    bfgs = optim.LBFGS([kappa])
+
+    def bfgs_closure():
+        bfgs.zero_grad()
+        obj = (_log_modified_bessel_fn(kappa, order=1) 
+               - _log_modified_bessel_fn(kappa, order=0)).exp()
+        obj = (obj - samples_r).abs()
+        obj.backward()
+        return obj
+
+    for i in range(n_iter):
+        bfgs.step(bfgs_closure)
+    return mu, kappa.detach()
 
 
 class VonMises(TorchDistribution):

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -4,8 +4,51 @@ import math
 
 import pytest
 import torch
+from torch import optim
 
 from pyro.distributions import VonMises, VonMises3D
+from pyro.distributions.von_mises import _log_modified_bessel_fn
+
+
+def _fit_params_from_samples(samples, n_iter=50):
+    assert samples.dim() == 1
+    samples_count = samples.size(0)
+    samples_cs = samples.cos().sum()
+    samples_ss = samples.sin().sum()
+    mu = torch.atan2(samples_ss / samples_count, samples_cs / samples_count)
+    samples_r = (samples_cs ** 2 + samples_ss ** 2).sqrt() / samples_count
+    # From Banerjee, Arindam, et al.
+    # "Clustering on the unit hypersphere using von Mises-Fisher distributions."
+    # Journal of Machine Learning Research 6.Sep (2005): 1345-1382.
+    # By mic (https://stats.stackexchange.com/users/67168/mic),
+    # Estimating kappa of von Mises distribution, URL (version: 2015-06-12):
+    # https://stats.stackexchange.com/q/156692
+    kappa = (samples_r * 2 - samples_r ** 3) / (1 - samples_r ** 2)
+    lr = 1e-2
+    kappa.requires_grad = True
+    bfgs = optim.LBFGS([kappa], lr=lr)
+
+    def bfgs_closure():
+        bfgs.zero_grad()
+        obj = (_log_modified_bessel_fn(kappa, order=1)
+               - _log_modified_bessel_fn(kappa, order=0)).exp()
+        obj = (obj - samples_r).abs()
+        obj.backward()
+        return obj
+
+    for i in range(n_iter):
+        bfgs.step(bfgs_closure)
+    return mu, kappa.detach()
+
+
+@pytest.mark.parametrize('loc', [-math.pi/2.0, 0.0, math.pi/2.0])
+@pytest.mark.parametrize('concentration', [0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0])
+def test_sample(loc, concentration, n_samples=int(1e6), n_iter=100):
+    prob = VonMises(loc, concentration)
+    samples = prob.sample((n_samples,))
+    mu, kappa = _fit_params_from_samples(samples)
+    assert abs(loc - mu) < 0.1
+    assert abs(concentration - kappa) < concentration / 5.0
 
 
 @pytest.mark.parametrize('concentration', [0.01, 0.03, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0])


### PR DESCRIPTION
Hi Pyro Devs!

I have tried to implement sampling for the von Mises distribution based on the algorithm by Best and Fisher that is referenced in the comments.
I have marked this as WIP since I have two aspects I would like to improve on:
* The algorithm is a rejection sampling based one, but it seems that I can't make it fit `Rejector` obviously, since the probability of the resulting sample being accepted is defined independently from the sample itself. Did I miss something that could have made this possible?
* I would like to test the sampling part of the distribution, do you have any recommendations?

Thanks!