### PR TITLE
Add different initialization methods for autoguides

### DIFF
--- a/docs/source/contrib.autoguide.rst
+++ b/docs/source/contrib.autoguide.rst
@@ -91,6 +91,7 @@ AutoDiscreteParallel
     :special-members: __call__
     :show-inheritance:
 
+.. _autoguide-initialization:
 
 Initialization
 --------------

--- a/docs/source/contrib.autoguide.rst
+++ b/docs/source/contrib.autoguide.rst
@@ -90,3 +90,13 @@ AutoDiscreteParallel
     :undoc-members:
     :special-members: __call__
     :show-inheritance:
+
+
+Initialization
+--------------
+.. automodule:: pyro.contrib.autoguide.initialization
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+    :member-order: bysource

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -276,7 +276,8 @@ class AutoDelta(AutoGuide):
                    constraint=constraints.positive)
 
     :param callable model: A Pyro model.
-    :param callable init_loc_fn: A per-site initialzation function.
+    :param callable init_loc_fn: A per-site initialization function.
+        See :ref:`autoguide-initialization` section for available functions.
     """
     def __init__(self, model, prefix="auto", init_loc_fn=init_to_median):
         model = InitMessenger(init_loc_fn)(model)
@@ -335,7 +336,8 @@ class AutoContinuous(AutoGuide):
         Blei
 
     :param callable model: A Pyro model.
-    :param callable init_loc_fn: A per-site initialzation function.
+    :param callable init_loc_fn: A per-site initialization function.
+        See :ref:`autoguide-initialization` section for available functions.
     """
     def __init__(self, model, prefix="auto", init_loc_fn=init_to_median):
         model = InitMessenger(init_loc_fn)(model)
@@ -573,6 +575,8 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
 
     :param callable model: a generative model
     :param int rank: the rank of the low-rank part of the covariance matrix
+    :param callable init_loc_fn: A per-site initialization function.
+        See :ref:`autoguide-initialization` section for available functions.
     :param str prefix: a prefix that will be prefixed to all param internal sites
     """
 
@@ -617,6 +621,8 @@ class AutoIAFNormal(AutoContinuous):
 
     :param callable model: a generative model
     :param int hidden_dim: number of hidden dimensions in the IAF
+    :param callable init_loc_fn: A per-site initialization function.
+        See :ref:`autoguide-initialization` section for available functions.
     :param str prefix: a prefix that will be prefixed to all param internal sites
     """
 

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -512,6 +512,7 @@ class AutoMultivariateNormal(AutoContinuous):
         scale = pyro.param("{}_scale_tril".format(self.prefix)).diag()
         return loc, scale
 
+
 class AutoDiagonalNormal(AutoContinuous):
     """
     This implementation of :class:`AutoContinuous` uses a Normal distribution

--- a/pyro/contrib/autoguide/initialization.py
+++ b/pyro/contrib/autoguide/initialization.py
@@ -1,35 +1,89 @@
+r"""
+The pyro.contrib.autoguide module contains initialization functions for
+automatic guides.
+
+The standard interface for initialization is a function that inputs a Pyro
+trace ``site`` dict and returns an appropriately sized ``value`` to serve
+as an initial constrained value for a guide estimate.
+"""
 from __future__ import absolute_import, division, print_function
 
 import torch
 from torch.distributions import transform_to
 
+from pyro.poutine.messenger import Messenger
+from pyro.util import torch_isnan
 
-@torch.no_grad()
+
 def init_to_feasible(site):
-    value = site["value"].detach()
+    """
+    Initialize to an arbitrary feasible point, ignoring distribution
+    parameters.
+    """
+    value = site["fn"].sample().detach()
     t = transform_to(site["fn"].support)
     return t(torch.zeros_like(t.inv(value)))
 
 
-@torch.no_grad()
 def init_to_sample(site):
-    return site["value"].detach()
+    """
+    Initialize to a random sample from the prior.
+    """
+    return site["fn"].sample().detach()
 
 
-@torch.no_grad()
-def init_to_mean(site):
+def init_to_median(site, num_samples=15):
+    """
+    Initialize to the prior median; fallback to a feasible point if median is
+    undefined.
+    """
     try:
-        value = site["fn"].mean.detach()
+        # Try to compute empirical median.
+        samples = site["fn"].sample(sample_shape=(num_samples,))
+        value = samples.median(dim=0)[0]
+        if torch_isnan(value):
+            raise ValueError
         if hasattr(site["fn"], "_validate_sample"):
-            # Fall back to a feasible point for distributions with
-            # infinite variance, e.g. Cauchy.
             site["fn"]._validate_sample(value)
         return value
-    except (NotImplementedError, ValueError):
+    except (RuntimeError, ValueError):
+        # Fall back to feasible point.
         return init_to_feasible(site)
 
 
-@torch.no_grad()
-def init_to_median(site, num_samples=32):
-    samples = site["fn"].sample(sample_shape=(num_samples,))
-    return samples.median(dim=0)[0]
+def init_to_mean(site):
+    """
+    Initialize to the prior mean; fallback to median if mean is undefined.
+    """
+    try:
+        # Try .mean() method.
+        value = site["fn"].mean.detach()
+        if torch_isnan(value):
+            raise ValueError
+        if hasattr(site["fn"], "_validate_sample"):
+            site["fn"]._validate_sample(value)
+        return value
+    except (NotImplementedError, ValueError):
+        # Fall back to a median.
+        # This is requred for distributions with infinite variance, e.g. Cauchy.
+        return init_to_median(site)
+
+
+class InitMessenger(Messenger):
+    """
+    Initializes a site by replacing ``.sample()`` calls with values
+    drawn from an initialization strategy. This is mainly for internal use by
+    autoguide classes.
+
+    :param callable init_fn: An initialization function.
+    """
+    def __init__(self, init_fn):
+        self.init_fn = init_fn
+        super(InitMessenger, self).__init__()
+
+    def _pyro_sample(self, msg):
+        if msg["done"] or msg["is_observed"] or type(msg["fn"]).__name__ == "_Subsample":
+            return
+        with torch.no_grad():
+            msg["value"] = self.init_fn(msg)
+        msg["done"] = True

--- a/pyro/contrib/autoguide/initialization.py
+++ b/pyro/contrib/autoguide/initialization.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, division, print_function
+
+import torch
+from torch.distributions import transform_to
+
+
+@torch.no_grad()
+def init_to_feasible(site):
+    value = site["value"].detach()
+    t = transform_to(site["fn"].support)
+    return t(torch.zeros_like(t.inv(value)))
+
+
+@torch.no_grad()
+def init_to_sample(site):
+    return site["value"].detach()
+
+
+@torch.no_grad()
+def init_to_mean(site):
+    try:
+        value = site["fn"].mean.detach()
+        if hasattr(site["fn"], "_validate_sample"):
+            # Fall back to a feasible point for distributions with
+            # infinite variance, e.g. Cauchy.
+            site["fn"]._validate_sample(value)
+        return value
+    except (NotImplementedError, ValueError):
+        return init_to_feasible(site)
+
+
+@torch.no_grad()
+def init_to_median(site, num_samples=32):
+    samples = site["fn"].sample(sample_shape=(num_samples,))
+    return samples.median(dim=0)[0]

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import functools
+
 import numpy as np
 import pytest
 import torch
@@ -10,7 +12,8 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.contrib.autoguide import (AutoCallable, AutoDelta, AutoDiagonalNormal, AutoDiscreteParallel, AutoGuideList,
                                     AutoIAFNormal, AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
-                                    AutoMultivariateNormal)
+                                    AutoMultivariateNormal, init_to_feasible, init_to_mean, init_to_median,
+                                    init_to_sample)
 from pyro.infer import SVI, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO
 from pyro.optim import Adam
 from tests.common import assert_equal
@@ -43,6 +46,12 @@ def test_scores(auto_class):
 
 
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("init_loc_fn", [
+    init_to_feasible,
+    init_to_mean,
+    init_to_median,
+    init_to_sample,
+])
 @pytest.mark.parametrize("auto_class", [
     AutoDelta,
     AutoDiagonalNormal,
@@ -51,7 +60,7 @@ def test_scores(auto_class):
     AutoIAFNormal,
     AutoLaplaceApproximation,
 ])
-def test_shapes(auto_class, Elbo):
+def test_shapes(auto_class, init_loc_fn, Elbo):
 
     def model():
         pyro.sample("z1", dist.Normal(0.0, 1.0))
@@ -59,7 +68,7 @@ def test_shapes(auto_class, Elbo):
         with pyro.plate("plate", 3):
             pyro.sample("z3", dist.Normal(torch.zeros(3), torch.ones(3)))
 
-    guide = auto_class(model)
+    guide = auto_class(model, init_loc_fn=init_loc_fn)
     elbo = Elbo(strict_enumeration_warning=False)
     loss = elbo.loss(model, guide)
     assert np.isfinite(loss), loss
@@ -125,6 +134,10 @@ def auto_guide_callable(model):
     AutoLaplaceApproximation,
     auto_guide_list_x,
     auto_guide_callable,
+    functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_feasible),
+    functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_mean),
+    functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_median),
+    functools.partial(AutoDiagonalNormal, init_loc_fn=init_to_sample),
 ])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
 def test_median(auto_class, Elbo):

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -114,7 +114,7 @@ def auto_guide_list_x(model):
 def auto_guide_callable(model):
     def guide_x():
         x_loc = pyro.param("x_loc", torch.tensor(1.))
-        x_scale = pyro.param("x_scale", torch.tensor(2.), constraint=constraints.positive)
+        x_scale = pyro.param("x_scale", torch.tensor(.1), constraint=constraints.positive)
         pyro.sample("x", dist.Normal(x_loc, x_scale))
 
     def median_x():

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -51,7 +51,7 @@ class AutoGaussianChain(GaussianChain):
                      .format(self.target_auto_diag_cov[1:].detach().cpu().numpy()))
 
         # TODO speed up with parallel num_particles > 1
-        adam = optim.Adam({"lr": .0005, "betas": (0.95, 0.999)})
+        adam = optim.Adam({"lr": .001, "betas": (0.95, 0.999)})
         svi = SVI(self.model, self.guide, adam, loss=Trace_ELBO())
 
         for k in range(n_steps):


### PR DESCRIPTION
This PR
- enables customization of initialization strategy in pyro.contrib.autoguide
- adds two new strategies: mean and median
- changes the default strategy to `init_to_median` (previously `Delta` used a single sample and `Auto*Normal` used an arbitrary feasible point).

This was motivated by a project I'm working on where I realized that the `AutoDiagonalNormal` initialization completely ignored the prior. In my project, `init_to_mean` converges faster (by orders of magnitude).

Resolves #1850
I've also added fixes to initialization code so as to preserve dtype and device info.

## Tested
- added a smoke test
- added a convergence test with `test_median`