### PR TITLE
Fix memory issue of MCMC for multiple chains

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -373,6 +373,9 @@ if __name__ == "__main__":
                         help="run this example in GPU")
     args = parser.parse_args()
 
+    # work around the error "CUDA error: initialization error" when arg.cuda is False
+    # see https://github.com/pytorch/pytorch/issues/2517
+    torch.multiprocessing.set_start_method("spawn")
     pyro.set_rng_seed(args.rng_seed)
     # Enable validation checks
     pyro.enable_validation(__debug__)

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import logging
 import math
+import six
 
 import pandas as pd
 import torch
@@ -375,7 +376,8 @@ if __name__ == "__main__":
 
     # work around the error "CUDA error: initialization error" when arg.cuda is False
     # see https://github.com/pytorch/pytorch/issues/2517
-    torch.multiprocessing.set_start_method("spawn")
+    if six.PY3:
+        torch.multiprocessing.set_start_method("spawn")
     pyro.set_rng_seed(args.rng_seed)
     # Enable validation checks
     pyro.enable_validation(__debug__)

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -14,7 +14,7 @@ import logging
 import signal
 import threading
 import warnings
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 
 import six
 import torch
@@ -107,13 +107,15 @@ class _Worker(object):
 def _gen_samples(kernel, warmup_steps, num_samples, hook, *args, **kwargs):
     kernel.setup(warmup_steps, *args, **kwargs)
     params = kernel.initial_params
+    # yield structure (key, value.shape) of params
+    yield {k: v.shape for k, v in params.items()}
     for i in range(warmup_steps):
         params = kernel.sample(params)
         hook(kernel, params, 'warmup', i)
     for i in range(num_samples):
         params = kernel.sample(params)
         hook(kernel, params, 'sample', i)
-        yield params
+        yield torch.cat([params[site].reshape(-1) for site in sorted(params)])
     yield kernel.diagnostics()
     kernel.cleanup()
 
@@ -337,18 +339,36 @@ class MCMC(object):
 
     def run(self, *args, **kwargs):
         num_samples = [0] * self.num_chains
-        z_acc = defaultdict(lambda: [[] for _ in range(self.num_chains)])
+        z_flat_acc = [[] for _ in range(self.num_chains)]
         with pyro.validation_enabled(not self.disable_validation):
             for x, chain_id in self.sampler.run(*args, **kwargs):
-                if num_samples[chain_id] == self.num_samples:
+                if num_samples[chain_id] == 0:
+                    num_samples[chain_id] += 1
+                    z_structure = x
+                elif num_samples[chain_id] == self.num_samples + 1:
                     self._diagnostics[chain_id] = x
                 else:
                     num_samples[chain_id] += 1
-                    for k, v in x.items():
-                        z_acc[k][chain_id].append(v)
+                    if self.num_chains > 1:
+                        x_cloned = x.clone()
+                        del x
+                    else:
+                        x_cloned = x
+                    z_flat_acc[chain_id].append(x_cloned)
 
-        z_acc = {k: [torch.stack(l) for l in v] for k, v in z_acc.items()}
-        z_acc = {k: v[0] if self.num_chains == 1 else torch.stack(v) for k, v in z_acc.items()}
+        z_flat_acc = torch.stack([torch.stack(l) for l in z_flat_acc])
+
+        # unpack latent
+        pos = 0
+        z_acc = z_structure.copy()
+        for k in sorted(z_structure):
+            shape = z_structure[k]
+            next_pos = pos + shape.numel()
+            # NB: squeeze in case num_chains=1
+            z_acc[k] = z_flat_acc[:, :, pos:next_pos].reshape(
+                (self.num_chains, self.num_samples) + shape).squeeze(dim=0)
+            pos = next_pos
+        assert pos == z_flat_acc.shape[-1]
 
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -115,7 +115,7 @@ def _gen_samples(kernel, warmup_steps, num_samples, hook, *args, **kwargs):
     for i in range(num_samples):
         params = kernel.sample(params)
         hook(kernel, params, 'sample', i)
-        yield torch.cat([params[site].reshape(-1) for site in sorted(params)])
+        yield torch.cat([params[site].reshape(-1) for site in sorted(params)]) if params else torch.tensor([])
     yield kernel.diagnostics()
     kernel.cleanup()
 


### PR DESCRIPTION
Addresses #1737 

This PR fixes shared memory issue when running mcmc with multiple chains. Previously, we hold all references of tensors in subprocesses and main process, which might cause memory issue when the number of samples is large. This PR clones and deletes shared tensors in the main process.

Because `.clone()` operator adds overhead, especially when the model has many latent sites, I revise `gen_samples` a bit to make it return only 1 flatten tensor. After collecting all flatten samples, we unpack them into the original `dict` format. As for benchmark, I don't observe any regression with this approach:
+ test for `logistic_regression` example, this PR took 15.05s while `dev` branch took 15.39s
+ for `beta_bernoulli` example, this PR took 18.72s while `dev` branch took 18.86s
+ for bayesian regression model, with 3000 samples, 1000 warmup steps, 4 chains, this PR took 1.28s while `dev` branch took 1.29s. In GPU, with 200 warmup steps and 200 samples, both took 45s.
+ similarly, the same performance for baseball example