### PR TITLE
Fix MNIST dataloader with newer torchvision package

### DIFF
--- a/examples/vae/utils/mnist_cached.py
+++ b/examples/vae/utils/mnist_cached.py
@@ -146,38 +146,38 @@ class MNISTCached(MNIST):
 
             # transform the training data if transformations are provided
             if transform is not None:
-                self.train_data = (transform(self.train_data.float()))
+                self.data = (transform(self.data.float()))
             if target_transform is not None:
-                self.train_labels = (target_transform(self.train_labels))
+                self.targets = (target_transform(self.targets))
 
             if MNISTCached.train_data_sup is None:
                 if sup_num is None:
                     assert mode == "unsup"
                     MNISTCached.train_data_unsup, MNISTCached.train_labels_unsup = \
-                        self.train_data, self.train_labels
+                        self.data, self.targets
                 else:
                     MNISTCached.train_data_sup, MNISTCached.train_labels_sup, \
                         MNISTCached.train_data_unsup, MNISTCached.train_labels_unsup, \
                         MNISTCached.data_valid, MNISTCached.labels_valid = \
-                        split_sup_unsup_valid(self.train_data, self.train_labels, sup_num)
+                        split_sup_unsup_valid(self.data, self.targets, sup_num)
 
             if mode == "sup":
-                self.train_data, self.train_labels = MNISTCached.train_data_sup, MNISTCached.train_labels_sup
+                self.data, self.targets = MNISTCached.train_data_sup, MNISTCached.train_labels_sup
             elif mode == "unsup":
-                self.train_data = MNISTCached.train_data_unsup
+                self.data = MNISTCached.train_data_unsup
 
                 # making sure that the unsupervised labels are not available to inference
-                self.train_labels = (torch.Tensor(
+                self.targets = (torch.Tensor(
                     MNISTCached.train_labels_unsup.shape[0]).view(-1, 1)) * np.nan
             else:
-                self.train_data, self.train_labels = MNISTCached.data_valid, MNISTCached.labels_valid
+                self.data, self.targets = MNISTCached.data_valid, MNISTCached.labels_valid
 
         else:
             # transform the testing data if transformations are provided
             if transform is not None:
-                self.test_data = (transform(self.test_data.float()))
+                self.data = (transform(self.data.float()))
             if target_transform is not None:
-                self.test_labels = (target_transform(self.test_labels))
+                self.targets = (target_transform(self.targets))
 
     def __getitem__(self, index):
         """
@@ -185,9 +185,9 @@ class MNISTCached(MNIST):
         :returns tuple: (image, target) where target is index of the target class.
         """
         if self.mode in ["sup", "unsup", "valid"]:
-            img, target = self.train_data[index], self.train_labels[index]
+            img, target = self.data[index], self.targets[index]
         elif self.mode == "test":
-            img, target = self.test_data[index], self.test_labels[index]
+            img, target = self.data[index], self.targets[index]
         else:
             assert False, "invalid mode: {}".format(self.mode)
         return img, target

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = [
     'matplotlib>=1.3',
     'observations>=0.1.4',
     'pillow',
-    'torchvision==0.2.1',
+    'torchvision>=0.2.2',
     'visdom>=0.1.4',
     'pandas',
     'seaborn',


### PR DESCRIPTION
Fixes https://github.com/pyro-ppl/pyro/issues/1782. Would be nice to address this in the minor release.

This updates the `mnist_cached.py` file so that it works with the latest torchvision package. The issue is that attributes like `test_data`, `train_data`, `test_labels`, `train_labels` are deprecated and cannot be set with the latest version. Instead, the package loads either the test / train dataset on `__init__` and these can be referenced using the `.data` and `.target` attributes. 

I think this class can probably be simplified and rewritten without depending on torchvision in the longer term, but I don't completely understand all the class internals, and hence didn't attempt a rewrite at this point.