### PR TITLE
Run without raising exceptions when HMC contains no stochastic site

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -4,7 +4,6 @@ import math
 from collections import OrderedDict
 
 import torch
-from torch import tensor
 from torch.distributions import biject_to, constraints
 
 import pyro

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -156,7 +156,7 @@ class HMC(TraceKernel):
 
     def _kinetic_energy(self, r):
         r_flat = torch.cat([r[site_name].reshape(-1) for site_name in sorted(r)]) if r \
-            else torch.tensor([])
+            else 0.
         if self.inverse_mass_matrix.dim() == 2:
             return 0.5 * self.inverse_mass_matrix.matmul(r_flat).dot(r_flat)
         else:

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -270,6 +270,11 @@ class NUTS(HMC):
 
     def sample(self, trace):
         z, potential_energy, z_grads = self._fetch_from_cache()
+        # return early if no sample sites
+        if not z:
+            self._accept_cnt += 1
+            self._t += 1
+            return self._get_trace(z)
         r, r_flat = self._sample_r(name="r_t={}".format(self._t))
         energy_current = self._kinetic_energy(r) + potential_energy
 

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -12,7 +12,7 @@ from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.mcmc import MCMC, _SingleSampler, _ParallelSampler
 from pyro.infer.mcmc.trace_kernel import TraceKernel
 from pyro.util import optional
-from tests.common import assert_equal
+from tests.common import assert_equal, skipif_param
 
 
 class PriorKernel(TraceKernel):
@@ -58,7 +58,7 @@ def test_mcmc_interface():
 
 @pytest.mark.parametrize("num_chains", [
     1,
-    pytest.param(2, marks=[pytest.mark.skipif("CI" in os.environ, reason="CI only provides 1 CPU")])
+    skipif_param(2, condition="CI" in os.environ, reason="CI only provides 1 CPU"),
 ])
 def test_mcmc_diagnostics(num_chains):
     data = torch.tensor([2.0]).repeat(3)
@@ -98,7 +98,10 @@ def _empty_model():
     (NUTS, _empty_model),
 ])
 @pytest.mark.parametrize("jit", [False, True])
-@pytest.mark.parametrize("num_chains", [1, 2])
+@pytest.mark.parametrize("num_chains", [
+    1,
+    skipif_param(2, condition="CI" in os.environ, reason="CI only provides 1 CPU")
+])
 def test_empty_sample_sites(kernel, kernel_args, jit, num_chains):
     num_warmup, num_samples = 10, 10
     kern = kernel(kernel_args, jit_compile=jit)

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -90,7 +90,7 @@ def test_num_chains(num_chains, cpu_count, monkeypatch):
 
 
 def _empty_model():
-    return torch.ones([])
+    return torch.tensor(1)
 
 
 @pytest.mark.parametrize("kernel, kernel_args", [


### PR DESCRIPTION
This makes sure that when HMC is presented with a model that does not contain stochastic sites, it simply returns the trace without throwing any exceptions. Many parts of our code however were designed with the assumption that there is at least a single stochastic site.

This situation can arise when we use conjugate distributions and collapse the latent site. In such cases, models with a single latent variable might have no latent variable when the model is wrapped with a handler that collapses such sites. 