### PR TITLE
Add SMCFilter class; Add simple model example that uses SMC Filter

### DIFF
--- a/docs/source/inference_algos.rst
+++ b/docs/source/inference_algos.rst
@@ -59,6 +59,14 @@ Importance
     :undoc-members:
     :show-inheritance:
 
+Sequential Monte Carlo
+----------------------
+
+.. automodule:: pyro.infer.smcfilter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Discrete Inference
 ------------------
 

--- a/examples/smcfilter.py
+++ b/examples/smcfilter.py
@@ -1,0 +1,111 @@
+import argparse
+import logging
+
+import torch
+
+import pyro
+import pyro.distributions as dist
+from pyro.infer import SMCFilter
+
+logging.basicConfig(format='%(relativeCreated) 9d %(message)s', level=logging.INFO)
+
+"""
+This file demonstrates how to use the SMCFilter algorithm with
+a simple model of a noisy harmonic oscillator of the form:
+
+    z[t] ~ N(A*z[t-1], B*sigma_z)
+    y[t] ~ N(z[t][0], sigma_y)
+
+"""
+
+
+class SimpleHarmonicModel:
+
+    def __init__(self, process_noise, measurement_noise):
+        self.A = torch.tensor([[0., 1.],
+                               [-1., 0.]])
+        self.B = torch.tensor([3., 3.])
+        self.sigma_z = torch.tensor(process_noise)
+        self.sigma_y = torch.tensor(measurement_noise)
+
+    def init(self, initial):
+        self.t = 0
+        self.z = initial
+        self.y = None
+
+    def step(self, y=None):
+        self.t += 1
+        self.z = pyro.sample("z_{}".format(self.t),
+                             dist.Normal(self.z.matmul(self.A), self.B*self.sigma_z).to_event(1))
+        self.y = pyro.sample("y_{}".format(self.t),
+                             dist.Normal(self.z[..., 0], self.sigma_y),
+                             obs=y)
+
+        return self.z, self.y
+
+
+class SimpleHarmonicModel_Guide:
+
+    def __init__(self, model):
+        self.model = model
+
+    def init(self, initial):
+        self.t = 0
+        self.z = initial
+
+    def step(self, y=None):
+        self.t += 1
+
+        # Proposal distribution
+        self.z = pyro.sample("z_{}".format(self.t),
+                             dist.Normal(self.z.matmul(self.model.A), torch.tensor([1., 1.])).to_event(1))
+
+
+def generate_data(args):
+    model = SimpleHarmonicModel(args.process_noise, args.measurement_noise)
+
+    initial = torch.tensor([1., 0.])
+    model.init(initial=initial)
+    zs = [initial]
+    ys = [None]
+    for t in range(args.num_timesteps):
+        z, y = model.step()
+        zs.append(z)
+        ys.append(y)
+
+    return zs, ys
+
+
+def main(args):
+    pyro.set_rng_seed(args.seed)
+    pyro.enable_validation(__debug__)
+
+    model = SimpleHarmonicModel(args.process_noise, args.measurement_noise)
+    guide = SimpleHarmonicModel_Guide(model)
+
+    smc = SMCFilter(model, guide, num_particles=args.num_particles, max_plate_nesting=0)
+
+    logging.info('Generating data')
+    zs, ys = generate_data(args)
+
+    logging.info('Filtering')
+    smc.init(initial=torch.tensor([1., 0.]))
+    for y in ys[1:]:
+        smc.step(y)
+
+    logging.info('Marginals')
+    empirical = smc.get_empirical()
+    for t in range(1, 1+args.num_timesteps):
+        z = empirical["z_{}".format(t)]
+        logging.info("{}\t{}\t{}\t{}".format(t, zs[t], z.mean, z.variance))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Simple Harmonic Oscillator w/ SMC Filtering Inference")
+    parser.add_argument("-n", "--num-timesteps", default=50, type=int)
+    parser.add_argument("-p", "--num-particles", default=100, type=int)
+    parser.add_argument("--process-noise", default=1., type=float)
+    parser.add_argument("--measurement-noise", default=1., type=float)
+    parser.add_argument("--seed", default=0, type=int)
+    args = parser.parse_args()
+    main(args)

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -7,6 +7,7 @@ from pyro.infer.elbo import ELBO
 from pyro.infer.enum import config_enumerate
 from pyro.infer.importance import Importance
 from pyro.infer.renyi_elbo import RenyiELBO
+from pyro.infer.smcfilter import SMCFilter
 from pyro.infer.svi import SVI
 from pyro.infer.trace_elbo import JitTrace_ELBO, Trace_ELBO
 from pyro.infer.trace_mean_field_elbo import JitTraceMeanField_ELBO, TraceMeanField_ELBO
@@ -29,6 +30,7 @@ __all__ = [
     "JitTraceMeanField_ELBO",
     "JitTrace_ELBO",
     "RenyiELBO",
+    "SMCFilter",
     "SVI",
     "TraceEnum_ELBO",
     "TraceGraph_ELBO",

--- a/pyro/infer/smcfilter.py
+++ b/pyro/infer/smcfilter.py
@@ -1,0 +1,125 @@
+import torch
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from pyro.poutine.util import prune_subsample_sites
+
+
+def _extract_samples(trace):
+    return {name: site["value"]
+            for name, site in trace.nodes.items()
+            if site["type"] == "sample"
+            if not site["is_observed"]
+            if type(site["fn"]).__name__ != "_Subsample"}
+
+
+class SMCFilter(object):
+    """
+    :class:`SMCFilter` is the top-level interface for filtering via sequential
+    monte carlo.
+
+    The model and guide should be objects with two methods: ``.init()`` and
+    ``.step()``. These two methods should have the same signature as :meth:`init`
+    and :meth:`step` of this class. These methods are intended to be called first
+    with :meth:`init`, then with :meth:`step` repeatedly.
+
+    :param object model: probabilistic model defined as a function
+    :param object guide: guide used for sampling defined as a function
+    :param int num_particles: The number of particles used to form the
+        distribution.
+    :param int max_plate_nesting: Bound on max number of nested
+        :func:`pyro.plate` contexts.
+    """
+    # TODO: Add window kwarg that defaults to float("inf")
+    def __init__(self, model, guide, num_particles, max_plate_nesting):
+        self.model = model
+        self.guide = guide
+        self.num_particles = num_particles
+        self.max_plate_nesting = max_plate_nesting
+
+        # Equivalent to an empirical distribution.
+        self._values = {}
+        self._log_weights = torch.zeros(self.num_particles)
+
+    def init(self, *args, **kwargs):
+        """
+        Perform any initialization for sequential importance resampling.
+        Any args or kwargs are passed to the model and guide
+        """
+        self.particle_plate = pyro.plate("particles", self.num_particles, dim=-1-self.max_plate_nesting)
+        with poutine.block(), self.particle_plate:
+            guide_trace = poutine.trace(self.guide.init).get_trace(*args, **kwargs)
+            model = poutine.replay(self.model.init, guide_trace)
+            model_trace = poutine.trace(model).get_trace(*args, **kwargs)
+
+        self._update_weights(model_trace, guide_trace)
+        self._values.update(_extract_samples(model_trace))
+        self._maybe_importance_resample()
+
+    def step(self, *args, **kwargs):
+        """
+        Take a filtering step using sequential importance resampling updating the
+        particle weights and values while resampling if desired.
+        Any args or kwargs are passed to the model and guide
+        """
+        with poutine.block(), self.particle_plate:
+            guide_trace = poutine.trace(self.guide.step).get_trace(*args, **kwargs)
+            model = poutine.replay(self.model.step, guide_trace)
+            model_trace = poutine.trace(model).get_trace(*args, **kwargs)
+
+        self._update_weights(model_trace, guide_trace)
+        self._values.update(_extract_samples(model_trace))
+        self._maybe_importance_resample()
+
+    def get_values_and_log_weights(self):
+        """
+        Returns the particles and its (unnormalized) log weights.
+        :returns: the values and unnormalized log weights.
+        :rtype: tuple of dict and floats where the dict is a key of name of latent to value of latent.
+        """
+        # TODO: Be clear that these are unnormalized weights. May want to normalize later.
+        return self._values, self._log_weights
+
+    def get_empirical(self):
+        """
+        :returns: a marginal distribution over every latent variable.
+        :rtype: a dictionary with keys which are latent variables and values
+            which are :class:`~pyro.distributions.Empirical` objects.
+        """
+        return {name: dist.Empirical(value, self._log_weights)
+                for name, value in self._values.items()}
+
+    @torch.no_grad()
+    def _update_weights(self, model_trace, guide_trace):
+        # w_t <-w_{t-1}*p(y_t|z_t) * p(z_t|z_t-1)/q(z_t)
+
+        model_trace = prune_subsample_sites(model_trace)
+        guide_trace = prune_subsample_sites(guide_trace)
+
+        model_trace.compute_log_prob()
+        guide_trace.compute_log_prob()
+
+        for name, guide_site in guide_trace.nodes.items():
+            if guide_site["type"] == "sample":
+                model_site = model_trace.nodes[name]
+                log_p = model_site["log_prob"].reshape(self.num_particles, -1).sum(-1)
+                log_q = guide_site["log_prob"].reshape(self.num_particles, -1).sum(-1)
+                self._log_weights += log_p - log_q
+
+        for site in model_trace.nodes.values():
+            if site["type"] == "sample" and site["is_observed"]:
+                log_p = site["log_prob"].reshape(self.num_particles, -1).sum(-1)
+                self._log_weights += log_p
+
+        self._log_weights -= self._log_weights.max()
+
+    def _maybe_importance_resample(self):
+        if True:  # TODO check perplexity
+            self._importance_resample()
+
+    def _importance_resample(self):
+        # TODO: Turn quadratic algo -> linear algo by being lazier
+        index = dist.Categorical(logits=self._log_weights).sample(sample_shape=(self.num_particles,))
+        self._values = {name: value[index].contiguous() for name, value in self._values.items()}
+        self._log_weights.fill_(0.)

--- a/tests/infer/test_smcfilter.py
+++ b/tests/infer/test_smcfilter.py
@@ -1,0 +1,167 @@
+import pytest
+import torch
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from pyro.infer import SMCFilter
+
+
+class SmokeModel:
+
+    def __init__(self, state_size, plate_size):
+        self.state_size = state_size
+        self.plate_size = plate_size
+
+    def init(self):
+        self.t = 0
+        self.x_mean = pyro.sample("x_mean", dist.Normal(0., 1.))
+        self.y_mean = pyro.sample("y_mean",
+                                  dist.MultivariateNormal(torch.zeros(self.state_size), torch.eye(self.state_size)))
+
+    def step(self, x=None, y=None):
+        v = pyro.sample("v_{}".format(self.t), dist.Normal(0., 1.))
+        with pyro.plate("plate", self.plate_size):
+            w = pyro.sample("w_{}".format(self.t), dist.Normal(v, 1.))
+            x = pyro.sample("x_{}".format(self.t),
+                            dist.Normal(self.x_mean + w, 1), obs=x)
+            y = pyro.sample("y_{}".format(self.t),
+                            dist.MultivariateNormal(self.y_mean + w.unsqueeze(-1), torch.eye(self.state_size)),
+                            obs=y)
+        self.t += 1
+
+        return x, y
+
+
+class SmokeGuide:
+
+    def __init__(self, state_size, plate_size):
+        self.state_size = state_size
+        self.plate_size = plate_size
+
+    def init(self):
+        self.t = 0
+        self.x_mean = pyro.sample("x_mean",
+                                  dist.Normal(0., 2.))
+        self.y_mean = pyro.sample("y_mean",
+                                  dist.MultivariateNormal(torch.zeros(self.state_size), 2.*torch.eye(self.state_size)))
+
+    def step(self, x=None, y=None):
+        v = pyro.sample("v_{}".format(self.t), dist.Normal(0., 2.))
+        with pyro.plate("plate", self.plate_size):
+            pyro.sample("w_{}".format(self.t), dist.Normal(v, 2.))
+
+        self.t += 1
+
+
+@pytest.mark.parametrize("max_plate_nesting", [1, 2])
+@pytest.mark.parametrize("state_size", [2, 5, 1])
+@pytest.mark.parametrize("plate_size", [3, 7, 1])
+@pytest.mark.parametrize("num_steps", [1, 2, 10])
+def test_smoke(max_plate_nesting, state_size, plate_size, num_steps):
+    model = SmokeModel(state_size, plate_size)
+    guide = SmokeGuide(state_size, plate_size)
+
+    smc = SMCFilter(model, guide, num_particles=100, max_plate_nesting=max_plate_nesting)
+
+    true_model = SmokeModel(state_size, plate_size)
+
+    true_model.init()
+    truth = [true_model.step() for t in range(num_steps)]
+
+    smc.init()
+    for xy in truth:
+        smc.step(*xy)
+    smc.get_values_and_log_weights()
+    smc.get_empirical()
+
+
+class HarmonicModel:
+
+    def __init__(self):
+        self.A = torch.tensor([[0., 1.],
+                               [-1., 0.]])
+        self.B = torch.tensor([3., 3.])
+        self.sigma_z = torch.tensor(1.)
+        self.sigma_y = torch.tensor(1.)
+
+    def init(self):
+        self.t = 0
+        self.z = torch.tensor([1., 0.])
+        self.y = None
+
+    def step(self, y=None):
+        self.t += 1
+        self.z = pyro.sample("z_{}".format(self.t),
+                             dist.Normal(self.z.matmul(self.A), self.B*self.sigma_z).to_event(1))
+        self.y = pyro.sample("y_{}".format(self.t),
+                             dist.Normal(self.z[..., 0], self.sigma_y),
+                             obs=y)
+
+        return self.z, self.y
+
+
+class HarmonicGuide:
+
+    def __init__(self):
+        self.model = HarmonicModel()
+
+    def init(self):
+        self.t = 0
+        self.z = torch.tensor([1., 0.])
+
+    def step(self, y=None):
+        self.t += 1
+
+        # Proposal distribution
+        self.z = pyro.sample("z_{}".format(self.t),
+                             dist.Normal(self.z.matmul(self.model.A), torch.tensor([2., 2.])).to_event(1))
+
+
+def generate_data():
+    model = HarmonicModel()
+
+    model.init()
+    zs = [torch.tensor([1., 0.])]
+    ys = [None]
+    for t in range(50):
+        z, y = model.step()
+        zs.append(z)
+        ys.append(y)
+
+    return zs, ys
+
+
+def score_latent(zs, ys):
+    model = HarmonicModel()
+    with poutine.trace() as trace:
+        with poutine.condition(data={"z_{}".format(t): z for t, z in enumerate(zs)}):
+            model.init()
+            for y in ys[1:]:
+                model.step(y)
+
+    return trace.trace.log_prob_sum()
+
+
+def test_likelihood_ratio():
+
+    model = HarmonicModel()
+    guide = HarmonicGuide()
+
+    smc = SMCFilter(model, guide, num_particles=100, max_plate_nesting=0)
+
+    zs, ys = generate_data()
+    zs_true, ys_true = generate_data()
+    smc.init()
+    for y in ys_true[1:]:
+        smc.step(y)
+    values, logweights = smc.get_values_and_log_weights()
+    i = logweights.max(0)[1]
+    values = {k: v[i] for k, v in values.items()}
+
+    zs_pred = [torch.tensor([1., 0.])]
+    zs_pred += [values.get("z_{}".format(t)) for t in range(1, 51)]
+
+    assert(score_latent(zs_true, ys_true) > score_latent(zs, ys_true))
+    assert(score_latent(zs_pred, ys_true) > score_latent(zs_pred, ys))
+    assert(score_latent(zs_pred, ys_true) > score_latent(zs, ys_true))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -53,6 +53,7 @@ CPU_EXAMPLES = [
     'rsa/schelling.py --num-samples=10',
     'rsa/schelling_false.py --num-samples=10',
     'rsa/semantic_parsing.py --num-samples=10',
+    'smcfilter.py --num-timesteps=3 --num-samples=10',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide custom',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide auto',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide easy',

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -53,7 +53,7 @@ CPU_EXAMPLES = [
     'rsa/schelling.py --num-samples=10',
     'rsa/schelling_false.py --num-samples=10',
     'rsa/semantic_parsing.py --num-samples=10',
-    'smcfilter.py --num-timesteps=3 --num-samples=10',
+    'smcfilter.py --num-timesteps=3 --num-particles=10',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide custom',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide auto',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide easy',

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -63,6 +63,7 @@ Welcome to Pyro Examples and Tutorials!
    sparse_gamma
    dkl
    einsum
+   smcfilter
 
 
 Indices and tables

--- a/tutorial/source/smcfilter.rst
+++ b/tutorial/source/smcfilter.rst
@@ -1,0 +1,11 @@
+Sequential Monte Carlo Filtering
+================================
+
+`View smcfilter.py on github`__
+
+.. _github: https://github.com/uber/pyro/blob/dev/examples/smcfilter.py
+
+__ github_
+
+.. literalinclude:: ../../examples/smcfilter.py
+    :language: python


### PR DESCRIPTION
Addresses #1304 
pair coded with @fritzo and @karalets 

This PR:
1. Implements SMCFilter class
2. Simple State Space model example to run SMCFiltering on.

## Tasks
- [x] add examples/smc.py
- [x] add a file tutorial/source/smc.rst following the pattern of tutorial/source/hmm.py, and register tutorial/source/smc.rst in tutorial/source/index.rst
- [x] add a docstring to `SMCFilter` as in other inference algorithms
- [x] add an `SMCFilter` section to docs/source/inference_algos.rst
- [x] add smoke tests with different numbers of sample sites and different `event_shape` and `batch_shape`. Tests should live in tests/infer/test_smcfilter.py
- [x] add a simple statistical test that evaluates correctness

## Traiged
- Implement Conjugate SMC Class (this should be in a separate PR)