### PR TITLE
Ability to clear cached potential energy computation in HMC

### DIFF
--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -86,13 +86,13 @@ class WarmupAdapter(object):
                                                 self._warmup_steps - 1))
         return adaptation_schedule
 
-    def reset_step_size_adaptation(self):
+    def reset_step_size_adaptation(self, z):
         r"""
         Finds a reasonable step size and resets step size adaptation scheme.
         """
         if self._find_reasonable_step_size is not None:
             with pyro.validation_enabled(False):
-                self.step_size = self._find_reasonable_step_size()
+                self.step_size = self._find_reasonable_step_size(z)
         self._step_size_adapt_scheme.prox_center = math.log(10 * self.step_size)
         self._step_size_adapt_scheme.reset()
 
@@ -175,7 +175,7 @@ class WarmupAdapter(object):
             if mass_matrix_adaptation_phase:
                 self.inverse_mass_matrix = self._mass_matrix_adapt_scheme.get_covariance()
                 if self.adapt_step_size:
-                    self.reset_step_size_adaptation()
+                    self.reset_step_size_adaptation(z)
 
             self._current_window += 1
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -149,14 +149,18 @@ class HMC(MCMCKernel):
         self._z_grads_last = None
         self._warmup_steps = None
 
-    def _find_reasonable_step_size(self):
+    def _find_reasonable_step_size(self, params):
         step_size = self.step_size
 
         # We are going to find a step_size which make accept_prob (Metropolis correction)
         # near the target_accept_prob. If accept_prob:=exp(-delta_energy) is small,
         # then we have to decrease step_size; otherwise, increase step_size.
         z, potential_energy, z_grads = self._fetch_from_cache()
-        if not z:
+        # recompute PE when cache is cleared
+        if z is None:
+            z = params
+            potential_energy = self.potential_fn(z)
+        elif len(z) == 0:
             return self.step_size
         r, _ = self._sample_r(name="r_presample_0")
         energy_current = self._kinetic_energy(r) + potential_energy
@@ -251,7 +255,7 @@ class HMC(MCMCKernel):
                                 find_reasonable_step_size_fn=self._find_reasonable_step_size)
 
         if self._adapter.adapt_step_size:
-            self._adapter.reset_step_size_adaptation()
+            self._adapter.reset_step_size_adaptation(self._initial_params)
 
     def setup(self, warmup_steps, *args, **kwargs):
         self._warmup_steps = warmup_steps

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -270,13 +270,22 @@ class HMC(MCMCKernel):
         self._potential_energy_last = potential_energy
         self._z_grads_last = z_grads
 
+    def clear_cache(self):
+        self._z_last = None
+        self._potential_energy_last = None
+        self._z_grads_last = None
+
     def _fetch_from_cache(self):
         return self._z_last, self._potential_energy_last, self._z_grads_last
 
     def sample(self, params):
         z, potential_energy, z_grads = self._fetch_from_cache()
+        # recompute PE when cache is cleared
+        if z is None:
+            z = params
+            potential_energy = self.potential_fn(z)
         # return early if no sample sites
-        if not z:
+        elif len(z) == 0:
             self._accept_cnt += 1
             self._t += 1
             return params

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -277,10 +277,14 @@ class NUTS(HMC):
                          z_proposal_pe, z_proposal_grads, r_sum, tree_weight, turning, diverging,
                          sum_accept_probs, num_proposals)
 
-    def sample(self, trace):
+    def sample(self, params):
         z, potential_energy, z_grads = self._fetch_from_cache()
+        # recompute PE when cache is cleared
+        if z is None:
+            z = params
+            potential_energy = self.potential_fn(z)
         # return early if no sample sites
-        if not z:
+        elif len(z) == 0:
             self._accept_cnt += 1
             self._t += 1
             return z

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -9,6 +9,7 @@ import torch
 
 import pyro
 import pyro.distributions as dist
+from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.mcmc import MCMC
 from tests.common import assert_equal
@@ -264,17 +265,31 @@ def test_bernoulli_latent_model(jit):
     assert_equal(posterior, y_prob, prec=0.06)
 
 
+@pytest.mark.parametrize("kernel", [HMC, NUTS])
 @pytest.mark.parametrize("jit", [False, mark_jit(True)], ids=jit_idfn)
-def test_unnormalized_normal(jit):
+def test_unnormalized_normal(kernel, jit):
     true_mean, true_std = torch.tensor(1.), torch.tensor(2.)
 
     def potential_fn(params):
         return 0.5 * torch.sum(((params["z"] - true_mean) / true_std) ** 2)
 
-    hmc_kernel = HMC(model=None, potential_fn=potential_fn, jit_compile=jit,
-                     ignore_jit_warnings=True)
-    hmc_kernel.initial_params = {"z": torch.tensor(0.)}
-    mcmc_run = MCMC(hmc_kernel, num_samples=4000, warmup_steps=500).run()
-    posterior = torch.stack([sample["z"] for sample in mcmc_run.exec_traces])
+    hmc_kernel = kernel(model=None, potential_fn=potential_fn, jit_compile=jit,
+                        ignore_jit_warnings=True)
+
+    samples = {"z": torch.tensor(0.)}
+    warmup_steps = 400
+    hmc_kernel.initial_params = samples
+    hmc_kernel.setup(warmup_steps)
+
+    for i in range(warmup_steps):
+        samples = hmc_kernel(samples)
+
+    posterior = []
+    for i in range(4000):
+        hmc_kernel.clear_cache()
+        samples = hmc_kernel(samples)
+        posterior.append(samples)
+
+    posterior = torch.stack([sample["z"] for sample in posterior])
     assert_equal(torch.mean(posterior), true_mean, prec=0.1)
     assert_equal(torch.std(posterior), true_std, prec=0.1)


### PR DESCRIPTION
Addresses #1926 - particularly, ability to clear the cache and recompute PE. 

I noticed that clearing the cache in warmup gives different results due to a different step size being learnt in adaptation (between steps 80 to 100), which is odd because this shouldn't affect the adaptation in any way. 

TODO:
 - [x] Debug why clearing the cache results in different adaptation results (step size changes after step 80 or so in warmup).