### PR TITLE
Use ClippedAdam in LDA example; add references

### DIFF
--- a/examples/lda.py
+++ b/examples/lda.py
@@ -1,12 +1,20 @@
 """
-This example demonstrates how to marginalize out discrete assignment variables
-in a Pyro model.
+This example implements amortized Latent Dirichlet Allocation [1],
+demonstrating how to marginalize out discrete assignment variables in a Pyro
+model. This model and inference algorithm treat documents as vectors of
+categorical variables (vectors of word ids), and collapses word-topic
+assignments using Pyro's enumeration. We use PyTorch's reparametrized Gamma and
+Dirichlet distributions [2], avoiding the need for Laplace approximations as in
+[1]. Following [1] we use the Adam optimizer and clip gradients.
 
-Our example model is Latent Dirichlet Allocation. While the model in this
-example does work, it is not the recommended way of coding up LDA in Pyro.
-Whereas the model in this example treats documents as vectors of categorical
-variables (vectors of word ids), it is usually more efficient to treat
-documents as bags of words (histograms of word counts).
+**References:**
+
+[1] Akash Srivastava, Charles Sutton. ICLR 2017.
+    "Autoencoding Variational Inference for Topic Models"
+    https://arxiv.org/pdf/1703.01488.pdf
+[2] Martin Jankowiak, Fritz Obermeyer. ICML 2018.
+    "Pathwise gradients beyond the reparametrization trick"
+    https://arxiv.org/pdf/1806.01851.pdf
 """
 from __future__ import absolute_import, division, print_function
 
@@ -21,7 +29,7 @@ from torch.distributions import constraints
 import pyro
 import pyro.distributions as dist
 from pyro.infer import SVI, JitTraceEnum_ELBO, TraceEnum_ELBO
-from pyro.optim import Adam
+from pyro.optim import ClippedAdam
 
 logging.basicConfig(format='%(relativeCreated) 9d %(message)s', level=logging.INFO)
 
@@ -117,7 +125,7 @@ def main(args):
     guide = functools.partial(parametrized_guide, predictor)
     Elbo = JitTraceEnum_ELBO if args.jit else TraceEnum_ELBO
     elbo = Elbo(max_plate_nesting=2)
-    optim = Adam({'lr': args.learning_rate})
+    optim = ClippedAdam({'lr': args.learning_rate})
     svi = SVI(model, guide, optim, elbo)
     logging.info('Step\tLoss')
     for step in range(args.num_steps):
@@ -137,7 +145,7 @@ if __name__ == '__main__':
     parser.add_argument("-wd", "--num-words-per-doc", default=64, type=int)
     parser.add_argument("-n", "--num-steps", default=1000, type=int)
     parser.add_argument("-l", "--layer-sizes", default="100-100")
-    parser.add_argument("-lr", "--learning-rate", default=0.001, type=float)
+    parser.add_argument("-lr", "--learning-rate", default=0.01, type=float)
     parser.add_argument("-b", "--batch-size", default=32, type=int)
     parser.add_argument('--jit', action='store_true')
     args = parser.parse_args()

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -46,6 +46,7 @@ Welcome to Pyro Examples and Tutorials!
    gp
    gplvm
    bo
+   easyguide
    tracking_1d
    csis
    RSA-implicature


### PR DESCRIPTION
This PR
1. Switches from `Adam` to `ClippedAdam` as recommended by Srivastava and Sutton (2017) to enable higher learning rate and avoid component collapsing. I've also increased default learning rate from 0.001 -> 0.01.
2. Rewords the example description, adding two references and underselling less.

## Tested
- ran with much larger learning rate (0.001 -> 0.1) and found faster convergence and no NAN
- made docs and tutorials (and added easyguide to tutorial index to eliminate a warning)