### PR TITLE
Avoid using legacy constructors Tensor.new_*()

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -9,7 +9,7 @@ import torch
 
 import pyro
 from pyro.distributions import Beta, Binomial, HalfCauchy, Normal, Pareto, Uniform
-from pyro.distributions.util import logsumexp
+from pyro.distributions.util import logsumexp, scalar_like
 from pyro.infer.abstract_infer import TracePredictive
 from pyro.infer.mcmc import MCMC, NUTS
 
@@ -67,7 +67,7 @@ def fully_pooled(at_bats, hits):
     :param (torch.Tensor) hits: Number of hits for the given at bats.
     :return: Number of hits predicted by the model.
     """
-    phi_prior = Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1))
+    phi_prior = Uniform(scalar_like(at_bats, 0), scalar_like(at_bats, 1))
     phi = pyro.sample("phi", phi_prior)
     return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
@@ -83,7 +83,7 @@ def not_pooled(at_bats, hits):
     """
     num_players = at_bats.shape[0]
     with pyro.plate("num_players", num_players):
-        phi_prior = Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1))
+        phi_prior = Uniform(scalar_like(at_bats, 0), scalar_like(at_bats, 1))
         phi = pyro.sample("phi", phi_prior)
         return pyro.sample("obs", Binomial(at_bats, phi), obs=hits)
 
@@ -101,8 +101,8 @@ def partially_pooled(at_bats, hits):
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
-    m = pyro.sample("m", Uniform(at_bats.new_tensor(0), at_bats.new_tensor(1)))
-    kappa = pyro.sample("kappa", Pareto(at_bats.new_tensor(1), at_bats.new_tensor(1.5)))
+    m = pyro.sample("m", Uniform(scalar_like(at_bats, 0), scalar_like(at_bats, 1)))
+    kappa = pyro.sample("kappa", Pareto(scalar_like(at_bats, 1), scalar_like(at_bats, 1.5)))
     with pyro.plate("num_players", num_players):
         phi_prior = Beta(m * kappa, (1 - m) * kappa)
         phi = pyro.sample("phi", phi_prior)
@@ -120,8 +120,8 @@ def partially_pooled_with_logit(at_bats, hits):
     :return: Number of hits predicted by the model.
     """
     num_players = at_bats.shape[0]
-    loc = pyro.sample("loc", Normal(at_bats.new_tensor(-1), at_bats.new_tensor(1)))
-    scale = pyro.sample("scale", HalfCauchy(scale=at_bats.new_tensor(1)))
+    loc = pyro.sample("loc", Normal(scalar_like(at_bats, -1), scalar_like(at_bats, 1)))
+    scale = pyro.sample("scale", HalfCauchy(scale=scalar_like(at_bats, 1)))
     with pyro.plate("num_players", num_players):
         alpha = pyro.sample("alpha", Normal(loc, scale))
         return pyro.sample("obs", Binomial(at_bats, logits=alpha), obs=hits)

--- a/examples/bayesian_regression.py
+++ b/examples/bayesian_regression.py
@@ -53,10 +53,11 @@ regression_model = RegressionModel(p)
 
 def model(data):
     # Create unit normal priors over the parameters
-    loc = data.new_zeros(torch.Size((1, p)))
-    scale = 2 * data.new_ones(torch.Size((1, p)))
-    bias_loc = data.new_zeros(torch.Size((1,)))
-    bias_scale = 2 * data.new_ones(torch.Size((1,)))
+    options = dict(dtype=data.dtype, device=data.device)
+    loc = torch.zeros(1, p, **options)
+    scale = 2 * torch.ones(1, p, **options)
+    bias_loc = torch.zeros(1, **options)
+    bias_scale = 2 * torch.ones(1, **options)
     w_prior = Normal(loc, scale).to_event(1)
     b_prior = Normal(bias_loc, bias_scale).to_event(1)
     priors = {'linear.weight': w_prior, 'linear.bias': b_prior}

--- a/examples/contrib/oed/gp_bayes_opt.py
+++ b/examples/contrib/oed/gp_bayes_opt.py
@@ -86,8 +86,8 @@ class GPBayesOptimizer(pyro.optim.multi.MultiOptimizer):
         candidates = []
         values = []
         for j in range(num_candidates):
-            x_init = self.gpmodel.X.new_empty(1).uniform_(
-                self.constraints.lower_bound, self.constraints.upper_bound)
+            x_init = (torch.empty(1, dtype=self.gpmodel.X.dtype, device=self.gpmodel.X.device)
+                      .uniform_(self.constraints.lower_bound, self.constraints.upper_bound))
             x, y = self.find_a_candidate(differentiable, x_init)
             if torch.isnan(y):
                 continue
@@ -109,7 +109,8 @@ class GPBayesOptimizer(pyro.optim.multi.MultiOptimizer):
         """
 
         # Initialize the return tensor
-        X = self.gpmodel.X.new_empty(num_acquisitions, *self.gpmodel.X.shape[1:])
+        X = self.gpmodel.X
+        X = torch.empty(num_acquisitions, *X.shape[1:], dtype=X.dtype, device=X.device)
 
         for i in range(num_acquisitions):
             sampler = self.gpmodel.iter_sample(noiseless=False)

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -101,7 +101,7 @@ def load_data(dataset):
 # this function takes a torch mini-batch and reverses each sequence
 # (w.r.t. the temporal axis, i.e. axis=1).
 def reverse_sequences(mini_batch, seq_lengths):
-    reversed_mini_batch = mini_batch.new_zeros(mini_batch.size())
+    reversed_mini_batch = torch.zeros_like(mini_batch)
     for b in range(mini_batch.size(0)):
         T = seq_lengths[b]
         time_slice = torch.arange(T - 1, -1, -1, device=mini_batch.device)

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -388,7 +388,8 @@ class TonesGenerator(nn.Module):
         # a bernoulli variable y. Whereas x will typically be enumerated, y will be observed.
         # We apply x_to_hidden independently from y_to_hidden, then broadcast the non-enumerated
         # y part up to the enumerated x part in the + operation.
-        x_onehot = y.new_zeros(x.shape[:-1] + (self.args.hidden_dim,)).scatter_(-1, x, 1)
+        x_onehot = (torch.zeros(x.shape[:-1] + (self.args.hidden_dim,), dtype=y.dtype, device=y.device)
+                    .scatter_(-1, x, 1))
         y_conv = self.relu(self.conv(y.unsqueeze(-2))).reshape(y.shape[:-1] + (-1,))
         h = self.relu(self.x_to_hidden(x_onehot) + self.y_to_hidden(y_conv))
         return self.hidden_to_logits(h)

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -19,17 +19,18 @@ and vector of variances.
 def model(y):
     d = y.shape[1]
     N = y.shape[0]
+    options = dict(dtype=y.dtype, device=y.device)
     # Vector of variances for each of the d variables
-    theta = pyro.sample("theta", dist.HalfCauchy(y.new_ones(d)))
+    theta = pyro.sample("theta", dist.HalfCauchy(torch.ones(d, **options)))
     # Lower cholesky factor of a correlation matrix
-    eta = y.new_ones(1)  # Implies a uniform distribution over correlation matrices
+    eta = torch.ones(1, **options)  # Implies a uniform distribution over correlation matrices
     L_omega = pyro.sample("L_omega", dist.LKJCorrCholesky(d, eta))
     # Lower cholesky factor of the covariance matrix
     L_Omega = torch.mm(torch.diag(theta.sqrt()), L_omega)
     # For inference with SVI, one might prefer to use torch.bmm(theta.sqrt().diag_embed(), L_omega)
 
     # Vector of expectations
-    mu = y.new_zeros(d)
+    mu = torch.zeros(d, **options)
 
     with pyro.plate("observations", N):
         obs = pyro.sample("obs", dist.MultivariateNormal(mu, scale_tril=L_Omega), obs=y)

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -102,16 +102,17 @@ class SSVAE(nn.Module):
         pyro.module("ss_vae", self)
 
         batch_size = xs.size(0)
+        options = dict(dtype=xs.dtype, device=xs.device)
         with pyro.plate("data"):
 
             # sample the handwriting style from the constant prior distribution
-            prior_loc = xs.new_zeros([batch_size, self.z_dim])
-            prior_scale = xs.new_ones([batch_size, self.z_dim])
+            prior_loc = torch.zeros(batch_size, self.z_dim, **options)
+            prior_scale = torch.ones(batch_size, self.z_dim, **options)
             zs = pyro.sample("z", dist.Normal(prior_loc, prior_scale).to_event(1))
 
             # if the label y (which digit to write) is supervised, sample from the
             # constant prior, otherwise, observe the value (i.e. score it against the constant prior)
-            alpha_prior = xs.new_ones([batch_size, self.output_size]) / (1.0 * self.output_size)
+            alpha_prior = torch.ones(batch_size, self.output_size, **options) / (1.0 * self.output_size)
             ys = pyro.sample("y", dist.OneHotCategorical(alpha_prior), obs=ys)
 
             # finally, score the image (x) using the handwriting style (z) and
@@ -167,8 +168,7 @@ class SSVAE(nn.Module):
         res, ind = torch.topk(alpha, 1)
 
         # convert the digit(s) to one-hot tensor(s)
-        ys = xs.new_zeros(alpha.size())
-        ys = ys.scatter_(1, ind, 1.0)
+        ys = torch.zeros_like(alpha).scatter_(1, ind, 1.0)
         return ys
 
     def model_classify(self, xs, ys=None):

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -83,8 +83,8 @@ class VAE(nn.Module):
         pyro.module("decoder", self.decoder)
         with pyro.plate("data", x.shape[0]):
             # setup hyperparameters for prior p(z)
-            z_loc = x.new_zeros(torch.Size((x.shape[0], self.z_dim)))
-            z_scale = x.new_ones(torch.Size((x.shape[0], self.z_dim)))
+            z_loc = torch.zeros(x.shape[0], self.z_dim, dtype=x.dtype, device=x.device)
+            z_scale = torch.ones(x.shape[0], self.z_dim, dtype=x.dtype, device=x.device)
             # sample from prior (value will be sampled by guide when computing the ELBO)
             z = pyro.sample("latent", dist.Normal(z_loc, z_scale).to_event(1))
             # decode the latent code z

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -431,7 +431,7 @@ class AutoContinuous(AutoGuide):
         :rtype: dict
         """
         loc, scale = self._loc_scale(*args, **kwargs)
-        quantiles = loc.new_tensor(quantiles).unsqueeze(-1)
+        quantiles = torch.tensor(quantiles, dtype=loc.dtype, device=loc.device).unsqueeze(-1)
         latents = dist.Normal(loc, scale).icdf(quantiles)
         result = {}
         for latent in latents:

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -270,7 +270,7 @@ class SVI(object):
         self.optim(params)
         # Zero out the gradients so that they don't accumulate.
         for p in params:
-            p.grad = p.new_zeros(p.shape)
+            p.grad = torch.zeros_like(p)
         return loss.item()
 
 

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -75,7 +75,7 @@ class EKFDistribution(TorchDistribution):
         state = EKFState(self.dynamic_model, self.x0, self.P0, time=0.)
         result = 0.
         assert value.shape == self.event_shape
-        zero = value.new_zeros(self.event_shape[-1])
+        zero = torch.zeros(self.event_shape[-1], dtype=value.dtype, device=value.device)
         for i, measurement_mean in enumerate(value):
             if i:
                 state = state.predict(self.dt)

--- a/pyro/contrib/tracking/dynamic_models.py
+++ b/pyro/contrib/tracking/dynamic_models.py
@@ -118,7 +118,7 @@ class DynamicModel(nn.Module):
         :return: :class:`~pyro.distributions.torch.MultivariateNormal`.
         '''
         Q = self.process_noise_cov(dt)
-        return dist.MultivariateNormal(Q.new_zeros(Q.shape[-1]), Q)
+        return dist.MultivariateNormal(torch.zeros(Q.shape[-1], dtype=Q.dtype, device=Q.device), Q)
 
 
 class DifferentiableDynamicModel(DynamicModel):
@@ -182,7 +182,7 @@ class Ncp(DifferentiableDynamicModel):
         :return: PV state estimate mean.
         '''
         with torch.no_grad():
-            x_pv = x.new_zeros(2*self._dimension)
+            x_pv = torch.zeros(2 * self._dimension, dtype=x.dtype, device=x.device)
             x_pv[:self._dimension] = x
         return x_pv
 
@@ -197,7 +197,7 @@ class Ncp(DifferentiableDynamicModel):
         '''
         d = 2*self._dimension
         with torch.no_grad():
-            P_pv = P.new_zeros((d, d))
+            P_pv = torch.zeros(d, d, dtype=P.dtype, device=P.device)
             P_pv[:self._dimension, :self._dimension] = P
         return P_pv
 
@@ -372,7 +372,7 @@ class NcvContinuous(Ncv):
                 d = self._dimension
                 dt2 = dt * dt
                 dt3 = dt2 * dt
-                Q = self.sa2.new_zeros(d, d)
+                Q = torch.zeros(d, d, dtype=self.sa2.dtype, device=self.sa2.device)
                 eye = eye_like(self.sa2, d//2)
                 Q[:d//2, :d//2] = dt3 * eye / 3.0
                 Q[:d//2, d//2:] = dt2 * eye / 2.0
@@ -445,7 +445,7 @@ class NcvDiscrete(Ncv):
                 dt2 = dt*dt
                 dt3 = dt2*dt
                 dt4 = dt2*dt2
-                Q = self.sa2.new_zeros(d, d)
+                Q = torch.zeros(d, d, dtype=self.sa2.dtype, device=self.sa2.device)
                 Q[:d//2, :d//2] = 0.25 * dt4 * eye_like(self.sa2, d//2)
                 Q[:d//2, d//2:] = 0.5 * dt3 * eye_like(self.sa2, d//2)
                 Q[d//2:, :d//2] = 0.5 * dt3 * eye_like(self.sa2, d//2)

--- a/pyro/contrib/tracking/extended_kalman_filter.py
+++ b/pyro/contrib/tracking/extended_kalman_filter.py
@@ -161,7 +161,7 @@ class EKFState(object):
         :return: Likelihood of hypothetical update.
         '''
         dz, S = self.innovation(measurement)
-        return dist.MultivariateNormal(S.new_zeros(S.shape[-1]),
+        return dist.MultivariateNormal(torch.zeros(S.size(-1), dtype=S.dtype, device=S.device),
                                        S).log_prob(dz)
 
     def update(self, measurement):

--- a/pyro/contrib/tracking/measurements.py
+++ b/pyro/contrib/tracking/measurements.py
@@ -116,7 +116,7 @@ class PositionMeasurement(DifferentiableMeasurement):
         super(PositionMeasurement, self).__init__(mean, cov, time=time, frame_num=frame_num)
         self._jacobian = torch.cat([
             eye_like(mean, self.dimension),
-            mean.new_zeros((self.dimension, self.dimension))], dim=1)
+            torch.zeros(self.dimension, self.dimension, dtype=mean.dtype, device=mean.device)], dim=1)
 
     def __call__(self, x, do_normalization=True):
         '''

--- a/pyro/distributions/avf_mvn.py
+++ b/pyro/distributions/avf_mvn.py
@@ -57,7 +57,7 @@ class AVFMultivariateNormal(MultivariateNormal):
 class _AVFMVNSample(Function):
     @staticmethod
     def forward(ctx, loc, scale_tril, control_var, shape):
-        white = loc.new_empty(shape).normal_()
+        white = torch.randn(shape, dtype=loc.dtype, device=loc.device)
         z = torch.matmul(white, scale_tril.t())
         ctx.save_for_backward(scale_tril, control_var, white)
         return loc + z

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -121,7 +121,7 @@ class DirichletMultinomial(TorchDistribution):
 
     def __init__(self, concentration, total_count=1, is_sparse=False, validate_args=None):
         if isinstance(total_count, numbers.Number):
-            total_count = concentration.new_tensor(total_count)
+            total_count = torch.tensor(total_count, dtype=concentration.dtype, device=concentration.device)
         total_count_1 = total_count.unsqueeze(-1)
         concentration, total_count = torch.broadcast_tensors(concentration, total_count_1)
         total_count = total_count_1.squeeze(-1)

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -34,7 +34,7 @@ class Delta(TorchDistribution):
         batch_shape = v.shape[:batch_dim]
         event_shape = v.shape[batch_dim:]
         if isinstance(log_density, numbers.Number):
-            log_density = v.new_empty(batch_shape).fill_(log_density)
+            log_density = torch.full(batch_shape, log_density, dtype=v.dtype, device=v.device)
         elif validate_args and log_density.shape != batch_shape:
             raise ValueError('Expected log_density.shape = {}, actual {}'.format(
                 log_density.shape, batch_shape))

--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -136,7 +136,7 @@ class _MixDiagNormalSample(Function):
         mu_cd = locs.unsqueeze(-2) - locs.unsqueeze(-3)  # b c d i
         mu_cd_norm = torch.pow(mu_cd, 2.0).sum(-1).sqrt()  # b c d
         mu_cd /= mu_cd_norm.unsqueeze(-1)  # b c d i
-        diagonals = z.new_empty((K,), dtype=torch.long)
+        diagonals = torch.empty((K,), dtype=torch.long, device=z.device)
         torch.arange(K, out=diagonals)
         mu_cd[..., diagonals, diagonals, :] = 0.0
 
@@ -145,7 +145,7 @@ class _MixDiagNormalSample(Function):
         z_perp_cd = z.unsqueeze(-2).unsqueeze(-2) - z_ll_cd.unsqueeze(-1) * mu_cd  # l b c d i
         z_perp_cd_sqr = torch.pow(z_perp_cd, 2.0).sum(-1)  # l b c d
 
-        shift_indices = z.new_empty((dim,), dtype=torch.long)
+        shift_indices = torch.empty((dim,), dtype=torch.long, device=z.device)
         torch.arange(dim, out=shift_indices)
         shift_indices = shift_indices - 1
         shift_indices[0] = 0
@@ -170,7 +170,7 @@ class _MixDiagNormalSample(Function):
         shift_log_scales[..., 0] = 0.0
         sigma_products = torch.cumsum(shift_log_scales, dim=-1).exp()  # b j i
 
-        reverse_indices = z.new_tensor(range(dim - 1, -1, -1), dtype=torch.long)
+        reverse_indices = torch.tensor(range(dim - 1, -1, -1), dtype=torch.long, device=z.device)
         reverse_log_sigma_0 = sigma_0.log()[..., reverse_indices]  # b 1 i
         sigma_0_products = torch.cumsum(reverse_log_sigma_0, dim=-1).exp()[..., reverse_indices - 1]  # b 1 i
         sigma_0_products[..., -1] = 1.0

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -106,7 +106,7 @@ class _MixDiagNormalSharedCovarianceSample(Function):
     @staticmethod
     def forward(ctx, locs, coord_scale, component_logits, pis, which, noise_shape):
         dim = coord_scale.size(-1)
-        white = locs.new(noise_shape).normal_()
+        white = torch.randn(noise_shape, dtype=locs.dtype, device=locs.device)
         n_unsqueezes = locs.dim() - which.dim()
         for _ in range(n_unsqueezes):
             which = which.unsqueeze(-1)
@@ -130,7 +130,7 @@ class _MixDiagNormalSharedCovarianceSample(Function):
         mu_ab = locs_tilde.unsqueeze(-2) - locs_tilde.unsqueeze(-3)  # b k j i
         mu_ab_norm = torch.pow(mu_ab, 2.0).sum(-1).sqrt()  # b k j
         mu_ab /= mu_ab_norm.unsqueeze(-1)  # b k j i
-        diagonals = z.new_empty((K,), dtype=torch.long)
+        diagonals = torch.empty((K,), dtype=torch.long, device=z.device)
         torch.arange(K, out=diagonals)
         mu_ab[..., diagonals, diagonals, :] = 0.0
 

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -210,5 +210,5 @@ class LKJCorrCholesky(TorchDistribution):
 
         values += log_diagonals.mul(eta.mul(2).add(-2.0))
         values = values.sum(-1) + lp
-        values, _ = torch.broadcast_tensors(values, torch.empty(self.batch_shape, dtype=values.dtype, device=values.device))
+        values, _ = torch.broadcast_tensors(values, torch.empty(self.batch_shape))
         return values

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -39,12 +39,12 @@ def _vector_to_l_cholesky(z):
     if D % 1 != 0:
         raise ValueError("Correlation matrix transformation requires d choose 2 inputs")
     D = int(D)
-    x = z.new_zeros(list(z.shape[:-1]) + [D, D])
+    x = torch.zeros(z.shape[:-1] + (D, D), dtype=z.dtype, device=z.device)
 
     x[..., 0, 0] = 1
     x[..., 1:, 0] = z[..., :(D - 1)]
     i = D - 1
-    last_squared_x = z.new_zeros(list(z.shape[:-1]) + [D])
+    last_squared_x = torch.zeros(z.shape[:-1] + (D,), dtype=z.dtype, device=z.device)
     for j in range(1, D):
         distance_to_copy = D - 1 - j
         last_squared_x = last_squared_x[..., 1:] + x[..., j:, (j - 1)].clone()**2
@@ -83,7 +83,7 @@ class CorrLCholeskyTransform(Transform):
             raise ValueError("A matrix that isn't square can't be a Cholesky factor of a correlation matrix")
         D = y.shape[-1]
 
-        z_tri = y.new_zeros(y.shape[:-2] + (D - 2, D - 2))
+        z_tri = torch.zeros(y.shape[:-2] + (D - 2, D - 2), dtype=y.dtype, device=y.device)
         z_stack = [
             y[..., 1:, 0]
         ]
@@ -149,7 +149,7 @@ class LKJCorrCholesky(TorchDistribution):
         vector_size = (d * (d - 1)) // 2
         alpha = eta.add(0.5 * (d - 1.0))
 
-        concentrations = eta.new_empty(vector_size,)
+        concentrations = torch.empty(vector_size, dtype=eta.dtype, device=eta.device)
         i = 0
         for k in range(d - 1):
             alpha -= .5
@@ -210,5 +210,5 @@ class LKJCorrCholesky(TorchDistribution):
 
         values += log_diagonals.mul(eta.mul(2).add(-2.0))
         values = values.sum(-1) + lp
-        values, _ = torch.broadcast_tensors(values, values.new_empty(self.batch_shape))
+        values, _ = torch.broadcast_tensors(values, torch.empty(self.batch_shape, dtype=values.dtype, device=values.device))
         return values

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -36,7 +36,7 @@ class OMTMultivariateNormal(MultivariateNormal):
 class _OMTMVNSample(Function):
     @staticmethod
     def forward(ctx, loc, scale_tril, shape):
-        white = loc.new_empty(shape).normal_()
+        white = torch.randn(shape, dtype=loc.dtype, device=loc.device)
         z = torch.matmul(white, scale_tril.t())
         ctx.save_for_backward(z, white, scale_tril)
         return loc + z

--- a/pyro/distributions/relaxed_straight_through.py
+++ b/pyro/distributions/relaxed_straight_through.py
@@ -44,7 +44,7 @@ class QuantizeCategorical(torch.autograd.Function):
     @staticmethod
     def forward(ctx, soft_value):
         argmax = soft_value.max(-1)[1]
-        hard_value = soft_value.new_zeros(soft_value.shape)
+        hard_value = torch.zeros_like(soft_value)
         hard_value._unquantize = soft_value
         if argmax.dim() < hard_value.dim():
             argmax = argmax.unsqueeze(-1)

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -114,7 +114,7 @@ class SpanningTree(TorchDistribution):
         grid = make_complete_graph(V)
         shift = self.edge_logits.max()
         edge_probs = (self.edge_logits - shift).exp()
-        adjacency = edge_probs.new_zeros(V, V)
+        adjacency = torch.zeros(V, V, dtype=edge_probs.dtype)
         adjacency[grid[0], grid[1]] = edge_probs
         adjacency[grid[1], grid[0]] = edge_probs
         laplacian = adjacency.sum(-1).diag() - adjacency
@@ -319,7 +319,7 @@ def _sample_tree_mcmc(edge_logits, edges):
 
     # Convert edge ids to a canonical list of pairs.
     edge_ids = edge_ids.sort()[0]
-    edges = edge_logits.new_empty((E, 2), dtype=torch.long)
+    edges = torch.empty((E, 2), dtype=torch.long)
     edges[:, 0] = grid[0, edge_ids]
     edges[:, 1] = grid[1, edge_ids]
     return edges
@@ -368,9 +368,9 @@ def _sample_tree_approx(edge_logits):
 
     # Each of E edges in the tree is stored as an id k in [0, K) indexing into
     # the complete graph. The id of an edge (v1,v2) is k = v1+v2*(v2-1)/2.
-    edge_ids = edge_logits.new_empty((E,), dtype=torch.long)
+    edge_ids = torch.empty((E,), dtype=torch.long)
     # This maps each vertex to whether it is a member of the cumulative tree.
-    components = edge_logits.new_zeros(V, dtype=torch.uint8)
+    components = torch.zeros(V, dtype=torch.uint8)
 
     # Sample the first edge at random.
     probs = (edge_logits - edge_logits.max()).exp()
@@ -390,7 +390,7 @@ def _sample_tree_approx(edge_logits):
 
     # Convert edge ids to a canonical list of pairs.
     edge_ids = edge_ids.sort()[0]
-    edges = edge_logits.new_empty((E, 2), dtype=torch.long)
+    edges = torch.empty((E, 2), dtype=torch.long)
     edges[:, 0] = grid[0, edge_ids]
     edges[:, 1] = grid[1, edge_ids]
     return edges

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -42,8 +42,10 @@ class RejectionStandardGamma(Rejector):
         return new
 
     def propose(self, sample_shape=torch.Size()):
-        # Marsaglia & Tsang's x == Naesseth's epsilon
-        x = self.concentration.new_empty(sample_shape + self.concentration.shape).normal_()
+        # Marsaglia & Tsang's x == Naesseth's epsilon`
+        x = torch.randn(sample_shape + self.concentration.shape,
+                        dtype=self.concentration.dtype,
+                        device=self.concentration.device)
         y = 1.0 + self._c * x
         v = y * y * y
         return (self._d * v).clamp_(1e-30, 1e30)
@@ -129,7 +131,8 @@ class ShapeAugmentedGamma(Gamma):
         x = self._rejection_gamma.rsample(sample_shape)
         boosted_x = x.clone()
         for i in range(self._boost):
-            boosted_x *= (1 - x.new_empty(x.shape).uniform_()) ** (1 / (i + self.concentration))
+            u = torch.rand(x.shape, dtype=x.dtype, device=x.device)
+            boosted_x *= (1 - u) ** (1 / (i + self.concentration))
         self._unboost_x_cache = boosted_x, x
         return boosted_x
 

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -106,7 +106,7 @@ def gather(value, index, dim):
     Broadcasted gather of indexed values along a named dim.
     """
     value, index = broadcast_all(value, index)
-    index = index.index_select(dim, index.new_tensor([0]))
+    index = index.index_select(dim, torch.tensor([0], device=index.device))
     return value.gather(dim, index)
 
 
@@ -194,7 +194,7 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
 def eye_like(value, m, n=None):
     if n is None:
         n = m
-    eye = value.new_zeros(m, n)
+    eye = torch.zeros(m, n, dtype=value.dtype, device=value.device)
     eye.view(-1)[:min(m, n) * n:n + 1] = 1
     return eye
 

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -190,6 +190,10 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
     return tensor
 
 
+def scalar_like(prototype, fill_value):
+    return torch.tensor(fill_value, dtype=prototype.dtype, device=prototype.device)
+
+
 # work around lack of jit support for torch.eye(..., out=value)
 def eye_like(value, m, n=None):
     if n is None:

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -8,6 +8,7 @@ import torch.distributions as torch_dist
 from torch import logsumexp
 from torch.distributions.utils import broadcast_all
 
+from pyro.util import ignore_jit_warnings
 
 _VALIDATION_ENABLED = False
 
@@ -106,7 +107,9 @@ def gather(value, index, dim):
     Broadcasted gather of indexed values along a named dim.
     """
     value, index = broadcast_all(value, index)
-    index = index.index_select(dim, torch.tensor([0], device=index.device))
+    with ignore_jit_warnings():
+        zero = torch.zeros(1, dtype=torch.long, device=index.device)
+    index = index.index_select(dim, zero)
     return value.gather(dim, index)
 
 

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -270,7 +270,7 @@ class TracePosterior(object):
                                    .log_prob(trace.nodes[obs_node]["value"]))
 
         ll = torch.stack(log_likelihoods, dim=0)
-        waic_value, p_waic = waic(ll, ll.new_tensor(self.log_weights), pointwise)
+        waic_value, p_waic = waic(ll, torch.tensor(self.log_weights, device=ll.device), pointwise)
         return OrderedDict([("waic", waic_value), ("p_waic", p_waic)])
 
 
@@ -317,7 +317,8 @@ class TracePredictive(TracePosterior):
                     # Select random sub-indices to replay values under conditionally independent stacks.
                     # Otherwise, we assume there is an dependence of indexes between training data
                     # and prediction data.
-                    subidxs = Categorical(logits=site["value"].new_ones(site["value"].size(cis.dim))).sample([cis.size])
+                    logits = torch.ones(site["value"].size(cis.dim), device=site["value"].device)
+                    subidxs = Categorical(logits=logits).sample([cis.size])
                     site["value"] = site["value"].index_select(cis.dim, subidxs)
             except KeyError:
                 pass

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -104,7 +104,9 @@ class WarmupAdapter(object):
         self.step_size = math.exp(log_step_size)
 
     def _update_r_dist(self):
-        loc = self._inverse_mass_matrix.new_zeros(self._inverse_mass_matrix.size(0))
+        loc = torch.zeros(self._inverse_mass_matrix.size(0),
+                          dtype=self._inverse_mass_matrix.dtype,
+                          device=self._inverse_mass_matrix.device)
         if self.is_diag_mass:
             self._r_dist = dist.Normal(loc, self._inverse_mass_matrix.rsqrt())
         else:

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -356,7 +356,7 @@ class HMC(TraceKernel):
         if site_value is not None:
             mass_matrix_size = sum(self._r_numels.values())
             if self._adapter.is_diag_mass:
-                initial_mass_matrix = torch.full(mass_matrix_size, dtype=site_value.dtype, device=site_value.device)
+                initial_mass_matrix = torch.ones(mass_matrix_size, dtype=site_value.dtype, device=site_value.device)
             else:
                 initial_mass_matrix = eye_like(site_value, mass_matrix_size)
             self._adapter.configure(self._warmup_steps,

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -9,8 +9,7 @@ from torch.distributions import biject_to, constraints
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.distributions.util import eye_like
-from pyro.distributions.utils import scalar_like
+from pyro.distributions.util import eye_like, scalar_like
 from pyro.infer import config_enumerate
 from pyro.infer.mcmc.adaptation import WarmupAdapter
 from pyro.infer.mcmc.trace_kernel import TraceKernel

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -297,7 +297,8 @@ class MCMCMarginals(Marginals):
             try:
                 site_stats["n_eff"] = stats.effective_sample_size(site_support)
             except NotImplementedError:
-                site_stats["n_eff"] = site_support.new_full(site_support.shape[2:], float("nan"))
+                site_stats["n_eff"] = torch.full(site_support.shape[2:], float("nan"),
+                                                 dtype=site_support.dtype, device=site_support)
             site_stats["r_hat"] = stats.split_gelman_rubin(site_support)
             self._diagnostics[site] = site_stats
         return self._diagnostics

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -298,7 +298,7 @@ class MCMCMarginals(Marginals):
                 site_stats["n_eff"] = stats.effective_sample_size(site_support)
             except NotImplementedError:
                 site_stats["n_eff"] = torch.full(site_support.shape[2:], float("nan"),
-                                                 dtype=site_support.dtype, device=site_support)
+                                                 dtype=site_support.dtype, device=site_support.device)
             site_stats["r_hat"] = stats.split_gelman_rubin(site_support)
             self._diagnostics[site] = site_stats
         return self._diagnostics

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -7,6 +7,7 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro.distributions.util import logsumexp
+from pyro.distributions.utils import scalar_like
 from pyro.infer.mcmc.hmc import HMC
 from pyro.ops.integrator import velocity_verlet
 from pyro.util import optional, torch_isnan
@@ -167,7 +168,7 @@ class NUTS(HMC):
         r_new_flat = torch.cat([r_new[site_name].reshape(-1) for site_name in sorted(r_new)])
         energy_new = potential_energy + self._kinetic_energy(r_new)
         # handle the NaN case
-        energy_new = energy_new.new_tensor(float("inf")) if torch_isnan(energy_new) else energy_new
+        energy_new = scalar_like(energy_new, float("inf")) if torch_isnan(energy_new) else energy_new
         sliced_energy = energy_new + log_slice
         diverging = (sliced_energy > self._max_sliced_energy)
         delta_energy = energy_new - energy_current
@@ -180,8 +181,7 @@ class NUTS(HMC):
             #   we eliminate states which p(z, r) < u, or dE > 0.
             # Due to this elimination (and stop doubling conditions),
             #   the weight of binary tree might not equal to 2^tree_depth.
-            tree_weight = (sliced_energy.new_ones(()) if sliced_energy <= 0
-                           else sliced_energy.new_zeros(()))
+            tree_weight = scalar_like(sliced_energy, 1. if sliced_energy <= 0 else 0.)
 
         return _TreeInfo(z_new, r_new, z_grads, z_new, r_new, z_grads, z_new, potential_energy,
                          z_grads, r_new_flat, tree_weight, False, diverging, accept_prob, 1)
@@ -232,7 +232,7 @@ class NUTS(HMC):
             #   we choose the proposal from the first half
             #   (any is fine, because the probability of picking it at the end is 0!).
             other_half_tree_prob = (other_half_tree.weight / tree_weight if tree_weight > 0
-                                    else tree_weight.new_zeros(()))
+                                    else scalar_like(tree_weight, 0.))
         is_other_half_tree = pyro.sample("is_other_half_tree",
                                          dist.Bernoulli(probs=other_half_tree_prob))
 
@@ -300,7 +300,7 @@ class NUTS(HMC):
             # sample log_slice directly using `energy`, so as to avoid potential underflow or
             # overflow issues ([2]).
             slice_exp_term = pyro.sample("slicevar_exp_t={}".format(self._t),
-                                         dist.Exponential(energy_current.new_tensor(1.)))
+                                         dist.Exponential(scalar_like(energy_current, 1.)))
             log_slice = -energy_current - slice_exp_term
 
         z_left = z_right = z
@@ -310,10 +310,7 @@ class NUTS(HMC):
         r_sum = r_flat
         sum_accept_probs = 0.
         num_proposals = 0
-        if self.use_multinomial_sampling:
-            tree_weight = energy_current.new_zeros(())
-        else:
-            tree_weight = energy_current.new_ones(())
+        tree_weight = scalar_like(energy_current, 0. if self.use_multinomial_sampling else 1.)
 
         # Temporarily disable distributions args checking as
         # NaNs are expected during step size adaptation.
@@ -322,7 +319,7 @@ class NUTS(HMC):
             tree_depth = 0
             while tree_depth < self._max_tree_depth:
                 direction = pyro.sample("direction_t={}_treedepth={}".format(self._t, tree_depth),
-                                        dist.Bernoulli(probs=tree_weight.new_tensor(0.5)))
+                                        dist.Bernoulli(probs=scalar_like(tree_weight, 0.5)))
                 direction = int(direction.item())
                 if direction == 1:  # go to the right, start from the right leaf of current tree
                     new_tree = self._build_tree(z_right, r_right, z_right_grads, log_slice,
@@ -351,8 +348,8 @@ class NUTS(HMC):
                 else:
                     new_tree_prob = new_tree.weight / tree_weight
                 rand = pyro.sample("rand_t={}_treedepth={}".format(self._t, tree_depth),
-                                   dist.Uniform(new_tree_prob.new_tensor(0.),
-                                                new_tree_prob.new_tensor(1.)))
+                                   dist.Uniform(scalar_like(new_tree_prob, 0.),
+                                                scalar_like(new_tree_prob, 1.)))
                 if rand < new_tree_prob:
                     accepted = True
                     z = new_tree.z_proposal

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -6,8 +6,7 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.distributions.util import logsumexp
-from pyro.distributions.utils import scalar_like
+from pyro.distributions.util import logsumexp, scalar_like
 from pyro.infer.mcmc.hmc import HMC
 from pyro.ops.integrator import velocity_verlet
 from pyro.util import optional, torch_isnan

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -182,15 +182,15 @@ class RenyiELBO(ELBO):
 
             if is_identically_zero(elbo_particle):
                 if tensor_holder is not None:
-                    elbo_particle = tensor_holder.new_zeros(tensor_holder.shape)
-                    surrogate_elbo_particle = tensor_holder.new_zeros(tensor_holder.shape)
+                    elbo_particle = torch.zeros_like(tensor_holder)
+                    surrogate_elbo_particle = torch.zeros_like(tensor_holder)
             else:  # elbo_particle is not None
                 if tensor_holder is None:
-                    tensor_holder = elbo_particle.new_empty(elbo_particle.shape)
+                    tensor_holder = torch.zeros_like(elbo_particle)
                     # change types of previous `elbo_particle`s
                     for i in range(len(elbo_particles)):
-                        elbo_particles[i] = tensor_holder.new_zeros(tensor_holder.shape)
-                        surrogate_elbo_particles[i] = tensor_holder.new_zeros(tensor_holder.shape)
+                        elbo_particles[i] = torch.zeros_like(tensor_holder)
+                        surrogate_elbo_particles[i] = torch.zeros_like(tensor_holder)
 
             elbo_particles.append(elbo_particle)
             surrogate_elbo_particles.append(surrogate_elbo_particle)

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -134,7 +134,7 @@ def _compute_elbo_non_reparam(guide_trace, non_reparam_nodes, downstream_costs):
             param_name = "__baseline_avg_downstream_cost_" + node
             with torch.no_grad():
                 avg_downstream_cost_old = pyro.param(param_name,
-                                                     guide_site['value'].new_zeros(dc_shape))
+                                                     torch.zeros(dc_shape, device=guide_site['value'].device))
                 avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
                     baseline_beta * avg_downstream_cost_old
             pyro.get_param_store()[param_name] = avg_downstream_cost_new

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -67,7 +67,7 @@ def zero_grads(tensors):
     """
     for p in tensors:
         if p.grad is not None:
-            p.grad = p.grad.new_zeros(p.shape)
+            p.grad = torch.zeros_like(p.grad)
 
 
 def get_plate_stacks(trace):
@@ -177,7 +177,7 @@ class Dice(object):
                         log_prob = log_prob - log_prob.detach()
                     log_prob = log_prob - math.log(num_samples)
                     if not isinstance(log_prob, torch.Tensor):
-                        log_prob = site["value"].new_tensor(log_prob)
+                        log_prob = torch.tensor(float(log_prob), device=site["value"].device)
                     log_prob._pyro_dims = dims
                     # I don't know why the following broadcast is needed, but it makes tests pass:
                     log_prob, _ = packed.broadcast_all(log_prob, site["packed"]["log_prob"])
@@ -236,7 +236,7 @@ class Dice(object):
                 for cost in cost_terms:
                     key = frozenset(cost._pyro_dims)
                     if queries[key] is None:
-                        query = cost.new_zeros(cost.shape)
+                        query = torch.zeros_like(cost)
                         query._pyro_dims = cost._pyro_dims
                         log_factors.append(query)
                         queries[key] = query

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -511,7 +511,8 @@ def naive_ubersum(equation, *operands, **kwargs):
             flat_operands.append(_select(operand, offsets, index))
 
     # Defer to unplated einsum.
-    result = operands[0].new_empty(torch.Size(sizes[d] for d in output))
+    result = torch.empty(torch.Size(sizes[d] for d in output),
+                         dtype=operands[0].dtype, device=operands[0].device)
     local_dims = [d for d in output if d in plates]
     offsets = [output.index(d) - len(output) for d in local_dims]
     for index in itertools.product(*(range(sizes[d]) for d in local_dims)):

--- a/pyro/ops/linalg.py
+++ b/pyro/ops/linalg.py
@@ -17,7 +17,7 @@ def rinverse(M, sym=False):
         return 1./M
     elif M.shape[-1] == 2:
         det = M[..., 0, 0]*M[..., 1, 1] - M[..., 1, 0]*M[..., 0, 1]
-        inv = M.new_empty(M.shape)
+        inv = torch.empty_like(M)
         inv[..., 0, 0] = M[..., 1, 1]
         inv[..., 1, 1] = M[..., 0, 0]
         inv[..., 0, 1] = -M[..., 0, 1]
@@ -65,7 +65,7 @@ def inv3d(H, sym=False):
     Calculates the inverse of a batched 3-D matrix
     """
     detH = determinant_3d(H)
-    Hinv = H.new_empty(H.shape)
+    Hinv = torch.empty_like(H)
     Hinv[..., 0, 0] = H[..., 1, 1] * H[..., 2, 2] - H[..., 1, 2] * H[..., 2, 1]
     Hinv[..., 1, 1] = H[..., 0, 0] * H[..., 2, 2] - H[..., 0, 2] * H[..., 2, 0]
     Hinv[..., 2, 2] = H[..., 0, 0] * H[..., 1, 1] - H[..., 0, 1] * H[..., 1, 0]

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -91,7 +91,7 @@ def gather(value, index, dim):
     value, index = broadcast_all(value, index)
     dims = value._pyro_dims.replace(dim, '')
     pos = value._pyro_dims.index(dim)
-    index = index.index_select(pos, index.new_tensor([0]))
+    index = index.index_select(pos, torch.tensor([0], device=index.device))
     value = value.gather(pos, index).squeeze(pos)
     value._pyro_dims = dims
     assert value.dim() == len(value._pyro_dims)

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -91,7 +91,9 @@ def gather(value, index, dim):
     value, index = broadcast_all(value, index)
     dims = value._pyro_dims.replace(dim, '')
     pos = value._pyro_dims.index(dim)
-    index = index.index_select(pos, torch.tensor([0], device=index.device))
+    with ignore_jit_warnings():
+        zero = torch.zeros(1, dtype=torch.long, device=index.device)
+    index = index.index_select(pos, zero)
     value = value.gather(pos, index).squeeze(pos)
     value._pyro_dims = dims
     assert value.dim() == len(value._pyro_dims)

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -115,20 +115,20 @@ def autocorrelation(input, dim=0):
 
     # centering and padding x
     centered_signal = input - input.mean(dim=-1, keepdim=True)
-    pad = input.new_zeros(input.shape[:-1] + (M2 - N,))
+    pad = torch.zeros(input.shape[:-1] + (M2 - N,), dtype=input.dtype)
     centered_signal = torch.cat([centered_signal, pad], dim=-1)
 
     # Fourier transform
     freqvec = torch.rfft(centered_signal, signal_ndim=1, onesided=False)
     # take square of magnitude of freqvec (or freqvec x freqvec*)
     freqvec_gram = freqvec.pow(2).sum(-1, keepdim=True)
-    freqvec_gram = torch.cat([freqvec_gram, input.new_zeros(freqvec_gram.shape)], dim=-1)
+    freqvec_gram = torch.cat([freqvec_gram, torch.zeros(freqvec_gram.shape, dtype=input.dtype)], dim=-1)
     # inverse Fourier transform
     autocorr = torch.irfft(freqvec_gram, signal_ndim=1, onesided=False)
 
     # truncate and normalize the result, then transpose back to original shape
     autocorr = autocorr[..., :N]
-    autocorr = autocorr / input.new_tensor(range(N, 0, -1))
+    autocorr = autocorr / torch.tensor(range(N, 0, -1), dtype=input.dtype)
     autocorr = autocorr / autocorr[..., :1]
     return autocorr.transpose(dim, -1)
 
@@ -154,7 +154,8 @@ def _cummin(input):
     # FIXME: is there a better trick to find accumulate min of a sequence?
     N = input.size(0)
     input_tril = input.unsqueeze(0).repeat((N,) + (1,) * input.dim())
-    triu_mask = input.new_ones(N, N).triu(diagonal=1).reshape((N, N) + (1,) * (input.dim() - 1))
+    triu_mask = (torch.ones(N, N, dtype=input.dtype, device=input.device)
+                 .triu(diagonal=1).reshape((N, N) + (1,) * (input.dim() - 1)))
     triu_mask = triu_mask.expand((N, N) + input.shape[1:]) > 0.5
     input_tril.masked_fill_(triu_mask, input.max())
     return input_tril.min(dim=1)[0]
@@ -229,7 +230,7 @@ def resample(input, num_samples, dim=0, replacement=False):
     :param int dim: dimension to draw from ``input``.
     :returns torch.Tensor: samples drawn randomly from ``input``.
     """
-    weights = input.new_ones(input.size(dim))
+    weights = torch.ones(input.size(dim), dtype=input.dtype, device=input.device)
     indices = torch.multinomial(weights, num_samples, replacement)
     return input.index_select(dim, indices)
 
@@ -245,7 +246,7 @@ def quantile(input, probs, dim=0):
     :returns torch.Tensor: quantiles of ``input`` at ``probs``.
     """
     if isinstance(probs, (numbers.Number, list, tuple)):
-        probs = input.new_tensor(probs)
+        probs = torch.tensor(probs, dtype=input.dtype, device=input.device)
     sorted_input = input.sort(dim)[0]
     max_index = input.size(dim) - 1
     indices = probs * max_index
@@ -290,9 +291,9 @@ def hpdi(input, prob, dim=0):
     mass = input.size(dim)
     index_length = int(prob * mass)
     intervals_left = sorted_input.index_select(
-        dim, input.new_tensor(range(mass - index_length), dtype=torch.long))
+        dim, torch.tensor(range(mass - index_length), dtype=torch.long, device=input.device))
     intervals_right = sorted_input.index_select(
-        dim, input.new_tensor(range(index_length, mass), dtype=torch.long))
+        dim, torch.tensor(range(index_length, mass), dtype=torch.long, device=input.device))
     intervals_length = intervals_right - intervals_left
     index_start = intervals_length.argmin(dim)
     indices = torch.stack([index_start, index_start + index_length], dim)
@@ -329,7 +330,8 @@ def waic(input, log_weights=None, pointwise=False, dim=0):
     :param int dim: the sample dimension of ``input``.
     :returns tuple: tuple of WAIC and effective number of parameters.
     """
-    log_weights = input.new_zeros(input.size(dim)) if log_weights is None else log_weights
+    if log_weights is None:
+        log_weights = torch.zeros(input.size(dim), dtype=input.dtype, device=input.device)
 
     # computes log pointwise predictive density: formula (3) of [1]
     dim = input.dim() + dim if dim < 0 else dim

--- a/pyro/optim/clipped_adam.py
+++ b/pyro/optim/clipped_adam.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import math
 
+import torch
 from torch.optim.optimizer import Optimizer
 
 
@@ -56,9 +57,9 @@ class ClippedAdam(Optimizer):
                 if len(state) == 0:
                     state['step'] = 0
                     # Exponential moving average of gradient values
-                    state['exp_avg'] = grad.new_zeros(grad.shape)
+                    state['exp_avg'] = torch.zeros_like(grad)
                     # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = grad.new_zeros(grad.shape)
+                    state['exp_avg_sq'] = torch.zeros_like(grad)
 
                 exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
                 beta1, beta2 = group['betas']

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -43,13 +43,13 @@ def test_simple():
     logger.debug('Compiling f')
     f = torch.jit.trace(f, (y,), check_trace=False)
     logger.debug('Calling f(y)')
-    assert_equal(f(y), y.new_tensor([2., 2.]))
+    assert_equal(f(y), torch.tensor([2., 2.]))
     logger.debug('Calling f(y)')
-    assert_equal(f(y), y.new_tensor([2., 2.]))
+    assert_equal(f(y), torch.tensor([2., 2.]))
     logger.debug('Calling f(torch.zeros(2))')
-    assert_equal(f(torch.zeros(2)), y.new_tensor([1., 1.]))
+    assert_equal(f(torch.zeros(2)), torch.tensor([1., 1.]))
     logger.debug('Calling f(torch.zeros(5))')
-    assert_equal(f(torch.ones(5)), y.new_tensor([2., 2., 2., 2., 2.]))
+    assert_equal(f(torch.ones(5)), torch.tensor([2., 2., 2., 2., 2.]))
 
 
 def test_multi_output():
@@ -65,13 +65,13 @@ def test_multi_output():
     logger.debug('Compiling f')
     f = torch.jit.trace(f, (y,), check_trace=False)
     logger.debug('Calling f(y)')
-    assert_equal(f(y)[1], y.new_tensor([2., 2.]))
+    assert_equal(f(y)[1], torch.tensor([2., 2.]))
     logger.debug('Calling f(y)')
-    assert_equal(f(y)[1], y.new_tensor([2., 2.]))
+    assert_equal(f(y)[1], torch.tensor([2., 2.]))
     logger.debug('Calling f(torch.zeros(2))')
-    assert_equal(f(torch.zeros(2))[1], y.new_tensor([1., 1.]))
+    assert_equal(f(torch.zeros(2))[1], torch.tensor([1., 1.]))
     logger.debug('Calling f(torch.zeros(5))')
-    assert_equal(f(torch.ones(5))[1], y.new_tensor([2., 2., 2., 2., 2.]))
+    assert_equal(f(torch.ones(5))[1], torch.tensor([2., 2., 2., 2., 2.]))
 
 
 def test_backward():
@@ -164,7 +164,7 @@ def test_masked_fill():
 def test_scatter():
 
     def make_one_hot(x, i):
-        return x.new_zeros(x.shape).scatter(-1, i.unsqueeze(-1), 1.0)
+        return torch.zeros_like(x).scatter(-1, i.unsqueeze(-1), 1.0)
 
     x = torch.randn(5, 4, 3)
     i = torch.randint(0, 3, torch.Size((5, 4)))
@@ -175,7 +175,7 @@ def test_scatter():
 def test_scatter_workaround():
 
     def make_one_hot_expected(x, i):
-        return x.new_zeros(x.shape).scatter(-1, i.unsqueeze(-1), 1.0)
+        return torch.zeros_like(x).scatter(-1, i.unsqueeze(-1), 1.0)
 
     def make_one_hot_actual(x, i):
         eye = torch.eye(x.shape[-1], dtype=x.dtype, device=x.device)


### PR DESCRIPTION
The following constructors are deprecated and are [unsupported by the jit](https://github.com/pytorch/pytorch/pull/16770):
- `Tensor.new_tensor()`
- `Tensor.new_empty()`
- `Tensor.new_zeros()`
- `Tensor.new_ones()`
- `Tensor.new_full()`

## Updated
- [x] pyro core
- [x] most of pyro.contrib
- [x] examples/
- [x] tests/infer/test_jit.py

## Triaged (not updated)
- pyro.contrib.gp (I'll let @fehiepsi handle pyro.contrib.gp)
- tutorials
- tests

## Tested
- refactoring is exercised by existing tests
- ran `CUDA_TEST=1 pytest -vx tests/test_examples.py::test_cuda` against torch==1.0.1