### PR TITLE
drop six dependency

### DIFF
--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import logging
 import math
-import six
 
 import pandas as pd
 import torch
@@ -376,8 +375,7 @@ if __name__ == "__main__":
 
     # work around the error "CUDA error: initialization error" when arg.cuda is False
     # see https://github.com/pytorch/pytorch/issues/2517
-    if six.PY3:
-        torch.multiprocessing.set_start_method("spawn")
+    torch.multiprocessing.set_start_method("spawn")
     pyro.set_rng_seed(args.rng_seed)
     # Enable validation checks
     pyro.enable_validation(__debug__)

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -15,9 +15,9 @@ und Kognitive Systeme at Universitaet Karlsruhe.
 
 import os
 from collections import namedtuple
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
+import pickle
 
-import six.moves.cPickle as pickle
 import torch
 import torch.nn as nn
 from torch.nn.utils.rnn import pad_sequence

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 import pandas as pd
 

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -8,20 +8,15 @@ from __future__ import absolute_import, division, print_function
 
 import collections
 
-import six
 import torch
-from six.moves import queue
+import queue
+import functools
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer.abstract_infer import TracePosterior
 from pyro.poutine.runtime import NonlocalExit
-
-if six.PY3:
-    import functools
-else:
-    import functools32 as functools
 
 
 def memoize(fn=None, **kwargs):

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -5,7 +5,6 @@ from abc import ABCMeta, abstractmethod
 
 import torch
 import torch.nn as nn
-from six import add_metaclass
 from torch.nn import functional
 from torchvision.utils import save_image
 
@@ -57,8 +56,7 @@ class Decoder(nn.Module):
         return torch.sigmoid(self.fc4(h3))
 
 
-@add_metaclass(ABCMeta)
-class VAE(object):
+class VAE(object, metaclass=ABCMeta):
     """
     Abstract class for the variational auto-encoder. The abstract method
     for training the network is implemented by subclasses.

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -6,7 +6,6 @@ from abc import ABCMeta, abstractmethod
 
 import torch
 from contextlib2 import ExitStack
-from six import add_metaclass
 from torch.distributions import biject_to
 
 import pyro
@@ -18,8 +17,7 @@ from pyro.distributions.util import broadcast_shape, sum_rightmost
 from pyro.poutine.util import prune_subsample_sites
 
 
-@add_metaclass(ABCMeta)
-class EasyGuide(object):
+class EasyGuide(object, metaclass=ABCMeta):
     """
     Base class for "easy guides".
 

--- a/pyro/contrib/oed/search.py
+++ b/pyro/contrib/oed/search.py
@@ -1,7 +1,6 @@
+import queue
 from pyro.infer.abstract_infer import TracePosterior
 import pyro.poutine as poutine
-
-from six.moves import queue
 
 ###################################
 # Search borrowed from RSA example

--- a/pyro/contrib/tracking/dynamic_models.py
+++ b/pyro/contrib/tracking/dynamic_models.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 import torch
 from torch import nn
@@ -8,8 +7,7 @@ import pyro.distributions as dist
 from pyro.distributions.util import eye_like
 
 
-@add_metaclass(ABCMeta)
-class DynamicModel(nn.Module):
+class DynamicModel(nn.Module, metaclass=ABCMeta):
     '''
     Dynamic model interface.
 

--- a/pyro/contrib/tracking/measurements.py
+++ b/pyro/contrib/tracking/measurements.py
@@ -1,12 +1,10 @@
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 import torch
 from pyro.distributions.util import eye_like
 
 
-@add_metaclass(ABCMeta)
-class Measurement(object):
+class Measurement(object, metaclass=ABCMeta):
     '''
     Gaussian measurement interface.
 

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -2,13 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 from abc import ABCMeta, abstractmethod
 
-from six import add_metaclass
-
 from pyro.distributions.score_parts import ScoreParts
 
 
-@add_metaclass(ABCMeta)
-class Distribution(object):
+class Distribution(object, metaclass=ABCMeta):
     """
     Base class for parameterized probability distributions.
 

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -6,7 +6,6 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict, defaultdict
 
 import torch
-from six import add_metaclass
 
 import pyro.poutine as poutine
 from pyro.distributions import Categorical, Empirical
@@ -159,8 +158,7 @@ class Marginals(object):
         return self._marginals
 
 
-@add_metaclass(ABCMeta)
-class TracePosterior(object):
+class TracePosterior(object, metaclass=ABCMeta):
     """
     Abstract TracePosterior object from which posterior inference algorithms inherit.
     When run, collects a bag of execution traces from the approximate posterior.

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -4,8 +4,6 @@ import logging
 import warnings
 from abc import ABCMeta, abstractmethod
 
-from six import add_metaclass
-
 import pyro
 import pyro.poutine as poutine
 from pyro.infer.util import is_validation_enabled
@@ -13,8 +11,7 @@ from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_site_shape
 
 
-@add_metaclass(ABCMeta)
-class ELBO(object):
+class ELBO(object, metaclass=ABCMeta):
     """
     :class:`ELBO` is the top-level interface for stochastic variational
     inference via optimization of the evidence lower bound.

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import numbers
 from functools import partial
-
-from six.moves.queue import LifoQueue
+from queue import LifoQueue
 
 from pyro import poutine
 from pyro.infer.util import is_validation_enabled

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -11,15 +11,14 @@ from __future__ import absolute_import, division, print_function
 
 import json
 import logging
+import queue
 import signal
 import threading
 import warnings
 from collections import OrderedDict
 
-import six
 import torch
 import torch.multiprocessing as mp
-from six.moves import queue
 
 import pyro
 from pyro.infer.mcmc import HMC, NUTS
@@ -177,9 +176,6 @@ class _MultiSampler(object):
         self.workers = []
         self.ctx = mp
         if mp_context:
-            if six.PY2:
-                raise ValueError("multiprocessing.get_context() is "
-                                 "not supported in Python 2.")
             self.ctx = mp.get_context(mp_context)
         self.result_queue = self.ctx.Queue()
         self.log_queue = self.ctx.Queue()
@@ -309,7 +305,7 @@ class MCMC(object):
                     if v.shape[0] != num_chains:
                         raise ValueError("The leading dimension of tensors in `initial_params` "
                                          "must match the number of chains.")
-                if mp_context is None and six.PY3:
+                if mp_context is None:
                     # change multiprocessing context to 'spawn' for CUDA tensors.
                     if list(initial_params.values())[0].is_cuda:
                         mp_context = "spawn"

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -6,11 +6,10 @@ import signal
 import threading
 import warnings
 from collections import OrderedDict
+import queue
 
-import six
 import torch
 import torch.multiprocessing as mp
-from six.moves import queue
 
 import pyro
 import pyro.ops.stats as stats
@@ -106,9 +105,6 @@ class _ParallelSampler(TracePosterior):
         self.workers = []
         self.ctx = mp
         if mp_context:
-            if six.PY2:
-                raise ValueError("multiprocessing.get_context() is "
-                                 "not supported in Python 2.")
             self.ctx = mp.get_context(mp_context)
         self.result_queue = self.ctx.Queue()
         self.log_queue = self.ctx.Queue()

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -2,11 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 from abc import ABCMeta, abstractmethod
 
-from six import add_metaclass
 
-
-@add_metaclass(ABCMeta)
-class MCMCKernel(object):
+class MCMCKernel(object, metaclass=ABCMeta):
 
     def setup(self, warmup_steps, *args, **kwargs):
         r"""

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import, division, print_function
 import warnings
 import weakref
 from collections import OrderedDict
+import queue
 
 import torch
 from opt_einsum import shared_intermediates
-from six.moves import queue
 
 import pyro
 import pyro.distributions as dist

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -7,7 +7,6 @@ from collections import OrderedDict, defaultdict
 import opt_einsum
 import torch
 from opt_einsum import shared_intermediates
-from six.moves import map
 
 from pyro.ops.rings import BACKEND_TO_RING, LogRing
 from pyro.util import ignore_jit_warnings

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -4,7 +4,6 @@ import weakref
 from abc import ABCMeta, abstractmethod
 
 import torch
-from six import add_metaclass
 
 from pyro.ops import packed
 from pyro.util import jit_iter
@@ -12,8 +11,7 @@ from pyro.util import jit_iter
 SAMPLE_SYMBOL = " "  # must be unique and precede alphanumeric characters
 
 
-@add_metaclass(ABCMeta)
-class Backward(object):
+class Backward(object, metaclass=ABCMeta):
     is_leaf = False
 
     def __call__(self):

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import operator
 
-from six.moves import reduce
+from functools import reduce
 
 from pyro.ops import packed
 from pyro.ops.einsum.adjoint import Backward, einsum_backward_sample, transpose, unflatten

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import operator
 
-from six.moves import reduce
+from functools import reduce
 
 import pyro.distributions as dist
 import pyro.ops.einsum.torch_log

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -4,15 +4,13 @@ import weakref
 from abc import ABCMeta, abstractmethod
 
 import torch
-from six import add_metaclass
 
 from pyro.ops.einsum import contract
 from pyro.ops.einsum.adjoint import SAMPLE_SYMBOL, Backward
 from pyro.util import ignore_jit_warnings
 
 
-@add_metaclass(ABCMeta)
-class Ring(object):
+class Ring(object, metaclass=ABCMeta):
     """
     Abstract tensor ring class.
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -50,8 +50,6 @@ from __future__ import absolute_import, division, print_function
 
 import functools
 
-from six.moves import xrange
-
 from pyro.poutine import util
 
 from .block_messenger import BlockMessenger
@@ -454,7 +452,7 @@ def queue(fn=None, queue=None, max_tries=None,
     def wrapper(wrapped):
         def _fn(*args, **kwargs):
 
-            for i in xrange(max_tries):
+            for i in range(max_tries):
                 assert not queue.empty(), \
                     "trying to get() from an empty queue will deadlock"
 

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 
-import six
-
 from .messenger import Messenger
 from .trace_struct import Trace
 from .util import site_is_subsample
@@ -148,9 +146,7 @@ class TraceHandler(object):
             except (ValueError, RuntimeError):
                 exc_type, exc_value, traceback = sys.exc_info()
                 shapes = self.msngr.trace.format_shapes()
-                six.reraise(exc_type,
-                            exc_type(u"{}\n{}".format(exc_value, shapes)),
-                            traceback)
+                raise exc_type(u"{}\n{}".format(exc_value, shapes)).with_traceback(traceback)
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 import sys
 
 import opt_einsum
-import six
 
 from pyro.distributions.score_parts import ScoreParts
 from pyro.distributions.util import scale_and_mask
@@ -192,10 +191,8 @@ class Trace(object):
                     except ValueError:
                         _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
-                        six.reraise(ValueError,
-                                    ValueError("Error while computing log_prob_sum at site '{}':\n{}\n"
-                                               .format(name, exc_value, shapes)),
-                                    traceback)
+                        raise ValueError("Error while computing log_prob_sum at site '{}':\n{}\n"
+                                         .format(name, exc_value, shapes)).with_traceback(traceback)
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"]).sum()
                     site["log_prob_sum"] = log_p
                     if is_validation_enabled():
@@ -219,10 +216,8 @@ class Trace(object):
                     except ValueError:
                         _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
-                        six.reraise(ValueError,
-                                    ValueError("Error while computing log_prob at site '{}':\n{}\n{}"
-                                               .format(name, exc_value, shapes)),
-                                    traceback)
+                        raise ValueError("Error while computing log_prob at site '{}':\n{}\n{}"
+                                         .format(name, exc_value, shapes)).with_traceback(traceback)
                     site["unscaled_log_prob"] = log_p
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"])
                     site["log_prob"] = log_p
@@ -248,10 +243,8 @@ class Trace(object):
                 except ValueError:
                     _, exc_value, traceback = sys.exc_info()
                     shapes = self.format_shapes(last_site=site["name"])
-                    six.reraise(ValueError,
-                                ValueError("Error while computing score_parts at site '{}':\n{}\n{}"
-                                           .format(name, exc_value, shapes)),
-                                traceback)
+                    raise ValueError("Error while computing score_parts at site '{}':\n{}\n{}"
+                                     .format(name, exc_value, shapes)).with_traceback(traceback)
                 site["unscaled_log_prob"] = value.log_prob
                 value = value.scale_and_mask(site["scale"], site["mask"])
                 site["score_parts"] = value
@@ -376,10 +369,8 @@ class Trace(object):
             except ValueError:
                 _, exc_value, traceback = sys.exc_info()
                 shapes = self.format_shapes(last_site=site["name"])
-                six.reraise(ValueError,
-                            ValueError("Error while packing tensors at site '{}':\n  {}\n{}"
-                                       .format(site["name"], exc_value, shapes)),
-                            traceback)
+                raise ValueError("Error while packing tensors at site '{}':\n  {}\n{}"
+                                 .format(site["name"], exc_value, shapes)).with_traceback(traceback)
 
     def format_shapes(self, title='Trace Shapes:', last_site=None):
         """

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -3,15 +3,13 @@ from __future__ import absolute_import, division, print_function
 import functools
 import numbers
 import random
-import types
 import warnings
 from collections import defaultdict
+from itertools import zip_longest
 
 import graphviz
-import six
 import torch
 from contextlib2 import contextmanager
-from six.moves import copyreg, zip_longest
 
 from pyro.poutine.util import site_is_subsample
 
@@ -413,16 +411,3 @@ def jit_compatible_arange(end, dtype=None, device=None):
 
 def torch_float(x):
     return x.float() if isinstance(x, torch.Tensor) else float(x)
-
-
-# TODO: Remove when python 2 support is removed.
-# Ability to serialize methods via pickle in Python 2.
-def _pickle_method(m):
-    if m.im_self is None:
-        return getattr, (m.im_class, m.im_func.func_name)
-    else:
-        return getattr, (m.im_self, m.im_func.func_name)
-
-
-if six.PY2:
-    copyreg.pickle(types.MethodType, _pickle_method)

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
         # numpy is necessary for some functionality of PyTorch
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
-        'six>=1.10.0',
         'torch>=1.1.0',
         'tqdm>=4.31',
     ],

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import inspect
 
 import pytest
-import six.moves.cPickle as pickle
+import pickle
 import torch
 
 import pyro.distributions as dist

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 
 import opt_einsum
 import pytest
-import six
 import torch
 
 import pyro.ops.jit
@@ -29,7 +28,7 @@ def deep_copy(x):
         return type(x)(deep_copy(value) for value in x)
     if isinstance(x, (dict, OrderedDict)):
         return type(x)((deep_copy(key), deep_copy(value)) for key, value in x.items())
-    if isinstance(x, six.string_types):
+    if isinstance(x, str):
         return x
     raise TypeError(type(x))
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 import pytest
 import torch
 import torch.nn as nn
-from six.moves.queue import Queue
+from queue import Queue
 
 import pyro
 import pyro.distributions as dist

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -16,13 +16,9 @@ from pyro.distributions.util import logsumexp
 from pyro.infer.abstract_infer import TracePosterior
 from pyro.poutine.runtime import NonlocalExit
 
-import six
-from six.moves import queue
+import queue
 import collections
-if six.PY3:
-    import functools
-else:
-    import functools32 as functools
+import functools
 
 
 def memoize(fn=None, **kwargs):


### PR DESCRIPTION
addresses #1963 

- [x] replace methods with their py3 libraries
- [x] replace `six.reraise()` with `raise exception(..).with_traceback(...)`
- [x] replace `@add_metaclass()` with `class foo(object, metaclass=)`
- [x] fix examples

only ran the test suite, assuming we have coverage for all these functions and exception handling.