### PR TITLE
Fix infer_discrete handling of plate of size 1

### DIFF
--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -16,9 +16,9 @@ from pyro.util import jit_iter
 _RINGS = {0: MapRing, 1: SampleRing}
 
 
-def _make_ring(temperature):
+def _make_ring(temperature, dim_to_size):
     try:
-        return _RINGS[temperature]()
+        return _RINGS[temperature](dim_to_size=dim_to_size)
     except KeyError:
         raise ValueError("temperature must be 0 (map) or 1 (sample) for now")
 
@@ -48,13 +48,16 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
     log_probs = OrderedDict()
     sum_dims = set()
     queries = []
+    dim_to_size = {}
     for node in enum_trace.nodes.values():
         if node["type"] == "sample":
             ordinal = frozenset(plate_to_symbol[f.name]
-                                for f in node["cond_indep_stack"] if f.vectorized)
+                                for f in node["cond_indep_stack"]
+                                if f.vectorized and f.size > 1)
             log_prob = node["packed"]["log_prob"]
             log_probs.setdefault(ordinal, []).append(log_prob)
             sum_dims.update(log_prob._pyro_dims)
+            dim_to_size.update(zip(log_prob._pyro_dims, log_prob.shape))
             for frame in node["cond_indep_stack"]:
                 if frame.vectorized and frame.size > 1:
                     sum_dims.remove(plate_to_symbol[frame.name])
@@ -65,7 +68,7 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
                 require_backward(log_prob)
 
     # Run forward-backward algorithm, collecting the ordinal of each connected component.
-    ring = _make_ring(temperature)
+    ring = _make_ring(temperature, dim_to_size)
     log_probs = contract_tensor_tree(log_probs, sum_dims, ring=ring)  # run forward algorithm
     query_to_ordinal = {}
     pending = object()  # a constant value for pending queries
@@ -99,7 +102,7 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
                 ordinal = query_to_ordinal[log_prob]
                 new_node["cond_indep_stack"] = tuple(
                     f for f in node["cond_indep_stack"]
-                    if not f.vectorized or plate_to_symbol[f.name] in ordinal)
+                    if not (f.vectorized and f.size > 1) or plate_to_symbol[f.name] in ordinal)
 
                 # Gather if node depended on an enumerated value.
                 sample = log_prob._pyro_backward_result

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -56,7 +56,7 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
             log_probs.setdefault(ordinal, []).append(log_prob)
             sum_dims.update(log_prob._pyro_dims)
             for frame in node["cond_indep_stack"]:
-                if frame.vectorized:
+                if frame.vectorized and frame.size > 1:
                     sum_dims.remove(plate_to_symbol[frame.name])
             # Note we mark all sample sites with require_backward to gather
             # enumerated sites and adjust cond_indep_stack of all sample sites.

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -35,7 +35,7 @@ def log_mean_prob(trace, particle_dim):
 
 
 @pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
-@pytest.mark.parametrize('plate_size', [1, 2])
+@pytest.mark.parametrize('plate_size', [2])
 def test_plate_smoke(temperature, plate_size):
     #       +-----------------+
     #  z1 --|--> z2 ---> x2   |
@@ -45,10 +45,11 @@ def test_plate_smoke(temperature, plate_size):
     @config_enumerate
     def model():
         p = pyro.param("p", torch.tensor([0.25, 0.75]))
+        q = pyro.param("q", torch.tensor([[0.25, 0.75], [0.75, 0.25]]))
         loc = pyro.param("loc", torch.tensor([-1., 1.]))
         z1 = pyro.sample("z1", dist.Categorical(p))
         with pyro.plate("plate", plate_size):
-            z2 = pyro.sample("z2", dist.Categorical(p))
+            z2 = pyro.sample("z2", dist.Categorical(q[z1]))
             pyro.sample("x2", dist.Normal(loc[z2], 1.), obs=torch.ones(plate_size))
 
     first_available_dim = -2

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -35,6 +35,27 @@ def log_mean_prob(trace, particle_dim):
 
 
 @pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
+@pytest.mark.parametrize('plate_size', [1, 2])
+def test_plate_smoke(temperature, plate_size):
+    #       +-----------------+
+    #  z1 --|--> z2 ---> x2   |
+    #       |               N | for N in {1,2}
+    #       +-----------------+
+
+    @config_enumerate
+    def model():
+        p = pyro.param("p", torch.tensor([0.25, 0.75]))
+        loc = pyro.param("loc", torch.tensor([-1., 1.]))
+        z1 = pyro.sample("z1", dist.Categorical(p))
+        with pyro.plate("plate", plate_size):
+            z2 = pyro.sample("z2", dist.Categorical(p))
+            pyro.sample("x2", dist.Normal(loc[z2], 1.), obs=torch.ones(plate_size))
+
+    first_available_dim = -2
+    infer_discrete(model, first_available_dim, temperature)()
+
+
+@pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
 def test_distribution_1(temperature):
     #      +-------+
     #  z --|--> x  |


### PR DESCRIPTION
This fixes `infer_discrete`'s handling of plates of size 1.

This issue arises because `pyro.ops.packed` ignores dims of size 1, but `infer_discrete` logic required (before this PR) all dims to be accounted for. I've also had to plumb `dim_to_size` through `_make_ring()` inside `infer_discrete`, which we must have forgotten originally (I followed the correct better-tested implementation in ubersum).

## Tested
- added a smoke test
- tested in the contrib-treecat branch as part of #1370 