### PR TITLE
get float acc instead of scalar tensor in svdkl

### DIFF
--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -70,6 +70,7 @@ def train(args, train_loader, gpmodule, optimizer, loss_fn, epoch):
         loss = loss_fn(gpmodule.model, gpmodule.guide)
         loss.backward()
         optimizer.step()
+        batch_idx = batch_idx + 1
         if batch_idx % args.log_interval == 0:
             print("Train Epoch: {:2d} [{:5d}/{} ({:2.0f}%)]\tLoss: {:.6f}"
                   .format(epoch, batch_idx * len(data), len(train_loader.dataset),

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -89,7 +89,7 @@ def test(args, test_loader, gpmodule):
         # use its likelihood to give prediction class
         pred = gpmodule.likelihood(f_loc, f_var)
         # compare prediction and target to count accuaracy
-        correct += pred.eq(target).long().cpu().sum()
+        correct += pred.eq(target).long().cpu().sum().item()
 
     print("\nTest set: Accuracy: {}/{} ({:.2f}%)\n"
           .format(correct, len(test_loader.dataset), 100. * correct / len(test_loader.dataset)))


### PR DESCRIPTION
This fixes a typo in reporting accuracy of the model: if `correct` is a scalar long tensor `tensor(9943)`, then `100. * correct` is also a long tensor, hence the reporting result of `100. * tensor(9943) / 10000` will be `99` instead of 99.43.