### PR TITLE
Add docs for MCMC utility functions

### DIFF
--- a/docs/source/pyro.infer.mcmc.txt
+++ b/docs/source/pyro.infer.mcmc.txt
@@ -26,3 +26,8 @@ NUTS
     :members:
     :undoc-members:
     :show-inheritance:
+
+Utilities
+---------
+
+.. autofunction:: pyro.infer.mcmc.util.initialize_model

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -129,9 +129,14 @@ class LKJCorrCholesky(TorchDistribution):
 
     Note that the `event_shape` of this distribution is `[d, d]`
 
-    Important note: When using this distribution with HMC/NUTS, it is important to
-    use a `step_size` such as 1e-4. If not, you are likely to experience LAPACK
-    errors regarding positive-definiteness.
+    .. note::
+
+       When using this distribution with HMC/NUTS, it is important to
+       use a `step_size` such as 1e-4. If not, you are likely to experience LAPACK
+       errors regarding positive-definiteness.
+
+    For example usage, refer to
+    `pyro/examples/lkj.py <https://github.com/pyro-ppl/pyro/blob/dev/examples/lkj.py>`_.
 
     :param int d: Dimensionality of the matrix
     :param torch.Tensor eta: A single positive number parameterizing the distribution.

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -263,12 +263,13 @@ def _get_init_params(model, model_args, model_kwargs, transforms, potential_fn, 
 def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max_plate_nesting=None,
                      jit_compile=False, jit_options=None, skip_jit_warnings=False):
     """
-    Generates models' properties for a Pyro model to be used in HMC/NUTS kernels
-    which contains
-    * initial parameters to be sampled using a HMC kernel,
-    * a potential function whose input is a dict of parameters in unconstrained space,
-    * transforms to transform latent sites of `model` to unconstrained space,
-    * a prototype trace to be used in MCMC to consume traces from sampled parameters.
+    Given a Python callable with Pyro primitives, generates the following model-specific
+    properties needed for inference using HMC/NUTS kernels:
+
+    - initial parameters to be sampled using a HMC kernel,
+    - a potential function whose input is a dict of parameters in unconstrained space,
+    - transforms to transform latent sites of `model` to unconstrained space,
+    - a prototype trace to be used in MCMC to consume traces from sampled parameters.
 
     :param model: a Pyro model which contains Pyro primitives.
     :param tuple model_args: optional args taken by `model`.


### PR DESCRIPTION
Addresses #1902. 
 - Add link to example for LKJCorrCholesky.
 - Expose `initialize_model` as a utility function in Pyro's MCMC docs.