### PR TITLE
Register pytest marker to avoid warning on latest pytest version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,9 @@ filterwarnings = error
 
 doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 
+markers =
+    benchmark
+
 [yapf]
 based_on_style = google
 column_limit = 120


### PR DESCRIPTION
On the latest pytest version, any custom markers from plugins need to be explicitly registered to avoid [PytestUnknownMarkWarning](https://docs.pytest.org/en/latest/mark.html#raising-errors-on-unknown-marks).

Our dev branch won't build until this is merged. 