### PR TITLE
Add lazily-compiled cpp files to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     description='A Python library for probabilistic modeling and inference',
     long_description=long_description,
     packages=find_packages(include=['pyro', 'pyro.*']),
+    package_data={"pyro.distributions": ["*.cpp"]},
     url='http://pyro.ai',
     author='Uber AI Labs',
     author_email='pyro@uber.com',

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
             'nbsphinx>=0.3.2',
             'nbstripout',
             'nbval',
+            'ninja',
             'pypandoc',
             'pytest>=4.1',
             'pytest-xdist',


### PR DESCRIPTION
This insures our lazily-compiled pyro/distributions/spanning_tree.cpp is distributed with Pyro, and adds `ninja` to our dev requirements in setup.py so that the cpp compiler can be called.

Before this PR, spanning_tree.cpp was only available when installing locally via `git clone ... ; pip install -e`. After this PR, spanning_tree.cpp should be available via all installation methods.

## Tested
I checked that the following steps work after but not before this PR:

1. Installed Pyro remotely via
  ```sh
  pip install git+https://github.com/pyro-ppl/pyro@cpp-manifest
  ```
2. Ran code that compiles spanning_tree.cpp
  ```py
  import torch
  from pyro.distributions.spanning_tree import sample_tree
  sample_tree(torch.randn(3), torch.tensor([[0,1], [1,2]]), backend="cpp")
  ```