### PR TITLE
Add profiler script for examples/hmm.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pyro/contrib/examples/raw
 pyro/_version.py
 processed
 raw
+*.pkl
 
 # Logs
 logs

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -551,7 +551,7 @@ def main(args):
         lengths.clamp_(max=args.truncate)
         sequences = sequences[:, :args.truncate]
     num_observations = float(lengths.sum())
-    pyro.set_rng_seed(0)
+    pyro.set_rng_seed(args.seed)
     pyro.clear_param_store()
     pyro.enable_validation(__debug__)
 
@@ -628,6 +628,7 @@ if __name__ == '__main__':
     parser.add_argument("-lr", "--learning-rate", default=0.05, type=float)
     parser.add_argument("-t", "--truncate", type=int)
     parser.add_argument("-p", "--print-shapes", action="store_true")
+    parser.add_argument("--seed", default=0, type=int)
     parser.add_argument('--cuda', action='store_true')
     parser.add_argument('--jit', action='store_true')
     parser.add_argument('-rp', '--raftery-parameterization', action='store_true')

--- a/profiler/hmm.py
+++ b/profiler/hmm.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+import pickle
+import subprocess
+import sys
+import timeit
+from collections import defaultdict
+
+from numpy import median
+
+
+def main(args):
+    # Decide what experiments to run.
+    configs = []
+    for model in args.model.split(","):
+        for seed in args.seed.split(","):
+            config = ["--seed={}".format(seed), "--model={}".format(model),
+                      "--num-steps={}".format(args.num_steps)]
+            if args.cuda:
+                config.append("--cuda")
+            if args.jit:
+                config.append("--jit")
+            configs.append(tuple(config))
+
+    # Run timing experiments serially.
+    results = {}
+    if os.path.exists(args.filename):
+        try:
+            with open(args.filename, "rb") as f:
+                results = pickle.load(f)
+        except Exception:
+            pass
+    for config in configs:
+        start_time = timeit.default_timer()
+        subprocess.check_call((sys.executable, "-O", "examples/hmm.py") + config)
+        elapsed = timeit.default_timer() - start_time
+        results[config] = elapsed
+        with open(args.filename, "wb") as f:
+            pickle.dump(results, f)
+
+    # Group by seed.
+    grouped = defaultdict(list)
+    for config, elapsed in results.items():
+        grouped[config[1:]].append(elapsed)
+
+    # Print a table in github markdown format.
+    print("| Min (sec) | Mean (sec) | Max (sec) | python -O examples/hmm.py ... |")
+    print("| -: | -: | -: | - |")
+    for config, times in sorted(grouped.items()):
+        print("| {:0.1f} | {:0.1f} | {:0.1f} | {} |".format(
+            min(times), median(times), max(times), " ".join(config)))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Profiler for examples/hmm.py")
+    parser.add_argument("-f", "--filename", default="hmm_profile.pkl")
+    parser.add_argument("-n", "--num-steps", default=50, type=int)
+    parser.add_argument("-s", "--seed", default="0,1,2,3,4")
+    parser.add_argument("-m", "--model", default="1,2,3,4,5,6,7")
+    parser.add_argument("--cuda", action="store_true")
+    parser.add_argument("--jit", action="store_true")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
This adds a simple script to collect timing results for models in examples/hmm.py.

I spent most of today making `Vindex` [smarter](https://github.com/pyro-ppl/pyro/compare/generalized-slice?expand=1) to avoid copying tensors when possible. The trick turned out not to speed things up, but at least I got this nice timing script out of the effort.

## Example output
| Min (sec) | Mean (sec) | Max (sec) | python -O examples/hmm.py ... |
| -: | -: | -: | - |
| 13.8 | 15.1 | 16.0 | --model=1 --num-steps=50 |
| 15.3 | 15.9 | 16.4 | --model=2 --num-steps=50 |
| 19.6 | 20.6 | 21.2 | --model=3 --num-steps=50 |
| 20.9 | 21.9 | 22.9 | --model=4 --num-steps=50 |
| 18.9 | 19.2 | 19.8 | --model=5 --num-steps=50 |
| 30.7 | 32.7 | 33.7 | --model=6 --num-steps=50 |
| 2.7 | 2.8 | 2.9 | --model=7 --num-steps=50 |

## Tested
- ran locally