### PR TITLE
Optimize Categorical.log_prob() of enumerated support

### DIFF
--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -5,14 +5,33 @@ from torch.distributions import constraints, kl_divergence, register_kl
 
 from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistributionMixin
 from pyro.distributions.util import sum_rightmost
-from pyro.ops.indexing import Vindex
 
 
+# This overloads .log_prob() and .enumerate_support() to speed up evaluating
+# log_prob on the support of this variable: we can completely avoid tensor ops
+# and merely reshape the self.logits tensor. This is especially important for
+# Pyro models that use enumeration.
 class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
+
     def log_prob(self, value):
-        if self._validate_args:
-            self._validate_sample(value)
-        return Vindex(self.logits)[..., value.long()]
+        if hasattr(value, '_pyro_categorical_support'):
+            # Assume value is a reshaped torch.arange(event_shape[0]).
+            # In this case we can call .reshape() rather than torch.gather().
+            if self._validate_args:
+                self._validate_sample(value)
+            assert value.size(0) == self.logits.size(-1)
+            logits = self.logits
+            if logits.dim() <= value.dim():
+                logits = logits.reshape((1,) * (1 + value.dim() - logits.dim()) + logits.shape)
+            assert logits.size(-1 - value.dim()) == 1
+            return logits.transpose(-1 - value.dim(), -1).squeeze(-1)
+        return super(Categorical, self).log_prob(value)
+
+    def enumerate_support(self, expand=True):
+        result = super(Categorical, self).enumerate_support(expand=expand)
+        if not expand:
+            result._pyro_categorical_support = None
+        return result
 
 
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -5,6 +5,14 @@ from torch.distributions import constraints, kl_divergence, register_kl
 
 from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistributionMixin
 from pyro.distributions.util import sum_rightmost
+from pyro.ops.indexing import Vindex
+
+
+class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return Vindex(self.logits)[..., value.long()]
 
 
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -17,13 +17,15 @@ class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
         if getattr(value, '_pyro_categorical_support', None) == id(self):
             # Assume value is a reshaped torch.arange(event_shape[0]).
             # In this case we can call .reshape() rather than torch.gather().
-            if self._validate_args:
-                self._validate_sample(value)
-            assert value.size(0) == self.logits.size(-1)
+            if not torch._C._get_tracing_state():
+                if self._validate_args:
+                    self._validate_sample(value)
+                assert value.size(0) == self.logits.size(-1)
             logits = self.logits
             if logits.dim() <= value.dim():
                 logits = logits.reshape((1,) * (1 + value.dim() - logits.dim()) + logits.shape)
-            assert logits.size(-1 - value.dim()) == 1
+            if not torch._C._get_tracing_state():
+                assert logits.size(-1 - value.dim()) == 1
             return logits.transpose(-1 - value.dim(), -1).squeeze(-1)
         return super(Categorical, self).log_prob(value)
 

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -14,7 +14,7 @@ from pyro.distributions.util import sum_rightmost
 class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
 
     def log_prob(self, value):
-        if hasattr(value, '_pyro_categorical_support'):
+        if getattr(value, '_pyro_categorical_support', None) == id(self):
             # Assume value is a reshaped torch.arange(event_shape[0]).
             # In this case we can call .reshape() rather than torch.gather().
             if self._validate_args:
@@ -30,7 +30,7 @@ class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
     def enumerate_support(self, expand=True):
         result = super(Categorical, self).enumerate_support(expand=expand)
         if not expand:
-            result._pyro_categorical_support = None
+            result._pyro_categorical_support = id(self)
         return result
 
 

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -71,7 +71,13 @@ class EnumerateMessenger(Messenger):
         # Move actual_dim to a safe target_dim.
         target_dim, id_ = _ENUM_ALLOCATOR.allocate(None if scope is None else param_dims)
         event_dim = msg["fn"].event_dim
-        if actual_dim < target_dim:
+        if hasattr(value, '_pyro_categorical_support'):
+            # Preserve categorical supports to speed up Categorical.log_prob().
+            # See pyro/distributions/torch.py for details.
+            assert target_dim < 0
+            value = value.reshape(value.shape[:1] + (1,) * (-1 - target_dim))
+            value._pyro_categorical_support = None
+        elif actual_dim < target_dim:
             assert value.size(target_dim - event_dim) == 1, \
                 'pyro.markov dim conflict at dim {}'.format(actual_dim)
             value = value.transpose(target_dim - event_dim, actual_dim - event_dim)

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -71,12 +71,13 @@ class EnumerateMessenger(Messenger):
         # Move actual_dim to a safe target_dim.
         target_dim, id_ = _ENUM_ALLOCATOR.allocate(None if scope is None else param_dims)
         event_dim = msg["fn"].event_dim
-        if hasattr(value, '_pyro_categorical_support'):
+        categorical_support = getattr(value, '_pyro_categorical_support', None)
+        if categorical_support is not None:
             # Preserve categorical supports to speed up Categorical.log_prob().
             # See pyro/distributions/torch.py for details.
             assert target_dim < 0
             value = value.reshape(value.shape[:1] + (1,) * (-1 - target_dim))
-            value._pyro_categorical_support = None
+            value._pyro_categorical_support = categorical_support
         elif actual_dim < target_dim:
             assert value.size(target_dim - event_dim) == 1, \
                 'pyro.markov dim conflict at dim {}'.format(actual_dim)


### PR DESCRIPTION
This adds an optimization to `dist.Categorical` to completely avoid tensor ops in `x.log_prob(x.enumerate_support())`, thus speeding up inference using enumeration. In particular it can replace a `torch.gather()` with a `reshape`-`transpose`-`unsqueeze`.

## Performance

- [examples/tabular.py](https://github.com/pyro-ppl/pyro/blob/contrib-treecat/examples/tabular.py): 139s -> 79s
  (that's overall; `torch.gather` was taking 70s alone, all of which is eliminated by this PR)
- examples/hmm.py --model 1: 15.5s -> 13.1s
- examples/hmm.py --model 4: 21.5s -> 18.8s
- examples/hmm.py --model 6: 73.9s -> 32.1s
- examples/hmm.py --model 6 --jit: 63.8s -> 26.4s

## Tested
- refactoring is covered by existing tests, especially test_enum.py
- tested performance on contrib-treecat branch