### PR TITLE
Add @weakmethod decorator to avoid memory leaks

### DIFF
--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -5,7 +5,7 @@ from torch.distributions.utils import broadcast_all
 
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.torch import Exponential
-from pyro.distributions.util import copy_docs_from
+from pyro.distributions.util import copy_docs_from, weakmethod
 
 
 @copy_docs_from(Exponential)
@@ -17,6 +17,7 @@ class RejectionExponential(Rejector):
         log_scale = self.factor.log()
         super(RejectionExponential, self).__init__(propose, self.log_prob_accept, log_scale)
 
+    @weakmethod
     def log_prob_accept(self, x):
         result = (self.factor - 1) * self.rate * x
         assert result.max() <= 0, result.max()

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -5,7 +5,7 @@ import torch
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.score_parts import ScoreParts
 from pyro.distributions.torch import Beta, Dirichlet, Gamma, Normal
-from pyro.distributions.util import copy_docs_from
+from pyro.distributions.util import copy_docs_from, weakmethod
 
 
 @copy_docs_from(Gamma)
@@ -41,6 +41,7 @@ class RejectionStandardGamma(Rejector):
         new._validate_args = self._validate_args
         return new
 
+    @weakmethod
     def propose(self, sample_shape=torch.Size()):
         # Marsaglia & Tsang's x == Naesseth's epsilon`
         x = torch.randn(sample_shape + self.concentration.shape,
@@ -60,6 +61,7 @@ class RejectionStandardGamma(Rejector):
         result += Normal(torch.zeros_like(self.concentration), torch.ones_like(self.concentration)).log_prob(x)
         return result
 
+    @weakmethod
     def log_prob_accept(self, value):
         v = value / self._d
         y = torch.pow(v, 1.0 / 3.0)

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -77,11 +77,18 @@ def weakmethod(fn):
                                  .format(fn.__name__))
         return fn(self, *args, **kwargs)
 
+    @property
     def weak_binder(self):
         weakself = weakref.ref(self)
         return functools.partial(weak_fn, weakself)
 
-    return property(weak_binder)
+    @weak_binder.setter
+    def weak_binder(self, new):
+        if not (isinstance(new, functools.partial) and new.func is weak_fn and
+                len(new.args) == 1 and new.args[0] is weakref.ref(self)):
+            raise AttributeError("cannot overwrite weakmethod {}".format(fn.__name__))
+
+    return weak_binder
 
 
 def is_identically_zero(x):

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+import sys
+import weakref
+
 import numpy as np
 import pytest
 import torch
 
-from pyro.distributions.util import broadcast_shape, sum_leftmost, sum_rightmost
+from pyro.distributions.util import broadcast_shape, sum_leftmost, sum_rightmost, weakmethod
 
 INF = float('inf')
 
@@ -95,3 +98,23 @@ def test_sum_leftmost():
     assert sum_leftmost(x, -1).shape == (4,)
     assert sum_leftmost(x, -2).shape == (3, 4)
     assert sum_leftmost(x, INF).shape == ()
+
+
+def test_weakmethod():
+
+    class Foo(object):
+        def __init__(self, state):
+            self.state = state
+            self.method = self._method
+
+        @weakmethod
+        def _method(self, *args, **kwargs):
+            return self.state, args, kwargs
+
+    foo = Foo(42)
+    assert foo.method(1, 2, 3, x=0) == (42, (1, 2, 3), {"x": 0})
+
+    foo_ref = weakref.ref(foo)
+    assert foo_ref() is foo
+    del foo
+    assert foo_ref() is None

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import sys
 import weakref
 
 import numpy as np


### PR DESCRIPTION
This adds a `@weakmethod` decorator for classes that store a bound copy of one of their methods.

The issue happens when an object `foo` is initialized with some state `bar` that needs a function, and that function is passed as a bound method `foo.method`. This creates a reference cycle: `foo` -> `bar` -> `foo.method` -> `foo`. The `@weakmethod` decorator breaks the final reference.

The only existing leaks I've found are in testing distributions. I'll also need this decorator in #1370 (see NUTS snippet below).

I'd happily replace this PR with a more standard solution if anyone knows one 🤔 

## Tested

- added a regression test that fails without `@weakmethod`
- tested in an example using the pattern:
    ```py
    class ABigInferenceAlgorithm(object):
        def __init__(self, ...):
            self.nuts = NUTS(potential_fn=self.potential_fn, ...)
            ...

        # I can't use @staticmethod here since this depends on dynamic state in self
        @weakmethod
        def potential_fn(self, params):
            ...
    ```