### PR TITLE
Minor changes to test-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test: lint docs doctest FORCE
 	pytest -vx -n auto --stage unit
 
 test-examples: lint FORCE
-	pytest -vx -n auto --stage test_examples
+	pytest -vx --stage test_examples
 
 test-tutorials: lint FORCE
 	grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \

--- a/pyro/contrib/examples/multi_mnist.py
+++ b/pyro/contrib/examples/multi_mnist.py
@@ -72,7 +72,7 @@ def load_mnist(root_path):
 def load(root_path):
     file_path = os.path.join(root_path, 'multi_mnist_uint8.npz')
     if os.path.exists(file_path):
-        data = np.load(file_path)
+        data = np.load(file_path, allow_pickle=True)
         return data['x'], data['y']
     else:
         # Set RNG to known state.

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ long_description = '\n'.join([str(line) for line in long_description.split('\n')
 EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'matplotlib>=1.3',
-    'observations>=0.1.4',
     'pillow',
     'torchvision>=0.2.2',
     'visdom>=0.1.4',


### PR DESCRIPTION
Fixes #1875, #1871. Also includes a change so that pickled files can be loaded by `np.load` in `multi_mnist`, which would otherwise throw ValueError when we try to load already downloaded dataset in the AIR example. See this [notice](https://nvd.nist.gov/vuln/detail/CVE-2019-6446).

*Caveat:* This changes the Makefile default so that `make test` does not run pytest in a distributed setting. Doing so can lead to race conditions as pointed out by @null-a when multiple subprocesses running the same example (with different arguments, for instance) try to download the dataset to the same directory. 

The ideal way to handle this would be by grouping some tests to run on the same worker in xdist. The support for such a feature is lacking. See: https://github.com/pytest-dev/pytest-xdist/issues/365, https://github.com/pytest-dev/pytest-xdist/issues/18. There are other alternatives that we can explore too - including grouping same examples into test classes and using LoadScope scheduler, or having a script that downloads and populates the datasets for all examples before distributing the tests. 

I am however not sure if `make test-examples` is used that often locally that this is worth optimizing for, and have therefore opted for the simplest solution that wouldn't give unexpected results to new users. Existing users who already have datasets populated locally can always distribute the tests if they so like. Suggestions on alternatives are welcome. 