### PR TITLE
Use refresh=False for tqdm

### DIFF
--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -46,7 +46,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    #assert pyro.__version__.startswith('0.3.3')
+    assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description='Eight Schools MCMC')
     parser.add_argument('--num-samples', type=int, default=1000,
                         help='number of MCMC samples (default: 1000)')

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -46,7 +46,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.3.3')
+    #assert pyro.__version__.startswith('0.3.3')
     parser = argparse.ArgumentParser(description='Eight Schools MCMC')
     parser.add_argument('--num-samples', type=int, default=1000,
                         help='number of MCMC samples (default: 1000)')

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -122,7 +122,7 @@ def _add_logging_hook(logger, progress_bar=None, hook=None):
         diagnostics = json.dumps(kernel.diagnostics())
         logger.info(diagnostics, extra={"msg_type": DIAGNOSTIC_MSG})
         if progress_bar:
-            progress_bar.set_description(stage)
+            progress_bar.set_description(stage, refresh=False)
         if hook:
             hook(kernel, params, stage, i)
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -55,7 +55,7 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains, disable_prog
                 if num_samples[pbar_pos] == warmup_steps:
                     progress_bars.set_description("Sample [{}]".format(pbar_pos + 1), pos=pbar_pos)
                 diagnostics = json.loads(msg, object_pairs_hook=OrderedDict)
-                progress_bars.set_postfix(diagnostics, pos=pbar_pos)
+                progress_bars.set_postfix(diagnostics, pos=pbar_pos, refresh=False)
                 progress_bars.update(pos=pbar_pos)
             else:
                 logger.handle(record)

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -200,7 +200,7 @@ class MCMCLoggingHandler(logging.Handler):
             if self.progress_bar and record.msg_type == DIAGNOSTIC_MSG:
                 diagnostics = json.loads(record.getMessage(),
                                          object_pairs_hook=OrderedDict)
-                self.progress_bar.set_postfix(diagnostics)
+                self.progress_bar.set_postfix(diagnostics, refresh=False)
                 self.progress_bar.update()
             else:
                 self.log_handler.handle(record)

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -49,7 +49,7 @@ def logger_thread(log_queue, warmup_steps, num_samples, num_chains, disable_prog
                 if num_samples[pbar_pos] == warmup_steps:
                     progress_bars.set_description("Sample [{}]".format(pbar_pos + 1), pos=pbar_pos)
                 diagnostics = json.loads(msg, object_pairs_hook=OrderedDict)
-                progress_bars.set_postfix(diagnostics, pos=pbar_pos)
+                progress_bars.set_postfix(diagnostics, pos=pbar_pos, refresh=False)
                 progress_bars.update(pos=pbar_pos)
             else:
                 logger.handle(record)


### PR DESCRIPTION
This PR uses `refresh=False` for progressbar. The hanging issue does not only happen in my system but also a user in forum.

#### Tested:
+ one chain + terminal/notebook + CPU/GPU + old/new api
+ multi chain + CPU/GPU + terminal + old api
+ multi chain + CPU + notebook + old api

#### What is not tested:
+ multi chain + GPU + notebook: It is a bit tricky to run multi chains in GPU in notebook. New version of pytorch only supports `spawn`/`forkserver` (see [the docs](https://pytorch.org/docs/master/notes/multiprocessing.html#cuda-in-multiprocessing)). On the other hand, [it is tricky to use spawn method](https://github.com/pytorch/pytorch/issues/20375) in jupyter notebook. MCMC does not run when I use those methods with CUDA tensors in notebooks.

Anyway, the above issue does not related to this PR because progress bars work well in notebook with CPU tensors.