### PR TITLE
Add missing import

### DIFF
--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import torch
 
 import pyro
+import pyro.optim
 import pyro.poutine as poutine
 from pyro.infer.abstract_infer import TracePosterior
 from pyro.infer.elbo import ELBO


### PR DESCRIPTION
Ran into this by attempting to use `optim='SGD'`

```
svi = pyro.infer.SVI(model=conditioned_model,
                     guide=guide,
                     optim='SGD',
                     loss=loss
)
```

`AttributeError: module 'pyro' has no attribute 'optim'`