### PR TITLE
NUTS: reduce _System usage_. Simpler `logsumexp`

### DIFF
--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -19,6 +19,7 @@ def _logsumexp(vals, dim=0):
     p = (vals-M).exp().sum().log() + M
     return p
 
+
 # sum_accept_probs and num_proposals are used to calculate
 # the statistic accept_prob for Dual Averaging scheme;
 # z_left_grads and z_right_grads are kept to avoid recalculating


### PR DESCRIPTION
For NUTS, a `logsumexp` with only two arguments is called many times.
Empirically this solves #1912, but as shown by the discussion, it's not clear exactly why this is the case.
