### PR TITLE
Minor change to the MCMC interface

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -12,7 +12,7 @@ from pyro.distributions import Beta, Binomial, HalfCauchy, Normal, Pareto, Unifo
 from pyro.distributions.util import scalar_like, sum_rightmost
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc import NUTS
-from pyro.infer.mcmc.util import diagnostics, predictive, initialize_model
+from pyro.infer.mcmc.util import predictive, initialize_model
 from pyro.poutine.util import site_is_subsample
 from pyro.util import ignore_experimental_warning
 

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -150,14 +150,12 @@ def get_site_stats(array, player_names):
     return df.apply(pd.Series.describe, axis=1)[["mean", "std", "25%", "50%", "75%"]]
 
 
-def summary(posterior, sites, player_names, transforms={}, return_diagnostics=True, num_chains=1):
+def summary(posterior, sites, player_names, transforms={}, diagnostics=None):
     """
     Return summarized statistics for each of the ``sites`` in the
     traces corresponding to the approximate posterior.
     """
-    site_stats, diag_stats = {}, {}
-    if return_diagnostics:
-        diag_stats = diagnostics(posterior, num_chains)
+    site_stats, diag_stats = {}, diagnostics
 
     for site_name in sites:
         marginal_site = posterior[site_name]
@@ -165,9 +163,6 @@ def summary(posterior, sites, player_names, transforms={}, return_diagnostics=Tr
         if site_name in transforms:
             marginal_site = transforms[site_name](marginal_site)
 
-        # Flatten samples from multiple chains onto a single axis
-        if num_chains > 1:
-            marginal_site = marginal_site.reshape((-1,) + marginal_site.shape[2:])
         site_stats[site_name] = get_site_stats(marginal_site.cpu().numpy(), player_names)
 
         if diag_stats:
@@ -196,7 +191,7 @@ def train_test_split(pd_dataframe):
 # ===================================
 
 
-def sample_posterior_predictive(model, posterior_samples, baseball_dataset, num_chains):
+def sample_posterior_predictive(model, posterior_samples, baseball_dataset):
     """
     Generate samples from posterior predictive distribution.
     """
@@ -209,26 +204,24 @@ def sample_posterior_predictive(model, posterior_samples, baseball_dataset, num_
     logging.info("-----------------------------")
     # set hits=None to convert it from observation node to sample node
     with ignore_experimental_warning():
-        train_predict = predictive(model, posterior_samples, at_bats, None, num_chains=num_chains)
+        train_predict = predictive(model, posterior_samples, at_bats, None)
     train_summary = summary(train_predict,
                             sites=["obs"],
-                            player_names=player_names,
-                            return_diagnostics=False)["obs"]
+                            player_names=player_names)["obs"]
     train_summary = train_summary.assign(ActualHits=baseball_dataset[["Hits"]].values)
     logging.info(train_summary)
     logging.info("\nHit Rate - Season Predictions")
     logging.info("-----------------------------")
     with ignore_experimental_warning():
-        test_predict = predictive(model, posterior_samples, at_bats_season, None, num_chains=num_chains)
+        test_predict = predictive(model, posterior_samples, at_bats_season, None)
     test_summary = summary(test_predict,
                            sites=["obs"],
-                           player_names=player_names,
-                           return_diagnostics=False)["obs"]
+                           player_names=player_names)["obs"]
     test_summary = test_summary.assign(ActualHits=baseball_dataset[["SeasonHits"]].values)
     logging.info(test_summary)
 
 
-def evaluate_log_posterior_density(model, posterior_samples, baseball_dataset, num_chains):
+def evaluate_log_posterior_density(model, posterior_samples, baseball_dataset):
     """
     Evaluate the log probability density of observing the unseen data (season hits)
     given a model and posterior distribution over the parameters.
@@ -237,7 +230,7 @@ def evaluate_log_posterior_density(model, posterior_samples, baseball_dataset, n
     at_bats_season, hits_season = test[:, 0], test[:, 1]
     with ignore_experimental_warning():
         trace = predictive(model, posterior_samples, at_bats_season, hits_season,
-                           num_chains=num_chains, return_trace=True)
+                           return_trace=True)
     # Use LogSumExp trick to evaluate $log(1/num_samples \sum_i p(new_data | \theta^{i})) $,
     # where $\theta^{i}$ are parameter samples from the model's posterior.
     trace.compute_log_prob()
@@ -271,72 +264,86 @@ def main(args):
                 num_chains=args.num_chains,
                 initial_params=init_params,
                 transforms=transforms)
-    num_chains = mcmc.num_chains  # Note that this might be less than args.num_chains  when CPU cores are limited.
-    samples_fully_pooled = mcmc.run(at_bats, hits)
+    mcmc.run(at_bats, hits)
+    diagnostics = mcmc.diagnostics()
+    samples_fully_pooled = mcmc.get_samples()
     logging.info("\nModel: Fully Pooled")
     logging.info("===================")
     logging.info("\nphi:")
     logging.info(summary(samples_fully_pooled,
                          sites=["phi"],
                          player_names=player_names,
-                         num_chains=num_chains)["phi"])
-    sample_posterior_predictive(fully_pooled, samples_fully_pooled, baseball_dataset, num_chains)
-    evaluate_log_posterior_density(fully_pooled, samples_fully_pooled, baseball_dataset, num_chains)
+                         diagnostics=diagnostics)["phi"])
+    num_divergences = sum(map(len, diagnostics["divergences"].values()))
+    logging.info("\nNumber of divergent transitions: {}\n".format(num_divergences))
+    sample_posterior_predictive(fully_pooled, samples_fully_pooled, baseball_dataset)
+    evaluate_log_posterior_density(fully_pooled, samples_fully_pooled, baseball_dataset)
 
     # (2) No Pooling Model
     init_params, potential_fn, transforms, _ = initialize_model(not_pooled, model_args=(at_bats, hits),
                                                                 num_chains=args.num_chains)
     nuts_kernel = NUTS(potential_fn=potential_fn)
-    samples_not_pooled = MCMC(nuts_kernel,
-                              num_samples=args.num_samples,
-                              warmup_steps=args.warmup_steps,
-                              num_chains=args.num_chains,
-                              initial_params=init_params,
-                              transforms=transforms).run(at_bats, hits)
+    mcmc = MCMC(nuts_kernel,
+                num_samples=args.num_samples,
+                warmup_steps=args.warmup_steps,
+                num_chains=args.num_chains,
+                initial_params=init_params,
+                transforms=transforms)
+    mcmc.run(at_bats, hits)
+    diagnostics = mcmc.diagnostics()
+    samples_not_pooled = mcmc.get_samples()
     logging.info("\nModel: Not Pooled")
     logging.info("=================")
     logging.info("\nphi:")
     logging.info(summary(samples_not_pooled,
                          sites=["phi"],
                          player_names=player_names,
-                         num_chains=num_chains)["phi"])
-    sample_posterior_predictive(not_pooled, samples_not_pooled, baseball_dataset, num_chains)
-    evaluate_log_posterior_density(not_pooled, samples_not_pooled, baseball_dataset, num_chains)
+                         diagnostics=diagnostics)["phi"])
+    num_divergences = sum(map(len, diagnostics["divergences"].values()))
+    logging.info("\nNumber of divergent transitions: {}\n".format(num_divergences))
+    sample_posterior_predictive(not_pooled, samples_not_pooled, baseball_dataset)
+    evaluate_log_posterior_density(not_pooled, samples_not_pooled, baseball_dataset)
 
     # (3) Partially Pooled Model
     init_params, potential_fn, transforms, _ = initialize_model(partially_pooled, model_args=(at_bats, hits),
                                                                 num_chains=args.num_chains)
     nuts_kernel = NUTS(potential_fn=potential_fn)
 
-    # TODO: Provide a way to record divergent transitions
-    with pyro.validation_enabled(False):
-        samples_partially_pooled = MCMC(nuts_kernel,
-                                        num_samples=args.num_samples,
-                                        warmup_steps=args.warmup_steps,
-                                        num_chains=args.num_chains,
-                                        initial_params=init_params,
-                                        transforms=transforms).run(at_bats, hits)
+    mcmc = MCMC(nuts_kernel,
+                num_samples=args.num_samples,
+                warmup_steps=args.warmup_steps,
+                num_chains=args.num_chains,
+                initial_params=init_params,
+                transforms=transforms)
+    mcmc.run(at_bats, hits)
+    diagnostics = mcmc.diagnostics()
+    samples_partially_pooled = mcmc.get_samples()
     logging.info("\nModel: Partially Pooled")
     logging.info("=======================")
     logging.info("\nphi:")
     logging.info(summary(samples_partially_pooled,
                          sites=["phi"],
                          player_names=player_names,
-                         num_chains=num_chains)["phi"])
-    sample_posterior_predictive(partially_pooled, samples_partially_pooled, baseball_dataset, num_chains)
-    evaluate_log_posterior_density(partially_pooled, samples_partially_pooled, baseball_dataset, num_chains)
+                         diagnostics=diagnostics)["phi"])
+    num_divergences = sum(map(len, diagnostics["divergences"].values()))
+    logging.info("\nNumber of divergent transitions: {}\n".format(num_divergences))
+    sample_posterior_predictive(partially_pooled, samples_partially_pooled, baseball_dataset)
+    evaluate_log_posterior_density(partially_pooled, samples_partially_pooled, baseball_dataset)
 
     # (4) Partially Pooled with Logit Model
     init_params, potential_fn, transforms, _ = initialize_model(partially_pooled_with_logit,
                                                                 model_args=(at_bats, hits),
                                                                 num_chains=args.num_chains)
     nuts_kernel = NUTS(potential_fn=potential_fn, transforms=transforms)
-    samples_partially_pooled_logit = MCMC(nuts_kernel,
-                                          num_samples=args.num_samples,
-                                          warmup_steps=args.warmup_steps,
-                                          num_chains=args.num_chains,
-                                          initial_params=init_params,
-                                          transforms=transforms).run(at_bats, hits)
+    mcmc = MCMC(nuts_kernel,
+                num_samples=args.num_samples,
+                warmup_steps=args.warmup_steps,
+                num_chains=args.num_chains,
+                initial_params=init_params,
+                transforms=transforms)
+    mcmc.run(at_bats, hits)
+    diagnostics = mcmc.diagnostics()
+    samples_partially_pooled_logit = mcmc.get_samples()
     logging.info("\nModel: Partially Pooled with Logit")
     logging.info("==================================")
     logging.info("\nSigmoid(alpha):")
@@ -344,11 +351,13 @@ def main(args):
                          sites=["alpha"],
                          player_names=player_names,
                          transforms={"alpha": torch.sigmoid},
-                         num_chains=num_chains)["alpha"])
+                         diagnostics=diagnostics)["alpha"])
+    num_divergences = sum(map(len, diagnostics["divergences"].values()))
+    logging.info("\nNumber of divergent transitions: {}\n".format(num_divergences))
     sample_posterior_predictive(partially_pooled_with_logit, samples_partially_pooled_logit,
-                                baseball_dataset, num_chains)
+                                baseball_dataset)
     evaluate_log_posterior_density(partially_pooled_with_logit, samples_partially_pooled_logit,
-                                   baseball_dataset, num_chains)
+                                   baseball_dataset)
 
 
 if __name__ == "__main__":

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -34,10 +34,12 @@ def conditioned_model(model, sigma, y):
 
 def main(args):
     nuts_kernel = NUTS(conditioned_model, jit_compile=args.jit,)
-    samples = MCMC(nuts_kernel,
-                   num_samples=args.num_samples,
-                   warmup_steps=args.warmup_steps,
-                   num_chains=args.num_chains).run(model, data.sigma, data.y)
+    mcmc = MCMC(nuts_kernel,
+                num_samples=args.num_samples,
+                warmup_steps=args.warmup_steps,
+                num_chains=args.num_chains)
+    mcmc.run(model, data.sigma, data.y)
+    samples = mcmc.get_samples()
     if args.num_chains > 1:
         samples = {k: v.reshape((-1,) + v.shape[2:]) for k, v in samples.items()}
     marginal = torch.cat(list(samples.values()), dim=-1).cpu().numpy()

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -47,9 +47,10 @@ class GPModel(Parameterized):
       get posterior samples for the Gaussian Process's parameters. For example:
 
         >>> hmc_kernel = HMC(gpr.model)
-        >>> mcmc_samples = MCMC(hmc_kernel, num_samples=10).run()
+        >>> mcmc = MCMC(hmc_kernel, num_samples=10)
+        >>> mcmc.run()
         >>> ls_name = "GPR/RBF/lengthscale"
-        >>> posterior_ls = mcmc_samples[ls_name]
+        >>> posterior_ls = mcmc.get_samples()[ls_name]
 
     + Using a variational inference on the pair :meth:`model`, :meth:`guide`:
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -25,7 +25,6 @@ import pyro
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.logger import initialize_logger, DIAGNOSTIC_MSG, TqdmHandler, ProgressBar
 from pyro.infer.mcmc.util import diagnostics, initialize_model
-from pyro.util import optional
 
 MAX_SEED = 2**32 - 1
 
@@ -377,9 +376,9 @@ class MCMC(object):
                 batch_dim = 0
             else:
                 batch_dim = 1
-            sample_tensor = samples.values()[0]
+            sample_tensor = list(samples.values())[0]
             batch_size, device = sample_tensor.shape[batch_dim], sample_tensor.device
-            idxs = torch.randint(0, batch_size, size=(num_samples,), device=sample_tensor.device)
+            idxs = torch.randint(0, batch_size, size=(num_samples,), device=device)
             samples = {k: v.index_select(batch_dim, idxs) for k, v in samples.items()}
         return samples
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -81,8 +81,9 @@ class HMC(MCMCKernel):
         ...     return y
         >>>
         >>> hmc_kernel = HMC(model, step_size=0.0855, num_steps=4)
-        >>> mcmc_samples = MCMC(hmc_kernel, num_samples=500, warmup_steps=100).run(data)
-        >>> mcmc_samples['beta'].mean(0)  # doctest: +SKIP
+        >>> mcmc = MCMC(hmc_kernel, num_samples=500, warmup_steps=100)
+        >>> mcmc.run(data)
+        >>> mcmc.get_samples()['beta'].mean(0)  # doctest: +SKIP
         tensor([ 0.9819,  1.9258,  2.9737])
     """
 

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -109,8 +109,9 @@ class NUTS(HMC):
         ...     return y
         >>>
         >>> nuts_kernel = NUTS(model, adapt_step_size=True)
-        >>> mcmc_samples = MCMC(nuts_kernel, num_samples=500, warmup_steps=300).run(data)
-        >>> mcmc_samples['beta'].mean(0)  # doctest: +SKIP
+        >>> mcmc = MCMC(nuts_kernel, num_samples=500, warmup_steps=300)
+        >>> mcmc.run(data)
+        >>> mcmc.get_samples()['beta'].mean(0)  # doctest: +SKIP
         tensor([ 0.9221,  1.9464,  2.9228])
     """
 

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -425,8 +425,6 @@ def predictive(model, posterior_samples, *args, **kwargs):
     :param kwargs: model kwargs; and other keyword arguments (see below).
 
     :Keyword Arguments:
-        * **num_chains** (``int``) - number of chains (determines leading dimension of tensors in
-          `posterior_samples`). By default, this is assumed to be 1.
         * **num_samples** (``int``) - number of samples to draw from the predictive distribution.
           This argument has no effect if ``posterior_samples`` is non-empty, in which case, the
           leading dimension size of samples in ``posterior_samples`` is used.
@@ -440,7 +438,6 @@ def predictive(model, posterior_samples, *args, **kwargs):
     """
     warnings.warn('This function or its interface might change in the future.',
                   ExperimentalWarning)
-    num_chains = kwargs.pop('num_chains', 1)
     num_samples = kwargs.pop('num_samples', None)
     return_sites = kwargs.pop('return_sites', None)
     return_trace = kwargs.pop('return_trace', False)
@@ -450,8 +447,6 @@ def predictive(model, posterior_samples, *args, **kwargs):
     reshaped_samples = {}
 
     for name, sample in posterior_samples.items():
-        if num_chains > 1:
-            sample = sample.reshape((-1,) + sample.shape[2:])
 
         batch_size, sample_shape = sample.shape[0], sample.shape[1:]
 

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -281,9 +281,10 @@ def test_hmc(model_class, X, y, kernel, likelihood):
     kernel.set_prior("lengthscale", dist.Uniform(torch.tensor(1.0), torch.tensor(3.0)))
 
     hmc_kernel = HMC(gp.model, step_size=1)
-    mcmc_samples = MCMC(hmc_kernel, num_samples=10).run()
+    mcmc = MCMC(hmc_kernel, num_samples=10)
+    mcmc.run()
 
-    for name, param in mcmc_samples.items():
+    for name, param in mcmc.get_samples().items():
         param_mean = torch.mean(param, 0)
         logger.info("Posterior mean - {}".format(name))
         logger.info(param_mean)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -186,8 +186,9 @@ def test_logistic_regression(step_size, trajectory_length, num_steps,
     hmc_kernel = HMC(model, step_size=step_size, trajectory_length=trajectory_length,
                      num_steps=num_steps, adapt_step_size=adapt_step_size,
                      adapt_mass_matrix=adapt_mass_matrix, full_mass=full_mass)
-    mcmc_run = MCMC(hmc_kernel, num_samples=500, warmup_steps=100, disable_progbar=True).run(data)
-    samples = mcmc_run['beta']
+    mcmc = MCMC(hmc_kernel, num_samples=500, warmup_steps=100, disable_progbar=True)
+    mcmc.run(data)
+    samples = mcmc.get_samples()['beta']
     assert_equal(rmse(true_coefs, samples.mean(0)).item(), 0.0, prec=0.1)
 
 
@@ -202,7 +203,9 @@ def test_dirichlet_categorical(jit):
     true_probs = torch.tensor([0.1, 0.6, 0.3])
     data = dist.Categorical(true_probs).sample(sample_shape=(torch.Size((2000,))))
     hmc_kernel = HMC(model, trajectory_length=1, jit_compile=jit, ignore_jit_warnings=True)
-    samples = MCMC(hmc_kernel, num_samples=200, warmup_steps=100).run(data)
+    mcmc = MCMC(hmc_kernel, num_samples=200, warmup_steps=100)
+    mcmc.run(data)
+    samples = mcmc.get_samples()
     assert_equal(samples['p_latent'].mean(0), true_probs, prec=0.02)
 
 
@@ -220,7 +223,9 @@ def test_beta_bernoulli(jit):
     data = dist.Bernoulli(true_probs).sample(sample_shape=(torch.Size((1000,))))
     hmc_kernel = HMC(model, trajectory_length=1, max_plate_nesting=2,
                      jit_compile=jit, ignore_jit_warnings=True)
-    samples = MCMC(hmc_kernel, num_samples=800, warmup_steps=500).run(data)
+    mcmc = MCMC(hmc_kernel, num_samples=800, warmup_steps=500)
+    mcmc.run(data)
+    samples = mcmc.get_samples()
     assert_equal(samples['p_latent'].mean(0), true_probs, prec=0.05)
 
 
@@ -236,7 +241,9 @@ def test_gamma_normal():
     data = dist.Normal(3, true_std).sample(sample_shape=(torch.Size((2000,))))
     hmc_kernel = HMC(model, trajectory_length=1, step_size=0.03, adapt_step_size=False,
                      jit_compile=True, ignore_jit_warnings=True)
-    samples = MCMC(hmc_kernel, num_samples=200, warmup_steps=200).run(data)
+    mcmc = MCMC(hmc_kernel, num_samples=200, warmup_steps=200)
+    mcmc.run(data)
+    samples = mcmc.get_samples()
     assert_equal(samples['p_latent'].mean(0), true_std, prec=0.05)
 
 
@@ -257,7 +264,9 @@ def test_bernoulli_latent_model(jit):
     data = dist.Normal(2. * z, 1.0).sample()
     hmc_kernel = HMC(model, trajectory_length=1, max_plate_nesting=1,
                      jit_compile=jit, ignore_jit_warnings=True)
-    samples = MCMC(hmc_kernel, num_samples=600, warmup_steps=200).run(data)
+    mcmc = MCMC(hmc_kernel, num_samples=600, warmup_steps=200)
+    mcmc.run(data)
+    samples = mcmc.get_samples()
     assert_equal(samples['y_prob'].mean(0), y_prob, prec=0.06)
 
 

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -30,10 +30,12 @@ def test_predictive(num_samples):
     init_params, potential_fn, transforms, _ = initialize_model(model,
                                                                 model_args=(data,))
     nuts_kernel = NUTS(potential_fn=potential_fn, transforms=transforms)
-    samples = MCMC(nuts_kernel,
-                   100,
-                   initial_params=init_params,
-                   warmup_steps=100).run(data)
+    mcmc = MCMC(nuts_kernel,
+                100,
+                initial_params=init_params,
+                warmup_steps=100)
+    mcmc.run(data)
+    samples = mcmc.get_samples()
     with ignore_experimental_warning():
         with optional(pytest.warns(UserWarning), num_samples not in (None, 100)):
             predictive_samples = predictive(model, samples,

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -93,8 +93,9 @@ def bernoulli_beta_hmc(**kwargs):
     kernel = kwargs.pop('kernel')
     num_samples = kwargs.pop('num_samples')
     mcmc_kernel = kernel(model, **kwargs)
-    mcmc_samples = MCMC(mcmc_kernel, num_samples=num_samples, warmup_steps=100).run(data)
-    return mcmc_samples['p_latent']
+    mcmc = MCMC(mcmc_kernel, num_samples=num_samples, warmup_steps=100)
+    mcmc.run(data)
+    return mcmc.get_samples()['p_latent']
 
 
 @register_model(num_steps=2000, whiten=False, id='VSGP::MultiClass_whiten=False')

--- a/tutorial/source/bayesian_regression_ii.ipynb
+++ b/tutorial/source/bayesian_regression_ii.ipynb
@@ -22,9 +22,7 @@
    "source": [
     "from __future__ import absolute_import, division, print_function\n",
     "\n",
-    "from functools import partial\n",
     "import logging\n",
-    "import math\n",
     "import os\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -36,15 +34,11 @@
     "\n",
     "import pyro\n",
     "import pyro.distributions as dist\n",
-    "import pyro.poutine as poutine\n",
-    "from pyro.distributions.util import logsumexp\n",
     "from pyro.infer import EmpiricalMarginal, SVI, Trace_ELBO\n",
-    "from pyro.infer.abstract_infer import TracePredictive\n",
     "from pyro.contrib.autoguide import AutoMultivariateNormal\n",
     "from pyro.infer.mcmc.api import MCMC\n",
     "from pyro.infer.mcmc import NUTS\n",
     "import pyro.optim as optim\n",
-    "import pyro.poutine as poutine\n",
     "\n",
     "pyro.set_rng_seed(1)\n",
     "assert pyro.__version__.startswith('0.3.3')"
@@ -99,7 +93,7 @@
     "    b_ar = pyro.sample(\"bAR\", dist.Normal(0., 1.))\n",
     "    sigma = pyro.sample(\"sigma\", dist.Uniform(0., 10.))\n",
     "    mean = a + b_a * is_cont_africa + b_r * ruggedness + b_ar * is_cont_africa * ruggedness\n",
-    "    with pyro.iarange(\"data\", len(ruggedness)):\n",
+    "    with pyro.plate(\"data\", len(ruggedness)):\n",
     "        pyro.sample(\"obs\", dist.Normal(mean, sigma), obs=log_gdp)\n",
     "        \n",
     "def guide(is_cont_africa, ruggedness, log_gdp):\n",
@@ -249,8 +243,8 @@
     "sites = [\"a\", \"bA\", \"bR\", \"bAR\", \"sigma\"]\n",
     "\n",
     "svi_samples = {site: EmpiricalMarginal(svi_diagnorm_posterior, sites=site)\n",
-    "                               .enumerate_support().detach().cpu().numpy()\n",
-    "                         for site in sites}\n",
+    "                     .enumerate_support().detach().cpu().numpy()\n",
+    "               for site in sites}\n",
     "\n",
     "for site, values in summary(svi_samples).items():\n",
     "    print(\"Site: {}\".format(site))\n",
@@ -282,10 +276,10 @@
    "source": [
     "nuts_kernel = NUTS(model)\n",
     "\n",
-    "hmc_samples = MCMC(nuts_kernel, num_samples=1000, warmup_steps=200) \\\n",
-    "    .run(is_cont_africa, ruggedness, log_gdp)\n",
+    "mcmc = MCMC(nuts_kernel, num_samples=1000, warmup_steps=200)\n",
+    "mcmc.run(is_cont_africa, ruggedness, log_gdp)\n",
     "\n",
-    "hmc_samples = {k: v.detach().cpu().numpy() for k, v in hmc_samples.items()}"
+    "hmc_samples = {k: v.detach().cpu().numpy() for k, v in mcmc.get_samples().items()}"
    ]
   },
   {

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -623,7 +623,8 @@
     "pyro.set_rng_seed(2)\n",
     "kernel = NUTS(model)\n",
     "mcmc = MCMC(kernel, num_samples=250, warmup_steps=50)\n",
-    "posterior_samples = mcmc.run(data)"
+    "mcmc.run(data)\n",
+    "posterior_samples = mcmc.get_samples()"
    ]
   },
   {


### PR DESCRIPTION
Based on discussions in #1942, this makes a change to the mcmc interface:

**Previous:**
```python
samples = MCMC(model, ..).run(x, y)
```

**Proposed:**
```python
mcmc = MCMC(model, ..)
mcmc.run(x, y)
samples = mcmc.get_samples()
diagnostics = mcmc.diagnostics()
```

The motivation for this change is that the `MCMC` class supports more methods now like `.diagnostics` and it therefore makes sense to have users hold a reference to the MCMC object itself, so that we can later call `mcmc.diagnostics()` etc. This also makes it convenient to get samples where the chain dim is collapsed/uncollapsed so that users don't need to do this for each sample site.

Other minor change is the `disable_validation=True` flag. Since we record divergent transitions, it makes sense to disable distribution validation checks, otherwise divergent transitions would exit with an exception which will be quite common with complex models.
