### PR TITLE
Clarify `tracegraph_elbo`

### DIFF
--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -297,7 +297,7 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
                         surrogate_elbo += surrogate_elbo_term
 
                     loss = - weight * elbo
-                    surrogate_loss = - weight * surrogate_elbo
+                    surrogate_loss = weight * (-surrogate_elbo + baseline_loss)
 
                 return loss, surrogate_loss
 

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -137,12 +137,7 @@ def _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes):
     for node in non_reparam_nodes:
         downstream_costs[node] = downstream_costs[node].sum_to(guide_trace.nodes[node]["cond_indep_stack"])
 
-    # Combine the included guide and model nodes for backward compatibility with tests
-    nodes_included = defaultdict(lambda: set())
-    [nodes_included[n].update(terms) for n, terms in included_model_terms.items()]
-    [nodes_included[n].update(terms) for n, terms in included_guide_terms.items()]
-
-    return downstream_costs, nodes_included
+    return downstream_costs, included_model_terms, included_guide_terms
 
 
 def _compute_elbo_reparam(model_trace, guide_trace):
@@ -336,7 +331,7 @@ class TraceGraph_ELBO(ELBO):
         # the following computations are only necessary if we have non-reparameterizable nodes
         non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
         if non_reparam_nodes:
-            downstream_costs, _ = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
+            downstream_costs, _, _ = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
             surrogate_elbo_term, baseline_loss = _compute_elbo_non_reparam(guide_trace,
                                                                            non_reparam_nodes,
                                                                            downstream_costs)

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -91,7 +91,7 @@ def _compute_downstream_costs(model_trace, guide_trace,  #
     return downstream_costs, downstream_guide_cost_nodes
 
 
-def _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes):
+def _compute_elbo_reparam(model_trace, guide_trace):
     elbo = 0.0
     surrogate_elbo = 0.0
 
@@ -227,15 +227,17 @@ class TraceGraph_ELBO(ELBO):
 
     def _loss_and_grads_particle(self, weight, model_trace, guide_trace):
         # compute elbo for reparameterized nodes
-        non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-        elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)
+        elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace)
+        baseline_loss = 0.0
 
         # the following computations are only necessary if we have non-reparameterizable nodes
-        baseline_loss = 0.0
+        non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
+
         if non_reparam_nodes:
             downstream_costs, _ = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
             surrogate_elbo_term, baseline_loss = _compute_elbo_non_reparam(guide_trace,
                                                                            non_reparam_nodes, downstream_costs)
+
             surrogate_elbo += surrogate_elbo_term
 
         # collect parameters to train from model and guide
@@ -244,12 +246,11 @@ class TraceGraph_ELBO(ELBO):
                                for site in trace.nodes.values())
 
         if trainable_params:
-            surrogate_loss = -surrogate_elbo
-            torch_backward(weight * (surrogate_loss + baseline_loss), retain_graph=self.retain_graph)
+            torch_backward(weight * (- surrogate_elbo + baseline_loss), retain_graph=self.retain_graph)
 
-        loss = -torch_item(elbo)
+        loss = torch_item(- weight * elbo)
         warn_if_nan(loss, "loss")
-        return weight * loss
+        return loss
 
 
 class JitTraceGraph_ELBO(TraceGraph_ELBO):
@@ -280,16 +281,14 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')
                 self = weakself()
-                loss = 0.0
-                surrogate_loss = 0.0
                 weight = 1.0 / self.num_particles
                 for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
                     # compute elbo for reparameterized nodes
-                    non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-                    elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace, non_reparam_nodes)
+                    elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace)
+                    baseline_loss = 0.0
 
                     # the following computations are only necessary if we have non-reparameterizable nodes
-                    baseline_loss = 0.0
+                    non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
                     if non_reparam_nodes:
                         downstream_costs, _ = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
                         surrogate_elbo_term, baseline_loss = _compute_elbo_non_reparam(guide_trace,
@@ -297,16 +296,17 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
                                                                                        downstream_costs)
                         surrogate_elbo += surrogate_elbo_term
 
-                    loss = loss - weight * elbo
-                    surrogate_loss = surrogate_loss - weight * surrogate_elbo
+                    loss = - weight * elbo
+                    surrogate_loss = - weight * surrogate_elbo
 
                 return loss, surrogate_loss
 
             self._loss_and_surrogate_loss = loss_and_surrogate_loss
 
         loss, surrogate_loss = self._loss_and_surrogate_loss(*args, **kwargs)
-        surrogate_loss.backward()
-        loss = loss.item()
 
+        surrogate_loss.backward()
+
+        loss = loss.item()
         warn_if_nan(loss, "loss")
         return loss

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -240,13 +240,7 @@ class TraceGraph_ELBO(ELBO):
 
             surrogate_elbo += surrogate_elbo_term
 
-        # collect parameters to train from model and guide
-        trainable_params = any(site["type"] == "param"
-                               for trace in (model_trace, guide_trace)
-                               for site in trace.nodes.values())
-
-        if trainable_params:
-            torch_backward(weight * (- surrogate_elbo + baseline_loss), retain_graph=self.retain_graph)
+        torch_backward(weight * (-surrogate_elbo + baseline_loss))
 
         loss = torch_item(- weight * elbo)
         warn_if_nan(loss, "loss")

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import weakref
-from operator import itemgetter
+from collections import defaultdict
 
 import torch
 
@@ -31,64 +31,118 @@ def _get_baseline_options(site):
     return options_tuple
 
 
-def _compute_downstream_costs(model_trace, guide_trace,  #
-                              non_reparam_nodes):
-    # recursively compute downstream cost nodes for all sample sites in model and guide
-    # (even though ultimately just need for non-reparameterizable sample sites)
-    # 1. downstream costs used for rao-blackwellization
-    # 2. model observe sites (as well as terms that arise from the model and guide having different
-    # dependency structures) are taken care of via 'children_in_model' below
-    topo_sort_guide_nodes = guide_trace.topological_sort(reverse=True)
-    topo_sort_guide_nodes = [x for x in topo_sort_guide_nodes
-                             if guide_trace.nodes[x]["type"] == "sample"]
-    ordered_guide_nodes_dict = {n: i for i, n in enumerate(topo_sort_guide_nodes)}
+def _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes):
 
-    downstream_guide_cost_nodes = {}
+    # Computes a surrogate cost for each nonreparam node in the guide. It would
+    # be equivalent (in expectation), to use the full ELBO as a cost for each
+    # node. But for many models/guides, there will be "upstream" terms in the
+    # ELBO which would only add variance to the gradient estimates.
+    #
+    # As in [1], only downstream costs are included. This multitree structure
+    # motivates a recursive computation. Note, while only the downstream costs
+    # for nonreparameterized guide nodes will ultimately be used, the reparam
+    # node costs count toward those downstream totals.
+
     downstream_costs = {}
+
+    # While accumulating costs, track which terms have been included for each
+    # node to support detecting and handling redundant paths.
+    included_model_terms = defaultdict(lambda: set())
+    included_guide_terms = defaultdict(lambda: set())
+
+    def charge(paying_node, cost):
+        # Add to the downstream total of paying_node
+        if paying_node in downstream_costs:
+            downstream_costs[paying_node].add(*cost.items())
+        else:
+            downstream_costs[paying_node] = cost
+
     stacks = get_plate_stacks(model_trace)
 
-    for node in topo_sort_guide_nodes:
-        downstream_costs[node] = MultiFrameTensor((stacks[node],
-                                                   model_trace.nodes[node]['log_prob'] -
-                                                   guide_trace.nodes[node]['log_prob']))
-        nodes_included_in_sum = set([node])
-        downstream_guide_cost_nodes[node] = set([node])
-        # make more efficient by ordering children appropriately (higher children first)
-        children = [(k, -ordered_guide_nodes_dict[k]) for k in guide_trace.successors(node)]
-        sorted_children = sorted(children, key=itemgetter(1))
-        for child, _ in sorted_children:
-            child_cost_nodes = downstream_guide_cost_nodes[child]
-            downstream_guide_cost_nodes[node].update(child_cost_nodes)
-            if nodes_included_in_sum.isdisjoint(child_cost_nodes):  # avoid duplicates
-                downstream_costs[node].add(*downstream_costs[child].items())
-                # XXX nodes_included_in_sum logic could be more fine-grained, possibly leading
-                # to speed-ups in case there are many duplicates
-                nodes_included_in_sum.update(child_cost_nodes)
-        missing_downstream_costs = downstream_guide_cost_nodes[node] - nodes_included_in_sum
-        # include terms we missed because we had to avoid duplicates
-        for missing_node in missing_downstream_costs:
-            downstream_costs[node].add((stacks[missing_node],
-                                        model_trace.nodes[missing_node]['log_prob'] -
-                                        guide_trace.nodes[missing_node]['log_prob']))
+    def charge_individual(paying_node, cost_node, model_term=True, guide_term=True):
 
-    # finish assembling complete downstream costs
-    # (the above computation may be missing terms from model)
-    for site in non_reparam_nodes:
-        children_in_model = set()
-        for node in downstream_guide_cost_nodes[site]:
-            children_in_model.update(model_trace.successors(node))
-        # remove terms accounted for above
-        children_in_model.difference_update(downstream_guide_cost_nodes[site])
-        for child in children_in_model:
-            assert (model_trace.nodes[child]["type"] == "sample")
-            downstream_costs[site].add((stacks[child],
-                                        model_trace.nodes[child]['log_prob']))
-            downstream_guide_cost_nodes[site].update([child])
+        log_prob = 0.0
+        if model_term:
+            log_prob += model_trace.nodes[cost_node]['log_prob']
+            included_model_terms[paying_node].add(cost_node)
+        if guide_term:
+            log_prob -= guide_trace.nodes[cost_node]['log_prob']
+            included_guide_terms[paying_node].add(cost_node)
 
-    for k in non_reparam_nodes:
-        downstream_costs[k] = downstream_costs[k].sum_to(guide_trace.nodes[k]["cond_indep_stack"])
+        cost = MultiFrameTensor((stacks[paying_node], log_prob))
+        charge(paying_node, cost)
 
-    return downstream_costs, downstream_guide_cost_nodes
+    def attempt_charge_downstream(paying_node, cost_node):
+        # If no duplication, charge paying_node for the full
+        # downstream cost from cost_node. Return any terms that *may* still
+        # be needed
+        required_model_terms = included_model_terms[cost_node]
+        required_guide_terms = included_guide_terms[cost_node]
+
+        already_model_terms = included_model_terms[paying_node]
+        already_guide_terms = included_guide_terms[paying_node]
+
+        needs_all = (
+            required_model_terms.isdisjoint(already_model_terms) and
+            required_guide_terms.isdisjoint(already_guide_terms)
+        )
+
+        if needs_all:
+            charge(paying_node, downstream_costs[cost_node])
+            already_model_terms.update(required_model_terms)
+            already_guide_terms.update(required_guide_terms)
+            return set(), set()
+
+        return required_model_terms, required_guide_terms
+
+    # The processing proceeds from later to earlier nodes in the guide
+    guide_nodes = [x for x in guide_trace.topological_sort(reverse=True)
+                   if guide_trace.nodes[x]["type"] == "sample"]
+    guide_node_to_index = dict((i, n) for n, i in enumerate(guide_nodes))
+
+    # From later to earlier...
+    for node in guide_nodes:
+        charge_individual(node, node)
+        # Process downstream nodes from earlier to later to potentially reduce
+        # the number of operations
+        children = sorted(
+            guide_trace.successors(node),
+            key=lambda n: guide_node_to_index[n],
+            reverse=True
+        )
+        required_model_terms = set()
+        required_guide_terms = set()
+        for child in children:
+            # In the case of duplicates, reduce the chance of further collisions
+            # by deferring adding the missing terms
+            more_model_terms, more_guide_terms = attempt_charge_downstream(node, child)
+            required_model_terms.update(more_model_terms)
+            required_guide_terms.update(more_guide_terms)
+
+        # Add any missing terms
+        for missing_node in required_model_terms.difference(included_model_terms[node]):
+            charge_individual(node, missing_node, guide_term=False)
+        for missing_node in required_guide_terms.difference(included_guide_terms[node]):
+            charge_individual(node, missing_node, model_term=False)
+
+    # Add any missing terms for children in the model of downstream guide nodes
+    for node in non_reparam_nodes:
+        possibly_missing_terms = set()
+        for downstream_node in included_guide_terms[node]:
+            possibly_missing_terms.update(model_trace.successors(downstream_node))
+        missing_model_terms = possibly_missing_terms.difference(included_model_terms[node])
+        [charge_individual(node, n, guide_term=False) for n in missing_model_terms]
+
+    # Collapse the conditionally independent stacks for needed costs
+    for node in non_reparam_nodes:
+        downstream_costs[node] = downstream_costs[node].sum_to(guide_trace.nodes[node]["cond_indep_stack"])
+
+    # Combine the included guide and model nodes for backward compatibility with tests
+    nodes_included = defaultdict(lambda: set())
+    [nodes_included[n].update(terms) for n, terms in included_model_terms.items()]
+    [nodes_included[n].update(terms) for n, terms in included_guide_terms.items()]
+
+    return downstream_costs, nodes_included
 
 
 def _compute_elbo_reparam(model_trace, guide_trace):

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -92,8 +92,8 @@ def _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes):
 
     # While accumulating costs, track which terms have been included for each
     # node to support detecting and handling redundant paths.
-    included_model_terms = defaultdict(lambda: set())
-    included_guide_terms = defaultdict(lambda: set())
+    included_model_terms = defaultdict(set)
+    included_guide_terms = defaultdict(set)
 
     def charge(paying_node, cost):
         # Add to the downstream total of paying_node

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -219,32 +219,49 @@ class TraceGraph_ELBO(ELBO):
         Performs backward on the latter. Num_particle many samples are used to form the estimators.
         If baselines are present, a baseline loss is also constructed and differentiated.
         """
-        loss = 0.0
-        weight = 1./self.num_particles
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-            loss += self._loss_and_grads_particle(weight, model_trace, guide_trace)
+
+        loss, surrogate_loss = self._loss_and_surrogate_loss(model, guide, *args, **kwargs)
+
+        torch_backward(surrogate_loss)
+
+        loss = torch_item(loss)
+        warn_if_nan(loss, "loss")
         return loss
 
-    def _loss_and_grads_particle(self, weight, model_trace, guide_trace):
+    def _loss_and_surrogate_loss(self, model, guide, *args, **kwargs):
+
+        loss = 0.0
+        surrogate_loss = 0.0
+
+        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+
+            lp, slp = self._loss_and_surrogate_loss_particle(model_trace, guide_trace, *args, **kwargs)
+            loss += lp
+            surrogate_loss += slp
+
+        loss /= self.num_particles
+        surrogate_loss /= self.num_particles
+
+        return loss, surrogate_loss
+
+    def _loss_and_surrogate_loss_particle(self, model_trace, guide_trace, *args, **kwargs):
+
         # compute elbo for reparameterized nodes
         elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace)
         baseline_loss = 0.0
 
         # the following computations are only necessary if we have non-reparameterizable nodes
         non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-
         if non_reparam_nodes:
             downstream_costs, _ = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
             surrogate_elbo_term, baseline_loss = _compute_elbo_non_reparam(guide_trace,
-                                                                           non_reparam_nodes, downstream_costs)
-
+                                                                           non_reparam_nodes,
+                                                                           downstream_costs)
             surrogate_elbo += surrogate_elbo_term
 
-        torch_backward(weight * (-surrogate_elbo + baseline_loss))
+        surrogate_loss = -surrogate_elbo + baseline_loss
 
-        loss = torch_item(- weight * elbo)
-        warn_if_nan(loss, "loss")
-        return loss
+        return elbo, surrogate_loss
 
 
 class JitTraceGraph_ELBO(TraceGraph_ELBO):
@@ -265,41 +282,23 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
     def loss_and_grads(self, model, guide, *args, **kwargs):
         kwargs['_pyro_model_id'] = id(model)
         kwargs['_pyro_guide_id'] = id(guide)
-        if getattr(self, '_loss_and_surrogate_loss', None) is None:
+        if getattr(self, '_jit_lsl', None) is None:
             # build a closure for loss_and_surrogate_loss
             weakself = weakref.ref(self)
 
             @pyro.ops.jit.trace(ignore_warnings=self.ignore_jit_warnings,
                                 jit_options=self.jit_options)
-            def loss_and_surrogate_loss(*args, **kwargs):
+            def jit_lsl(*args, **kwargs):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')
                 self = weakself()
-                weight = 1.0 / self.num_particles
-                for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
-                    # compute elbo for reparameterized nodes
-                    elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace)
-                    baseline_loss = 0.0
+                return self._loss_and_surrogate_loss(model, guide, *args, **kwargs)
 
-                    # the following computations are only necessary if we have non-reparameterizable nodes
-                    non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-                    if non_reparam_nodes:
-                        downstream_costs, _ = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
-                        surrogate_elbo_term, baseline_loss = _compute_elbo_non_reparam(guide_trace,
-                                                                                       non_reparam_nodes,
-                                                                                       downstream_costs)
-                        surrogate_elbo += surrogate_elbo_term
+            self._jit_lsl = jit_lsl
 
-                    loss = - weight * elbo
-                    surrogate_loss = weight * (-surrogate_elbo + baseline_loss)
+        loss, surrogate_loss = self._jit_lsl(*args, **kwargs)
 
-                return loss, surrogate_loss
-
-            self._loss_and_surrogate_loss = loss_and_surrogate_loss
-
-        loss, surrogate_loss = self._loss_and_surrogate_loss(*args, **kwargs)
-
-        surrogate_loss.backward()
+        surrogate_loss.backward()  # triggers jit compilation
 
         loss = loss.item()
         warn_if_nan(loss, "loss")

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -31,6 +31,51 @@ def _get_baseline_options(site):
     return options_tuple
 
 
+def _construct_baseline(node, guide_site, downstream_cost):
+
+    # XXX should the average baseline be in the param store as below?
+
+    baseline = 0.0
+    baseline_loss = 0.0
+
+    (nn_baseline, nn_baseline_input, use_decaying_avg_baseline, baseline_beta,
+        baseline_value) = _get_baseline_options(guide_site)
+
+    use_nn_baseline = nn_baseline is not None
+    use_baseline_value = baseline_value is not None
+
+    use_baseline = use_nn_baseline or use_decaying_avg_baseline or use_baseline_value
+
+    assert(not (use_nn_baseline and use_baseline_value)), \
+        "cannot use baseline_value and nn_baseline simultaneously"
+    if use_decaying_avg_baseline:
+        dc_shape = downstream_cost.shape
+        param_name = "__baseline_avg_downstream_cost_" + node
+        with torch.no_grad():
+            avg_downstream_cost_old = pyro.param(param_name,
+                                                 torch.zeros(dc_shape, device=guide_site['value'].device))
+            avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
+                baseline_beta * avg_downstream_cost_old
+        pyro.get_param_store()[param_name] = avg_downstream_cost_new
+        baseline += avg_downstream_cost_old
+    if use_nn_baseline:
+        # block nn_baseline_input gradients except in baseline loss
+        baseline += nn_baseline(detach_iterable(nn_baseline_input))
+    elif use_baseline_value:
+        # it's on the user to make sure baseline_value tape only points to baseline params
+        baseline += baseline_value
+    if use_nn_baseline or use_baseline_value:
+        # accumulate baseline loss
+        baseline_loss += torch.pow(downstream_cost.detach() - baseline, 2.0).sum()
+
+    if use_baseline:
+        if downstream_cost.shape != baseline.shape:
+            raise ValueError("Expected baseline at site {} to be {} instead got {}".format(
+                node, downstream_cost.shape, baseline.shape))
+
+    return use_baseline, baseline_loss, baseline
+
+
 def _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes):
 
     # Computes a surrogate cost for each nonreparam node in the guide. It would
@@ -135,6 +180,28 @@ def _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes):
     return downstream_costs, included_model_terms, included_guide_terms
 
 
+def _compute_elbo_non_reparam(guide_trace, non_reparam_nodes, downstream_costs):
+    # construct all the reinforce-like terms.
+    # we include only downstream costs to reduce variance
+    # optionally include baselines to further reduce variance
+    surrogate_elbo = 0.0
+    baseline_loss = 0.0
+    for node in non_reparam_nodes:
+        guide_site = guide_trace.nodes[node]
+        downstream_cost = downstream_costs[node]
+        score_function = guide_site["score_parts"].score_function
+
+        use_baseline, baseline_loss_term, baseline = _construct_baseline(node, guide_site, downstream_cost)
+
+        if use_baseline:
+            downstream_cost -= baseline
+            baseline_loss += baseline_loss_term
+
+        surrogate_elbo += (score_function * downstream_cost.detach()).sum()
+
+    return surrogate_elbo, baseline_loss
+
+
 def _compute_elbo_reparam(model_trace, guide_trace):
 
     # Compute a surrogate ELBO. In [1], this is simply the ELBO because
@@ -164,73 +231,6 @@ def _compute_elbo_reparam(model_trace, guide_trace):
                 surrogate_elbo -= entropy_term.sum()
 
     return elbo, surrogate_elbo
-
-
-def _construct_baseline(node, guide_site, downstream_cost):
-
-    # XXX should the average baseline be in the param store as below?
-
-    baseline = 0.0
-    baseline_loss = 0.0
-
-    (nn_baseline, nn_baseline_input, use_decaying_avg_baseline, baseline_beta,
-        baseline_value) = _get_baseline_options(guide_site)
-
-    use_nn_baseline = nn_baseline is not None
-    use_baseline_value = baseline_value is not None
-
-    use_baseline = use_nn_baseline or use_decaying_avg_baseline or use_baseline_value
-
-    assert(not (use_nn_baseline and use_baseline_value)), \
-        "cannot use baseline_value and nn_baseline simultaneously"
-    if use_decaying_avg_baseline:
-        dc_shape = downstream_cost.shape
-        param_name = "__baseline_avg_downstream_cost_" + node
-        with torch.no_grad():
-            avg_downstream_cost_old = pyro.param(param_name,
-                                                 torch.zeros(dc_shape, device=guide_site['value'].device))
-            avg_downstream_cost_new = (1 - baseline_beta) * downstream_cost + \
-                baseline_beta * avg_downstream_cost_old
-        pyro.get_param_store()[param_name] = avg_downstream_cost_new
-        baseline += avg_downstream_cost_old
-    if use_nn_baseline:
-        # block nn_baseline_input gradients except in baseline loss
-        baseline += nn_baseline(detach_iterable(nn_baseline_input))
-    elif use_baseline_value:
-        # it's on the user to make sure baseline_value tape only points to baseline params
-        baseline += baseline_value
-    if use_nn_baseline or use_baseline_value:
-        # accumulate baseline loss
-        baseline_loss += torch.pow(downstream_cost.detach() - baseline, 2.0).sum()
-
-    if use_baseline:
-        if downstream_cost.shape != baseline.shape:
-            raise ValueError("Expected baseline at site {} to be {} instead got {}".format(
-                node, downstream_cost.shape, baseline.shape))
-
-    return use_baseline, baseline_loss, baseline
-
-
-def _compute_elbo_non_reparam(guide_trace, non_reparam_nodes, downstream_costs):
-    # construct all the reinforce-like terms.
-    # we include only downstream costs to reduce variance
-    # optionally include baselines to further reduce variance
-    surrogate_elbo = 0.0
-    baseline_loss = 0.0
-    for node in non_reparam_nodes:
-        guide_site = guide_trace.nodes[node]
-        downstream_cost = downstream_costs[node]
-        score_function = guide_site["score_parts"].score_function
-
-        use_baseline, baseline_loss_term, baseline = _construct_baseline(node, guide_site, downstream_cost)
-
-        if use_baseline:
-            downstream_cost -= baseline
-            baseline_loss += baseline_loss_term
-
-        surrogate_elbo += (score_function * downstream_cost.detach()).sum()
-
-    return surrogate_elbo, baseline_loss
 
 
 class TraceGraph_ELBO(ELBO):

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -37,9 +37,9 @@ def torch_item(x):
 def torch_backward(x, retain_graph=None):
     """
     Like ``x.backward()`` for a :class:`~torch.Tensor`, but also accepts
-    numbers (a no-op if given a number).
+    numbers and tensors without grad_fn (resulting in a no-op)
     """
-    if torch.is_tensor(x):
+    if torch.is_tensor(x) and x.grad_fn:
         x.backward(retain_graph=retain_graph)
 
 

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 import math
 
+from collections import defaultdict
+
 import pytest
 import torch
 
@@ -115,8 +117,12 @@ def test_compute_downstream_costs_big_model_guide_pair(include_inner_1, include_
     guide_trace.compute_log_prob()
     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
 
-    dc, dc_nodes = _compute_downstream_costs(model_trace, guide_trace,
-                                             non_reparam_nodes)
+    dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
+                                                                               non_reparam_nodes)
+
+    dc_nodes = defaultdict(lambda: set())
+    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
+    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
 
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace,
                                                                      non_reparam_nodes)
@@ -235,8 +241,13 @@ def test_compute_downstream_costs_duplicates(dim):
 
     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
 
-    dc, dc_nodes = _compute_downstream_costs(model_trace, guide_trace,
-                                             non_reparam_nodes)
+    dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
+                                                                               non_reparam_nodes)
+
+    dc_nodes = defaultdict(lambda: set())
+    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
+    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace,
                                                                      non_reparam_nodes)
 
@@ -297,8 +308,13 @@ def test_compute_downstream_costs_plate_in_iplate(dim1):
 
     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
 
-    dc, dc_nodes = _compute_downstream_costs(model_trace, guide_trace,
-                                             non_reparam_nodes)
+    dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
+                                                                               non_reparam_nodes)
+
+    dc_nodes = defaultdict(lambda: set())
+    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
+    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace,
                                                                      non_reparam_nodes)
 
@@ -357,7 +373,14 @@ def test_compute_downstream_costs_iplate_in_plate(dim1, dim2):
     guide_trace.compute_log_prob()
 
     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-    dc, dc_nodes = _compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
+
+    dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
+                                                                               non_reparam_nodes)
+
+    dc_nodes = defaultdict(lambda: set())
+    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
+    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
 
     assert dc_nodes == dc_nodes_brute
@@ -413,8 +436,12 @@ def test_compute_downstream_costs_plate_reuse(dim1, dim2):
     guide_trace.compute_log_prob()
 
     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
-    dc, dc_nodes = _compute_downstream_costs(model_trace, guide_trace,
-                                             non_reparam_nodes)
+    dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
+                                                                               non_reparam_nodes)
+
+    dc_nodes = defaultdict(lambda: set())
+    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
+    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
     assert dc_nodes == dc_nodes_brute
 

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -95,6 +95,13 @@ def big_model_guide(include_obs=True, include_single=False, include_inner_1=Fals
                             obs=torch.ones(d2.size()))
 
 
+def combine_terms(included_model_terms, included_guide_terms):
+    dc_nodes = defaultdict(set)
+    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
+    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+    return dc_nodes
+
+
 @pytest.mark.parametrize("include_inner_1", [True, False])
 @pytest.mark.parametrize("include_single", [True, False])
 @pytest.mark.parametrize("flip_c23", [True, False])
@@ -119,10 +126,7 @@ def test_compute_downstream_costs_big_model_guide_pair(include_inner_1, include_
 
     dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
                                                                                non_reparam_nodes)
-
-    dc_nodes = defaultdict(lambda: set())
-    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
-    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+    dc_nodes = combine_terms(included_model_terms, included_guide_terms)
 
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace,
                                                                      non_reparam_nodes)
@@ -243,10 +247,7 @@ def test_compute_downstream_costs_duplicates(dim):
 
     dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
                                                                                non_reparam_nodes)
-
-    dc_nodes = defaultdict(lambda: set())
-    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
-    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+    dc_nodes = combine_terms(included_model_terms, included_guide_terms)
 
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace,
                                                                      non_reparam_nodes)
@@ -310,10 +311,7 @@ def test_compute_downstream_costs_plate_in_iplate(dim1):
 
     dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
                                                                                non_reparam_nodes)
-
-    dc_nodes = defaultdict(lambda: set())
-    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
-    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+    dc_nodes = combine_terms(included_model_terms, included_guide_terms)
 
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace,
                                                                      non_reparam_nodes)
@@ -376,10 +374,7 @@ def test_compute_downstream_costs_iplate_in_plate(dim1, dim2):
 
     dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
                                                                                non_reparam_nodes)
-
-    dc_nodes = defaultdict(lambda: set())
-    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
-    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
+    dc_nodes = combine_terms(included_model_terms, included_guide_terms)
 
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
 
@@ -438,10 +433,8 @@ def test_compute_downstream_costs_plate_reuse(dim1, dim2):
     non_reparam_nodes = set(guide_trace.nonreparam_stochastic_nodes)
     dc, included_model_terms, included_guide_terms = _compute_downstream_costs(model_trace, guide_trace,
                                                                                non_reparam_nodes)
+    dc_nodes = combine_terms(included_model_terms, included_guide_terms)
 
-    dc_nodes = defaultdict(lambda: set())
-    [dc_nodes[n].update(terms) for n, terms in included_model_terms.items()]
-    [dc_nodes[n].update(terms) for n, terms in included_guide_terms.items()]
     dc_brute, dc_nodes_brute = _brute_force_compute_downstream_costs(model_trace, guide_trace, non_reparam_nodes)
     assert dc_nodes == dc_nodes_brute
 


### PR DESCRIPTION
### Description

Refactors several functions in `tracegraph_elbo`, adds comments on how the implementation relates to [the paper](https://arxiv.org/abs/1506.05254), and possibly fixes a small bug by including a baseline loss in the jit version.

Two of the changes are substantial enough to highlight:

#### Downstream cost accumulation

The downstream costs are now accumulated in a single pass instead of including a second stage to add missing nodes from the model. This may be less efficient for some models/guides where the new order of accumulation results in more collisions. 

From here it may be easier to modify the accumulation. If a particular subset of nodes are a source of frequent collisions, their costs could be accumulated separately. Or the cost tree could be walked in the case of a collision instead of jumping to the leaves. 

#### Sharing code with jit version

The surrogate loss computation is now shared between `TraceGraph_ELBO` and `JitTraceGraph_ELBO`. I may have neglected some subtleties of jit in torch. 

### Testing

* `make test` passes
* have not assessed test coverage
* have not done any profiling