### PR TITLE
Repopulate HMC cache after clearing

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -263,7 +263,7 @@ class HMC(MCMCKernel):
     def cleanup(self):
         self._reset()
 
-    def _cache(self, z, potential_energy, z_grads):
+    def _cache(self, z, potential_energy, z_grads=None):
         self._z_last = z
         self._potential_energy_last = potential_energy
         self._z_grads_last = z_grads
@@ -282,6 +282,7 @@ class HMC(MCMCKernel):
         if z is None:
             z = params
             potential_energy = self.potential_fn(z)
+            self._cache(z, potential_energy)
         # return early if no sample sites
         elif len(z) == 0:
             self._accept_cnt += 1

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -283,6 +283,7 @@ class NUTS(HMC):
         if z is None:
             z = params
             potential_energy = self.potential_fn(z)
+            self._cache(z, potential_energy)
         # return early if no sample sites
         elif len(z) == 0:
             self._accept_cnt += 1


### PR DESCRIPTION
This follows up #1927 by caching the recomputed `z` and `potential_energy`.

Before this PR, rejected samples would need to repeatedly recompute `z` and `potential_energy`. After this PR, only the first recomputation is necessary.

A second motivation is that I'm diagnosing convergence by logging `._potential_energy_last`, and this PR gives access to `._potential_energy_last` even after `.clear_cache()` has been called.

## Tested
- exercised by existing unit tests
- ran in pipeline that logged `._potential_energy_last`