### PR TITLE
Performance tweaks: Trace.__contains__ and ignore_jit_warnings

### DIFF
--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -8,7 +8,7 @@ import torch
 
 import pyro
 import pyro.poutine as poutine
-from pyro.util import ignore_jit_warnings, optional
+from pyro.util import ignore_jit_warnings
 
 
 def _hash(value, allow_id):
@@ -85,7 +85,9 @@ class CompiledFunction(object):
                     constrained_params[name] = constrained_param
                 return poutine.replay(self.fn, params=constrained_params)(*args, **kwargs)
 
-            with pyro.validation_enabled(False), optional(ignore_jit_warnings(), self.ignore_warnings):
+            if self.ignore_warnings:
+                compiled = ignore_jit_warnings()(compiled)
+            with pyro.validation_enabled(False):
                 self.compiled[key] = torch.jit.trace(compiled, params_and_args, **self.jit_options)
         else:
             unconstrained_params = [pyro.param(name).unconstrained()

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -78,9 +78,11 @@ class Trace(object):
         self._succ = OrderedDict()
         self._pred = OrderedDict()
 
+    def __contains__(self, name):
+        return name in self.nodes
+
     def __iter__(self):
-        for node in self.nodes:
-            yield node
+        return iter(self.nodes.keys())
 
     def __len__(self):
         return len(self.nodes)

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -338,9 +338,15 @@ def ignore_jit_warnings(filter=None):
     Ignore JIT tracer warnings with messages that match `filter`. If
     `filter` is not specified all tracer warnings are ignored.
 
+    Note this only installs warning filters if executed within traced code.
+
     :param filter: A list containing either warning message (str),
         or tuple consisting of (warning message (str), Warning class).
     """
+    if not torch._C._get_tracing_state():
+        yield
+        return
+
     with warnings.catch_warnings():
         if filter is None:
             warnings.filterwarnings("ignore",


### PR DESCRIPTION
This PR makes two tweaks to remove overhead of small Python ops:
1. Adds a `Trace.__contains__()` method. Previously `site_name in self` was executed using `Trace.__iter__` hence linearly scanning through the trace. This quadratic cost is apparent in large models with ~1000 sample sites. After this PR, `Trace.add_node()` takes negligible time.
2. Changes the `ignore_jit_warnings()` context manager to only install warnings *inside* jitted code. Installing warnings filters is surprisingly expensive, and was happening at each sample site. After this PR, `ignore_jit_warnings()` must be used inside jitted functions, hence the changes to pyro.ops.jit and pyro.infer.mcmc.util.

## Performance
1. 7% speedup of a TreeCat inference run
2. 5% speedup of a TreeCat inference run

These are independent and total to a 12% speedup.
## Tested
- exercised by existing tests
- ran a TreeCat inference script to verify speedup