### PR TITLE
Fix version string for release tagged commits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,12 @@ for line in open(os.path.join(PROJECT_PATH, 'pyro', '__init__.py')):
 # Append current commit sha to version
 commit_sha = ''
 try:
-    commit_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
-                                         cwd=PROJECT_PATH).decode('ascii').strip()
+    current_tag = subprocess.check_output(['git', 'tag', '--points-at', 'HEAD'],
+                                          cwd=PROJECT_PATH).decode('ascii').strip()
+    # only add sha if HEAD does not point to the release tag
+    if not current_tag == version:
+        commit_sha = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
+                                             cwd=PROJECT_PATH).decode('ascii').strip()
 except OSError:
     pass
 


### PR DESCRIPTION
We have a sha id that gets appended to the version string to make it easier to collect debug information, specially when users are using Pyro's dev branch. This however also appends the sha id when HEAD is pointing to a release tag, which doesn't play well when we want to upload to pypi. This adds a fix so that if HEAD points to a release tag no sha id is appended to the version string.

@fritzo - Let me know if this seems reasonable, I don't want to unwittingly introduce other complications. 😄 