### PR TITLE
Respect transforms for new hmc api

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -233,7 +233,8 @@ class HMC(MCMCKernel):
         )
         self.potential_fn = potential_fn
         self.transforms = transforms
-        self._initial_params = init_params
+        if self._initial_params is None:
+            self._initial_params = init_params
         self._prototype_trace = trace
 
     def _initialize_adapter(self):

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -190,10 +190,11 @@ class _SingleSampler(TracePosterior):
     # and transforms needed to do this wrapping. Note that only unconstrained parameters
     # are passed to `MCMCKernel` classes.
     def _trace_wrap(self, z, *args, **kwargs):
+        if self.kernel.transforms:
+            for name, transform in self.kernel.transforms.items():
+                z[name] = transform.inv(z[name])
         if self.kernel.model is None:
             return z
-        for name, transform in self.kernel.transforms.items():
-            z[name] = transform.inv(z[name])
         z_trace = self.kernel._prototype_trace
         for name, value in z.items():
             z_trace.nodes[name]["value"] = value


### PR DESCRIPTION
This makes a quick fix so that users using dev branch can get expected behaviour. Currently, we can use the new `initialize_model` utility to feed `potential_fn` and `transforms` into HMC kernel, but MCMC only returns params in unconstrained space. This PR makes it return samples in constrained space instead.