### PR TITLE
Support combination of auto and manual init in autoguides

### DIFF
--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -267,7 +267,7 @@ class AutoDelta(AutoGuide):
 
     By default latent variables are initialized using ``init_loc_fn()``. To
     change this default behavior the user should call :func:`pyro.param` before
-    beginning inference, with ``"auto_"`` prefixed to the targetd sample site
+    beginning inference, with ``"auto_"`` prefixed to the targeted sample site
     names e.g. for sample sites named "level" and "concentration", initialize
     via::
 


### PR DESCRIPTION
Addresses #1824 

This makes #1849 more useful by allowing users to interleave manually-initialized autoguide params (via `pyro.param("auto_...", ...)`) and automatic initialization strategies (e.g. `init_from_median`). This is often useful when manually initializing top-level parameters followed by automatically initializing lower level parameters based on top-level parameters.

Before this PR, manual param initialization would be ignored when initializing subsequent parameters via strategies. After this PR, manually initialized params will override strategies.

## Tested
- refactoring is exercised by existing tests
- manually confirmed behavior in the contrib-treecat branch