### PR TITLE
Fix issue with categorical and readd `keep_sites` and `keep_plates` for TracePredictive

### DIFF
--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -327,7 +327,8 @@ class TracePredictive(TracePosterior):
                     # Otherwise, we assume there is an dependence of indexes between training data
                     # and prediction data.
                     batch_dim = cis.dim - site["fn"].event_dim
-                    subidxs = torch.randint(0, site['value'].size(batch_dim), (cis.size,))
+                    subidxs = torch.randint(0, site['value'].size(batch_dim), (cis.size,),
+                                            device=site["value"].device)
                     site["value"] = site["value"].index_select(batch_dim, subidxs)
             except KeyError:
                 pass


### PR DESCRIPTION
Hi Pyro Devs!

It seems that I apparently did need to allow an argument to allow choosing which sites should be sampled from the posterior predictive and which sites should be re-sampled in `TracePredictive`.

In particular, this is useful for 'local' parameters that allow prediction for specific data input, where I want to resample for the new data input instead of reuse predictions from the inferred posterior. 