### PR TITLE
Support ReduceLROnPlateau scheduler

### DIFF
--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -20,7 +20,7 @@ class PyroLRScheduler(PyroOptim):
         for i in range(epochs):
             for minibatch in DataLoader(dataset, batch_size):
                 svi.step(minibatch)
-            scheduler.step(epoch=epoch)
+            scheduler.step(epoch=i)
     """
     def __init__(self, scheduler_constructor, optim_args):
         # pytorch scheduler

--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -18,6 +18,7 @@ class PyroLRScheduler(PyroOptim):
         pyro_scheduler = pyro.optim.ExponentialLR({'optimizer': optimizer, 'optim_args': {'lr': 0.01}, 'gamma': 0.1})
         svi = SVI(model, guide, pyro_scheduler, loss=TraceGraph_ELBO())
         svi.step()
+        pyro_scheduler.step(epoch=epoch)
     """
     def __init__(self, scheduler_constructor, optim_args):
         # pytorch scheduler
@@ -35,3 +36,7 @@ class PyroLRScheduler(PyroOptim):
     def _get_optim(self, params):
         optim = super(PyroLRScheduler, self)._get_optim(params)
         return self.pt_scheduler_constructor(optim, **self.kwargs)
+
+    def step(self, *args, **kwargs):
+        for scheduler in self.optim_objs.values():
+            scheduler.step(*args, **kwargs)

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -51,12 +51,12 @@ class PyroOptim(object):
                     state = self._state_waiting_to_be_consumed.pop(param_name)
                     self.optim_objs[p].load_state_dict(state)
 
-            # actually perform the step for the optim object
-            self.optim_objs[p].step(*args, **kwargs)
-
-            # if optim object was a scheduler, perform an actual optim step
-            if isinstance(self.optim_objs[p], torch.optim.lr_scheduler._LRScheduler):
+            if isinstance(self.optim_objs[p], torch.optim.lr_scheduler._LRScheduler) or \
+                    isinstance(self.optim_objs[p], torch.optim.lr_scheduler.ReduceLROnPlateau):
+                # if optim object was a scheduler, perform an actual optim step
                 self.optim_objs[p].optimizer.step(*args, **kwargs)
+            else:
+                self.optim_objs[p].step(*args, **kwargs)
 
     def get_state(self):
         """

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -53,7 +53,7 @@ class PyroOptim(object):
 
             if isinstance(self.optim_objs[p], torch.optim.lr_scheduler._LRScheduler) or \
                     isinstance(self.optim_objs[p], torch.optim.lr_scheduler.ReduceLROnPlateau):
-                # if optim object was a scheduler, perform an actual optim step
+                # if optim object was a scheduler, perform an optimizer step
                 self.optim_objs[p].optimizer.step(*args, **kwargs)
             else:
                 self.optim_objs[p].step(*args, **kwargs)

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -104,7 +104,7 @@ def test_dynamic_lr(scheduler):
         loc = pyro.param('loc').unconstrained()
         opt_loc = scheduler.optim_objs[loc].optimizer
         opt_scale = scheduler.optim_objs[loc].optimizer
-        if scheduler.pt_scheduler_constructor is torch.optim.lr_scheduler.ReduceLROnPlateau:
+        if issubclass(scheduler.pt_scheduler_constructor, torch.optim.lr_scheduler.ReduceLROnPlateau):
             scheduler.step(1.)
             if epoch == 2:
                 assert opt_loc.state_dict()['param_groups'][0]['lr'] == 0.1

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -82,7 +82,9 @@ class OptimTests(TestCase):
                                        optim.StepLR({'optimizer': torch.optim.SGD, 'optim_args': {'lr': 0.01},
                                                      'gamma': 2, 'step_size': 1}),
                                        optim.ExponentialLR({'optimizer': torch.optim.SGD, 'optim_args': {'lr': 0.01},
-                                                            'gamma': 2})])
+                                                            'gamma': 2}),
+                                       optim.ReduceLROnPlateau({'optimizer': torch.optim.SGD, 'optim_args': {'lr': 1.0},
+                                                                'factor': 0.1, 'patience': 1})])
 def test_dynamic_lr(scheduler):
     pyro.clear_param_store()
 
@@ -98,19 +100,31 @@ def test_dynamic_lr(scheduler):
     svi = SVI(model, guide, scheduler, loss=TraceGraph_ELBO())
     for epoch in range(4):
         svi.step()
+        svi.step()
         loc = pyro.param('loc').unconstrained()
         opt_loc = scheduler.optim_objs[loc].optimizer
         opt_scale = scheduler.optim_objs[loc].optimizer
+        if scheduler.pt_scheduler_constructor is torch.optim.lr_scheduler.ReduceLROnPlateau:
+            scheduler.step(1.)
+            if epoch == 2:
+                assert opt_loc.state_dict()['param_groups'][0]['lr'] == 0.1
+                assert opt_scale.state_dict()['param_groups'][0]['lr'] == 0.1
+            if epoch == 4:
+                assert opt_loc.state_dict()['param_groups'][0]['lr'] == 0.01
+                assert opt_scale.state_dict()['param_groups'][0]['lr'] == 0.01
+            continue
         assert opt_loc.state_dict()['param_groups'][0]['initial_lr'] == 0.01
         assert opt_scale.state_dict()['param_groups'][0]['initial_lr'] == 0.01
         if epoch == 0:
+            scheduler.step()
             assert opt_loc.state_dict()['param_groups'][0]['lr'] == 0.02
             assert opt_scale.state_dict()['param_groups'][0]['lr'] == 0.02
             assert abs(pyro.param('loc').item()) > 1e-5
             assert abs(pyro.param('scale').item() - 0.5) > 1e-5
         if epoch == 2:
-            assert opt_loc.state_dict()['param_groups'][0]['lr'] == 0.08
-            assert opt_scale.state_dict()['param_groups'][0]['lr'] == 0.08
+            scheduler.step(epoch=epoch)
+            assert opt_loc.state_dict()['param_groups'][0]['lr'] == 0.04
+            assert opt_scale.state_dict()['param_groups'][0]['lr'] == 0.04
 
 
 @pytest.mark.parametrize('factory', [optim.Adam, optim.ClippedAdam, optim.RMSprop, optim.SGD])


### PR DESCRIPTION
This PR:
1) changes the scheduler interface to be more similar to PyTorch's (and changes the order of the calls as per 1.1)
2) supports the remaining schedulers (esp ReduceLROnPlateau [which has been requested](https://forum.pyro.ai/t/properly-using-a-scheduler-with-an-optimizer/730/4))

there are still some outstanding bugs that are being fixed on the pytorch end.

Tested:
- schedulers that have different interfaces
- fixed and variable epochs