### PR TITLE
Downgrade scipy dependency for travis tests to pass

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,9 @@ setup(
             'nbval',
             'pytest>=4.1',
             'pytest-cov',
-            'scipy>=1.1',
+            # TODO: remove once https://github.com/pyro-ppl/pyro/issues/1871
+            # is fixed.
+            'scipy>=1.1, <1.3',
         ],
         'profile': ['prettytable', 'pytest-benchmark', 'snakeviz'],
         'dev': EXTRAS_REQUIRE + [


### PR DESCRIPTION
This enables the travis tests to pass again by using a lower version of scipy that has `imresize` function used by the AIR tutorial. This is needed until https://github.com/pyro-ppl/pyro/issues/1871 is fixed. 
