### PR TITLE
Update README with links to the new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 -----------------------------------------
 
-[![Build Status](https://travis-ci.org/uber/pyro.svg?branch=dev)](https://travis-ci.org/uber/pyro)
-[![codecov.io](https://codecov.io/github/uber/pyro/branch/dev/graph/badge.svg)](https://codecov.io/github/uber/pyro)
+[![Build Status](https://travis-ci.org/pyro-ppl/pyro.svg?branch=dev)](https://travis-ci.org/uber/pyro)
+[![codecov.io](https://codecov.io/github/pyro-ppl/pyro/branch/dev/graph/badge.svg)](https://codecov.io/github/uber/pyro)
 [![Latest Version](https://badge.fury.io/py/pyro-ppl.svg)](https://pypi.python.org/pypi/pyro-ppl)
 [![Documentation Status](https://readthedocs.org/projects/pyro-ppl/badge/?version=dev)](http://pyro-ppl.readthedocs.io/en/stable/?badge=dev)
 
@@ -13,7 +13,7 @@
 [Getting Started](http://pyro.ai/examples) |
 [Documentation](http://docs.pyro.ai/) |
 [Community](http://forum.pyro.ai/) |
-[Contributing](https://github.com/uber/pyro/blob/master/CONTRIBUTING.md)
+[Contributing](https://github.com/pyro-ppl/pyro/blob/master/CONTRIBUTING.md)
 
 Pyro is a flexible, scalable deep probabilistic programming library built on PyTorch.  Notably, it was designed with these principles in mind:
 - **Universal**: Pyro is a universal PPL -- it can represent any computable probability distribution.
@@ -36,7 +36,7 @@ pip install pyro-ppl
 
 **Install from source:**
 ```sh
-git clone git@github.com:uber/pyro.git
+git clone git@github.com:pyro-ppl/pyro.git
 cd pyro
 git checkout master  # master is pinned to the latest release
 pip install .
@@ -48,7 +48,7 @@ To install the dependencies required to run the probabilistic models included in
 ```sh
 pip install pyro-ppl[extras] 
 ```
-Make sure that the models come from the same release version of the [Pyro source code](https://github.com/uber/pyro/releases) as you have installed.
+Make sure that the models come from the same release version of the [Pyro source code](https://github.com/pyro-ppl/pyro/releases) as you have installed.
 
 ### Installing Pyro dev branch
 
@@ -57,18 +57,18 @@ For recent features you can install Pyro from source.
 **Install using pip:**
 
 ```sh
-pip install git+https://github.com/uber/pyro.git
+pip install git+https://github.com/pyro-ppl/pyro.git
 ```
 
 or, with the `extras` dependency to run the probabilistic models included in the `examples`/`tutorials` directories:
 ```sh
-pip install git+https://github.com/uber/pyro.git#egg=project[extras]
+pip install git+https://github.com/pyro-ppl/pyro.git#egg=project[extras]
 ```
 
 **Install from source:**
 
 ```sh
-git clone https://github.com/uber/pyro
+git clone https://github.com/pyro-ppl/pyro
 cd pyro
 pip install .  # pip install .[extras] for running models in examples/tutorials
 ```


### PR DESCRIPTION
While most links redirect, I noticed this because our build badge is broken.