### PR TITLE
Adding support for exact inference in HMC with conjugate pairs

### DIFF
--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -45,7 +45,6 @@ class _BetaBinomial(dist.BetaBinomial):
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(_BetaBinomial, _instance)
         new.parent = self.parent
-        self.parent._conditional = self
         return super(_BetaBinomial, self).expand(batch_shape, _instance=new)
 
 

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -7,7 +7,20 @@ from pyro.poutine.messenger import Messenger
 from pyro.poutine.replay_messenger import ReplayMessenger
 
 
-def _make_cls(base, class_attrs, instance_attrs, parent_linkage=None):
+def _make_cls(base, static_attrs, instance_attrs, parent_linkage=None):
+    r"""
+    Dynamically create classes named `_ + base.__name__`, which extend the
+    base class with other optional instance and class attributes, and have
+    a custom `.expand` method to propagate these attributes on expanded
+    instances.
+
+    :param cls base: Base class.
+    :param dict static_attrs: static attributes to add to class.
+    :param dict instance_attrs: instance attributes for initialization.
+    :param str parent_linkage: attribute in the parent class that holds
+        a reference to the distribution class.
+    :return cls: dynamically generated class.
+    """
     def _expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(cls, _instance)
         for attr in instance_attrs:
@@ -18,7 +31,7 @@ def _make_cls(base, class_attrs, instance_attrs, parent_linkage=None):
 
     name = "_" + base.__name__
     cls = type(name, (base,), instance_attrs)
-    for k, v in class_attrs.items():
+    for k, v in static_attrs.items():
         setattr(cls, k, v)
     cls.expand = _expand
     return cls

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -64,7 +64,6 @@ class BetaBinomialPair(object):
         concentration0 = self._latent.concentration0
         total_count = self._conditional.total_count
         reduce_dims = len(obs.size()) - len(concentration1.size())
-        num_obs = obs.shape[:reduce_dims].numel()
         # Unexpand total_count to have the same shape as concentration0.
         # Raise exception if this isn't possible.
         total_count = sum_leftmost(total_count, reduce_dims)

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -1,0 +1,114 @@
+from functools import reduce
+from operator import mul
+
+import pyro.distributions as dist
+from pyro.distributions.util import sum_leftmost
+from pyro.poutine.messenger import Messenger
+from pyro.poutine.replay_messenger import ReplayMessenger
+
+
+class _LatentBeta(dist.Beta):
+    collapsible = True
+
+    def __init__(self, parent, *args, **kwargs):
+        self.parent = parent
+        super(_LatentBeta, self).__init__(*args, **kwargs)
+
+
+class _CondBinomial(dist.Binomial):
+    marginalize_latent = True
+
+    def __init__(self, parent, probs, **kwargs):
+        self.parent = parent
+        self.latent_param = probs
+        super(_CondBinomial, self).__init__(probs=probs, **kwargs)
+
+
+class BetaBinomialConjugate(object):
+    def __init__(self):
+        self._latent = None
+        self._conditioned = None
+        self.cond_kwargs = {}
+
+    def latent(self, *args, **kwargs):
+        self._latent = _LatentBeta(self, *args, **kwargs)
+        return self._latent
+
+    def conditioned(self, probs, **kwargs):
+        self.cond_kwargs = kwargs
+        self._conditioned = _CondBinomial(self, probs, **kwargs)
+        return self._conditioned
+
+    def posterior(self, obs):
+        concentration1 = self._latent.concentration1
+        concentration0 = self._latent.concentration0
+        total_count = self.cond_kwargs["total_count"]
+        reduce_dims = len(obs.size()) - len(concentration1.size())
+        num_obs = reduce(mul, obs.size()[:reduce_dims], 1)
+        total_count = total_count[tuple(slice(1) if i < reduce_dims else slice(None)
+                                  for i in range(total_count.dim()))].reshape(concentration0.shape)
+        summed_obs = sum_leftmost(obs, reduce_dims)
+        return dist.Beta(concentration1 + summed_obs,
+                         num_obs * total_count + concentration0 - summed_obs,
+                         validate_args=self._latent._validate_args)
+
+    def compound(self):
+        return dist.BetaBinomial(concentration1=self._latent.concentration1,
+                                 concentration0=self._latent.concentration0,
+                                 total_count=self._conditioned.total_count)
+
+
+class UncollapseConjugateMessenger(ReplayMessenger):
+    r"""
+    Extends `~pyro.poutine.replay_messenger.ReplayMessenger` to uncollapse
+    compound distributions. Note that if the original collapsed observed site
+    was named "x", it is replaced with a sample site named "x.latent" followed
+    by an observed site name "x.predictive".
+    """
+    def _pyro_sample(self, msg):
+        is_collapsible = getattr(msg["fn"], "collapsible", False)
+        if is_collapsible:
+            conj_node = self.trace.nodes[msg["name"]]["fn"].parent
+            for site_name in self.trace.observation_nodes:
+                obs_parent = getattr(self.trace.nodes[site_name]["fn"], "parent")
+                if obs_parent == conj_node:
+                    observed_node = self.trace.nodes[site_name]
+                    break
+            msg["fn"] = conj_node.posterior(observed_node["value"])
+            msg["value"] = msg["fn"].sample()
+        else:
+            return super(UncollapseConjugateMessenger, self)._pyro_sample(msg)
+
+
+def uncollapse_conjugate(fn=None, trace=None, params=None):
+    r"""
+    This extends the behavior of :function:`~pyro.poutine.replay` poutine, so that in
+    addition to replaying the values at sample sites from the ``trace`` in the
+    original callable ``fn`` when the same sites are sampled, this also "uncollapses"
+    any observed compound distributions (defined in :module:`pyro.distributions.conjugate`)
+    by sampling the originally collapsed parameter values from its posterior distribution
+    followed by observing the data with the sampled parameter values.
+    """
+    msngr = UncollapseConjugateMessenger(trace, params)
+    return msngr(fn) if fn is not None else msngr
+
+
+class CollapseConjugateMessenger(Messenger):
+    def _pyro_sample(self, msg):
+        is_collapsible = getattr(msg["fn"], "collapsible", False)
+        marginalize_latent = getattr(msg["fn"], "marginalize_latent", False)
+        if is_collapsible:
+            msg["stop"] = True
+        elif marginalize_latent:
+            msg["fn"] = msg["fn"].parent.compound()
+        else:
+            return
+
+
+def collapse_conjugate(fn=None):
+    r"""
+    This simply collapses (removes from the trace) and sample sites that have
+    `collapse=True` set in their `infer` config.
+    """
+    msngr = CollapseConjugateMessenger()
+    return msngr(fn) if fn is not None else msngr

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -1,6 +1,3 @@
-from functools import reduce
-from operator import mul
-
 import pyro.distributions as dist
 from pyro.distributions.util import sum_leftmost
 from pyro.poutine.messenger import Messenger
@@ -67,7 +64,7 @@ class BetaBinomialPair(object):
         concentration0 = self._latent.concentration0
         total_count = self._conditional.total_count
         reduce_dims = len(obs.size()) - len(concentration1.size())
-        num_obs = reduce(mul, obs.size()[:reduce_dims], 1)
+        num_obs = obs.shape[:reduce_dims].numel()
         # Unexpand total_count to have the same shape as concentration0.
         # Raise exception if this isn't possible.
         total_count = total_count[tuple(slice(None) if stride else slice(1)
@@ -105,7 +102,7 @@ class GammaPoissonPair(object):
         concentration = self._latent.concentration
         rate = self._latent.rate
         reduce_dims = len(obs.size()) - len(rate.size())
-        num_obs = reduce(mul, obs.size()[:reduce_dims], 1)
+        num_obs = obs.shape[:reduce_dims].numel()
         summed_obs = sum_leftmost(obs, reduce_dims)
         return dist.Gamma(concentration + summed_obs, rate + num_obs)
 

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -67,16 +67,10 @@ class BetaBinomialPair(object):
         num_obs = obs.shape[:reduce_dims].numel()
         # Unexpand total_count to have the same shape as concentration0.
         # Raise exception if this isn't possible.
-        total_count = total_count[tuple(slice(None) if stride else slice(1)
-                                  for stride in total_count.stride())]
-        try:
-            total_count = total_count.reshape(concentration0.shape)
-        except RuntimeError:
-            raise ValueError("`total_count.dim() = {}` cannot be unexpanded to `concentration0.dim() = {}`."
-                             .format(total_count.dim(), concentration0.dim()))
+        total_count = sum_leftmost(total_count, reduce_dims)
         summed_obs = sum_leftmost(obs, reduce_dims)
         return dist.Beta(concentration1 + summed_obs,
-                         num_obs * total_count + concentration0 - summed_obs,
+                         total_count + concentration0 - summed_obs,
                          validate_args=self._latent._validate_args)
 
     def compound(self):

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -329,7 +329,7 @@ def test_beta_binomial(hyperpriors):
             beta = pyro.sample("beta", dist.HalfCauchy(1.)) if hyperpriors else torch.tensor([1., 1.])
             beta_binom = BetaBinomialPair()
             with pyro.plate("plate_1", data.shape[-2]):
-                probs = pyro.sample("beta", beta_binom.latent(alpha, beta))
+                probs = pyro.sample("probs", beta_binom.latent(alpha, beta))
                 with pyro.plate("data", data.shape[0]):
                     pyro.sample("binomial", beta_binom.conditional(probs=probs, total_count=1000), obs=data)
 
@@ -339,5 +339,5 @@ def test_beta_binomial(hyperpriors):
     mcmc_run = MCMC(hmc_kernel, num_samples=80, warmup_steps=50).run(data)
     mcmc_run.exec_traces = [poutine.trace(uncollapse_conjugate(model, tr)).get_trace(data)
                             for tr in mcmc_run.exec_traces]
-    posterior = mcmc_run.marginal(["beta"]).empirical["beta"]
+    posterior = mcmc_run.marginal(["probs"]).empirical["probs"]
     assert_equal(posterior.mean, true_probs, prec=0.05)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -331,10 +331,11 @@ def test_beta_binomial(hyperpriors):
             with pyro.plate("plate_1", data.shape[-2]):
                 probs = pyro.sample("probs", beta_binom.latent(alpha, beta))
                 with pyro.plate("data", data.shape[0]):
-                    pyro.sample("binomial", beta_binom.conditional(probs=probs, total_count=1000), obs=data)
+                    pyro.sample("binomial", beta_binom.conditional(probs=probs, total_count=total_count), obs=data)
 
     true_probs = torch.tensor([[0.7, 0.4], [0.6, 0.4]])
-    data = dist.Binomial(total_count=1000, probs=true_probs).sample(sample_shape=(torch.Size((10,))))
+    total_count = torch.tensor([[1000, 600], [400, 800]])
+    data = dist.Binomial(total_count=total_count, probs=true_probs).sample(sample_shape=(torch.Size((10,))))
     hmc_kernel = NUTS(collapse_conjugate(model), jit_compile=True, ignore_jit_warnings=True)
     mcmc_run = MCMC(hmc_kernel, num_samples=80, warmup_steps=50).run(data)
     mcmc_run.exec_traces = [poutine.trace(uncollapse_conjugate(model, tr)).get_trace(data)

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -331,7 +331,7 @@ def test_beta_binomial(hyperpriors):
             with pyro.plate("plate_1", data.shape[-2]):
                 probs = pyro.sample("beta", beta_binom.latent(alpha, beta))
                 with pyro.plate("data", data.shape[0]):
-                    pyro.sample("binomial", beta_binom.conditional(probs, total_count=1000), obs=data)
+                    pyro.sample("binomial", beta_binom.conditional(probs=probs, total_count=1000), obs=data)
 
     true_probs = torch.tensor([[0.7, 0.4], [0.6, 0.4]])
     data = dist.Binomial(total_count=1000, probs=true_probs).sample(sample_shape=(torch.Size((10,))))


### PR DESCRIPTION
This resurrects the previously closed #1716, with a cleaner and more general interface. I have put all the code in `contrib.conjugate` since this handles a restricted set of cases where a single pair of latent and observed sites are conjugate (the more general case will be handled by funsors, and is outside the purview of this PR). In such cases, the model can be written as (e.g. a gamma-poisson pair):

```python
gamma_poisson = GammaPoissonPair()
# Sample latent rate
rate = pyro.sample("rate", gamma_poisson.latent(alpha, beta))
    with pyro.plate("data", N):
        pyro.sample("obs", gamma_poisson.conditional(rate), obs=data)
```

When doing inference we can use `collapse_conjugate(model)` to remove the latent `rate` variable from the trace and replace the observed site with a `GammaPoisson` compound distribution. We can subsequently use the `uncollapse_conjugate(model, trace)` handler which is the same as `replay` except that it also uncollapses any latent sites by instead sampling from the posterior (exact) distribution. Note that this requires knowing which sites are paired as conjugate distributions by the two handlers, which is handled by the `BetaBinomialPair` and `GammaPoissonPair` classes.