### PR TITLE
fix docstring in importance.py

### DIFF
--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -101,7 +101,7 @@ def vectorized_importance_weights(model, guide, *args, **kwargs):
 
         log_weights, model_trace, guide_trace = \\
             vectorized_importance_weights(model, guide, *args,
-                                          num_particles=1000,
+                                          num_samples=1000,
                                           max_plate_nesting=4,
                                           normalized=False)
     """


### PR DESCRIPTION
@eb8680 is the definition of `max_plate_nesting` here different than elsewhere?

in particular i think you want 

```with pyro.plate("num_particles_vectorized", num_samples, dim=-max_plate_nesting):``` 
=> 
```with pyro.plate("num_particles_vectorized", num_samples, dim=-max_plate_nesting-1):```

(sorry had to reopen PR because the previous one was messed up)