### PR TITLE
Implement a SpanningTree distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: true
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
+        - TMPDIR=$HOME/tmp
 
 cache:
     directories:
@@ -19,6 +20,7 @@ install:
       fi
     - pip install .[test]
     - pip freeze
+    - mkdir -p $HOME/tmp
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: true
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
+        - CXX="g++-8"
+        - CC="gcc-8"
 
 addons:
     apt:
@@ -18,9 +20,6 @@ addons:
 cache:
     directories:
         - $HOME/.data
-
-before_install:
-    - if [ "$CXX" = "g++" ]; then export CXX="g++-8" CC="gcc-8"; fi
 
 install:
     - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ branches:
 jobs:
     fast_finish: true
     include:
+        - stage: debug
+          python: 3.6
+          env: STAGE=unit
+          script: pytest -vsx tests/distributions/test_spanning_tree.py::test_make_complete_graph
         - stage: lint
           python: 2.7
           before_install: pip install flake8 nbstripout nbformat

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,6 @@ branches:
 jobs:
     fast_finish: true
     include:
-        - stage: debug
-          python: 3.6
-          env: STAGE=unit
-          script: pytest -vsx tests/distributions/test_spanning_tree.py::test_make_complete_graph
         - stage: lint
           python: 2.7
           before_install: pip install flake8 nbstripout nbformat

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
         packages:
             - gcc-4.9
             - g++-4.9
+            - ninja-build
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: true
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
-        - TMPDIR=$HOME/tmp
 
 cache:
     directories:
@@ -20,7 +19,6 @@ install:
       fi
     - pip install .[test]
     - pip freeze
-    - mkdir -p $HOME/tmp
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ addons:
         sources:
             - ubuntu-toolchain-r-test
         packages:
-            - gcc-4.9
-            - g++-4.9
+            - gcc-8
+            - g++-8
             - ninja-build
 
 cache:
@@ -20,7 +20,7 @@ cache:
         - $HOME/.data
 
 before_install:
-    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-8" CC="gcc-8"; fi
 
 install:
     - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: true
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
+        - CXX="g++-4.9"
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,21 @@ sudo: true
 env:
     global:
         - PYTHONPATH=$PWD:$PYTHONPATH
-        - CXX="g++-4.9"
+
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - gcc-4.9
+            - g++-4.9
 
 cache:
     directories:
         - $HOME/.data
+
+before_install:
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 
 install:
     - pip install -U pip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE.md MANIFEST.in
-recursive-include *.cpp
+recursive-include pyro *.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE.md MANIFES.in
+include LICENSE.md MANIFEST.in
 recursive-include *.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.md MANIFES.in
+recursive-include *.cpp

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -147,6 +147,13 @@ Rejector
     :undoc-members:
     :show-inheritance:
 
+SpanningTree
+------------
+.. autoclass:: pyro.distributions.SpanningTree
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 VonMises
 --------
 .. autoclass:: pyro.distributions.VonMises

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -20,6 +20,7 @@ from pyro.distributions.radial import RadialFlow
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.relaxed_straight_through import (RelaxedBernoulliStraightThrough,
                                                          RelaxedOneHotCategoricalStraightThrough)
+from pyro.distributions.spanning_tree import SpanningTree
 from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
@@ -56,6 +57,7 @@ __all__ = [
     "Rejector",
     "RelaxedBernoulliStraightThrough",
     "RelaxedOneHotCategoricalStraightThrough",
+    "SpanningTree",
     "TorchDistribution",
     "TransformModule",
     "VonMises",

--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -1,0 +1,66 @@
+#include <cmath>
+
+#include <torch/torch.h>
+
+at::Tensor make_complete_graph(long num_vertices) {
+  const long V = num_vertices;
+  const long K = V * (V - 1) / 2;
+  auto grid = torch::empty({2, K}, at::kLong);
+  int k = 0;
+  for (int v2 = 0; v2 != V; ++v2) {
+    for (int v1 = 0; v1 != v2; ++v1) {
+      grid[0][k] = v1;
+      grid[1][k] = v2;
+      k += 1;
+    }
+  }
+  return grid;
+}
+
+at::Tensor sample_tree_mcmc(at::Tensor edge_logits, at::Tensor edges) {
+  return edges;  // TODO implement a sampler.
+}
+
+at::Tensor sample_tree_approx(at::Tensor edge_logits) {
+  torch::NoGradGuard no_grad;
+
+  const long K = edge_logits.size(0);
+  const long V = static_cast<long>(0.5 + std::sqrt(0.25 + 2 * K));
+  const long E = V - 1;
+  auto grid = make_complete_graph(V);
+  auto components = torch::zeros({V}, at::kByte);
+  auto e2k = torch::empty({E}, at::kLong);
+
+  // Sample the first edge at random.
+  auto probs = (edge_logits - edge_logits.max()).exp();
+  auto k = probs.multinomial(1)[0];
+  components[grid[0][k]] = 1;
+  components[grid[1][k]] = 1;
+  e2k[0] = k;
+
+  // Sample edges connecting the cumulative tree to a new leaf.
+  for (int e = 1; e != E; ++e) {
+    auto c1 = components.index_select(0, grid[0]);
+    auto c2 = components.index_select(0, grid[1]);
+    auto mask = c1.__xor__(c2);
+    auto valid_logits = edge_logits.masked_select(mask);
+    auto probs = (valid_logits - valid_logits.max()).exp();
+    auto k = mask.nonzero().view(-1)[probs.multinomial(1)[0]];
+    components[grid[0][k]] = 1;
+    components[grid[1][k]] = 1;
+    e2k[e] = k;
+  }
+
+  e2k.sort();
+  auto edges = torch::empty({E, 2}, at::kLong);
+  for (int e = 0; e != E; ++e) {
+    edges[e][0] = grid[0][e2k[e]];
+    edges[e][1] = grid[1][e2k[e]];
+  }
+  return edges;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("sample_tree_mcmc", &sample_tree_mcmc, "Sample a random spanning tree using MCMC");
+  m.def("sample_tree_approx", &sample_tree_approx, "Approximate sample a random spanning tree");
+}

--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -20,10 +20,10 @@ at::Tensor make_complete_graph(int num_vertices) {
   return grid;
 }
 
-int _remove_edge(at::Tensor grid, at::Tensor e2k,
+int _remove_edge(at::Tensor grid, at::Tensor edge_ids,
                  std::vector<std::unordered_set<int>> &neighbors,
                  std::vector<bool> &components, int e) {
-  int k = e2k[e].item().to<int>();
+  int k = edge_ids[e].item().to<int>();
   int v1 = grid[0][k].item().to<int>();
   int v2 = grid[1][k].item().to<int>();
   neighbors[v1].erase(v2);
@@ -43,10 +43,10 @@ int _remove_edge(at::Tensor grid, at::Tensor e2k,
   return k;
 }
 
-void _add_edge(at::Tensor grid, at::Tensor e2k,
+void _add_edge(at::Tensor grid, at::Tensor edge_ids,
                std::vector<std::unordered_set<int>> &neighbors,
                std::vector<bool> &components, int e, int k) {
-  e2k[e] = k;
+  edge_ids[e] = k;
   int v1 = grid[0][k].item().to<int>();
   int v2 = grid[1][k].item().to<int>();
   neighbors[v1].insert(v2);
@@ -54,7 +54,7 @@ void _add_edge(at::Tensor grid, at::Tensor e2k,
   std::fill(components.begin(), components.end(), 0);
 }
 
-int _find_valid_edges(const std::vector<bool> &components, at::Tensor valid_edges) {
+int _find_valid_edges(const std::vector<bool> &components, at::Tensor valid_edge_ids) {
   int k = 0;
   int end = 0;
   const int V = components.size();
@@ -62,7 +62,7 @@ int _find_valid_edges(const std::vector<bool> &components, at::Tensor valid_edge
     bool c2 = components[v2];
     for (int v1 = 0; v1 != v2; ++v1) {
       if (c2 ^ components[v1]) {
-        valid_edges[end] = k;
+        valid_edge_ids[end] = k;
         end += 1;
       }
       k += 1;
@@ -82,37 +82,39 @@ at::Tensor sample_tree_mcmc(at::Tensor edge_logits, at::Tensor edges) {
   const int V = E + 1;
   const int K = V * (V - 1) / 2;
   auto grid = make_complete_graph(V);
-  auto e2k = torch::empty({E}, at::kLong);
+  auto edge_ids = torch::empty({E}, at::kLong);
   std::vector<std::unordered_set<int>> neighbors(V);
   std::vector<bool> components(V);
   for (int e = 0; e != E; ++e) {
     int v1 = edges[e][0].item().to<int>();
     int v2 = edges[e][1].item().to<int>();
-    e2k[e] = v1 + v2 * (v2 - 1) / 2;
+    edge_ids[e] = v1 + v2 * (v2 - 1) / 2;
     neighbors[v1].insert(v2);
     neighbors[v2].insert(v1);
   }
   auto valid_edges_buffer = torch::empty({K}, at::kLong);
 
-  for (int e = 0; e != E; ++e) {
-     int k = _remove_edge(grid, e2k, neighbors, components, e);
+  auto order = torch::randperm(E);
+  for (int i = 0; i != E; ++i) {
+     int e = order[i].item().to<int>();
+     int k = _remove_edge(grid, edge_ids, neighbors, components, e);
      int num_valid_edges = _find_valid_edges(components, valid_edges_buffer);
-     auto valid_edges = valid_edges_buffer.slice(0, 0, num_valid_edges);
-     auto valid_logits = edge_logits.index_select(0, valid_edges);
+     auto valid_edge_ids = valid_edges_buffer.slice(0, 0, num_valid_edges);
+     auto valid_logits = edge_logits.index_select(0, valid_edge_ids);
      auto valid_probs = (valid_logits - valid_logits.max()).exp();
      double total_prob = valid_probs.sum().item().to<double>();
      if (total_prob > 0) {
        int sample = valid_probs.multinomial(1)[0].item().to<int>();
-       k = valid_edges[sample].item().to<int>();
+       k = valid_edge_ids[sample].item().to<int>();
      }
-     _add_edge(grid, e2k, neighbors, components, e, k);
+     _add_edge(grid, edge_ids, neighbors, components, e, k);
   }
 
-  e2k.sort();
+  edge_ids = std::get<0>(edge_ids.sort());
   edges = torch::empty({E, 2}, at::kLong);
   for (int e = 0; e != E; ++e) {
-    edges[e][0] = grid[0][e2k[e]];
-    edges[e][1] = grid[1][e2k[e]];
+    edges[e][0] = grid[0][edge_ids[e]];
+    edges[e][1] = grid[1][edge_ids[e]];
   }
   return edges;
 }
@@ -125,14 +127,14 @@ at::Tensor sample_tree_approx(at::Tensor edge_logits) {
   const int E = V - 1;
   auto grid = make_complete_graph(V);
   auto components = torch::zeros({V}, at::kByte);
-  auto e2k = torch::empty({E}, at::kLong);
+  auto edge_ids = torch::empty({E}, at::kLong);
 
   // Sample the first edge at random.
   auto probs = (edge_logits - edge_logits.max()).exp();
   int k = probs.multinomial(1)[0].item().to<int>();
   components[grid[0][k]] = 1;
   components[grid[1][k]] = 1;
-  e2k[0] = k;
+  edge_ids[0] = k;
 
   // Sample edges connecting the cumulative tree to a new leaf.
   for (int e = 1; e != E; ++e) {
@@ -145,14 +147,14 @@ at::Tensor sample_tree_approx(at::Tensor edge_logits) {
     int k = mask.nonzero().view(-1)[sample].item().to<int>();
     components[grid[0][k]] = 1;
     components[grid[1][k]] = 1;
-    e2k[e] = k;
+    edge_ids[e] = k;
   }
 
-  e2k.sort();
+  edge_ids = std::get<0>(edge_ids.sort());
   auto edges = torch::empty({E, 2}, at::kLong);
   for (int e = 0; e != E; ++e) {
-    edges[e][0] = grid[0][e2k[e]];
-    edges[e][1] = grid[1][e2k[e]];
+    edges[e][0] = grid[0][edge_ids[e]];
+    edges[e][1] = grid[1][edge_ids[e]];
   }
   return edges;
 }

--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -63,4 +63,5 @@ at::Tensor sample_tree_approx(at::Tensor edge_logits) {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("sample_tree_mcmc", &sample_tree_mcmc, "Sample a random spanning tree using MCMC");
   m.def("sample_tree_approx", &sample_tree_approx, "Approximate sample a random spanning tree");
+  m.def("make_complete_graph", &make_complete_graph, "Constructs a complete graph");
 }

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -300,67 +300,6 @@ def _sample_tree_approx(edge_logits):
 
 
 _cpp_module = None
-_cpp_source = """
-#include <cmath>
-
-at::Tensor make_complete_graph(long num_vertices) {
-  const long V = num_vertices;
-  const long K = V * (V - 1) / 2;
-  auto grid = torch::empty({2, K}, at::kLong);
-  int k = 0;
-  for (int v2 = 0; v2 != V; ++v2) {
-    for (int v1 = 0; v1 != v2; ++v1) {
-      grid[0][k] = v1;
-      grid[1][k] = v2;
-      k += 1;
-    }
-  }
-  return grid;
-}
-
-at::Tensor sample_tree_mcmc(at::Tensor edge_logits, at::Tensor edges) {
-  return edges;  // TODO implement a sampler.
-}
-
-at::Tensor sample_tree_approx(at::Tensor edge_logits) {
-  torch::NoGradGuard no_grad;
-
-  const long K = edge_logits.size(0);
-  const long V = static_cast<long>(0.5 + std::sqrt(0.25 + 2 * K));
-  const long E = V - 1;
-  auto grid = make_complete_graph(V);
-  auto components = torch::zeros({V}, at::kByte);
-  auto e2k = torch::empty({E}, at::kLong);
-
-  // Sample the first edge at random.
-  auto probs = (edge_logits - edge_logits.max()).exp();
-  auto k = probs.multinomial(1)[0];
-  components[grid[0][k]] = 1;
-  components[grid[1][k]] = 1;
-  e2k[0] = k;
-
-  // Sample edges connecting the cumulative tree to a new leaf.
-  for (int e = 1; e != E; ++e) {
-    auto c1 = components.index_select(0, grid[0]);
-    auto c2 = components.index_select(0, grid[1]);
-    auto mask = c1.__xor__(c2);
-    auto valid_logits = edge_logits.masked_select(mask);
-    auto probs = (valid_logits - valid_logits.max()).exp();
-    auto k = mask.nonzero().view(-1)[probs.multinomial(1)[0]];
-    components[grid[0][k]] = 1;
-    components[grid[1][k]] = 1;
-    e2k[e] = k;
-  }
-
-  e2k.sort();
-  auto edges = torch::empty({E, 2}, at::kLong);
-  for (int e = 0; e != E; ++e) {
-    edges[e][0] = grid[0][e2k[e]];
-    edges[e][1] = grid[1][e2k[e]];
-  }
-  return edges;
-}
-"""
 
 
 def _get_cpp_module():
@@ -369,16 +308,16 @@ def _get_cpp_module():
     """
     global _cpp_module
     if _cpp_module is None:
+        import os
         import warnings
-        from torch.utils.cpp_extension import load_inline
+        from torch.utils.cpp_extension import load
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "spanning_tree.cpp")
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
-            _cpp_module = load_inline(
-                name="cpp_spanning_tree",
-                cpp_sources=[_cpp_source],
-                functions=["sample_tree_approx", "sample_tree_mcmc"],
-                extra_cflags=['-O2'],
-                verbose=True)
+            _cpp_module = load(name="cpp_spanning_tree",
+                               sources=[path],
+                               extra_cflags=['-O2'],
+                               verbose=True)
     return _cpp_module
 
 

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -45,6 +45,8 @@ class SpanningTree(TorchDistribution):
     has_enumerate_support = True
 
     def __init__(self, edge_logits, sampler_options=None, validate_args=None):
+        if edge_logits.is_cuda():
+            raise NotImplementedError("SpanningTree does not support cuda tensors")
         K = len(edge_logits)
         V = int(round(0.5 + (0.25 + 2 * K)**0.5))
         assert K == V * (V - 1) // 2

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -237,7 +237,7 @@ def _sample_tree_mcmc(edge_logits, edges):
     for e in range(E):
         v1, v2 = map(int, edges[e])
         assert v1 < v2
-        e2k[e] = v1 + v2 * (v2 - 1) // 2;
+        e2k[e] = v1 + v2 * (v2 - 1) // 2
         neighbors[v1].add(v2)
         neighbors[v2].add(v1)
     valid_edges_buffer = torch.empty(K, dtype=torch.long)

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -123,15 +123,12 @@ def _get_cpp_module():
     global _cpp_module
     if _cpp_module is None:
         import os
-        import warnings
         from torch.utils.cpp_extension import load
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "spanning_tree.cpp")
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            _cpp_module = load(name="cpp_spanning_tree",
-                               sources=[path],
-                               extra_cflags=['-O2'],
-                               verbose=True)
+        _cpp_module = load(name="cpp_spanning_tree",
+                           sources=[path],
+                           extra_cflags=['-O2'],
+                           verbose=True)
     return _cpp_module
 
 

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import itertools
 
 import torch
-from six.moves import range
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property
 

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -365,8 +365,12 @@ def _sample_tree_approx(edge_logits):
     assert K == V * (V - 1) // 2
     E = V - 1
     grid = make_complete_graph(V)
-    components = edge_logits.new_zeros(V, dtype=torch.uint8)
+
+    # Each of E edges in the tree is stored as an id k in [0, K) indexing into
+    # the complete graph. The id of an edge (v1,v2) is k = v1+v2*(v2-1)/2.
     edge_ids = edge_logits.new_empty((E,), dtype=torch.long)
+    # This maps each vertex to whether it is a member of the cumulative tree.
+    components = edge_logits.new_zeros(V, dtype=torch.uint8)
 
     # Sample the first edge at random.
     probs = (edge_logits - edge_logits.max()).exp()

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -1,0 +1,193 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+from torch.distributions import constraints
+from six.moves import range
+
+from pyro.distributions.torch_distribution import TorchDistribution
+
+
+def find_complete_edge(v1, v2):
+    """
+    Find the edge index k of an unsorted pair of vertices (v1, v2).
+    """
+    if v2 < v1:
+        v1, v2 = v2, v1
+    return v1 + v2 * (v2 - 1) // 2
+
+
+def make_complete_graph(num_vertices):
+    """
+    Constructs a complete graph.
+
+    The pairing function is: ``k = v1 + v2 * (v2 - 1) // 2``
+
+    :param int num_vertices: Number of vertices.
+    :returns: A tuple with elements:
+        V: Number of vertices.
+        K: Number of edges.
+        grid: a 3 x K grid of (edge, vertex, vertex) triples.
+    """
+    if num_vertices < 2:
+        raise ValueError('PyTorch cannot handle zero-sized multidimensional tensors')
+    V = num_vertices
+    K = V * (V - 1) // 2
+    grid = torch.zeros((3, K), dtype=torch.long)
+    k = 0
+    for v2 in range(V):
+        for v1 in range(v2):
+            grid[0, k] = k
+            grid[1, k] = v1
+            grid[2, k] = v2
+            k += 1
+    return grid
+
+
+def remove_edge(grid, e2k, neighbors, components, e):
+    """
+    Remove an edge from a spanning tree.
+    """
+    k = e2k[e]
+    v1 = grid[1, k].item()
+    v2 = grid[2, k].item()
+    neighbors[v1].remove(v2)
+    neighbors[v2].remove(v1)
+    pending = {v1}
+    while pending:
+        v1 = pending.pop()
+        components[v1] = 1
+        for v2 in neighbors[v1]:
+            if not components[v2]:
+                pending.add(v2)
+    return k
+
+
+def add_edge(grid, e2k, neighbors, components, e, k):
+    """
+    Add an edge connecting two components to create a spanning tree.
+    """
+    e2k[e] = k
+    v1 = grid[1, k].item()
+    v2 = grid[2, k].item()
+    neighbors[v1].add(v2)
+    neighbors[v2].add(v1)
+    components[:] = 0
+
+
+def find_valid_edges(components, valid_edges):
+    """
+    Find all edges between two components in a complete undirected graph.
+
+    :param components: A [V]-shaped array of boolean component ids. This
+        assumes there are exactly two nonemtpy components.
+    :param valid_edges: An uninitialized array where output is written. On
+        return, the subarray valid_edges[:end] will contain edge ids k for all
+        valid edges.
+    :returns: The number of valid edges found.
+    """
+    k = 0
+    end = 0
+    for v2, c2 in enumerate(components):
+        for v1 in range(v2):
+            if c2 ^ components[v1]:
+                valid_edges[end] = k
+                end += 1
+            k += 1
+    return end
+
+
+def sample_tree(grid, edge_logits, edges):
+    """
+    Sample a random spanning tree of a dense weighted graph using MCMC.
+
+    This uses Gibbs sampling on edges. Consider E undirected edges that can
+    move around a graph of ``V=1+E`` vertices. The edges are constrained so
+    that no two edges can span the same pair of vertices and so that the edges
+    must form a spanning tree. To Gibbs sample, chose one of the E edges at
+    random and move it anywhere else in the graph. After we remove the edge,
+    notice that the graph is split into two connected components. The
+    constraints imply that the edge must be replaced so as to connect the two
+    components.  Hence to Gibbs sample, we collect all such bridging
+    (vertex,vertex) pairs and sample from them in proportion to
+    ``exp(edge_logits)``.
+
+    :param grid: A 3 x K array as returned by :func:`make_complete_graph`.
+    :param edge_logits: A length-K array of nonnormalized log probabilities.
+    :param edges: A list of E initial edges in the form of (vertex,vertex) pairs.
+    :returns: A list of ``(vertex, vertex)`` pairs.
+    """
+    if len(edges) <= 1:
+        return edges
+    E = len(edges)
+    V = E + 1
+    K = V * (V - 1) // 2
+    e2k = torch.zeros(E, dtype=torch.long)
+    neighbors = {v: set() for v in range(V)}
+    components = torch.zeros(V, dtype=torch.uint8)
+    for e in range(E):
+        v1, v2 = edges[e]
+        e2k[e] = find_complete_edge(v1, v2)
+        neighbors[v1].add(v2)
+        neighbors[v2].add(v1)
+    valid_edges = torch.empty(K, dtype=torch.long)
+
+    for e in torch.randperm(E):  # Sequential scanning doesn't seem to work.
+        e = e.item()
+        k1 = remove_edge(grid, e2k, neighbors, components, e)
+        num_valid_edges = find_valid_edges(components, valid_edges)
+        valid_logits = edge_logits[valid_edges[:num_valid_edges]]
+        valid_probs = torch.exp(valid_logits - valid_logits.max())
+        total_prob = valid_probs.sum()
+        if total_prob > 0:
+            k2 = valid_edges[torch.multinomial(valid_probs, 1)[0]]
+        else:
+            k2 = k1
+        add_edge(grid, e2k, neighbors, components, e, k2)
+
+    edges = sorted((grid[1, k].item(), grid[2, k].item()) for k in e2k)
+    assert len(edges) == E
+    return edges
+
+
+class SpanningTree(TorchDistribution):
+    """
+    Distribution over spanning trees on a fixed set of vertices.
+    """
+    arg_constraings = {'edge_logits': constraints.real}
+    support = constraints.positive_integer
+
+    def __init__(self, edge_logits, initial_edges=None, mcmc_steps=1, validate_args=None):
+        K = len(edge_logits)
+        V = int(round(0.5 + (0.25 + 2 * K)**0.5))
+        assert K == V * (V - 1) // 2
+        E = V - 1
+        event_shape = (E, 2)
+        batch_shape = ()
+        super(SpanningTree, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        if initial_edges is None:
+            initial_edges = torch.stack((torch.arange(0, V - 1), torch.arange(1, V)), dim=-1)
+        if self._validate_args:
+            if edge_logits.shape != (K, 2):
+                raise ValueError("Expected edge_logits of shape ({},2), but got shape {}"
+                                 .format(K, edge_logits.shape))
+            if initial_edges.shape != (E, 2):
+                raise ValueError("Expected initial_edges of shape ({},2), but got shape {}"
+                                 .format(K, edge_logits.shape))
+        self.edge_logits = edge_logits
+        self.initial_edges = initial_edges
+        self.mcmc_steps = mcmc_steps
+        self.complete_graph = make_complete_graph(V)
+
+    def log_prob(self, edges):
+        return self.edge_logits.new_tensor(0.)
+
+    def sample(self, sample_shape=torch.Size()):
+        if sample_shape:
+            raise NotImplementedError("SpanningTree does not support batching")
+        edges = [(v1.item(), v2.item()) for v1, v2 in self.initial_edges]
+        for _ in range(self.mcmc_steps):
+            edges = sample_tree(self.complete_graph, self.edge_logits, edges)
+        result = self.edge_logits.new_empty((len(edges), 2), dtype=torch.long)
+        for e, vs in edges:
+            result[e] = vs
+        return result

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import pyro
-from pyro.distributions.spanning_tree import make_complete_graph, sample_tree, sample_tree_2
+from pyro.distributions.spanning_tree import make_complete_graph, sample_tree, sample_tree_2, sample_tree_3
 from tests.common import assert_equal
 
 # https://oeis.org/A000272
@@ -48,9 +48,21 @@ def test_sample_tree_2_smoke(num_edges):
     grid = make_complete_graph(V)
     K = grid.shape[1]
     edge_logits = torch.rand(K)
-    edges = [(v, v + 1) for v in range(V - 1)]
     for _ in range(10):
         sample_tree_2(grid, edge_logits)
+
+
+@pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
+def test_sample_tree_3_smoke(num_edges):
+    pyro.set_rng_seed(num_edges)
+    E = num_edges
+    V = 1 + E
+    grid = make_complete_graph(V)
+    K = grid.shape[1]
+    edge_logits = torch.rand(K)
+    for _ in range(10):
+        result = sample_tree_3(edge_logits)
+        assert (result == -edge_logits).all()
 
 
 @pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -27,7 +27,8 @@ def test_make_complete_graph(num_vertices, expected_grid, backend):
 
 
 @pytest.mark.parametrize('num_edges', [1, 3, 10, 30])
-def test_sample_tree_mcmc_smoke(num_edges):
+@pytest.mark.parametrize('backend', ["python", "cpp"])
+def test_sample_tree_mcmc_smoke(num_edges, backend):
     pyro.set_rng_seed(num_edges)
     E = num_edges
     V = 1 + E
@@ -35,7 +36,7 @@ def test_sample_tree_mcmc_smoke(num_edges):
     edge_logits = torch.rand(K)
     edges = torch.tensor([(v, v + 1) for v in range(V - 1)], dtype=torch.long)
     for _ in range(10):
-        edges = sample_tree_mcmc(edge_logits, edges)
+        edges = sample_tree_mcmc(edge_logits, edges, backend=backend)
 
 
 @pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
@@ -51,7 +52,7 @@ def test_sample_tree_approx_smoke(num_edges, backend):
 
 
 @pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
-@pytest.mark.parametrize('backend', ["python"])
+@pytest.mark.parametrize('backend', ["python", "cpp"])
 def test_sample_tree_mcmc_gof(num_edges, backend):
     goftests = pytest.importorskip('goftests')
     pyro.set_rng_seed(2 ** 32 - num_edges)

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import defaultdict
+
+import pytest
+import torch
+
+import pyro
+from pyro.distributions.spanning_tree import make_complete_graph, sample_tree
+from tests.common import assert_equal
+
+# https://oeis.org/A000272
+NUM_SPANNING_TREES = [1, 1, 1, 3, 16, 125, 1296, 16807, 262144, 4782969]
+
+
+@pytest.mark.parametrize('num_vertices,expected_grid', [
+    (2, [[0], [0], [1]]),
+    (3, [[0, 1, 2], [0, 0, 1], [1, 2, 2]]),
+    (4, [[0, 1, 2, 3, 4, 5], [0, 0, 1, 0, 1, 2], [1, 2, 2, 3, 3, 3]]),
+])
+def test_make_complete_graph(num_vertices, expected_grid):
+    V = num_vertices
+    K = V * (V - 1) // 2
+    expected_grid = torch.tensor(expected_grid, dtype=torch.long).reshape(3, K)
+
+    grid = make_complete_graph(V)
+    assert_equal(grid, expected_grid)
+
+
+@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
+def test_sample_tree_smoke(num_edges):
+    pyro.set_rng_seed(num_edges)
+    E = num_edges
+    V = 1 + E
+    grid = make_complete_graph(V)
+    K = grid.shape[1]
+    edge_logits = torch.rand(K)
+    edges = [(v, v + 1) for v in range(V - 1)]
+    for _ in range(100):
+        edges = sample_tree(grid, edge_logits, edges)
+
+
+@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
+def test_sample_tree_gof(num_edges):
+    goftests = pytest.importorskip('goftests')
+    pyro.set_rng_seed(2 ** 32 - num_edges)
+    E = num_edges
+    V = 1 + E
+    grid = make_complete_graph(V)
+    K = grid.shape[1]
+    edge_logits = torch.rand(K)
+    edge_logits_dict = {(v1, v2): edge_logits[k] for k, v1, v2 in grid.t().numpy()}
+
+    # Generate many samples via MCMC.
+    num_samples = 30 * NUM_SPANNING_TREES[V]
+    counts = defaultdict(int)
+    edges = [(v, v + 1) for v in range(V - 1)]
+    for _ in range(num_samples):
+        edges = sample_tree(grid, edge_logits, edges)
+        counts[tuple(edges)] += 1
+    assert len(counts) == NUM_SPANNING_TREES[V]
+
+    # Check accuracy using Pearson's chi-squared test.
+    keys = counts.keys()
+    counts = torch.tensor([counts[key] for key in keys])
+    probs = torch.tensor([sum(edge_logits_dict[edge] for edge in key) for key in keys])
+    probs /= probs.sum()
+
+    # Possibly truncate.
+    T = 100
+    truncated = False
+    if len(counts) > T:
+        counts = counts[:T]
+        probs = probs[:T]
+        truncated = True
+
+    gof = goftests.multinomial_goodness_of_fit(
+        probs.numpy(), counts.numpy(), num_samples, plot=True, truncated=truncated)
+    assert 1e-2 < gof

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -26,7 +26,7 @@ def test_make_complete_graph(num_vertices, expected_grid, backend):
     assert_equal(grid, expected_grid)
 
 
-@pytest.mark.parametrize('num_edges', [1, 3, 10, 30])
+@pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
 @pytest.mark.parametrize('backend', ["python", "cpp"])
 def test_sample_tree_mcmc_smoke(num_edges, backend):
     pyro.set_rng_seed(num_edges)
@@ -35,7 +35,7 @@ def test_sample_tree_mcmc_smoke(num_edges, backend):
     K = V * (V - 1) // 2
     edge_logits = torch.rand(K)
     edges = torch.tensor([(v, v + 1) for v in range(V - 1)], dtype=torch.long)
-    for _ in range(10):
+    for _ in range(10 if backend == "cpp" or num_edges <= 30 else 1):
         edges = sample_tree_mcmc(edge_logits, edges, backend=backend)
 
 
@@ -47,75 +47,8 @@ def test_sample_tree_approx_smoke(num_edges, backend):
     V = 1 + E
     K = V * (V - 1) // 2
     edge_logits = torch.rand(K)
-    for _ in range(10):
+    for _ in range(10 if backend == "cpp" or num_edges <= 30 else 1):
         sample_tree_approx(edge_logits, backend=backend)
-
-
-@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
-@pytest.mark.parametrize('backend', ["python", "cpp"])
-def test_sample_tree_mcmc_gof(num_edges, backend):
-    goftests = pytest.importorskip('goftests')
-    pyro.set_rng_seed(2 ** 32 - num_edges)
-    E = num_edges
-    V = 1 + E
-    K = V * (V - 1) // 2
-    edge_logits = torch.rand(K)
-
-    # Generate many samples via MCMC.
-    num_samples = 30 * NUM_SPANNING_TREES[V]
-    counts = Counter()
-    tensors = {}
-    edges = torch.tensor([(v, v + 1) for v in range(V - 1)], dtype=torch.long)
-    for _ in range(num_samples):
-        edges = sample_tree_mcmc(edge_logits, edges, backend=backend)
-        key = tuple(sorted((v1.item(), v2.item()) for v1, v2 in edges))
-        counts[key] += 1
-        tensors[key] = edges
-    assert len(counts) == NUM_SPANNING_TREES[V]
-
-    # Check accuracy using a Pearson's chi-squared test.
-    keys = [k for k, _ in counts.most_common(100)]
-    truncated = (len(keys) < len(counts))
-    counts = torch.tensor([counts[k] for k in keys])
-    tensors = torch.stack([tensors[k] for k in keys])
-    probs = SpanningTree(edge_logits).log_prob(tensors).exp()
-    gof = goftests.multinomial_goodness_of_fit(
-        probs.numpy(), counts.numpy(), num_samples, plot=True, truncated=truncated)
-    assert 1e-3 < gof
-
-
-# TODO Switch this to do 1 MCMC step.
-@pytest.mark.xfail(reason="approximate sampler is used only for initialization")
-@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
-@pytest.mark.parametrize('backend', ["python", "cpp"])
-def test_sample_tree_approx_gof(num_edges, backend):
-    goftests = pytest.importorskip('goftests')
-    pyro.set_rng_seed(2 ** 32 - num_edges)
-    E = num_edges
-    V = 1 + E
-    K = V * (V - 1) // 2
-    edge_logits = torch.rand(K)
-
-    # Generate many samples.
-    num_samples = 30 * NUM_SPANNING_TREES[V]
-    counts = Counter()
-    tensors = {}
-    for _ in range(num_samples):
-        edges = sample_tree_approx(edge_logits, backend=backend)
-        key = tuple(sorted((v1.item(), v2.item()) for v1, v2 in edges))
-        counts[key] += 1
-        tensors[key] = edges
-    assert len(counts) == NUM_SPANNING_TREES[V]
-
-    # Check accuracy using a Pearson's chi-squared test.
-    keys = [k for k, _ in counts.most_common(100)]
-    truncated = (len(keys) < len(counts))
-    counts = torch.tensor([counts[k] for k in keys])
-    tensors = torch.stack([tensors[k] for k in keys])
-    probs = SpanningTree(edge_logits).log_prob(tensors).exp()
-    gof = goftests.multinomial_goodness_of_fit(
-        probs.numpy(), counts.numpy(), num_samples, plot=True, truncated=truncated)
-    assert 1e-3 < gof
 
 
 @pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5, 6])
@@ -165,3 +98,43 @@ def test_log_prob(num_edges):
     assert log_probs.shape == (len(support),)
     log_total = log_probs.logsumexp(0).item()
     assert abs(log_total) < 1e-6, log_total
+
+
+@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
+@pytest.mark.parametrize('backend', ["python", "cpp"])
+@pytest.mark.parametrize('method', ["mcmc", "approx"])
+def test_sample_tree_gof(method, backend, num_edges):
+    goftests = pytest.importorskip('goftests')
+    pyro.set_rng_seed(2 ** 32 - num_edges)
+    E = num_edges
+    V = 1 + E
+    K = V * (V - 1) // 2
+    edge_logits = torch.rand(K)
+
+    # Generate many samples.
+    num_samples = 30 * NUM_SPANNING_TREES[V]
+    counts = Counter()
+    tensors = {}
+    edges = torch.tensor([(v, v + 1) for v in range(V - 1)], dtype=torch.long)
+    for _ in range(num_samples):
+        if method == "approx":
+            # Reset the chain with an approximate sample, then perform 1 step of mcmc.
+            edges = sample_tree_approx(edge_logits, backend=backend)
+        edges = sample_tree_mcmc(edge_logits, edges, backend=backend)
+        key = tuple(sorted((v1.item(), v2.item()) for v1, v2 in edges))
+        counts[key] += 1
+        tensors[key] = edges
+    assert len(counts) == NUM_SPANNING_TREES[V]
+
+    # Check accuracy using a Pearson's chi-squared test.
+    keys = [k for k, _ in counts.most_common(100)]
+    truncated = (len(keys) < len(counts))
+    counts = torch.tensor([counts[k] for k in keys])
+    tensors = torch.stack([tensors[k] for k in keys])
+    probs = SpanningTree(edge_logits).log_prob(tensors).exp()
+    gof = goftests.multinomial_goodness_of_fit(
+        probs.numpy(), counts.numpy(), num_samples, plot=True, truncated=truncated)
+    if method == "approx":
+        assert gof >= 5e-5
+    else:
+        assert gof >= 5e-3

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -30,12 +30,11 @@ def test_sample_tree_smoke(num_edges):
     pyro.set_rng_seed(num_edges)
     E = num_edges
     V = 1 + E
-    grid = make_complete_graph(V)
-    K = grid.size(1)
+    K = V * (V - 1) // 2
     edge_logits = torch.rand(K)
     edges = [(v, v + 1) for v in range(V - 1)]
     for _ in range(10):
-        edges = sample_tree(grid, edge_logits, edges)
+        edges = sample_tree(edge_logits, edges)
 
 
 @pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
@@ -43,11 +42,10 @@ def test_sample_tree_2_smoke(num_edges):
     pyro.set_rng_seed(num_edges)
     E = num_edges
     V = 1 + E
-    grid = make_complete_graph(V)
-    K = grid.size(1)
+    K = V * (V - 1) // 2
     edge_logits = torch.rand(K)
     for _ in range(10):
-        sample_tree_2(grid, edge_logits)
+        sample_tree_2(edge_logits)
 
 
 @pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
@@ -67,8 +65,8 @@ def test_sample_tree_gof(num_edges):
     pyro.set_rng_seed(2 ** 32 - num_edges)
     E = num_edges
     V = 1 + E
+    K = V * (V - 1) // 2
     grid = make_complete_graph(V)
-    K = grid.size(1)
     edge_logits = torch.rand(K)
     edge_logits_dict = {(v1, v2): edge_logits[k] for k, (v1, v2) in enumerate(grid.t().numpy())}
 
@@ -77,7 +75,7 @@ def test_sample_tree_gof(num_edges):
     counts = defaultdict(int)
     edges = [(v, v + 1) for v in range(V - 1)]
     for _ in range(num_samples):
-        edges = sample_tree(grid, edge_logits, edges)
+        edges = sample_tree(edge_logits, edges)
         counts[tuple(edges)] += 1
     assert len(counts) == NUM_SPANNING_TREES[V]
 
@@ -107,8 +105,8 @@ def test_sample_tree_2_gof(num_edges):
     pyro.set_rng_seed(2 ** 32 - num_edges)
     E = num_edges
     V = 1 + E
+    K = V * (V - 1) // 2
     grid = make_complete_graph(V)
-    K = grid.size(1)
     edge_logits = torch.rand(K)
     edge_logits_dict = {(v1, v2): edge_logits[k] for k, (v1, v2) in enumerate(grid.t().numpy())}
 
@@ -116,7 +114,7 @@ def test_sample_tree_2_gof(num_edges):
     num_samples = 30 * NUM_SPANNING_TREES[V]
     counts = defaultdict(int)
     for _ in range(num_samples):
-        edges = sample_tree_2(grid, edge_logits)
+        edges = sample_tree_2(edge_logits)
         counts[edges] += 1
     assert len(counts) == NUM_SPANNING_TREES[V]
 
@@ -146,8 +144,8 @@ def test_sample_tree_3_gof(num_edges):
     pyro.set_rng_seed(2 ** 32 - num_edges)
     E = num_edges
     V = 1 + E
+    K = V * (V - 1) // 2
     grid = make_complete_graph(V)
-    K = grid.size(1)
     edge_logits = torch.rand(K)
     edge_logits_dict = {(v1, v2): edge_logits[k] for k, (v1, v2) in enumerate(grid.t().numpy())}
 

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import logging
 from collections import Counter
 
 import pytest
@@ -138,7 +139,5 @@ def test_sample_tree_gof(method, backend, num_edges):
     probs = SpanningTree(edge_logits).log_prob(tensors).exp()
     gof = goftests.multinomial_goodness_of_fit(
         probs.numpy(), counts.numpy(), num_samples, plot=True, truncated=truncated)
-    if method == "approx":
-        assert gof >= 5e-5
-    else:
-        assert gof >= 5e-3
+    logging.info('gof = {}'.format(gof))
+    assert gof >= 0.01

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -100,6 +100,7 @@ def test_sample_tree_gof(num_edges):
     assert 1e-2 < gof
 
 
+@pytest.mark.xfail(reason="approximate sampler is used only for initialization")
 @pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
 def test_sample_tree_2_gof(num_edges):
     goftests = pytest.importorskip('goftests')
@@ -138,6 +139,7 @@ def test_sample_tree_2_gof(num_edges):
     assert 1e-2 < gof
 
 
+@pytest.mark.xfail(reason="approximate sampler is used only for initialization")
 @pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
 def test_sample_tree_3_gof(num_edges):
     goftests = pytest.importorskip('goftests')
@@ -177,7 +179,7 @@ def test_sample_tree_3_gof(num_edges):
     assert 1e-2 < gof
 
 
-@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
+@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5, 6])
 def test_enumerate_support(num_edges):
     pyro.set_rng_seed(2 ** 32 - num_edges)
     E = num_edges
@@ -192,7 +194,7 @@ def test_enumerate_support(num_edges):
     assert support.size(0) == NUM_SPANNING_TREES[V]
 
 
-@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
+@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5, 6])
 def test_partition_function(num_edges):
     pyro.set_rng_seed(2 ** 32 - num_edges)
     E = num_edges
@@ -210,7 +212,7 @@ def test_partition_function(num_edges):
     assert (actual - expected).abs() < 1e-6, (actual, expected)
 
 
-@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
+@pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5, 6])
 def test_log_prob(num_edges):
     pyro.set_rng_seed(2 ** 32 - num_edges)
     E = num_edges

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -12,14 +12,14 @@ from tests.common import assert_equal, xfail_if_not_implemented
 
 
 @pytest.mark.parametrize('num_vertices,expected_grid', [
-    (2, [[0], [0], [1]]),
-    (3, [[0, 1, 2], [0, 0, 1], [1, 2, 2]]),
-    (4, [[0, 1, 2, 3, 4, 5], [0, 0, 1, 0, 1, 2], [1, 2, 2, 3, 3, 3]]),
+    (2, [[0], [1]]),
+    (3, [[0, 0, 1], [1, 2, 2]]),
+    (4, [[0, 0, 1, 0, 1, 2], [1, 2, 2, 3, 3, 3]]),
 ])
 def test_make_complete_graph(num_vertices, expected_grid):
     V = num_vertices
     K = V * (V - 1) // 2
-    expected_grid = torch.tensor(expected_grid, dtype=torch.long).reshape(3, K)
+    expected_grid = torch.tensor(expected_grid, dtype=torch.long).reshape(2, K)
 
     grid = make_complete_graph(V)
     assert_equal(grid, expected_grid)
@@ -31,7 +31,7 @@ def test_sample_tree_smoke(num_edges):
     E = num_edges
     V = 1 + E
     grid = make_complete_graph(V)
-    K = grid.shape[1]
+    K = grid.size(1)
     edge_logits = torch.rand(K)
     edges = [(v, v + 1) for v in range(V - 1)]
     for _ in range(10):
@@ -44,7 +44,7 @@ def test_sample_tree_2_smoke(num_edges):
     E = num_edges
     V = 1 + E
     grid = make_complete_graph(V)
-    K = grid.shape[1]
+    K = grid.size(1)
     edge_logits = torch.rand(K)
     for _ in range(10):
         sample_tree_2(grid, edge_logits)
@@ -68,9 +68,9 @@ def test_sample_tree_gof(num_edges):
     E = num_edges
     V = 1 + E
     grid = make_complete_graph(V)
-    K = grid.shape[1]
+    K = grid.size(1)
     edge_logits = torch.rand(K)
-    edge_logits_dict = {(v1, v2): edge_logits[k] for k, v1, v2 in grid.t().numpy()}
+    edge_logits_dict = {(v1, v2): edge_logits[k] for k, (v1, v2) in enumerate(grid.t().numpy())}
 
     # Generate many samples via MCMC.
     num_samples = 30 * NUM_SPANNING_TREES[V]
@@ -108,9 +108,9 @@ def test_sample_tree_2_gof(num_edges):
     E = num_edges
     V = 1 + E
     grid = make_complete_graph(V)
-    K = grid.shape[1]
+    K = grid.size(1)
     edge_logits = torch.rand(K)
-    edge_logits_dict = {(v1, v2): edge_logits[k] for k, v1, v2 in grid.t().numpy()}
+    edge_logits_dict = {(v1, v2): edge_logits[k] for k, (v1, v2) in enumerate(grid.t().numpy())}
 
     # Generate many samples.
     num_samples = 30 * NUM_SPANNING_TREES[V]
@@ -147,9 +147,9 @@ def test_sample_tree_3_gof(num_edges):
     E = num_edges
     V = 1 + E
     grid = make_complete_graph(V)
-    K = grid.shape[1]
+    K = grid.size(1)
     edge_logits = torch.rand(K)
-    edge_logits_dict = {(v1, v2): edge_logits[k] for k, v1, v2 in grid.t().numpy()}
+    edge_logits_dict = {(v1, v2): edge_logits[k] for k, (v1, v2) in enumerate(grid.t().numpy())}
 
     # Generate many samples.
     num_samples = 30 * NUM_SPANNING_TREES[V]

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -124,11 +124,10 @@ def test_sample_tree_gof(method, backend, num_edges, pattern):
         num_samples = 30 * NUM_SPANNING_TREES[V]
     elif pattern == "sparse":
         edge_logits = torch.rand(K)
-        k = 0
         for v2 in range(V):
             for v1 in range(v2):
                 if v1 + 1 < v2:
-                    edge_logits[k] = -float('inf')
+                    edge_logits[v1 + v2 * (v2 - 1) // 2] = -float('inf')
         num_samples = 10 * NUM_SPANNING_TREES[V]
 
     # Generate many samples.

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -10,6 +10,7 @@ from pyro.distributions.spanning_tree import (NUM_SPANNING_TREES, SpanningTree, 
                                               sample_tree_mcmc)
 from tests.common import assert_equal, xfail_if_not_implemented
 
+
 @pytest.mark.filterwarnings("always")
 @pytest.mark.parametrize('num_vertices,expected_grid', [
     (2, [[0], [1]]),

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -10,7 +10,7 @@ from pyro.distributions.spanning_tree import (NUM_SPANNING_TREES, SpanningTree, 
                                               sample_tree_mcmc)
 from tests.common import assert_equal, xfail_if_not_implemented
 
-
+@pytest.mark.filterwarnings("always")
 @pytest.mark.parametrize('num_vertices,expected_grid', [
     (2, [[0], [1]]),
     (3, [[0, 0, 1], [1, 2, 2]]),
@@ -26,6 +26,7 @@ def test_make_complete_graph(num_vertices, expected_grid, backend):
     assert_equal(grid, expected_grid)
 
 
+@pytest.mark.filterwarnings("always")
 @pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
 @pytest.mark.parametrize('backend', ["python", "cpp"])
 def test_sample_tree_mcmc_smoke(num_edges, backend):
@@ -39,6 +40,7 @@ def test_sample_tree_mcmc_smoke(num_edges, backend):
         edges = sample_tree_mcmc(edge_logits, edges, backend=backend)
 
 
+@pytest.mark.filterwarnings("always")
 @pytest.mark.parametrize('num_edges', [1, 3, 10, 30, 100])
 @pytest.mark.parametrize('backend', ["python", "cpp"])
 def test_sample_tree_approx_smoke(num_edges, backend):
@@ -100,6 +102,7 @@ def test_log_prob(num_edges):
     assert abs(log_total) < 1e-6, log_total
 
 
+@pytest.mark.filterwarnings("always")
 @pytest.mark.parametrize('num_edges', [1, 2, 3, 4, 5])
 @pytest.mark.parametrize('backend', ["python", "cpp"])
 @pytest.mark.parametrize('method', ["mcmc", "approx"])


### PR DESCRIPTION
Addresses #1824 

This implements a sampler, log_prob evaluator, and enumerator for random spanning trees.

The motivating application is sampling latent structures in models like [TreeCat](https://github.com/posterior/treecat). The sampler in this PR was forked from TreeCat's [numba-based sampler](https://github.com/posterior/treecat/blob/0.1.10/treecat/structure.py#L365).

I've implemented two versions of the sampler: a simple slow Python version and a C++ version which is compiled as a PyTorch extension module. I've tried to keep the Python and C++ sources synchronized as nearly line-by-line translations. To avoid installation issues for this seldom-used extension, I've used PyTorch's just-in-time extension module mechanism and included the `.cpp` file in the Pyro distribution via `MANIFEST.in` (rather than building the extension in setup.py).

## Review requests
- @neerajprad Could you please review the distribution interface and C++ extension module? 
- @martinjankowiak Could you please lightly review the stats? I've added some strong tests, so I'm fairly confident in correctness. I'm happy to explain the MCMC sampler offline.

## Tested
- [x] exact tests for `.log_prob()` and `.enumerate_support()` on small graphs.
- [x] smoke tests for both python and C++ samplers
- [x] goodness-of-fit tests for the samplers. These are **not** run on CI, and are only run locally if the [goftests](https://github.com/posterior/goftests) package is installed. This seems reasonable since these tests are expensive and we don't plan to change the algorithms frequently (there are smoke tests to ensure the code still runs).
- [x] uniform tests suggested by @martinjankowiak 