### PR TITLE
Improve numerical stability of MixtureOfDiagNormals using logsumexp

### DIFF
--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -88,9 +88,9 @@ class MixtureOfDiagNormals(TorchDistribution):
         epsilon = (value.unsqueeze(-2) - self.locs) / self.coord_scale  # L B K D
         eps_sqr = 0.5 * torch.pow(epsilon, 2.0).sum(-1)  # L B K
         eps_sqr_min = torch.min(eps_sqr, -1)[0]  # L B K
-        coord_scale_prod = self.coord_scale.log().sum(-1).exp()  # B K
-        result = self.probs * torch.exp(-eps_sqr + eps_sqr_min.unsqueeze(-1)) / coord_scale_prod  # L B K
-        result = torch.log(result.sum(-1))  # L B
+        coord_scale_prod_log_sum = self.coord_scale.log().sum(-1)  # B K
+        result = self.categorical.logits + (-eps_sqr + eps_sqr_min.unsqueeze(-1)) - coord_scale_prod_log_sum  # L B K
+        result = torch.logsumexp(result, dim=-1)  # L B
         result = result - 0.5 * math.log(2.0 * math.pi) * float(self.dim)
         result = result - eps_sqr_min
         return result

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -84,17 +84,17 @@ class MixtureOfDiagNormalsSharedCovariance(TorchDistribution):
         return new
 
     def log_prob(self, value):
-        # TODO: use torch.logsumexp once it's in PyTorch release
         coord_scale = self.coord_scale.unsqueeze(-2) if self.batch_mode else self.coord_scale
         epsilon = (value.unsqueeze(-2) - self.locs) / coord_scale  # L B K D
         eps_sqr = 0.5 * torch.pow(epsilon, 2.0).sum(-1)  # L B K
         eps_sqr_min = torch.min(eps_sqr, -1)[0]  # L B
-        result = self.probs * torch.exp(-eps_sqr + eps_sqr_min.unsqueeze(-1))  # L B K
-        result = torch.log(result.sum(-1))  # L B
-        result -= 0.5 * math.log(2.0 * math.pi) * float(self.dim)
-        result -= torch.log(self.coord_scale).sum(-1)
-        result -= eps_sqr_min
+        result = self.categorical.logits + (-eps_sqr + eps_sqr_min.unsqueeze(-1))  # L B K
+        result = torch.logsumexp(result, dim=-1)  # L B
+        result = result - (0.5 * math.log(2.0 * math.pi) * float(self.dim))
+        result = result - (torch.log(self.coord_scale).sum(-1))
+        result = result - eps_sqr_min
         return result
+
 
     def rsample(self, sample_shape=torch.Size()):
         which = self.categorical.sample(sample_shape)

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -95,7 +95,6 @@ class MixtureOfDiagNormalsSharedCovariance(TorchDistribution):
         result = result - eps_sqr_min
         return result
 
-
     def rsample(self, sample_shape=torch.Size()):
         which = self.categorical.sample(sample_shape)
         return _MixDiagNormalSharedCovarianceSample.apply(self.locs, self.coord_scale, self.component_logits,

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -85,7 +85,7 @@ class GaussianScaleMixture(TorchDistribution):
         component_scale_log_power = self.component_scale.log() * -self.dim
         # logits in Categorical is already normalized
         result = torch.logsumexp(
-            component_scale_log_power + self.categorical.logits + \
+            component_scale_log_power + self.categorical.logits +
             -0.5 * epsilon_sqr / torch.pow(self.component_scale, 2.0), dim=-1)  # K
         result -= 0.5 * math.log(2.0 * math.pi) * float(self.dim)
         result -= self.coord_scale.log().sum()

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -80,15 +80,15 @@ class GaussianScaleMixture(TorchDistribution):
         return coeffs
 
     def log_prob(self, value):
-        # TODO: use torch.logsumexp once it's in PyTorch release
         assert value.dim() == 1 and value.size(0) == self.dim
         epsilon_sqr = torch.pow(value / self.coord_scale, 2.0).sum()
-        component_scale_power = torch.pow(self.component_scale, -self.dim)
-        result = component_scale_power * self.categorical.probs * \
-            torch.exp(-0.5 * epsilon_sqr / torch.pow(self.component_scale, 2.0))  # K
-        result = torch.log(result.sum())
+        component_scale_log_power = self.component_scale.log() * -self.dim
+        # logits in Categorical is already normalized
+        result = torch.logsumexp(
+            component_scale_log_power + self.categorical.logits + \
+            -0.5 * epsilon_sqr / torch.pow(self.component_scale, 2.0), dim=-1)  # K
         result -= 0.5 * math.log(2.0 * math.pi) * float(self.dim)
-        result -= torch.log(self.coord_scale).sum()
+        result -= self.coord_scale.log().sum()
         return result
 
     def rsample(self, sample_shape=torch.Size()):


### PR DESCRIPTION
I was running into some numerical stability issues with this distribution, so with the help of @mhw32 - I swapped a few things around to allow for the use of `torch.logsumexp`.