### PR TITLE
Ignore ipynb_checkpoints for flake8 and isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ known_third_party = opt_einsum, six, torch, torchvision
 [tool:pytest]
 filterwarnings = error
     ignore::DeprecationWarning
+    once::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,16 @@
 [flake8]
 max-line-length = 120
-exclude = docs/src, build, dist
+exclude = docs/src, build, dist, .ipynb_checkpoints
 
 [isort]
 line_length = 120
 not_skip = __init__.py
+skip_glob = .ipynb_checkpoints
 known_first_party = pyro, tests
 known_third_party = opt_einsum, six, torch, torchvision
 
 [tool:pytest]
 filterwarnings = error
-    ignore::DeprecationWarning
     once::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ known_third_party = opt_einsum, six, torch, torchvision
 
 [tool:pytest]
 filterwarnings = error
-    once::DeprecationWarning
+    ignore::DeprecationWarning
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 


### PR DESCRIPTION
I mainly use jupyterlab for writing scripts/editing files, which leaves many `.ipynb_checkpoints` folders. On the other hand, `flake8` and `isort` act on all files including files in `ipynb_checkpoints` folders. This PR adds ipynb_checkpoints exceptions for these tools.