### PR TITLE
Fix max_plate_nesting off-by-one error in vectorized_importance_weights

### DIFF
--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -111,6 +111,7 @@ def vectorized_importance_weights(model, guide, *args, **kwargs):
 
     if max_plate_nesting is None:
         raise ValueError("must provide max_plate_nesting")
+    max_plate_nesting += 1
 
     def vectorize(fn):
         def _fn(*args, **kwargs):


### PR DESCRIPTION
As pointed out by @martinjankowiak in #1907 