### PR TITLE
Correct egg info file in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,6 @@ test-jit: FORCE
 		-k JIT=True | tee -a jit.log
 
 clean: FORCE
-	git clean -dfx -e pyro-egg.info
+	git clean -dfx -e pyro_ppl.egg-info
 
 FORCE:


### PR DESCRIPTION
I'm not sure if the egg info filename is consistence with various platforms, but in my linux system, it has the name is `pyro_ppl.egg-info`.

@neerajprad Could you please check the name of egg-info in Mac?