### PR TITLE
Add JitTrace_ELBO class to minipyro

### DIFF
--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -40,7 +40,8 @@ def main(args):
     with pyro_backend(args.backend):
         # Construct an SVI object so we can do variational inference on our
         # model/guide pair.
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if args.jit else infer.Trace_ELBO
+        elbo = Elbo()
         adam = optim.Adam({"lr": args.learning_rate})
         svi = infer.SVI(model, guide, adam, elbo)
 
@@ -69,5 +70,6 @@ if __name__ == "__main__":
     parser.add_argument("-b", "--backend", default="minipyro")
     parser.add_argument("-n", "--num-steps", default=1001, type=int)
     parser.add_argument("-lr", "--learning-rate", default=0.02, type=float)
+    parser.add_argument("--jit", action="store_true")
     args = parser.parse_args()
     main(args)

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -13,10 +13,13 @@ found at examples/minipyro.py.
 """
 from __future__ import absolute_import, division, print_function
 
-from collections import OrderedDict
+import warnings
 import weakref
+from collections import OrderedDict
 
 import torch
+
+from pyro.distributions import validation_enabled
 
 # Pyro keeps track of two kinds of global state:
 # i)  The effect handler stack, which enables non-standard interpretations of
@@ -70,7 +73,8 @@ class trace(Messenger):
     # trace illustrates why we need postprocess_message in addition to process_message:
     # We only want to record a value after all other effects have been applied
     def postprocess_message(self, msg):
-        assert msg["name"] not in self.trace, "all sites must have unique names"
+        assert msg["type"] != "sample" or msg["name"] not in self.trace, \
+            "sample sites must have unique names"
         self.trace[msg["name"]] = msg.copy()
 
     def get_trace(self, *args, **kwargs):
@@ -306,5 +310,46 @@ def elbo(model, guide, *args, **kwargs):
 
 
 # This is a wrapper for compatibility with full Pyro.
-def Trace_ELBO(*args, **kwargs):
+def Trace_ELBO(**kwargs):
     return elbo
+
+
+# This is a Jit wrapper around elbo() that (1) delays tracing until the first
+# invocation, and (2) registers pyro.param() statements with torch.jit.trace.
+# This version does not support variable number of args or non-tensor kwargs.
+class JitTrace_ELBO(object):
+    def __init__(self, **kwargs):
+        self.ignore_jit_warnings = kwargs.pop("ignore_jit_warnings", False)
+        self._compiled = None
+        self._param_trace = None
+
+    def __call__(self, model, guide, *args):
+        # On first call, initialize params and save their names.
+        if self._param_trace is None:
+            with block(), trace() as tr, block(hide_fn=lambda m: m["type"] != "param"):
+                elbo(model, guide, *args)
+            self._param_trace = tr
+
+        # Augment args with reads from the global param store.
+        unconstrained_params = tuple(param(name).unconstrained()
+                                     for name in self._param_trace)
+        params_and_args = unconstrained_params + args
+
+        # On first call, create a compiled elbo.
+        if self._compiled is None:
+
+            def compiled(*params_and_args):
+                unconstrained_params = params_and_args[:len(self._param_trace)]
+                args = params_and_args[len(self._param_trace):]
+                for name, unconstrained_param in zip(self._param_trace, unconstrained_params):
+                    constrained_param = param(name)  # assume param has been initialized
+                    assert constrained_param.unconstrained() is unconstrained_param
+                    self._param_trace[name]["value"] = constrained_param
+                return replay(elbo, guide_trace=self._param_trace)(model, guide, *args)
+
+            with validation_enabled(False), warnings.catch_warnings():
+                if self.ignore_jit_warnings:
+                    warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
+                self._compiled = torch.jit.trace(compiled, params_and_args, check_trace=False)
+
+        return self._compiled(*params_and_args)

--- a/tests/contrib/test_minipyro.py
+++ b/tests/contrib/test_minipyro.py
@@ -84,8 +84,9 @@ def test_generate_data_plate(backend):
         assert 1.9 <= mean <= 2.1
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro"])
-def test_nonempty_model_empty_guide_ok(backend):
+def test_nonempty_model_empty_guide_ok(backend, jit):
 
     def model(data):
         loc = pyro.param("loc", torch.tensor(0.0))
@@ -96,12 +97,14 @@ def test_nonempty_model_empty_guide_ok(backend):
 
     data = torch.tensor(2.)
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo, data)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro"])
-def test_plate_ok(backend):
+def test_plate_ok(backend, jit):
     data = torch.randn(10)
 
     def model():
@@ -117,12 +120,14 @@ def test_plate_ok(backend):
             pyro.sample("x", dist.Categorical(p))
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro"])
-def test_nested_plate_plate_ok(backend):
+def test_nested_plate_plate_ok(backend, jit):
     data = torch.randn(2, 3)
 
     def model():
@@ -139,15 +144,17 @@ def test_nested_plate_plate_ok(backend):
             pyro.sample("x", dist.Normal(loc, scale))
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", [
     "pyro",
     xfail_param("minipyro", reason="not implemented"),
 ])
-def test_local_param_ok(backend):
+def test_local_param_ok(backend, jit):
     data = torch.randn(10)
 
     def model():
@@ -163,7 +170,8 @@ def test_local_param_ok(backend):
         return p
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)
 
         # Check that pyro.param() can be called without init_value.
@@ -172,8 +180,9 @@ def test_local_param_ok(backend):
         assert_close(actual, expected)
 
 
+@pytest.mark.parametrize("jit", [False, True], ids=["py", "jit"])
 @pytest.mark.parametrize("backend", ["pyro", "minipyro"])
-def test_constraints(backend):
+def test_constraints(backend, jit):
     data = torch.tensor(0.5)
 
     def model():
@@ -188,5 +197,6 @@ def test_constraints(backend):
         pyro.sample("x", dist.Categorical(q))
 
     with pyro_backend(backend):
-        elbo = infer.Trace_ELBO()
+        Elbo = infer.JitTrace_ELBO if jit else infer.Trace_ELBO
+        elbo = Elbo(ignore_jit_warnings=True)
         assert_ok(model, guide, elbo)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -117,6 +117,8 @@ JIT_EXAMPLES = [
     'hmm.py --num-steps=1 --truncate=10 --model=4 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=5 --jit',
     xfail_jit('lda.py --num-steps=2 --num-words=100 --num-docs=100 --num-words-per-doc=8 --jit'),
+    'minipyro.py --backend=pyro --jit',
+    'minipyro.py --jit',
     xfail_jit('vae/ss_vae_M2.py --num-epochs=1 --aux-loss --jit'),
     'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=parallel --jit',
     'vae/ss_vae_M2.py --num-epochs=1 --enum-discrete=sequential --jit',


### PR DESCRIPTION
This adds a `JitTrace_ELBO` class to pyro.contrib.minipyro.

Motivation is twofold:
- didactic to help users understand what our jit wrappers elbos, and
- standardization to support `JitTrace_ELBO` implementations in other backends like funsor.
```
time    command line
---------------------------------------------------------------------
16.06s  python examples/minipyro.py -n 10000 --backend=pyro
 8.81s  python examples/minipyro.py -n 10000 --backend=pyro --jit
 8.73s  python examples/minipyro.py -n 10000 --backend=minipyro
 7.21s  python examples/minipyro.py -n 10000 --backend=minipyro --jit
```

## Tested
- [x] added unit test cases in test_minipyro.py
- [x] updated examples/minipyro.py and confirmed convergence
- [x] added test cases to tests/test_examples.py