### PR TITLE
Fix PyTorch training in VAE comparison example

### DIFF
--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -250,7 +250,7 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--num-epochs', nargs='?', default=10, type=int)
     parser.add_argument('--batch_size', nargs='?', default=128, type=int)
     parser.add_argument('--rng_seed', nargs='?', default=0, type=int)
-    parser.add_argument('--impl', nargs='?', default='pytorch', type=str)
+    parser.add_argument('--impl', nargs='?', default='pyro', type=str)
     parser.add_argument('--skip_eval', action='store_true')
     parser.add_argument('--jit', action='store_true')
     parser.set_defaults(skip_eval=False)

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -103,7 +103,7 @@ class VAE(object):
         """
         z_mean, z_var = self.vae_encoder(x)
         if self.mode == TRAIN:
-            z = Normal(z_mean, z_var.sqrt()).sample()
+            z = Normal(z_mean, z_var.sqrt()).rsample()
         else:
             z = z_mean
         return self.vae_decoder(z), z_mean, z_var
@@ -250,7 +250,7 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--num-epochs', nargs='?', default=10, type=int)
     parser.add_argument('--batch_size', nargs='?', default=128, type=int)
     parser.add_argument('--rng_seed', nargs='?', default=0, type=int)
-    parser.add_argument('--impl', nargs='?', default='pyro', type=str)
+    parser.add_argument('--impl', nargs='?', default='pytorch', type=str)
     parser.add_argument('--skip_eval', action='store_true')
     parser.add_argument('--jit', action='store_true')
     parser.set_defaults(skip_eval=False)


### PR DESCRIPTION
Fixes #1852. As pointed out by @sameerkhurana10, we need to use `.rsample` when computing the training loss with pytorch. 