### PR TITLE
Minor fixes for progress bar for MCMC diagnostics

### DIFF
--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -4,7 +4,8 @@ import os
 import sys
 from collections import OrderedDict
 
-from tqdm.auto import tqdm
+from tqdm import tqdm
+from tqdm.auto import tqdm as tqdm_nb
 
 try:
     get_ipython
@@ -38,22 +39,72 @@ DIAGNOSTIC_MSG = "DIAGNOSTICS"
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-# TODO: Remove once https://github.com/tqdm/tqdm/issues/650 is resolved.
-class ProgressBar(tqdm):
-    def __init__(self, *args, **kwargs):
-        super(ProgressBar, self).__init__(*args, **kwargs)
+class ProgressBar(object):
+    """
+    Initialize progress bars using :class:`~tqdm.tqdm`.
+
+    :param int warmup_steps: Number of warmup steps.
+    :param int num_samples: Number of MCMC samples.
+    :param int min_width: Minimum column width of the bar.
+    :param int max_width: Maximum column width of the bar.
+    :param int pos: Position of the bar (e.g. in the case of
+        multiple parallel samplers).
+    :param bool disable: Disable progress bar.
+    :param int num_bars: Number of progress bars to initialize.
+        If multiple bars are initialized, they need to be separately
+        updated via the ``pos`` kwarg.
+    """
+    def __init__(self, warmup_steps, num_samples, min_width=80, max_width=120,
+                 disable=False, num_bars=1):
+        total_steps = warmup_steps + num_samples
+        # Disable progress bar in "CI"
+        # (see https://github.com/travis-ci/travis-ci/issues/1337).
+        disable = disable or "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
+        bar_format = None
+        if not ipython_env:
+            bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"
+        pbar_cls = tqdm_nb if num_bars > 1 and ipython_env else tqdm
+        self.progress_bars = []
+        for i in range(num_bars):
+            description = "Warmup" if num_bars == 1 else "Warmup [{}]".format(i + 1)
+            pbar = pbar_cls(total=total_steps, desc=description, bar_format=bar_format,
+                            position=i, file=sys.stderr, disable=disable)
+            # Assume reasonable values when terminal width not available
+            if getattr(pbar, "ncols", None) is not None:
+                pbar.ncols = max(min_width, pbar.ncols)
+                pbar.ncols = min(max_width, pbar.ncols)
+            self.progress_bars.append(pbar)
+        self.disable = disable
+        self.ipython_env = ipython_env
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
 
     def set_description(self, *args, **kwargs):
+        pos = kwargs.pop("pos", 0)
         if not self.disable:
-            super(ProgressBar, self).set_description(*args, **kwargs)
+            self.progress_bars[pos].set_description(*args, **kwargs)
 
     def set_postfix(self, *args, **kwargs):
+        pos = kwargs.pop("pos", 0)
         if not self.disable:
-            super(ProgressBar, self).set_postfix(*args, **kwargs)
+            self.progress_bars[pos].set_postfix(*args, **kwargs)
 
     def update(self, *args, **kwargs):
+        pos = kwargs.pop("pos", 0)
         if not self.disable:
-            super(ProgressBar, self).update(*args, **kwargs)
+            self.progress_bars[pos].update(*args, **kwargs)
+
+    def close(self):
+        for pbar in self.progress_bars:
+            pbar.close()
+        # Required to not overwrite multiple progress bars on exit.
+        if not self.ipython_env and not self.disable:
+            sys.stderr.write("\n" * len(self.progress_bars))
 
 
 class QueueHandler(logging.Handler):
@@ -175,37 +226,6 @@ class MetadataFilter(logging.Filter):
         if not getattr(record, "msg_type", None):
             record.msg_type = LOG_MSG
         return True
-
-
-def initialize_progbar(warmup_steps, num_samples, min_width=80, max_width=120, pos=None,
-                       disable=False):
-    """
-    Initialize progress bar using :class:`~tqdm.tqdm`.
-
-    :param int warmup_steps: Number of warmup steps.
-    :param int num_samples: Number of MCMC samples.
-    :param int min_width: Minimum column width of the bar.
-    :param int max_width: Maximum column width of the bar.
-    :param int pos: Position of the bar (e.g. in the case of
-        multiple parallel samplers).
-    :param bool disable: Disable progress bar.
-    """
-    description = "Warmup" if pos is None else "Warmup [{}]".format(pos + 1)
-    total_steps = warmup_steps + num_samples
-    # Disable progress bar in "CI"
-    # (see https://github.com/travis-ci/travis-ci/issues/1337).
-    disable = disable or "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
-    bar_format = None
-    if not ipython_env:
-        bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"
-    progress_bar = ProgressBar(total=total_steps, desc=description, bar_format=bar_format,
-                               position=pos, file=sys.stderr, disable=disable)
-    progress_bar._ipython_env = ipython_env
-
-    if getattr(progress_bar, "ncols", None) is not None:
-        progress_bar.ncols = max(min_width, progress_bar.ncols)
-        progress_bar.ncols = min(max_width, progress_bar.ncols)
-    return progress_bar
 
 
 def initialize_logger(logger, logger_id, progress_bar=None, log_queue=None):

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -47,8 +47,6 @@ class ProgressBar(object):
     :param int num_samples: Number of MCMC samples.
     :param int min_width: Minimum column width of the bar.
     :param int max_width: Maximum column width of the bar.
-    :param int pos: Position of the bar (e.g. in the case of
-        multiple parallel samplers).
     :param bool disable: Disable progress bar.
     :param int num_bars: Number of progress bars to initialize.
         If multiple bars are initialized, they need to be separately


### PR DESCRIPTION
Refactoring of mcmc progress bar logging with the following changes:
 - Fixes #1728 - Uses `tqdm` instead of the more experimental ipywidget based implementation in all situations unless we are using multiprocessing in the notebook environment.
 - Fixes an issue with progress bars getting over-written when `.close()` is called.
 - Simplifies the code for single / multi progress bars by moving all of them into a single class that maintains its own tqdm instance (or multiple instances when `num_chains > 1`) under the hood. Given the number of behavioral overrides we had made to tqdm, this consolidates all of those tweaks into a single class.

**In the notebook env with:**

num_chains = 1
<img width="835" alt="screen shot 2019-02-07 at 11 16 27 pm" src="https://user-images.githubusercontent.com/1762463/52464291-18244c00-2b2f-11e9-8aa5-226cd5d75b82.png">

num_chains = 2
<img width="788" alt="screen shot 2019-02-07 at 11 16 47 pm" src="https://user-images.githubusercontent.com/1762463/52464296-1c506980-2b2f-11e9-9fda-5f76dd754a42.png">

