### PR TITLE
Use Vindex in Categorical.log_prob()?

### DIFF
--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -5,6 +5,14 @@ from torch.distributions import constraints, kl_divergence, register_kl
 
 from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistributionMixin
 from pyro.distributions.util import sum_rightmost
+from pyro.ops.indexing import Vindex
+
+
+class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return Vindex(self.logits)[..., value.long()]
 
 
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):


### PR DESCRIPTION
This PR aims to speed up `Categorical.log_prob()` by replacing `torch.gather` with `Vindex`.

This is sometimes faster, sometimes slower than `torch.distributions.Categorical.log_prob()`. But in my treecat example it is 10x faster. Probably we should determine in what circumstances `Vindex` is cheaper than `torch.gather` and put some special handling logic in `log_prob()`.

Here are the `logit,value` shapes in examples/tabular.py (where the speedup is significant):
```
--------------------------------------
   COUNT SHAPES
     304 ((16, 1, 506, 16), (16, 1))
     294 ((16, 506, 16), (16, 1, 1))
      46 ((506, 16), (16, 1))
       7 ((16, 100, 20, 16), (16, 1, 1, 1))
       6 ((16, 1, 100, 20, 16), (16, 1, 1))
       1 ((100, 20, 16), (16, 1, 1))
--------------------------------------
```

## Tested
- [x] distributions tests
- [x] performance tests on CPU
    - 10x speedup for `Categorical.log_prob()` in [examples/tabular.py](https://github.com/pyro-ppl/pyro/blob/contrib-treecat/examples/tabular.py)
    - 20% slowdown in examples/hmm.py
- [ ] performance tests on CUDA