### PR TITLE
Support outside contributions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ ARG pytorch_branch=release
 ARG uid=1000
 ARG gid=1000
 ARG ostype=Linux
+ARG pyro_git_url=https://github.com/pyro-ppl/pyro.git
 
 # Configurable settings
 ENV USER_NAME pyromancer

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,6 +11,7 @@ GID=$(shell id -g)
 OSTYPE=$(shell uname)
 USER=pyromancer
 DOCKER_WORK_DIR=/home/${USER}/workspace/shared
+pyro_git_url=https://github.com/pyro-ppl/pyro.git
 
 # Optional args
 python_version?=2.7
@@ -54,6 +55,7 @@ build: ##
 	--build-arg ostype=${OSTYPE} \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \
+	--build-arg pyro_git_url=${pyro_git_url} \
 	--build-arg pyro_branch=${pyro_branch} -f ${DOCKER_FILE} .
 
 build-gpu: ##
@@ -75,6 +77,7 @@ build-gpu: ##
 	--build-arg cuda=1 \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \
+	--build-arg pyro_git_url=${pyro_git_url} \
 	--build-arg pyro_branch=${pyro_branch} -f ${DOCKER_FILE} .
 
 create-host-workspace: ##

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -30,6 +30,6 @@ if [ ${pyro_branch} = "release" ]
 then
     pip install pyro-ppl
 else
-    git clone https://github.com/uber/pyro.git
+    git clone ${pyro_git_url}
     (cd pyro && git checkout ${pyro_branch} && pip install .[dev])
 fi


### PR DESCRIPTION
### Description

Support configuring the location of the pyro repo. 

I'm planning to use this to run containerized tests on my fork before submitting another small PR. I've left the image naming alone. My thinking is that development will typically be based on a single repo, so name collisions will be infrequent. 

Note that the default repo location now lives in both `docker/Makefile` and `docker/install.sh`. It might be cleaner to gate on the existence of a `PYRO_REPO_URL` environment variable?

### Testing

* Built a docker container locally using `make build pyro_branch=support-outside-contrib pyro_git_url=https://github.com/mattwescott/pyro.git` and the container contained the target repo and branch
