### PR TITLE
Add TraceEnumSample_ELBO = TraceEnum_ELBO + infer_discrete

### DIFF
--- a/docs/source/inference_algos.rst
+++ b/docs/source/inference_algos.rst
@@ -65,6 +65,7 @@ Discrete Inference
 .. automodule:: pyro.infer.discrete
     :members:
     :show-inheritance:
+    :member-order: bysource
 
 Inference Utilities
 -------------------

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -195,17 +195,17 @@ class TraceEnumSample_ELBO(TraceEnum_ELBO):
     The following are equivalent but the first is cheaper, sharing work
     between the computations of ``loss`` and ``z``::
 
-            # Version 1.
-            elbo = TraceEnumSample_ELBO(first_available_dim=-2)
-            loss = elbo.loss(*args, **kwargs)
-            z = elbo.sample_saved()
+        # Version 1.
+        elbo = TraceEnumSample_ELBO(first_available_dim=-2)
+        loss = elbo.loss(*args, **kwargs)
+        z = elbo.sample_saved()
 
-            # Version 2.
-            elbo = TraceEnum_ELBO(first_available_dim=-2)
-            loss = elbo.loss(*args, **kwargs)
-            guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
-            z = infer_discrete(poutine.replay(model, guide_trace),
-                               first_available_dim=-2)(*args, **kwargs)
+        # Version 2.
+        elbo = TraceEnum_ELBO(first_available_dim=-2)
+        loss = elbo.loss(*args, **kwargs)
+        guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
+        z = infer_discrete(poutine.replay(model, guide_trace),
+                           first_available_dim=-2)(*args, **kwargs)
 
     """
     def _get_trace(self, model, guide, *args, **kwargs):

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -196,12 +196,12 @@ class TraceEnumSample_ELBO(TraceEnum_ELBO):
     between the computations of ``loss`` and ``z``::
 
         # Version 1.
-        elbo = TraceEnumSample_ELBO(first_available_dim=-2)
+        elbo = TraceEnumSample_ELBO(max_plate_nesting=1)
         loss = elbo.loss(*args, **kwargs)
         z = elbo.sample_saved()
 
         # Version 2.
-        elbo = TraceEnum_ELBO(first_available_dim=-2)
+        elbo = TraceEnum_ELBO(max_plate_nesting=1)
         loss = elbo.loss(*args, **kwargs)
         guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
         z = infer_discrete(poutine.replay(model, guide_trace),

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -83,7 +83,7 @@ def _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs
 
     # We take special care to match the term ordering in
     # pyro.infer.traceenum_elbo._compute_model_factors() to allow
-    # contract_tensor_tree() to use shared_intermediates() inside.
+    # contract_tensor_tree() to use shared_intermediates() inside
     # TraceEnumSample_ELBO. The special ordering is: first all cost terms in
     # order of model_trace, then all enum_terms in order of model trace.
     log_probs = cost_terms
@@ -192,7 +192,8 @@ class TraceEnumSample_ELBO(TraceEnum_ELBO):
     This extends :class:`TraceEnum_ELBO` to make it cheaper to sample from
     discrete latent states during SVI.
 
-    The following are equivalent, but the first is cheaper::
+    The following are equivalent but the first is cheaper, sharing work
+    between the computations of ``loss`` and ``z``::
 
             # Version 1.
             elbo = TraceEnumSample_ELBO(first_available_dim=-2)

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -3,8 +3,11 @@ from __future__ import absolute_import, division, print_function
 import functools
 from collections import OrderedDict
 
+from opt_einsum import shared_intermediates
+
 import pyro.ops.packed as packed
 from pyro import poutine
+from pyro.infer.traceenum_elbo import TraceEnum_ELBO
 from pyro.ops.contract import contract_tensor_tree
 from pyro.ops.einsum.adjoint import require_backward
 from pyro.ops.rings import MapRing, SampleRing
@@ -16,9 +19,9 @@ from pyro.util import jit_iter
 _RINGS = {0: MapRing, 1: SampleRing}
 
 
-def _make_ring(temperature, dim_to_size):
+def _make_ring(temperature, cache, dim_to_size):
     try:
-        return _RINGS[temperature](dim_to_size=dim_to_size)
+        return _RINGS[temperature](cache=cache, dim_to_size=dim_to_size)
     except KeyError:
         raise ValueError("temperature must be 0 (map) or 1 (sample) for now")
 
@@ -42,34 +45,56 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
     enum_trace = prune_subsample_sites(enum_trace)
     enum_trace.compute_log_prob()
     enum_trace.pack_tensors()
+
+    return _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs)
+
+
+def _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs):
     plate_to_symbol = enum_trace.plate_to_symbol
 
     # Collect a set of query sample sites to which the backward algorithm will propagate.
-    log_probs = OrderedDict()
     sum_dims = set()
     queries = []
     dim_to_size = {}
+    cost_terms = OrderedDict()
+    enum_terms = OrderedDict()
     for node in enum_trace.nodes.values():
         if node["type"] == "sample":
             ordinal = frozenset(plate_to_symbol[f.name]
                                 for f in node["cond_indep_stack"]
                                 if f.vectorized and f.size > 1)
-            log_prob = node["packed"]["log_prob"]
-            log_probs.setdefault(ordinal, []).append(log_prob)
+            log_prob = node["packed"]["unscaled_log_prob"]
             sum_dims.update(log_prob._pyro_dims)
-            dim_to_size.update(zip(log_prob._pyro_dims, log_prob.shape))
             for frame in node["cond_indep_stack"]:
                 if frame.vectorized and frame.size > 1:
                     sum_dims.remove(plate_to_symbol[frame.name])
+            if sum_dims.isdisjoint(log_prob._pyro_dims):
+                continue
+            dim_to_size.update(zip(log_prob._pyro_dims, log_prob.shape))
+            if node["infer"].get("_enumerate_dim") is None:
+                cost_terms.setdefault(ordinal, []).append(log_prob)
+            else:
+                enum_terms.setdefault(ordinal, []).append(log_prob)
             # Note we mark all sample sites with require_backward to gather
             # enumerated sites and adjust cond_indep_stack of all sample sites.
             if not node["is_observed"]:
                 queries.append(log_prob)
                 require_backward(log_prob)
 
+    # We take special care to match the term ordering in
+    # pyro.infer.traceenum_elbo._compute_model_factors() to allow
+    # contract_tensor_tree() to use shared_intermediates() inside.
+    # TraceEnumSample_ELBO. The special ordering is: first all cost terms in
+    # order of model_trace, then all enum_terms in order of model trace.
+    log_probs = cost_terms
+    for ordinal, terms in enum_terms.items():
+        log_probs.setdefault(ordinal, []).extend(terms)
+
     # Run forward-backward algorithm, collecting the ordinal of each connected component.
-    ring = _make_ring(temperature, dim_to_size)
-    log_probs = contract_tensor_tree(log_probs, sum_dims, ring=ring)  # run forward algorithm
+    cache = getattr(enum_trace, "_sharing_cache", {})
+    ring = _make_ring(temperature, cache, dim_to_size)
+    with shared_intermediates(cache):
+        log_probs = contract_tensor_tree(log_probs, sum_dims, ring=ring)  # run forward algorithm
     query_to_ordinal = {}
     pending = object()  # a constant value for pending queries
     for query in queries:
@@ -96,7 +121,7 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
                 "cond_indep_stack": node["cond_indep_stack"],
                 "value": node["value"],
             }
-            log_prob = node["packed"]["log_prob"]
+            log_prob = node["packed"]["unscaled_log_prob"]
             if hasattr(log_prob, "_pyro_backward_result"):
                 # Adjust the cond_indep_stack.
                 ordinal = query_to_ordinal[log_prob]
@@ -160,3 +185,47 @@ def infer_discrete(fn=None, first_available_dim=None, temperature=1):
                                  first_available_dim=first_available_dim,
                                  temperature=temperature)
     return functools.partial(_sample_posterior, fn, first_available_dim, temperature)
+
+
+class TraceEnumSample_ELBO(TraceEnum_ELBO):
+    """
+    This extends :class:`TraceEnum_ELBO` to make it cheaper to sample from
+    discrete latent states during SVI.
+
+    The following are equivalent, but the first is cheaper::
+
+            # Version 1.
+            elbo = TraceEnumSample_ELBO(first_available_dim=-2)
+            loss = elbo.loss(*args, **kwargs)
+            z = elbo.sample_saved()
+
+            # Version 2.
+            elbo = TraceEnum_ELBO(first_available_dim=-2)
+            loss = elbo.loss(*args, **kwargs)
+            guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
+            z = infer_discrete(poutine.replay(model, guide_trace),
+                               first_available_dim=-2)(*args, **kwargs)
+
+    """
+    def _get_trace(self, model, guide, *args, **kwargs):
+        model_trace, guide_trace = super(TraceEnumSample_ELBO, self)._get_trace(
+            model, guide, *args, **kwargs)
+
+        # Mark all sample sites with require_backward to gather enumerated
+        # sites and adjust cond_indep_stack of all sample sites.
+        for node in model_trace.nodes.values():
+            if node["type"] == "sample" and not node["is_observed"]:
+                log_prob = node["packed"]["unscaled_log_prob"]
+                require_backward(log_prob)
+
+        self._saved_state = model, model_trace, guide_trace, args, kwargs
+        return model_trace, guide_trace
+
+    def sample_saved(self):
+        """
+        Generate latent samples while reusing work from SVI.step().
+        """
+        model, model_trace, guide_trace, args, kwargs = self._saved_state
+        model = poutine.replay(model, guide_trace)
+        temperature = 1
+        return _sample_posterior_from_trace(model, model_trace, temperature, *args, **kwargs)

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -138,7 +138,7 @@ def _compute_dice_elbo(model_trace, guide_trace):
         with shared_intermediates() as cache:
             ring = SampleRing(cache=cache, dim_to_size=dim_to_size)
             log_factors = contract_tensor_tree(log_factors, sum_dims, ring=ring)
-            model_trace._sharing_cache = cache
+            model_trace._sharing_cache = cache  # For TraceEnumSample_ELBO.
         for t, log_factors_t in log_factors.items():
             marginal_costs_t = marginal_costs.setdefault(t, [])
             for term in log_factors_t:

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -18,6 +18,7 @@ from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_dis
 from pyro.infer.util import Dice, is_validation_enabled
 from pyro.ops import packed
 from pyro.ops.contract import contract_tensor_tree, contract_to_tensor
+from pyro.ops.rings import SampleRing
 from pyro.poutine.enumerate_messenger import EnumerateMessenger
 from pyro.util import check_traceenum_requirements, ignore_jit_warnings, warn_if_nan
 
@@ -121,6 +122,11 @@ def _compute_dice_elbo(model_trace, guide_trace):
     marginal_costs, log_factors, ordering, sum_dims, scale = _compute_model_factors(
             model_trace, guide_trace)
     if log_factors:
+        dim_to_size = {}
+        for terms in log_factors.values():
+            for term in terms:
+                dim_to_size.update(zip(term._pyro_dims, term.shape))
+
         # Note that while most applications of tensor message passing use the
         # contract_to_tensor() interface and can be easily refactored to use ubersum(),
         # the application here relies on contract_tensor_tree() to extract the dependency
@@ -130,7 +136,9 @@ def _compute_dice_elbo(model_trace, guide_trace):
         # replace contract_tensor_tree() with a RaggedTensor -> RaggedTensor contraction
         # that preserves some dependency structure.
         with shared_intermediates() as cache:
-            log_factors = contract_tensor_tree(log_factors, sum_dims, cache=cache)
+            ring = SampleRing(cache=cache, dim_to_size=dim_to_size)
+            log_factors = contract_tensor_tree(log_factors, sum_dims, ring=ring)
+            model_trace._sharing_cache = cache
         for t, log_factors_t in log_factors.items():
             marginal_costs_t = marginal_costs.setdefault(t, [])
             for term in log_factors_t:

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -11,11 +11,34 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.infer import TraceEnum_ELBO
-from pyro.infer.discrete import infer_discrete
+from pyro.infer.discrete import TraceEnumSample_ELBO, infer_discrete
 from pyro.infer.enum import config_enumerate
 from tests.common import assert_equal
 
 logger = logging.getLogger(__name__)
+
+
+def elbo_infer_discrete(model, first_available_dim, temperature):
+    """
+    Wrapper around ``TraceEnumSample_ELBO`` to test agreement with
+    ``TraceEnum_ELBO`` and then return ``.sample_saved()``.
+    """
+    assert temperature == 1
+    max_plate_nesting = -first_available_dim - 1
+    expected_elbo = TraceEnum_ELBO(max_plate_nesting=max_plate_nesting)
+    actual_elbo = TraceEnumSample_ELBO(max_plate_nesting=max_plate_nesting)
+
+    def empty_guide(*args, **kwargs):
+        pass
+
+    def inferred_model(*args, **kwargs):
+        with poutine.block():
+            expected_loss = expected_elbo.loss(model, empty_guide, *args, **kwargs)
+            actual_loss = actual_elbo.loss(model, empty_guide, *args, **kwargs)
+        assert_equal(actual_loss, expected_loss)
+        return actual_elbo.sample_saved()
+
+    return inferred_model
 
 
 def log_mean_prob(trace, particle_dim):
@@ -34,9 +57,13 @@ def log_mean_prob(trace, particle_dim):
     return total.logsumexp(0) - math.log(num_particles)
 
 
-@pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
+@pytest.mark.parametrize('infer,temperature', [
+    (infer_discrete, 0),
+    (infer_discrete, 1),
+    (elbo_infer_discrete, 1),
+], ids=['map', 'sample', 'sample-elbo'])
 @pytest.mark.parametrize('plate_size', [2])
-def test_plate_smoke(temperature, plate_size):
+def test_plate_smoke(infer, temperature, plate_size):
     #       +-----------------+
     #  z1 --|--> z2 ---> x2   |
     #       |               N | for N in {1,2}
@@ -53,11 +80,15 @@ def test_plate_smoke(temperature, plate_size):
             pyro.sample("x2", dist.Normal(loc[z2], 1.), obs=torch.ones(plate_size))
 
     first_available_dim = -2
-    infer_discrete(model, first_available_dim, temperature)()
+    infer(model, first_available_dim, temperature)()
 
 
-@pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
-def test_distribution_1(temperature):
+@pytest.mark.parametrize('infer,temperature', [
+    (infer_discrete, 0),
+    (infer_discrete, 1),
+    (elbo_infer_discrete, 1),
+], ids=['map', 'sample', 'sample-elbo'])
+def test_distribution_1(infer, temperature):
     #      +-------+
     #  z --|--> x  |
     #      +-------+
@@ -74,7 +105,7 @@ def test_distribution_1(temperature):
                 pyro.sample("x", dist.Normal(z, 1.), obs=data)
 
     first_available_dim = -3
-    sampled_model = infer_discrete(model, first_available_dim, temperature)
+    sampled_model = infer(model, first_available_dim, temperature)
     sampled_trace = poutine.trace(sampled_model).get_trace(num_particles)
     conditioned_traces = {z: poutine.trace(model).get_trace(z=torch.tensor(z)) for z in [0., 1.]}
 
@@ -89,8 +120,12 @@ def test_distribution_1(temperature):
     assert_equal(actual_z_mean, expected_z_mean, prec=1e-2)
 
 
-@pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
-def test_distribution_2(temperature):
+@pytest.mark.parametrize('infer,temperature', [
+    (infer_discrete, 0),
+    (infer_discrete, 1),
+    (elbo_infer_discrete, 1),
+], ids=['map', 'sample', 'sample-elbo'])
+def test_distribution_2(infer, temperature):
     #       +--------+
     #  z1 --|--> x1  |
     #   |   |        |
@@ -114,7 +149,7 @@ def test_distribution_2(temperature):
                 pyro.sample("x2", dist.Normal(loc[z2], 1.), obs=data[1])
 
     first_available_dim = -3
-    sampled_model = infer_discrete(model, first_available_dim, temperature)
+    sampled_model = infer(model, first_available_dim, temperature)
     sampled_trace = poutine.trace(
         sampled_model).get_trace(num_particles)
     conditioned_traces = {(z1, z2): poutine.trace(model).get_trace(z1=torch.tensor(z1),
@@ -137,8 +172,12 @@ def test_distribution_2(temperature):
     assert_equal(expected_probs, actual_probs, prec=1e-2)
 
 
-@pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
-def test_distribution_3(temperature):
+@pytest.mark.parametrize('infer,temperature', [
+    (infer_discrete, 0),
+    (infer_discrete, 1),
+    (elbo_infer_discrete, 1),
+], ids=['map', 'sample', 'sample-elbo'])
+def test_distribution_3(infer, temperature):
     #       +---------+  +---------------+
     #  z1 --|--> x1   |  |  z2 ---> x2   |
     #       |       3 |  |             2 |
@@ -159,7 +198,7 @@ def test_distribution_3(temperature):
                 pyro.sample("x2", dist.Normal(loc[z2], 1.), obs=data[1])
 
     first_available_dim = -3
-    sampled_model = infer_discrete(model, first_available_dim, temperature)
+    sampled_model = infer(model, first_available_dim, temperature)
     sampled_trace = poutine.trace(
         sampled_model).get_trace(num_particles)
     conditioned_traces = {(z1, z20, z21): poutine.trace(model).get_trace(z1=torch.tensor(z1),
@@ -184,8 +223,12 @@ def test_distribution_3(temperature):
 
 
 @pytest.mark.parametrize('length', [1, 2, 10, 100])
-@pytest.mark.parametrize('temperature', [0, 1], ids=['map', 'sample'])
-def test_hmm_smoke(temperature, length):
+@pytest.mark.parametrize('infer,temperature', [
+    (infer_discrete, 0),
+    (infer_discrete, 1),
+    (elbo_infer_discrete, 1),
+], ids=['map', 'sample', 'sample-elbo'])
+def test_hmm_smoke(infer, temperature, length):
 
     # This should match the example in the infer_discrete docstring.
     def hmm(data, hidden_dim=10):
@@ -204,8 +247,8 @@ def test_hmm_smoke(temperature, length):
     assert len(data) == length
     assert len(true_states) == 1 + len(data)
 
-    decoder = infer_discrete(config_enumerate(hmm),
-                             first_available_dim=-1, temperature=temperature)
+    decoder = infer(config_enumerate(hmm),
+                    first_available_dim=-1, temperature=temperature)
     inferred_states, _ = decoder(data)
     assert len(inferred_states) == len(true_states)
 


### PR DESCRIPTION
Addresses #1824 

This adds a `TraceEnumSample_ELBO` class that allows sharing work between `TraceEnum_ELBO` and a subsequent call to `infer_discrete`, which can speed up inference by over ~1.6x. From the docs:

> The following are equivalent but the first is cheaper, sharing work
between the computations of ``loss`` and ``z``:
```py
# Version 1.
elbo = TraceEnumSample_ELBO(max_plate_nesting=1)
loss = elbo.loss(*args, **kwargs)
z = elbo.sample_saved()

# Version 2.
elbo = TraceEnum_ELBO(max_plate_nesting=1)
loss = elbo.loss(*args, **kwargs)
guide_trace = poutine.trace(guide).get_trace(*args, **kwargs)
z = infer_discrete(poutine.replay(model, guide_trace),
                   first_available_dim=-2)(*args, **kwargs)
```

This PR also makes `infer_discrete` compatible with data subsampling, switching from `log_prob` to `unscaled_log_prob` to match behavior in `TraceEnum_ELBO`.

## Tested
- added unit tests
- tested extensively on the contrib-treecat branch with large CPU and GPU computations