### PR TITLE
Force ipython < 7.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ long_description = '\n'.join([str(line) for line in long_description.split('\n')
 
 # examples/tutorials
 EXTRAS_REQUIRE = [
+    # TODO: remove once https://github.com/ipython/ipython/issues/11809 is fixed.
+    'ipython<7.6.0',
     'jupyter>=1.0.0',
     'matplotlib>=1.3',
     'pillow',
@@ -95,8 +97,7 @@ setup(
         'extras': EXTRAS_REQUIRE,
         'test': EXTRAS_REQUIRE + [
             'nbval',
-            # pytest 5.0 only supports python 3.5+
-            'pytest>=4.1, <5.0',
+            'pytest>=4.1',
             'pytest-cov',
             # TODO: remove once https://github.com/pyro-ppl/pyro/issues/1871
             # is fixed.

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
         'extras': EXTRAS_REQUIRE,
         'test': EXTRAS_REQUIRE + [
             'nbval',
-            'pytest>=4.1',
+            # pytest 5.0 only supports python 3.5+
+            'pytest>=4.1, <5.0',
             'pytest-cov',
             # TODO: remove once https://github.com/pyro-ppl/pyro/issues/1871
             # is fixed.


### PR DESCRIPTION
The latest version of ipython causes error in `jit` tutorial. I have filed [the issue](https://github.com/ipython/ipython/issues/11809) upstream. This PR adds an upper limit for ipython version.

Note also that the latest version of pytest (v5.0) only supports python 3.5+ (see [its changelog](https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#pytest-500-2019-06-28)). Maybe we should add an upper limit for pytest version if it causes errors in the future too.