### PR TITLE
Fix torchvision dependency in .travis to enable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ install:
     - pip install -U pip
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
           pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl;
+          pip install https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp27-cp27mu-linux_x86_64.whl;
       else
           pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl;
+          pip install https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl;
       fi
     - pip install .[test]
     - pip freeze


### PR DESCRIPTION
Currently pip installing torchvision results in an ImportError:

```
ImportError: libcudart.so.9.0: cannot open shared object file: No such file or directory
```

, which is fixed by https://github.com/pytorch/vision/issues/946 by providing separate CPU only wheels. 