### PR TITLE
Subsample pyro.param inside plate if event_dim is given

### DIFF
--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -183,7 +183,7 @@ class ParamStoreDict(object):
         assert self._params[param_name] is old_param.unconstrained()
         self[param_name] = new_param
 
-    def get_param(self, name, init_tensor=None, constraint=constraints.real):
+    def get_param(self, name, init_tensor=None, constraint=constraints.real, event_dim=None):
         """
         Get parameter from its name. If it does not yet exist in the
         ParamStore, it will be created and stored.
@@ -195,6 +195,7 @@ class ParamStoreDict(object):
         :type init_tensor: torch.Tensor
         :param constraint: torch constraint
         :type constraint: torch.distributions.constraints.Constraint
+        :param int event_dim: (ignored)
         :returns: parameter
         :rtype: torch.Tensor
         """

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -184,7 +184,7 @@ class ParamStoreDict(object):
         self[param_name] = new_param
 
     def get_param(self, name, init_tensor=None, constraint=constraints.real):
-        r"""
+        """
         Get parameter from its name. If it does not yet exist in the
         ParamStore, it will be created and stored.
         The Pyro primitive `pyro.param` dispatches to this method.

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -184,7 +184,7 @@ class ParamStoreDict(object):
         self[param_name] = new_param
 
     def get_param(self, name, init_tensor=None, constraint=constraints.real):
-        """
+        r"""
         Get parameter from its name. If it does not yet exist in the
         ParamStore, it will be created and stored.
         The Pyro primitive `pyro.param` dispatches to this method.

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import torch
 
 from pyro.distributions.distribution import Distribution
+from pyro.poutine.util import is_validation_enabled
 from pyro.util import ignore_jit_warnings, jit_compatible_arange
 
 from .indep_messenger import CondIndepStackFrame, IndepMessenger
@@ -130,9 +131,18 @@ class SubsampleMessenger(IndepMessenger):
         msg["scale"] = msg["scale"] * self.size / self.subsample_size
 
     def _postprocess_message(self, msg):
-        if msg["type"] == "param" and self.subsample_size < self.size:
-            # Subsample parameters with known batch semantics.
+        if msg["type"] == "param":
             event_dim = msg["kwargs"].get("event_dim")
             if event_dim is not None:
-                assert event_dim >= 0
-                msg["value"] = msg["value"].index_select(self.dim - event_dim, self._indices)
+                dim = self.dim - event_dim
+                shape = msg["value"].shape
+                if len(shape) >= -dim and shape[dim] != 1:
+                    if is_validation_enabled() and shape[dim] != self.size:
+                        raise ValueError(
+                            "Inside pyro.plate({}, {}, dim={}) "
+                            "invalid shape of pyro.param({}, ..., event_dim={}): {}"
+                            .format(self.name, self.size, self.dim, msg["name"], event_dim, shape))
+                    # Subsample parameters with known batch semantics.
+                    if self.subsample_size < self.size:
+                        assert event_dim >= 0
+                        msg["value"] = msg["value"].index_select(dim, self._indices)

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -131,7 +131,7 @@ class SubsampleMessenger(IndepMessenger):
         msg["scale"] = msg["scale"] * self.size / self.subsample_size
 
     def _postprocess_message(self, msg):
-        if msg["type"] == "param":
+        if msg["type"] == "param" and self.dim is not None:
             event_dim = msg["kwargs"].get("event_dim")
             if event_dim is not None:
                 dim = self.dim - event_dim

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -134,6 +134,7 @@ class SubsampleMessenger(IndepMessenger):
         if msg["type"] == "param" and self.dim is not None:
             event_dim = msg["kwargs"].get("event_dim")
             if event_dim is not None:
+                assert event_dim >= 0
                 dim = self.dim - event_dim
                 shape = msg["value"].shape
                 if len(shape) >= -dim and shape[dim] != 1:
@@ -144,5 +145,4 @@ class SubsampleMessenger(IndepMessenger):
                             .format(self.name, self.size, self.dim, msg["name"], event_dim, shape))
                     # Subsample parameters with known batch semantics.
                     if self.subsample_size < self.size:
-                        assert event_dim >= 0
                         msg["value"] = msg["value"].index_select(dim, self._indices)

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -30,7 +30,10 @@ def clear_param_store():
     return _PYRO_PARAM_STORE.clear()
 
 
-_param = effectful(_PYRO_PARAM_STORE.get_param, type="param")
+@effectful(type="param")
+def _param(name, **kwargs):
+    kwargs.pop('event_dim', None)
+    return _PYRO_PARAM_STORE.get_param(name, **kwargs)
 
 
 def param(name, *args, **kwargs):
@@ -43,7 +46,9 @@ def param(name, *args, **kwargs):
     :returns: parameter
     """
     kwargs["name"] = name
-    return _param(name, *args, **kwargs)
+    # Convert args to kwargs to make it easier for handlers to inspect.
+    kwargs.update(zip(('init_tensor', 'constraint', 'event_dim'), args))
+    return _param(name, **kwargs)
 
 
 def sample(name, fn, *args, **kwargs):

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -30,10 +30,7 @@ def clear_param_store():
     return _PYRO_PARAM_STORE.clear()
 
 
-@effectful(type="param")
-def _param(name, **kwargs):
-    kwargs.pop('event_dim', None)
-    return _PYRO_PARAM_STORE.get_param(name, **kwargs)
+_param = effectful(_PYRO_PARAM_STORE.get_param, type="param")
 
 
 def param(name, *args, **kwargs):
@@ -60,9 +57,7 @@ def param(name, *args, **kwargs):
     :rtype: torch.Tensor
     """
     kwargs["name"] = name
-    # Convert args to kwargs to make it easier for handlers to inspect.
-    kwargs.update(zip(('init_tensor', 'constraint', 'event_dim'), args))
-    return _param(name, **kwargs)
+    return _param(name, *args, **kwargs)
 
 
 def sample(name, fn, *args, **kwargs):

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -42,8 +42,22 @@ def param(name, *args, **kwargs):
     To interact with the param store or write to disk,
     see `Parameters <parameters.html>`_.
 
-    :param name: name of parameter
+    :param str name: name of parameter
+    :param init_tensor: initial tensor or lazy callable that returns a tensor.
+        For large tensors, it may be cheaper to write e.g.
+        ``lambda: torch.randn(100000)``, which will only be evaluated on the
+        initial statement.
+    :type init_tensor: torch.Tensor or callable
+    :param constraint: torch constraint, defaults to ``constraints.real``.
+    :type constraint: torch.distributions.constraints.Constraint
+    :param int event_dim: (optional) number of rightmost dimensions unrelated
+        to baching. Dimension to the left of this will be considered batch
+        dimensions; if the param statement is inside a subsampled plate, then
+        corresponding batch dimensions of the parameter will be correspondingly
+        subsampled. If unspecified, all dimensions will be considered event
+        dims and no subsampling will be performed.
     :returns: parameter
+    :rtype: torch.Tensor
     """
     kwargs["name"] = name
     # Convert args to kwargs to make it easier for handlers to inspect.

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -48,11 +48,10 @@ def test_subsample_gradient(Elbo, reparameterized, subsample, local_samples, sca
             pyro.sample("x", Normal(z, 1), obs=x)
 
     def guide(subsample):
-        loc = pyro.param("loc", lambda: torch.zeros(len(data), requires_grad=True))
-        scale = pyro.param("scale", lambda: torch.tensor([1.0], requires_grad=True))
-        with pyro.plate("data", len(data), subsample_size, subsample) as ind:
-            loc_ind = loc[ind]
-            pyro.sample("z", Normal(loc_ind, scale))
+        scale = pyro.param("scale", lambda: torch.tensor([1.0]))
+        with pyro.plate("data", len(data), subsample_size, subsample):
+            loc = pyro.param("loc", lambda: torch.zeros(len(data)), event_dim=0)
+            pyro.sample("z", Normal(loc, scale))
 
     if scale != 1.0:
         model = poutine.scale(model, scale=scale)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -503,22 +503,21 @@ def test_nested_plate_plate_dim_error_4(Elbo):
 def test_nested_plate_plate_subsample_param_ok(Elbo):
 
     def model():
-        p = torch.tensor(0.5, requires_grad=True)
-        with pyro.plate("plate_outer", 10, 5) as ind_outer:
+        with pyro.plate("plate_outer", 10, 5):
             pyro.sample("x", dist.Bernoulli(0.2))
-            with pyro.plate("plate_inner", 11, 6) as ind_inner:
+            with pyro.plate("plate_inner", 11, 6):
                 pyro.sample("y", dist.Bernoulli(0.2))
 
     def guide():
         p0 = pyro.param("p0", 0.5 * torch.ones(4, 5), event_dim=2)
         assert p0.shape == (4, 5)
-        with pyro.plate("plate_outer", 10, 5) as ind_outer:
+        with pyro.plate("plate_outer", 10, 5):
             p1 = pyro.param("p1", 0.5 * torch.ones(10, 3), event_dim=1)
             assert p1.shape == (5, 3)
             px = pyro.param("px", 0.5 * torch.ones(10), event_dim=0)
             assert px.shape == (5,)
             pyro.sample("x", dist.Bernoulli(px))
-            with pyro.plate("plate_inner", 11, 6) as ind_inner:
+            with pyro.plate("plate_inner", 11, 6):
                 py = pyro.param("py", 0.5 * torch.ones(11, 10), event_dim=0)
                 assert py.shape == (6, 5)
                 pyro.sample("y", dist.Bernoulli(py))


### PR DESCRIPTION
Fixes #238 

This adds a new optional kwarg `event_dim` to `pyro.param` statements. If `event_dim` is not specified, previous behavior is preserved i.e. all dims are considered event dims.

When `event_dim` is specified (e.g. 0, 1, 2), dims to the left are considered batch dims. When a param statement occurs inside a `pyro.plate`, the `event_dim` argument gives Pyro enough information to subsample the parameters (via `.index_select(plate.dim - event_dim, plate.ind)`).

This PR also anticipates named dimensions (possibly coming in PyTorch 1.2). By specifying `event_dim`, Pyro will have enough information to annotate plate names to the dims of a param tensor.

## Tested
- [x] tests of shape in test_valid_models.py
- [x] updated test_gradients.py to use this slick new syntax
- [x] add test of shape error