### PR TITLE
Add summary method to MCMC

### DIFF
--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import logging
 
-import pandas as pd
 import torch
 
 import data

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -39,14 +39,7 @@ def main(args):
                 warmup_steps=args.warmup_steps,
                 num_chains=args.num_chains)
     mcmc.run(model, data.sigma, data.y)
-    samples = mcmc.get_samples()
-    if args.num_chains > 1:
-        samples = {k: v.reshape((-1,) + v.shape[2:]) for k, v in samples.items()}
-    marginal = torch.cat(list(samples.values()), dim=-1).cpu().numpy()
-    params = ['mu', 'tau', 'eta[0]', 'eta[1]', 'eta[2]', 'eta[3]', 'eta[4]', 'eta[5]', 'eta[6]', 'eta[7]']
-    df = pd.DataFrame(marginal, columns=params).transpose()
-    df_summary = df.apply(pd.Series.describe, axis=1)[["mean", "std", "25%", "50%", "75%"]]
-    logging.info(df_summary)
+    mcmc.summary(prob=0.5)
 
 
 if __name__ == '__main__':

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -24,7 +24,7 @@ from six.moves import queue
 import pyro
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.logger import initialize_logger, DIAGNOSTIC_MSG, TqdmHandler, ProgressBar
-from pyro.infer.mcmc.util import diagnostics, initialize_model
+from pyro.infer.mcmc.util import diagnostics, initialize_model, summary
 
 MAX_SEED = 2**32 - 1
 
@@ -392,3 +392,14 @@ class MCMC(object):
             diag[diag_name] = {'chain {}'.format(i): self._diagnostics[i][diag_name]
                                for i in range(self.num_chains)}
         return diag
+
+    def summary(self, prob=0.9):
+        """
+        Prints a summary table displaying diagnostics of samples obtained from
+        posterior. The diagnostics displayed are mean, standard deviation, median,
+        the 90% Credibility Interval, :func:`~pyro.ops.stats.effective_sample_size`,
+        :func:`~pyro.ops.stats.split_gelman_rubin`.
+
+        :param float prob: the probability mass of samples within the credibility interval.
+        """
+        summary(self._samples, prob=prob, num_chains=self.num_chains)

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,6 +1,7 @@
 import warnings
 from collections import OrderedDict, defaultdict
 from functools import partial, reduce
+from itertools import product
 
 import torch
 from torch.distributions import biject_to
@@ -450,6 +451,7 @@ def summary(samples, prob=0.9, num_chains=1):
                 idx_str = '[{}]'.format(','.join(map(str, idx)))
                 print(row_format.format(name + idx_str, mean[idx], sd[idx], median[idx],
                                         hpd[0][idx], hpd[1][idx], n_eff[idx], r_hat[idx]))
+    print('\n')
 
 
 def predictive(model, posterior_samples, *args, **kwargs):

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -104,7 +104,8 @@ def _empty_model():
 @pytest.mark.parametrize("jit", [False, True])
 @pytest.mark.parametrize("num_chains", [
     1,
-    skipif_param(2, condition="CI" in os.environ, reason="CI only provides 2-core CPU")
+    skipif_param(2, condition="CI" in os.environ or "CUDA_TEST" in os.environ,
+                 reason="CI only provides 2-core CPU; also see https://github.com/pytorch/pytorch/issues/2517")
 ])
 def test_empty_sample_sites(kernel, kernel_args, jit, num_chains):
     num_warmup, num_samples = 10, 10

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -118,7 +118,8 @@ def _empty_model():
 @pytest.mark.parametrize("jit", [False, True])
 @pytest.mark.parametrize("num_chains", [
     1,
-    skipif_param(2, condition="CI" in os.environ, reason="CI only provides 2-core CPU")
+    skipif_param(2, condition="CI" in os.environ or "CUDA_TEST" in os.environ,
+                 reason="CI only provides 2-core CPU; also see https://github.com/pytorch/pytorch/issues/2517")
 ])
 def test_null_model_with_hook(kernel, model, jit, num_chains):
     num_warmup, num_samples = 10, 10


### PR DESCRIPTION
Addresses #1934. Here is an example output of eight school example.

```
sample: 100%|████████████████████████████████| 2000/2000 [00:39, 50.23it/s, step size=2.75e-01, acc. rate=0.957]
                                                                                                                
                                                                                                                
                                                                                                                
                mean       std    median     25.0%     75.0%     n_eff     r_hat                                
    eta[0]      0.45      0.95      0.44     -0.16      1.14    733.62      1.00                                
    eta[1]      0.04      0.82      0.05     -0.47      0.55    979.80      1.00                                
    eta[2]     -0.16      0.93     -0.15     -0.70      0.55    943.84      1.00                                
    eta[3]      0.02      0.90      0.03     -0.51      0.64   1089.02      1.00                                
    eta[4]     -0.31      0.90     -0.31     -0.95      0.21    608.36      1.00                                
    eta[5]     -0.14      0.84     -0.17     -0.83      0.22    966.65      1.00                                
    eta[6]      0.35      0.94      0.40     -0.09      1.10    762.29      1.00                                
    eta[7]      0.12      0.89      0.13     -0.34      0.85    921.91      1.00                                
     mu[0]      6.18      4.60      6.32      3.48      9.50    484.82      1.00                                
    tau[0]      6.20      4.88      5.14      0.30      5.35    318.87      1.00                                
                                                                                                                
                                                                                                                
```