### PR TITLE
enable baseball gpu test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,7 +7,7 @@ from subprocess import check_call
 
 import pytest
 
-from tests.common import EXAMPLES_DIR, requires_cuda, skipif_param, xfail_param
+from tests.common import EXAMPLES_DIR, requires_cuda, skipif_param
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.stage('test_examples')
@@ -72,8 +72,7 @@ CPU_EXAMPLES = [
 CUDA_EXAMPLES = [
     'air/main.py --num-steps=1 --cuda',
     'bayesian_regression.py --num-epochs=1 --cuda',
-    xfail_param('baseball.py --num-samples=200 --warmup-steps=100 --num-chains=2 --cuda',
-                reason='https://github.com/pyro-ppl/pyro/issues/1725'),
+    'baseball.py --num-samples=200 --warmup-steps=100 --num-chains=2 --cuda',
     'contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --cuda',
     'lkj.py --n=50 --num-chains=1 --warmup-steps=100 --num-samples=200 --cuda',
     'dmm/dmm.py --num-epochs=1 --cuda',


### PR DESCRIPTION
With https://github.com/pytorch/pytorch/pull/16854, we can run MCMC with multi-chain in GPU, so I enable the baseball example test. This is a really nice feature of pytorch 1.1!