### PR TITLE
 Change MCMC kernels to not depend on trace

### DIFF
--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -266,8 +266,9 @@ class MCMC(TracePosterior):
             self.sampler = _SingleSampler(kernel, num_samples, self.warmup_steps, disable_progbar)
         super(MCMC, self).__init__(num_chains=num_chains)
 
-    # TODO: Refactor so that the MCMC class directly has access to the
-    # trace generator and transforms needed to do this wrapping.
+    # TODO: Refactor so that the MCMC class directly has access to the trace generator
+    # and transforms needed to do this wrapping. Note that only unconstrained parameters
+    # are passed to `MCMCKernel` classes.
     def _trace_wrap(self, z, *args, **kwargs):
         for name, transform in self.kernel.transforms.items():
             z[name] = transform.inv(z[name])

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -262,7 +262,6 @@ class MCMC(TracePosterior):
     """
     def __init__(self, kernel, num_samples, warmup_steps=None,
                  num_chains=1, mp_context=None, disable_progbar=False):
-        self.kernel = kernel
         self.warmup_steps = num_samples if warmup_steps is None else warmup_steps  # Stan
         self.num_samples = num_samples
         if num_chains > 1:

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -53,16 +53,17 @@ class MCMCKernel(object):
     @initial_params.setter
     def initial_params(self, params):
         """
-        Sets the parameters to initiate the MCMC run.
+        Sets the parameters to initiate the MCMC run. Note that the parameters must
+        have unconstrained support.
         """
         raise NotImplementedError
 
     @abstractmethod
     def sample(self, params):
         """
-        Samples parameters from the posterior distribution, when given an existing trace.
+        Samples parameters from the posterior distribution, when given existing parameters.
 
-        :param trace: Current parameter values.
+        :param dict params: Current parameter values.
         :param int time_step: Current time step.
         :return: New parameters from the posterior distribution.
         """

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -6,7 +6,7 @@ from six import add_metaclass
 
 
 @add_metaclass(ABCMeta)
-class TraceKernel(object):
+class MCMCKernel(object):
 
     def setup(self, warmup_steps, *args, **kwargs):
         r"""
@@ -42,34 +42,34 @@ class TraceKernel(object):
         pass
 
     @property
-    def initial_trace(self):
+    def initial_params(self):
         """
-        Returns an initial trace (by default, from the prior) to initiate the MCMC run.
+        Returns a dict of initial params (by default, from the prior) to initiate the MCMC run.
 
-        :return: Trace instance.
+        :return: dict of parameter values keyed by their name.
         """
         raise NotImplementedError
 
-    @initial_trace.setter
-    def initial_trace(self, trace):
+    @initial_params.setter
+    def initial_params(self, params):
         """
-        Sets the trace to initiate the MCMC run.
+        Sets the parameters to initiate the MCMC run.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def sample(self, trace):
+    def sample(self, params):
         """
-        Samples a trace from the approximate posterior distribution, when given an existing trace.
+        Samples parameters from the posterior distribution, when given an existing trace.
 
-        :param trace: Current execution trace.
+        :param trace: Current parameter values.
         :param int time_step: Current time step.
-        :return: New trace sampled from the approximate posterior distribution.
+        :return: New parameters from the posterior distribution.
         """
         raise NotImplementedError
 
-    def __call__(self, trace):
+    def __call__(self, params):
         """
-        Alias for TraceKernel.sample() method.
+        Alias for MCMCKernel.sample() method.
         """
-        return self.sample(trace)
+        return self.sample(params)

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -273,7 +273,7 @@ class NUTS(HMC):
         if not z:
             self._accept_cnt += 1
             self._t += 1
-            return self._get_trace(z)
+            return z
         r, r_flat = self._sample_r(name="r_t={}".format(self._t))
         energy_current = self._kinetic_energy(r) + potential_energy
 
@@ -371,8 +371,4 @@ class NUTS(HMC):
             self._accept_cnt += 1
 
         self._t += 1
-        # get trace with the constrained values for `z`.
-        z = z.copy()
-        for name, transform in self.transforms.items():
-            z[name] = transform.inv(z[name])
-        return self._get_trace(z)
+        return z.copy()

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -177,7 +177,7 @@ def test_logistic_regression(step_size, trajectory_length, num_steps,
     labels = dist.Bernoulli(logits=(true_coefs * data).sum(-1)).sample()
 
     def model(data):
-        coefs_mean = torch.zeros(dim)
+        coefs_mean = pyro.param('coefs_mean', torch.zeros(dim))
         coefs = pyro.sample('beta', dist.Normal(coefs_mean, torch.ones(dim)))
         y = pyro.sample('y', dist.Bernoulli(logits=(coefs * data).sum(-1)), obs=labels)
         return y
@@ -263,7 +263,7 @@ def test_bernoulli_latent_model(jit):
     assert_equal(posterior, y_prob, prec=0.06)
 
 
-def test_initial_trace(monkeypatch):
+def test_initial_params(monkeypatch):
     dim = 3
     data = torch.randn(2000, dim)
     true_coefs = torch.arange(1., dim + 1.)
@@ -283,5 +283,5 @@ def test_initial_trace(monkeypatch):
     hmc_kernel = HMC(model, adapt_step_size=False)
     monkeypatch.setattr(hmc_kernel, '_compute_trace_log_prob', tr_log_prob)
     hmc_kernel.setup(0, data)
-    hmc_kernel.initial_trace
+    hmc_kernel.initial_params
     assert len(trace_log_prob_replay) == 0

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -10,18 +10,19 @@ import pyro.distributions as dist
 from pyro import poutine
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.mcmc import MCMC, _SingleSampler, _ParallelSampler
-from pyro.infer.mcmc.trace_kernel import TraceKernel
+from pyro.infer.mcmc.mcmc_kernel import MCMCKernel
 from pyro.util import optional
 from tests.common import assert_equal, skipif_param
 
 
-class PriorKernel(TraceKernel):
+class PriorKernel(MCMCKernel):
     """
     Disregards the value of the current trace (or observed data) and
     samples a value from the model's prior.
     """
     def __init__(self, model):
         self.model = model
+        self.transforms = {}
         self.data = None
 
     def setup(self, warmup_steps, data):
@@ -30,11 +31,12 @@ class PriorKernel(TraceKernel):
     def cleanup(self):
         self.data = None
 
-    def initial_trace(self):
-        return poutine.trace(self.model).get_trace(self.data)
+    def initial_params(self):
+        trace = poutine.trace(self.model).get_trace(self.data)
+        return {k: v["value"] for k, v in trace.iter_stochastic_nodes()}
 
     def sample(self, trace):
-        return self.initial_trace()
+        return self.initial_params()
 
 
 def normal_normal_model(data):

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -24,9 +24,11 @@ class PriorKernel(MCMCKernel):
         self.model = model
         self.transforms = {}
         self.data = None
+        self._prototype_trace = None
 
     def setup(self, warmup_steps, data):
         self.data = data
+        self._prototype_trace = poutine.trace(self.model).get_trace(data)
 
     def cleanup(self):
         self.data = None


### PR DESCRIPTION
As discussed in #1845, this renames `TraceKernel` to `MCMCKernel` and changes the interface so that the kernels take in dicts instead of model traces. 

I have tried to make minimal changes. ~but since the current interface is very coupled with the `model`, I had to make slightly more changes than I had planned~. Existing tests work as expected. 