### PR TITLE
Replace acceptance rate by mean accept prob for hmc logging

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -290,8 +290,10 @@ class HMC(MCMCKernel):
             self._cache(z, potential_energy)
         # return early if no sample sites
         elif len(z) == 0:
-            self._accept_cnt += 1
             self._t += 1
+            self._mean_accept_prob = 1.
+            if self._t > self._warmup_steps:
+                self._accept_cnt += 1
             return params
         r, _ = self._sample_r(name="r_t={}".format(self._t))
         energy_current = self._kinetic_energy(r) + potential_energy
@@ -341,4 +343,5 @@ class HMC(MCMCKernel):
         ])
 
     def diagnostics(self):
-        return {"divergences": self._divergences, "acceptance rate": self._accept_cnt / self._t}
+        return {"divergences": self._divergences,
+                "acceptance rate": self._accept_cnt / (self._t - self._warmup_steps)}

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -384,12 +384,16 @@ class NUTS(HMC):
                     else:
                         tree_weight = tree_weight + new_tree.weight
 
-        if self._t < self._warmup_steps:
-            accept_prob = sum_accept_probs / num_proposals
-            self._adapter.step(self._t, z, accept_prob)
-
-        if accepted:
-            self._accept_cnt += 1
+        accept_prob = sum_accept_probs / num_proposals
 
         self._t += 1
+        if self._t > self._warmup_steps:
+            n = self._t - self._warmup_steps
+            if accepted:
+                self._accept_cnt += 1
+        else:
+            n = self._t
+            self._adapter.step(self._t, z, accept_prob)
+        self._mean_accept_prob += (accept_prob.item() - self._mean_accept_prob) / n
+
         return z.copy()

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -286,8 +286,10 @@ class NUTS(HMC):
             self._cache(z, potential_energy)
         # return early if no sample sites
         elif len(z) == 0:
-            self._accept_cnt += 1
             self._t += 1
+            self._mean_accept_prob = 1.
+            if self._t > self._warmup_steps:
+                self._accept_cnt += 1
             return z
         r, r_flat = self._sample_r(name="r_t={}".format(self._t))
         energy_current = self._kinetic_energy(r) + potential_energy


### PR DESCRIPTION
In NUTS, it is better to observe the progress of mean accept prob instead of acceptance rate. Consider a trajectory with length 2: z0 -> z1 -> z2. When z1_accept_prob = 1, z2_accept_prob = 0, the initial state z0 will always move to `z1`, hence if this phenomenon happens for other trajectories too, then we will end up with reporting acceptance_rate=1. In NUTS, we compute accept_prob (for step_size adaptation) as the mean value of all state accept probs , hence accept_prob = 0.5 will be used for step_size adaptation. And step_size will be adapted so that `accept_prob` will match `target_accept_prob`.

This PR replaces acceptance rate by mean accept prob for hmc logging. Users can still get acceptance rate by using `diagnostics()` method.