### PR TITLE
Use pyro.enable_validation(__debug__) in examples

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -324,7 +324,7 @@ if __name__ == "__main__":
 
     pyro.set_rng_seed(args.rng_seed)
     # Enable validation checks
-    pyro.enable_validation(True)
+    pyro.enable_validation(__debug__)
 
     # work around with the error "RuntimeError: received 0 items of ancdata"
     # see https://discuss.pytorch.org/t/received-0-items-of-ancdata-pytorch-0-4-0/19823

--- a/examples/capture_recapture/cjs.py
+++ b/examples/capture_recapture/cjs.py
@@ -226,7 +226,7 @@ models = {name[len('model_'):]: model
 def main(args):
     pyro.set_rng_seed(0)
     pyro.clear_param_store()
-    pyro.enable_validation(True)
+    pyro.enable_validation(__debug__)
 
     # load data
     if args.dataset == "dipper":

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -52,7 +52,7 @@ def local_guide(latent, k):
 
 def main(args):
     pyro.set_rng_seed(0)
-    pyro.enable_validation()
+    pyro.enable_validation(__debug__)
 
     optim = Adam({"lr": 0.1})
     elbo = JitTrace_ELBO() if args.jit else Trace_ELBO()

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -71,7 +71,7 @@ def guide_recurse(data, latent):
 
 def main(args):
     pyro.set_rng_seed(0)
-    pyro.enable_validation()
+    pyro.enable_validation(__debug__)
 
     optim = Adam({"lr": 0.1})
     inference = SVI(model, guide, optim, loss=Trace_ELBO())

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -13,7 +13,7 @@ import pyro.poutine as poutine
 from pyro.infer.mcmc import MCMC, NUTS
 
 logging.basicConfig(format='%(message)s', level=logging.INFO)
-pyro.enable_validation(True)
+pyro.enable_validation(__debug__)
 pyro.set_rng_seed(0)
 
 

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -523,7 +523,7 @@ def main(args):
     num_observations = float(lengths.sum())
     pyro.set_rng_seed(0)
     pyro.clear_param_store()
-    pyro.enable_validation(True)
+    pyro.enable_validation(__debug__)
 
     # We'll train using MAP Baum-Welch, i.e. MAP estimation while marginalizing
     # out the hidden state x. This is accomplished via an automatic guide that

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -105,7 +105,7 @@ def main(args):
     logging.info('Generating data')
     pyro.set_rng_seed(0)
     pyro.clear_param_store()
-    pyro.enable_validation(True)
+    pyro.enable_validation(__debug__)
 
     # We can generate synthetic data directly by calling the model.
     true_topic_weights, true_topic_words, data = model(args=args)

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     pyro.set_rng_seed(args.rng_seed)
     # Enable validation checks
-    pyro.enable_validation(True)
+    pyro.enable_validation(__debug__)
 
     # work around with the error "RuntimeError: received 0 items of ancdata"
     # see https://discuss.pytorch.org/t/received-0-items-of-ancdata-pytorch-0-4-0/19823

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -34,7 +34,7 @@ from pyro.contrib.easyguide import EasyGuide
 
 
 torch.set_default_tensor_type('torch.FloatTensor')
-pyro.enable_validation(True)
+pyro.enable_validation(__debug__)
 pyro.util.set_rng_seed(0)
 
 


### PR DESCRIPTION
I've found it convenient in pyro scripts to use the idiom
```py
pyro.enable_validation(__debug__)
```
so that `python -O` both disables assertions and disables Pyro validation. This PR changes our example scripts to start using that idiom.