### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -246,7 +246,7 @@ def main(**kwargs):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Pyro AIR example", argument_default=argparse.SUPPRESS)
     parser.add_argument('-n', '--num-steps', type=int, default=int(1e8),
                         help='number of optimization steps to take')

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -310,7 +310,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Baseball batting average using HMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=200, type=int)
     parser.add_argument("--num-chains", nargs='?', default=4, type=int)

--- a/examples/bayesian_regression.py
+++ b/examples/bayesian_regression.py
@@ -137,7 +137,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=1000, type=int)
     parser.add_argument('-b', '--batch-size', default=N, type=int)

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -74,7 +74,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=200, type=int)
     parser.add_argument('--jit', action='store_true')

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -66,7 +66,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=200, type=int)
     args = parser.parse_args()

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -104,7 +104,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=100, type=int)
     args = parser.parse_args()

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -163,7 +163,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description='Pyro GP MNIST Example')
     parser.add_argument('--data-dir', type=str, default=None, metavar='PATH',
                         help='default directory to cache MNIST data')

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -113,7 +113,7 @@ def main(num_vi_steps, num_bo_steps, seed):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="A/B test experiment design using VI")
     parser.add_argument("-n", "--num-vi-steps", nargs="?", default=5000, type=int)
     parser.add_argument('--num-bo-steps', nargs="?", default=5, type=int)

--- a/examples/contrib/oed/item_response.py
+++ b/examples/contrib/oed/item_response.py
@@ -69,7 +69,7 @@ def main(N, M):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Item response experiment design using NMC")
     parser.add_argument("-N", nargs="?", default=5000, type=int)
     parser.add_argument("-M", nargs="?", default=5000, type=int)

--- a/examples/contrib/oed/sequential_oed_sigmoid_lm.py
+++ b/examples/contrib/oed/sequential_oed_sigmoid_lm.py
@@ -144,7 +144,7 @@ def main(num_experiments, num_runs, plot=True):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Sigmoid iterated experiment design")
     parser.add_argument("--num-experiments", nargs="?", default=5, type=int)
     parser.add_argument("--num-runs", nargs="?", default=5, type=int)

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -432,7 +432,7 @@ def main(args):
 
 # parse command-line arguments and execute the main method
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
 
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', type=int, default=5000)

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -46,7 +46,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description='Eight Schools MCMC')
     parser.add_argument('--num-samples', type=int, default=1000,
                         help='number of MCMC samples (default: 1000)')

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -74,7 +74,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description='Eight Schools SVI')
     parser.add_argument('--lr', type=float, default=0.01,
                         help='learning rate (default: 0.01)')

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -584,7 +584,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="MAP Baum-Welch learning Bach Chorales")
     parser.add_argument("-m", "--model", default="1", type=str,
                         help="one of: {}".format(", ".join(sorted(models.keys()))))

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -121,7 +121,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=500, type=int)
     args = parser.parse_args()

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -131,7 +131,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Amortized Latent Dirichlet Allocation")
     parser.add_argument("-t", "--num-topics", default=8, type=int)
     parser.add_argument("-w", "--num-words", default=1024, type=int)

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -47,7 +47,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Demonstrate the use of an LKJ Prior")
     parser.add_argument("--num-samples", nargs="?", default=200, type=int)
     parser.add_argument("--n", nargs="?", default=500, type=int)

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -65,7 +65,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="Mini Pyro demo")
     parser.add_argument("-b", "--backend", default="minipyro")
     parser.add_argument("-n", "--num-steps", default=1001, type=int)

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -154,7 +154,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     args = parser.parse_args()

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -151,7 +151,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--price', default=10000, type=int)

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -76,7 +76,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--depth', default=2, type=int)

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -89,7 +89,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--depth', default=3, type=int)

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -337,7 +337,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     args = parser.parse_args()

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -187,7 +187,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=1000, type=int, help='number of training epochs')

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -380,7 +380,7 @@ EXAMPLE_RUN = "example run: python ss_vae_M2.py --seed 0 --cuda -n 2 --aux-loss 
               "-sup 3000 -zd 50 -hl 500 -lr 0.00042 -b1 0.95 -bs 200 -log ./tmp.log"
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
 
     parser = argparse.ArgumentParser(description="SS-VAE\n{}".format(EXAMPLE_RUN))
 

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -198,7 +198,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=101, type=int, help='number of training epochs')

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -245,7 +245,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.2')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description='VAE using MNIST dataset')
     parser.add_argument('-n', '--num-epochs', nargs='?', default=10, type=int)
     parser.add_argument('--batch_size', nargs='?', default=128, type=int)

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -7,7 +7,7 @@ from pyro.primitives import (clear_param_store, enable_validation, get_param_sto
                              plate, random_module, sample, validation_enabled)
 from pyro.util import set_rng_seed
 
-version_prefix = '0.3.2'
+version_prefix = '0.3.3'
 
 # Get the __version__ string from the auto-generated _version.py file, if exists.
 try:

--- a/tutorial/source/air.ipynb
+++ b/tutorial/source/air.ipynb
@@ -41,7 +41,7 @@
     "import numpy as np\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/bayesian_regression.ipynb
+++ b/tutorial/source/bayesian_regression.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "# for CI testing\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(1)\n",
     "pyro.enable_validation(True)"

--- a/tutorial/source/bayesian_regression_ii.ipynb
+++ b/tutorial/source/bayesian_regression_ii.ipynb
@@ -45,7 +45,7 @@
     "import pyro.optim as optim\n",
     "import pyro.poutine as poutine\n",
     "\n",
-    "assert pyro.__version__.startswith('0.3.2')"
+    "assert pyro.__version__.startswith('0.3.3')"
    ]
   },
   {

--- a/tutorial/source/bo.ipynb
+++ b/tutorial/source/bo.ipynb
@@ -54,7 +54,7 @@
     "import pyro\n",
     "import pyro.contrib.gp as gp\n",
     "\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)  # can help with debugging\n",
     "pyro.set_rng_seed(1)"
    ]

--- a/tutorial/source/ekf.ipynb
+++ b/tutorial/source/ekf.ipynb
@@ -98,7 +98,7 @@
     "from pyro.contrib.tracking.measurements import PositionMeasurement\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -50,7 +50,7 @@
     "from pyro.ops.indexing import Vindex\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation()\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -41,7 +41,7 @@
     "from pyro.infer import SVI, TraceEnum_ELBO, config_enumerate, infer_discrete\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/gp.ipynb
+++ b/tutorial/source/gp.ipynb
@@ -61,7 +61,7 @@
     "import pyro.distributions as dist\n",
     "\n",
     "smoke_test = ('CI' in os.environ)  # ignore; used to check code integrity in the Pyro repo\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/gplvm.ipynb
+++ b/tutorial/source/gplvm.ipynb
@@ -39,7 +39,7 @@
     "import pyro.ops.stats as stats\n",
     "\n",
     "smoke_test = ('CI' in os.environ)  # ignore; used to check code integrity in the Pyro repo\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(1)"
    ]

--- a/tutorial/source/jit.ipynb
+++ b/tutorial/source/jit.ipynb
@@ -48,7 +48,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!"
    ]
   },

--- a/tutorial/source/svi_part_i.ipynb
+++ b/tutorial/source/svi_part_i.ipynb
@@ -266,7 +266,7 @@
     "n_steps = 2 if smoke_test else 2000\n",
     "\n",
     "# enable validation (e.g. validate parameters of distributions)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)\n",
     "\n",
     "# clear the param store in case we're in a REPL\n",

--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -285,7 +285,7 @@
     "import sys\n",
     "\n",
     "# enable validation (e.g. validate parameters of distributions)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)\n",
     "\n",
     "# this is for running the notebook in our testing framework\n",

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -52,7 +52,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!\n",
     "\n",
     "# We'll ue this helper to check our models are correct.\n",

--- a/tutorial/source/tracking_1d.ipynb
+++ b/tutorial/source/tracking_1d.ipynb
@@ -31,7 +31,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)\n",
     "smoke_test = ('CI' in os.environ)"
    ]

--- a/tutorial/source/vae.ipynb
+++ b/tutorial/source/vae.ipynb
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert pyro.__version__.startswith('0.3.2')\n",
+    "assert pyro.__version__.startswith('0.3.3')\n",
     "pyro.enable_validation(True)\n",
     "pyro.distributions.enable_validation(False)\n",
     "pyro.set_rng_seed(0)\n",


### PR DESCRIPTION
This bumps up the version of Pyro from `0.3.2` to `0.3.3`. Since `0.3.2` was released quite recently, this mostly has some minor code changes due to functions that got deprecated in `torch==1.1.0`. 

