### PR TITLE
Expose torch.jit.trace options to ELBO constructor

### DIFF
--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -43,6 +43,8 @@ class ELBO(object):
     :param bool ignore_jit_warnings: Flag to ignore warnings from the JIT
         tracer. When this is True, all :class:`torch.jit.TracerWarning` will
         be ignored. Defaults to False.
+    :param bool jit_options: Optional dict of options to pass to
+        :func:`torch.jit.trace` , e.g. ``{"optimize": False}``.
     :param bool retain_graph: Whether to retain autograd graph during an SVI
         step. Defaults to None (False).
     :param float tail_adaptive_beta: Exponent beta with ``-1.0 <= beta < 0.0`` for
@@ -64,6 +66,7 @@ class ELBO(object):
                  vectorize_particles=False,
                  strict_enumeration_warning=True,
                  ignore_jit_warnings=False,
+                 jit_options=None,
                  retain_graph=None,
                  tail_adaptive_beta=-1.0):
         if max_iarange_nesting is not None:
@@ -78,6 +81,7 @@ class ELBO(object):
             self.max_plate_nesting += 1
         self.strict_enumeration_warning = strict_enumeration_warning
         self.ignore_jit_warnings = ignore_jit_warnings
+        self.jit_options = jit_options
         self.tail_adaptive_beta = tail_adaptive_beta
 
     def _guess_max_plate_nesting(self, model, guide, *args, **kwargs):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -160,7 +160,8 @@ class JitTrace_ELBO(Trace_ELBO):
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
+            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings,
+                                jit_options=self.jit_options)
             def loss_and_surrogate_loss(*args, **kwargs):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -141,7 +141,8 @@ class JitTraceMeanField_ELBO(TraceMeanField_ELBO):
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
+            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings,
+                                jit_options=self.jit_options)
             def differentiable_loss(*args, **kwargs):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -443,7 +443,8 @@ class JitTraceEnum_ELBO(TraceEnum_ELBO):
             # build a closure for differentiable_loss
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
+            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings,
+                                jit_options=self.jit_options)
             def differentiable_loss(*args, **kwargs):
                 kwargs.pop('_model_id')
                 kwargs.pop('_guide_id')

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -274,7 +274,8 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
-            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings)
+            @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings,
+                                jit_options=self.jit_options)
             def loss_and_surrogate_loss(*args, **kwargs):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -50,10 +50,12 @@ class CompiledFunction(object):
     The actual PyTorch compilation artifact is stored in :attr:`compiled`.
     Call diagnostic methods on this attribute.
     """
-    def __init__(self, fn, ignore_warnings=False):
+    def __init__(self, fn, ignore_warnings=False, jit_options=None):
         self.fn = fn
         self.compiled = {}  # len(args) -> callable
         self.ignore_warnings = ignore_warnings
+        self.jit_options = {} if jit_options is None else jit_options
+        self.jit_options.setdefault('check_trace', False)
         self._param_names = None
 
     def __call__(self, *args, **kwargs):
@@ -84,7 +86,7 @@ class CompiledFunction(object):
                 return poutine.replay(self.fn, params=constrained_params)(*args, **kwargs)
 
             with pyro.validation_enabled(False), optional(ignore_jit_warnings(), self.ignore_warnings):
-                self.compiled[key] = torch.jit.trace(compiled, params_and_args, check_trace=False)
+                self.compiled[key] = torch.jit.trace(compiled, params_and_args, **self.jit_options)
         else:
             unconstrained_params = [pyro.param(name).unconstrained()
                                     for name in self._param_names]
@@ -102,7 +104,7 @@ class CompiledFunction(object):
         return ret
 
 
-def trace(fn=None, ignore_warnings=False):
+def trace(fn=None, ignore_warnings=False, jit_options=None):
     """
     Lazy replacement for :func:`torch.jit.trace` that works with
     Pyro functions that call :func:`pyro.param`.
@@ -121,7 +123,12 @@ def trace(fn=None, ignore_warnings=False):
             cond_model = pyro.condition(model, data={"y": y})
             tr = pyro.poutine.trace(cond_model).get_trace(x)
             return tr.log_prob_sum()
+
+    :param callable fn: The function to be traced.
+    :param bool ignore_warnins: Whether to ignore jit warnings.
+    :param dict jit_options: Optional dict of options to pass to
+        :func:`torch.jit.trace` , e.g. ``{"optimize": False}``.
     """
     if fn is None:
-        return lambda fn: trace(fn, ignore_warnings=ignore_warnings)
-    return CompiledFunction(fn, ignore_warnings=ignore_warnings)
+        return lambda fn: trace(fn, ignore_warnings=ignore_warnings, jit_options=jit_options)
+    return CompiledFunction(fn, ignore_warnings=ignore_warnings, jit_options=jit_options)

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -441,7 +441,8 @@ def test_traceenum_elbo(length):
         pass
 
     expected_loss = TraceEnum_ELBO(max_plate_nesting=0).differentiable_loss(model, guide, data)
-    actual_loss = JitTraceEnum_ELBO(max_plate_nesting=0).differentiable_loss(model, guide, data)
+    actual_loss = JitTraceEnum_ELBO(max_plate_nesting=0,
+                                    jit_options={"optimize": False}).differentiable_loss(model, guide, data)
     assert_equal(expected_loss, actual_loss)
 
     expected_grads = grad(expected_loss, [transition, means], allow_unused=True)


### PR DESCRIPTION
This plumbs a `jit_options` dict from our `JitTrace*_ELBO` classes down to `torch.jit.trace`. The main option of use os `optimize=False`, which may speed up jitting. Note that the PyTorch optimizer has slowed down between the 1.0 and 1.1 releases, so it will be nice to be able to control it more finely.

## Tested
- added an example in tests/infer/test_jit.py