### PR TITLE
fixed typo in deferred_conditioned_scale

### DIFF
--- a/tutorial/source/intro_part_ii.ipynb
+++ b/tutorial/source/intro_part_ii.ipynb
@@ -87,7 +87,7 @@
    "outputs": [],
    "source": [
     "def deferred_conditioned_scale(measurement, *args, **kwargs):\n",
-    "    return pyro.condition(scale, data={\"measurement\": measurement})(*args, **kwargs)"
+    "    return pyro.condition(scale, data={\"measurement\": measurement}, *args, **kwargs)"
    ]
   },
   {

--- a/tutorial/source/intro_part_ii.ipynb
+++ b/tutorial/source/intro_part_ii.ipynb
@@ -86,8 +86,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def deferred_conditioned_scale(measurement, *args, **kwargs):\n",
-    "    return pyro.condition(scale, data={\"measurement\": measurement}, *args, **kwargs)"
+    "def deferred_conditioned_scale(measurement, guess):\n",
+    "    return pyro.condition(scale, data={\"measurement\": measurement})(guess)"
    ]
   },
   {


### PR DESCRIPTION
The original definition of deferred_conditioned_scale gave "TypeError: scale() missing 1 required positional argument: 'guess'" when fed to pyro.infer.SVI in place of conditioend_scale later in the tutorial this way:
```python
conditioned_scale1 = deferred_conditioned_scale(
    measurement=9.5,
)

pyro.clear_param_store()
svi = pyro.infer.SVI(model=conditioned_scale1,
                     guide=scale_parametrized_guide_constrained,
                     optim=pyro.optim.SGD({"lr": 0.001, "momentum":0.1}),
                     loss=pyro.infer.Trace_ELBO())
```
The new version runs without an error and gives the same results as `conditioned_scale`