### PR TITLE
Support poutine.mask in infer_discrete

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -102,7 +102,10 @@ def _compute_model_factors(model_trace, guide_trace):
             else:
                 # For sites that depend on an enumerated variable, we need to apply
                 # the mask inside- and the scale outside- of the log expectation.
-                cost = packed.scale_and_mask(site["packed"]["unscaled_log_prob"], mask=site["packed"]["mask"])
+                if "masked_log_prob" not in site["packed"]:
+                    site["packed"]["masked_log_prob"] = packed.scale_and_mask(
+                        site["packed"]["unscaled_log_prob"], mask=site["packed"]["mask"])
+                cost = site["packed"]["masked_log_prob"]
                 log_factors.setdefault(t, []).append(cost)
                 scales.append(site["scale"])
     if log_factors:


### PR DESCRIPTION
Addresses #1824 

This adds support for `poutine.mask` in `infer_discrete`, copying the logic from `TraceEnum_ELBO`. This PR also
- caches intermediate results of `TraceEnum_ELBO` so they can be reused in `TraceEnumSample_ELBO` (following #1877).
- moves a jit guard from `scale_and_mask()` down to `is_identically_zero()` and `is_identically_one()` so that these operations become a little smarter when jitting.

This PR is needed by the `TreeCat` model #1370 to correctly train on masked data.

## Tested
- added a unit test that fails before this PR
- confirmed opt_einsum sharing works on the contrib-treecat branch