### PR TITLE
Fix some numerical/shape issues in GP

### DIFF
--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -118,12 +118,12 @@ def conditional(Xnew, X, kernel, f_loc, f_scale_tril=None, Lff=None, full_cov=Fa
     if full_cov:
         Kss = kernel(Xnew)
         Qss = W.matmul(W.t())
-        # Theoretically, Kss - Qss is non-negative; but due to numerical
-        # computation, that might not be the case in practice.
-        cov = (Kss - Qss).clamp(min=0)
+        cov = Kss - Qss
     else:
         Kssdiag = kernel(Xnew, diag=True)
         Qssdiag = W.pow(2).sum(dim=-1)
+        # Theoretically, Kss - Qss is non-negative; but due to numerical
+        # computation, that might not be the case in practice.
         var = (Kssdiag - Qssdiag).clamp(min=0)
 
     if f_scale_tril is not None:

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -118,11 +118,13 @@ def conditional(Xnew, X, kernel, f_loc, f_scale_tril=None, Lff=None, full_cov=Fa
     if full_cov:
         Kss = kernel(Xnew)
         Qss = W.matmul(W.t())
-        cov = Kss - Qss
+        # Theoretically, Kss - Qss is non-negative; but due to numerical
+        # computation, that might not be the case in practice.
+        cov = (Kss - Qss).clamp(min=0)
     else:
         Kssdiag = kernel(Xnew, diag=True)
         Qssdiag = W.pow(2).sum(dim=-1)
-        var = Kssdiag - Qssdiag
+        var = (Kssdiag - Qssdiag).clamp(min=0)
 
     if f_scale_tril is not None:
         W_S_shape = (Xnew.size(0),) + f_scale_tril.shape[1:]


### PR DESCRIPTION
This PR fixes some small issues collected in forum and numpyro gp example:

+ Fix the numerical issue when use the trick
```py
pyro.sample("log_density", dist.Bernoulli(probs=torch.exp(log_density)),
                     obs=torch.tensor(1.))
```
which is due to claiming logic in Bernoulli: `dist.Bernoulli(probs=torch.exp(x)).log_prob(torch.tensor(1.)) = -15` when `x=-20`. On the other hand, `torch.exp(log_density)` will be `0` when `log_density` is too small. I replace it with Delta distribution, which correctly injects this log_density term to the model's log_prob

+ Fix the numerical issue in gp `conditional` where `K** - K*f @ inv(Kff) @ Kf*` is semipositive definite (which implies diagonal part is non-negative) but might not happen in practice because precision issue. I face that issue long time ago but recently meet this again in gp example in numpyro.

+ Correct the output shape of `sgpr` for the case `full_cov=False`.