### PR TITLE
remove future imports and contextlib2

### DIFF
--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -5,7 +5,7 @@ AIR applied to the multi-mnist data set [1].
 understanding with generative models." Advances in Neural Information
 Processing Systems. 2016.
 """
-from __future__ import division
+
 
 import argparse
 import math

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import logging
 import math

--- a/examples/capture_recapture/cjs.py
+++ b/examples/capture_recapture/cjs.py
@@ -27,8 +27,6 @@ References
 [7] https://github.com/stan-dev/example-models/tree/master/BPA/Ch.07
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 
 import torch

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import torch
 from torch.distributions import constraints

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 
 import torch

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -25,8 +25,6 @@ Reference:
 """
 
 # Code adapted from https://github.com/pytorch/examples/tree/master/mnist
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import time
 

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 from functools import partial
 import torch

--- a/examples/eight_schools/data.py
+++ b/examples/eight_schools/data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import logging
 

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import logging
 

--- a/examples/einsum.py
+++ b/examples/einsum.py
@@ -18,8 +18,6 @@ You can measure complexity of different einsum problems by specifying
 ``--equation`` and ``--plates``.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import timeit
 

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -32,8 +32,6 @@ References
 Fritz Obermeyer, Eli Bingham, Martin Jankowiak, Justin Chiu,
 Neeraj Pradhan, Alexander Rush, Noah Goodman. https://arxiv.org/abs/1902.03210
 """
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import logging
 

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 import argparse
 

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -16,8 +16,6 @@ Dirichlet distributions [2], avoiding the need for Laplace approximations as in
     "Pathwise gradients beyond the reparametrization trick"
     https://arxiv.org/pdf/1806.01851.pdf
 """
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import functools
 import logging

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import torch
 

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -4,8 +4,6 @@ which is a minimal implementation of the Pyro Probabilistic Programming
 Language that was created for didactic purposes.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 
 import torch

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import json

--- a/examples/mixed_hmm/model.py
+++ b/examples/mixed_hmm/model.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 from urllib.request import urlopen
 

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -7,9 +7,6 @@ by recursively reasoning about one another.
 
 Taken from: http://forestdb.org/models/schelling.html
 """
-
-from __future__ import print_function
-
 import argparse
 import torch
 

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -8,9 +8,6 @@ by recursively reasoning about one another.
 
 Taken from: http://forestdb.org/models/schelling-falsebelief.html
 """
-
-from __future__ import print_function
-
 import argparse
 import torch
 

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -4,8 +4,6 @@ Inference algorithms and utilities used in the RSA example models.
 Adapted from: http://dippl.org/chapters/03-enumeration.html
 """
 
-from __future__ import absolute_import, division, print_function
-
 import collections
 
 import torch

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -11,8 +11,6 @@
 # Compare to Christian Naesseth's implementation here:
 # https://github.com/blei-lab/ars-reparameterization/tree/master/sparse%20gamma%20def
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import errno
 import os

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 
 import torch

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import cProfile
 from io import StringIO
 import functools

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pyro.poutine as poutine
 from pyro.logger import log
 from pyro.poutine import condition, do, markov

--- a/pyro/contrib/__init__.py
+++ b/pyro/contrib/__init__.py
@@ -6,8 +6,6 @@ Contributed Code
     This code makes no guarantee about maintaining backwards compatibility.
 """
 
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib import autoguide, autoname, bnn, easyguide, gp, oed, tracking
 
 __all__ = [

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -13,8 +13,6 @@ Automatic guides can also be combined using :func:`pyro.poutine.block` and
 :class:`AutoGuideList`.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import numbers
 import weakref
 from contextlib import ExitStack  # python 3

--- a/pyro/contrib/autoguide/__init__.py
+++ b/pyro/contrib/autoguide/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division, print_function
 
 import numbers
 import weakref
+from contextlib import ExitStack  # python 3
 
 import torch
 from torch.distributions import biject_to, constraints
@@ -31,11 +32,6 @@ from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
 from pyro.infer.enum import config_enumerate
 from pyro.nn import AutoRegressiveNN
 from pyro.poutine.util import prune_subsample_sites
-
-try:
-    from contextlib import ExitStack  # python 3
-except ImportError:
-    from contextlib2 import ExitStack  # python 2
 
 __all__ = [
     'AutoCallable',

--- a/pyro/contrib/autoguide/initialization.py
+++ b/pyro/contrib/autoguide/initialization.py
@@ -6,8 +6,6 @@ The standard interface for initialization is a function that inputs a Pyro
 trace ``site`` dict and returns an appropriately sized ``value`` to serve
 as an initial constrained value for a guide estimate.
 """
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import transform_to
 

--- a/pyro/contrib/autoname/__init__.py
+++ b/pyro/contrib/autoname/__init__.py
@@ -2,8 +2,6 @@
 The :mod:`pyro.contrib.autoname` module provides tools for automatically
 generating unique, semantically meaningful names for sample sites.
 """
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.autoname import named
 from pyro.contrib.autoname.scoping import scope, name_count
 

--- a/pyro/contrib/autoname/named.py
+++ b/pyro/contrib/autoname/named.py
@@ -46,8 +46,6 @@ examples.
 
 Authors: Fritz Obermeyer, Alexander Rush
 """
-from __future__ import absolute_import, division, print_function
-
 import functools
 
 import pyro

--- a/pyro/contrib/bnn/__init__.py
+++ b/pyro/contrib/bnn/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.bnn.hidden_layer import HiddenLayer
 
 __all__ = [

--- a/pyro/contrib/bnn/hidden_layer.py
+++ b/pyro/contrib/bnn/hidden_layer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 
 import torch
 from torch.distributions.utils import lazy_property

--- a/pyro/contrib/bnn/utils.py
+++ b/pyro/contrib/bnn/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import math
 

--- a/pyro/contrib/easyguide/__init__.py
+++ b/pyro/contrib/easyguide/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.easyguide.easyguide import EasyGuide, easy_guide
 
 

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -5,7 +5,7 @@ import weakref
 from abc import ABCMeta, abstractmethod
 
 import torch
-from contextlib2 import ExitStack
+from contextlib import ExitStack
 from torch.distributions import biject_to
 
 import pyro

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import re
 import weakref
 from abc import ABCMeta, abstractmethod

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 

--- a/pyro/contrib/glmm/glmm.py
+++ b/pyro/contrib/glmm/glmm.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import warnings
 from collections import OrderedDict
 from functools import partial
+from contextlib import ExitStack
+
 import torch
 from torch.nn.functional import softplus
 from torch.distributions import constraints
@@ -11,11 +13,6 @@ from torch.distributions.transforms import AffineTransform, SigmoidTransform
 import pyro
 import pyro.distributions as dist
 from pyro.contrib.util import rmv, iter_plates_to_shape
-
-try:
-    from contextlib import ExitStack  # python 3
-except ImportError:
-    from contextlib2 import ExitStack  # python 2
 
 # TODO read from torch float spec
 epsilon = torch.tensor(2**-24)

--- a/pyro/contrib/glmm/glmm.py
+++ b/pyro/contrib/glmm/glmm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 from collections import OrderedDict
 from functools import partial

--- a/pyro/contrib/glmm/guides.py
+++ b/pyro/contrib/glmm/guides.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import torch
 from torch import nn
 
+from contextlib import ExitStack
+
 import pyro
 import pyro.distributions as dist
 from pyro import poutine
@@ -10,11 +12,6 @@ from pyro.contrib.util import (
     tensor_to_dict, rmv, rvv, rtril, lexpand, iter_plates_to_shape
 )
 from pyro.ops.linalg import rinverse
-
-try:
-    from contextlib import ExitStack  # python 3
-except ImportError:
-    from contextlib2 import ExitStack  # python 2
 
 
 class LinearModelPosteriorGuide(nn.Module):

--- a/pyro/contrib/glmm/guides.py
+++ b/pyro/contrib/glmm/guides.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch import nn
 

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.gp import kernels, likelihoods, models, parameterized, util
 
 __all__ = [

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.gp.kernels.brownian import Brownian
 from pyro.contrib.gp.kernels.coregionalize import Coregionalize
 from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial

--- a/pyro/contrib/gp/kernels/brownian.py
+++ b/pyro/contrib/gp/kernels/brownian.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/kernels/dot_product.py
+++ b/pyro/contrib/gp/kernels/dot_product.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/kernels/isotropic.py
+++ b/pyro/contrib/gp/kernels/isotropic.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 
 from pyro.contrib.gp.parameterized import Parameterized

--- a/pyro/contrib/gp/kernels/periodic.py
+++ b/pyro/contrib/gp/kernels/periodic.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/contrib/gp/kernels/static.py
+++ b/pyro/contrib/gp/kernels/static.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.gp.likelihoods.binary import Binary
 from pyro.contrib.gp.likelihoods.gaussian import Gaussian
 from pyro.contrib.gp.likelihoods.likelihood import Likelihood

--- a/pyro/contrib/gp/likelihoods/binary.py
+++ b/pyro/contrib/gp/likelihoods/binary.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro

--- a/pyro/contrib/gp/likelihoods/gaussian.py
+++ b/pyro/contrib/gp/likelihoods/gaussian.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/likelihoods/likelihood.py
+++ b/pyro/contrib/gp/likelihoods/likelihood.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.gp.parameterized import Parameterized
 
 

--- a/pyro/contrib/gp/likelihoods/multi_class.py
+++ b/pyro/contrib/gp/likelihoods/multi_class.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch.nn.functional as F
 
 import pyro

--- a/pyro/contrib/gp/likelihoods/poisson.py
+++ b/pyro/contrib/gp/likelihoods/poisson.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro

--- a/pyro/contrib/gp/models/__init__.py
+++ b/pyro/contrib/gp/models/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.gp.models.gplvm import GPLVM
 from pyro.contrib.gp.models.gpr import GPRegression
 from pyro.contrib.gp.models.model import GPModel

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from torch.nn import Parameter
 
 import pyro.distributions as dist

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import torch.distributions as torchdist
 from torch.nn import Parameter

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.gp.parameterized import Parameterized
 
 

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/parameterized.py
+++ b/pyro/contrib/gp/parameterized.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import OrderedDict
 
 import torch.nn as nn

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.infer import TraceMeanField_ELBO

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -11,8 +11,6 @@ module.
 An accompanying example that makes use of this implementation can be
 found at examples/minipyro.py.
 """
-from __future__ import absolute_import, division, print_function
-
 import warnings
 import weakref
 from collections import OrderedDict

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import math
 import warnings

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import torch
 

--- a/pyro/contrib/tracking/__init__.py
+++ b/pyro/contrib/tracking/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.contrib.tracking import assignment
 
 __all__ = [

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 import math
 import numbers

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import heapq
 import itertools
 from collections import defaultdict

--- a/pyro/contrib/util.py
+++ b/pyro/contrib/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import OrderedDict
 import torch
 import pyro

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pyro.distributions.torch_patch  # noqa F403
 from pyro.distributions.avf_mvn import AVFMultivariateNormal
 from pyro.distributions.conjugate import BetaBinomial, DirichletMultinomial, GammaPoisson

--- a/pyro/distributions/avf_mvn.py
+++ b/pyro/distributions/avf_mvn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 
 import torch

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 
 import torch

--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+
 import math
 
 import torch

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from abc import ABCMeta, abstractmethod
 
 from pyro.distributions.score_parts import ScoreParts

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+
 import math
 
 import torch

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/inverse_gamma.py
+++ b/pyro/distributions/inverse_gamma.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from torch.distributions import constraints
 from torch.distributions.transforms import PowerTransform
 from pyro.distributions.torch import Gamma, TransformedDistribution

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable

--- a/pyro/distributions/rejector.py
+++ b/pyro/distributions/rejector.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.distributions.score_parts import ScoreParts

--- a/pyro/distributions/relaxed_straight_through.py
+++ b/pyro/distributions/relaxed_straight_through.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.distributions.torch import RelaxedOneHotCategorical, RelaxedBernoulli

--- a/pyro/distributions/score_parts.py
+++ b/pyro/distributions/score_parts.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import namedtuple
 
 from pyro.distributions.util import scale_and_mask

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 import math
 

--- a/pyro/distributions/testing/fakes.py
+++ b/pyro/distributions/testing/fakes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.distributions.torch import Beta, Dirichlet, Gamma, Normal
 
 

--- a/pyro/distributions/testing/naive_dirichlet.py
+++ b/pyro/distributions/testing/naive_dirichlet.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.distributions.torch import Beta, Dirichlet, Gamma

--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions.utils import broadcast_all
 

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.distributions.rejector import Rejector

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints, kl_divergence, register_kl
 

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 
 import torch

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import weakref
 
 import torch

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 

--- a/pyro/distributions/transforms/affine_coupling.py
+++ b/pyro/distributions/transforms/affine_coupling.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/transforms/batch_norm.py
+++ b/pyro/distributions/transforms/batch_norm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import torch.nn as nn
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/block_autoregressive.py
+++ b/pyro/distributions/transforms/block_autoregressive.py
@@ -1,6 +1,4 @@
 # This implementation is adapted in part from https://github.com/nicola-decao/BNAF under the MIT license.
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import warnings
 

--- a/pyro/distributions/transforms/iaf.py
+++ b/pyro/distributions/transforms/iaf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import torch.nn as nn
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/naf.py
+++ b/pyro/distributions/transforms/naf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions.transforms import Transform
 from torch.distributions.utils import lazy_property

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import torch.nn as nn
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/utils.py
+++ b/pyro/distributions/transforms/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 
 def clamp_preserve_gradients(x, min, max):
     # This helper function clamps gradients but still passes through the gradient in clamped regions

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import functools
 import numbers
 import weakref

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/distributions/zero_inflated_poisson.py
+++ b/pyro/distributions/zero_inflated_poisson.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all, lazy_property

--- a/pyro/generic.py
+++ b/pyro/generic.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import importlib
 
 from contextlib import contextmanager

--- a/pyro/generic.py
+++ b/pyro/generic.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import importlib
 
-from contextlib2 import contextmanager
+from contextlib import contextmanager
 
 
 class GenericModule(object):

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.infer.abstract_infer import EmpiricalMarginal, TracePosterior, TracePredictive
 from pyro.infer.csis import CSIS
 from pyro.infer.discrete import infer_discrete

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 import warnings
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/csis.py
+++ b/pyro/infer/csis.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 
 import torch

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import functools
 from collections import OrderedDict
 

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import warnings
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 from functools import partial
 from queue import LifoQueue

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import warnings
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -7,8 +7,6 @@ This module offers a modified interface for MCMC inference with the following ob
   - minimal memory consumption with multiprocessing and CUDA.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import json
 import logging
 import queue

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 from collections import OrderedDict
 

--- a/pyro/infer/mcmc/mcmc.py
+++ b/pyro/infer/mcmc/mcmc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import json
 import logging
 import signal

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from abc import ABCMeta, abstractmethod
 
 

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import namedtuple
 
 import torch

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import warnings
 

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import weakref
 
 import pyro

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 import weakref
 

--- a/pyro/infer/trace_mmd.py
+++ b/pyro/infer/trace_mmd.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import defaultdict
 
 import torch

--- a/pyro/infer/trace_tail_adaptive_elbo.py
+++ b/pyro/infer/trace_tail_adaptive_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 
 import torch

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 import weakref
 from collections import OrderedDict

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import weakref
 from operator import itemgetter
 

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import numbers
 from collections import Counter, defaultdict

--- a/pyro/logger.py
+++ b/pyro/logger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.nn.auto_reg_nn import AutoRegressiveNN, MaskedLinear
 from pyro.nn.dense_nn import DenseNN
 

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 
 import torch

--- a/pyro/nn/dense_nn.py
+++ b/pyro/nn/dense_nn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import torch.nn as nn
 

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 import warnings
 from collections import OrderedDict, defaultdict

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 
 class DualAveraging(object):
     """

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import opt_einsum
 
 from pyro.util import ignore_jit_warnings

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import weakref
 from abc import ABCMeta, abstractmethod
 

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.ops.einsum.util import Tensordot

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import operator
 
 from functools import reduce

--- a/pyro/ops/einsum/torch_marginal.py
+++ b/pyro/ops/einsum/torch_marginal.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pyro.ops.einsum.torch_log
 from pyro.ops.einsum.adjoint import Backward, transpose
 from pyro.ops.einsum.util import Tensordot

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import operator
 
 from functools import reduce

--- a/pyro/ops/einsum/util.py
+++ b/pyro/ops/einsum/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 EINSUM_SYMBOLS_BASE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 

--- a/pyro/ops/indexing.py
+++ b/pyro/ops/indexing.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.autograd import grad
 

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import warnings
 import weakref

--- a/pyro/ops/linalg.py
+++ b/pyro/ops/linalg.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/ops/newton.py
+++ b/pyro/ops/newton.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.autograd import grad
 

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import weakref
 from abc import ABCMeta, abstractmethod
 

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 
 import torch

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.optim.lr_scheduler import PyroLRScheduler
 from pyro.optim.optim import AdagradRMSProp, ClippedAdam, PyroOptim
 from pyro.optim.pytorch_optimizers import __all__ as pytorch_optims

--- a/pyro/optim/adagrad_rmsprop.py
+++ b/pyro/optim/adagrad_rmsprop.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.optim.optimizer import Optimizer
 

--- a/pyro/optim/clipped_adam.py
+++ b/pyro/optim/clipped_adam.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.optim.optim import PyroOptim
 
 

--- a/pyro/optim/multi.py
+++ b/pyro/optim/multi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.ops.newton import newton_step

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.params.param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
 
 __all__ = [

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import re
 import warnings
 import weakref

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, replay,
                        scale, trace, uncondition)
 from .runtime import NonlocalExit

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from functools import partial
 
 from pyro.poutine.messenger import Messenger

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.util import ignore_jit_warnings
 from .messenger import Messenger
 

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .messenger import Messenger
 from .trace_struct import Trace
 

--- a/pyro/poutine/enumerate_messenger.py
+++ b/pyro/poutine/enumerate_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from pyro.distributions.torch_distribution import TorchDistributionMixin
 from pyro.util import ignore_jit_warnings
 

--- a/pyro/poutine/escape_messenger.py
+++ b/pyro/poutine/escape_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .messenger import Messenger
 from .runtime import NonlocalExit
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -46,8 +46,6 @@ in just a few lines of code::
     monte_carlo_elbo = model_tr.log_prob_sum() - guide_tr.log_prob_sum()
 """
 
-from __future__ import absolute_import, division, print_function
-
 import functools
 
 from pyro.poutine import util

--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numbers
 from collections import namedtuple
 

--- a/pyro/poutine/infer_config_messenger.py
+++ b/pyro/poutine/infer_config_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .messenger import Messenger
 
 

--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 
 from pyro import params

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -1,13 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Counter
+from contextlib import ExitStack  # python 3
 
 from .reentrant_messenger import ReentrantMessenger
-
-try:
-    from contextlib import ExitStack  # python 3
-except ImportError:
-    from contextlib2 import ExitStack  # python 2
 
 
 class MarkovMessenger(ReentrantMessenger):

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import Counter
 from contextlib import ExitStack  # python 3
 

--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.util import ignore_jit_warnings

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from functools import partial
 
 from .runtime import _PYRO_STACK

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .broadcast_messenger import BroadcastMessenger
 from .subsample_messenger import SubsampleMessenger
 

--- a/pyro/poutine/reentrant_messenger.py
+++ b/pyro/poutine/reentrant_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import functools
 
 from .messenger import Messenger

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .messenger import Messenger
 
 

--- a/pyro/poutine/scale_messenger.py
+++ b/pyro/poutine/scale_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.poutine.util import is_validation_enabled

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.distributions.distribution import Distribution

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import sys
 
 from .messenger import Messenger

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import OrderedDict
 import sys
 

--- a/pyro/poutine/uncondition_messenger.py
+++ b/pyro/poutine/uncondition_messenger.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from .messenger import Messenger
 
 

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 
 _VALIDATION_ENABLED = False
 

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import copy
 import warnings
 from collections import OrderedDict

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import functools
 import numbers
 import random

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -9,7 +9,7 @@ from itertools import zip_longest
 
 import graphviz
 import torch
-from contextlib2 import contextmanager
+from contextlib import contextmanager
 
 from pyro.poutine.util import site_is_subsample
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import subprocess
 import sys

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
     install_requires=[
         # if you add any additional libraries, please also
         # add them to `docs/requirements.txt`
-        'contextlib2',
         'graphviz>=0.8',
         # numpy is necessary for some functionality of PyTorch
         'numpy>=1.7',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import os

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import contextlib
 import numbers
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import warnings
 

--- a/tests/contrib/__init__.py
+++ b/tests/contrib/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/contrib/autoguide/test_advi.py
+++ b/tests/contrib/autoguide/test_advi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import functools
 
 import numpy as np

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import numpy as np

--- a/tests/contrib/autoname/test_named.py
+++ b/tests/contrib/autoname/test_named.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro

--- a/tests/contrib/bnn/test_hidden_layer.py
+++ b/tests/contrib/bnn/test_hidden_layer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import torch.nn.functional as F
 from torch.distributions import Normal

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/contrib/easyguide/test_easyguide.py
+++ b/tests/contrib/easyguide/test_easyguide.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.distributions import constraints

--- a/tests/contrib/glmm/test_glmm.py
+++ b/tests/contrib/glmm/test_glmm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.distributions.transforms import AffineTransform, SigmoidTransform

--- a/tests/contrib/gp/__init__.py
+++ b/tests/contrib/gp/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/contrib/gp/test_conditional.py
+++ b/tests/contrib/gp/test_conditional.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import namedtuple
 
 import pytest

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import namedtuple
 
 import pytest

--- a/tests/contrib/gp/test_likelihoods.py
+++ b/tests/contrib/gp/test_likelihoods.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import namedtuple
 
 import pytest

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 from collections import namedtuple
 

--- a/tests/contrib/gp/test_parameterized.py
+++ b/tests/contrib/gp/test_parameterized.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/tests/contrib/oed/test_finite_spaces_eig.py
+++ b/tests/contrib/oed/test_finite_spaces_eig.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import pytest
 

--- a/tests/contrib/oed/test_linear_models_eig.py
+++ b/tests/contrib/oed/test_linear_models_eig.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 import pytest
 

--- a/tests/contrib/test_minipyro.py
+++ b/tests/contrib/test_minipyro.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 
 import pytest

--- a/tests/contrib/test_util.py
+++ b/tests/contrib/test_util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from collections import OrderedDict
 import pytest
 import torch

--- a/tests/contrib/tracking/__init__.py
+++ b/tests/contrib/tracking/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/contrib/tracking/test_distributions.py
+++ b/tests/contrib/tracking/test_distributions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.contrib.tracking.distributions import EKFDistribution

--- a/tests/contrib/tracking/test_dynamic_models.py
+++ b/tests/contrib/tracking/test_dynamic_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.contrib.tracking.dynamic_models import (NcpContinuous, NcvContinuous,

--- a/tests/contrib/tracking/test_ekf.py
+++ b/tests/contrib/tracking/test_ekf.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.contrib.tracking.extended_kalman_filter import EKFState

--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import math
 

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import pytest

--- a/tests/contrib/tracking/test_measurements.py
+++ b/tests/contrib/tracking/test_measurements.py
@@ -1,6 +1,4 @@
 
-from __future__ import absolute_import, division, print_function
-
 import torch
 from pyro.contrib.tracking.measurements import PositionMeasurement
 

--- a/tests/distributions/__init__.py
+++ b/tests/distributions/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import numpy as np

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import numpy as np

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from unittest import TestCase
 
 import numpy as np

--- a/tests/distributions/test_conjugate.py
+++ b/tests/distributions/test_conjugate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import pytest

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from unittest import TestCase
 
 import numpy as np

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numpy as np
 import pytest
 import torch

--- a/tests/distributions/test_flows.py
+++ b/tests/distributions/test_flows.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from functools import partial
 from unittest import TestCase
 

--- a/tests/distributions/test_gaussian_mixtures.py
+++ b/tests/distributions/test_gaussian_mixtures.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import math
 

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import opt_einsum
 import pytest
 import torch

--- a/tests/distributions/test_ig.py
+++ b/tests/distributions/test_ig.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import torch

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.distributions.utils import _sum_rightmost

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 import math

--- a/tests/distributions/test_lowrank_mvn.py
+++ b/tests/distributions/test_lowrank_mvn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 from pyro.distributions import LowRankMultivariateNormal, MultivariateNormal

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch import tensor

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numpy as np
 import torch
 

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from unittest import TestCase
 
 import numpy as np

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import inspect
 
 import pytest

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/distributions/test_reshape.py
+++ b/tests/distributions/test_reshape.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 

--- a/tests/distributions/test_shapes.py
+++ b/tests/distributions/test_shapes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro.distributions as dist

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import os
 from collections import Counter

--- a/tests/distributions/test_tensor_type.py
+++ b/tests/distributions/test_tensor_type.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import scipy.stats as sp
 import torch

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import weakref
 
 import numpy as np

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import os
 

--- a/tests/distributions/test_zip.py
+++ b/tests/distributions/test_zip.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 

--- a/tests/infer/__init__.py
+++ b/tests/infer/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/infer/conftest.py
+++ b/tests/infer/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import os
 from collections import namedtuple

--- a/tests/infer/mcmc/test_mcmc.py
+++ b/tests/infer/mcmc/test_mcmc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 
 import pytest

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 from functools import partial
 

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import os
 from collections import namedtuple

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 
 import pytest

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import math
 

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import pytest

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import math
 import os

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import numpy as np

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 from unittest import TestCase
 

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import warnings
 

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from unittest import TestCase
 
 import pytest

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import warnings
 from collections import defaultdict

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import os
 import time

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 from unittest import TestCase
 

--- a/tests/nn/__init__.py
+++ b/tests/nn/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/nn/conftest.py
+++ b/tests/nn/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/nn/test_autoregressive.py
+++ b/tests/nn/test_autoregressive.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from unittest import TestCase
 
 import pytest

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/ops/einsum/conftest.py
+++ b/tests/ops/einsum/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/ops/einsum/test_adjoint.py
+++ b/tests/ops/einsum/test_adjoint.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 
 import pytest

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 
 import pytest

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 import numbers
 from collections import OrderedDict

--- a/tests/ops/test_indexing.py
+++ b/tests/ops/test_indexing.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 
 import pytest

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 from collections import namedtuple
 

--- a/tests/ops/test_jit.py
+++ b/tests/ops/test_jit.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro.ops.jit

--- a/tests/ops/test_linalg.py
+++ b/tests/ops/test_linalg.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 import logging
 

--- a/tests/ops/test_packed.py
+++ b/tests/ops/test_packed.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import itertools
 import random
 

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+
 import warnings
 
 import pytest

--- a/tests/optim/__init__.py
+++ b/tests/optim/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/optim/conftest.py
+++ b/tests/optim/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 from torch.distributions import constraints

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from unittest import TestCase
 
 import pytest

--- a/tests/params/__init__.py
+++ b/tests/params/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/params/conftest.py
+++ b/tests/params/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/params/test_module.py
+++ b/tests/params/test_module.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 import torch.nn as nn

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from copy import copy
 from unittest import TestCase
 

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import cProfile
 import os

--- a/tests/poutine/__init__.py
+++ b/tests/poutine/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import absolute_import, division, print_function

--- a/tests/poutine/conftest.py
+++ b/tests/poutine/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 
 

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 
 import pytest

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import functools
 import logging
 import pickle

--- a/tests/poutine/test_properties.py
+++ b/tests/poutine/test_properties.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import pytest
 import torch
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import os
 import sys

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import warnings
 import pytest
 

--- a/tutorial/source/bayesian_regression_ii.ipynb
+++ b/tutorial/source/bayesian_regression_ii.ipynb
@@ -20,8 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import absolute_import, division, print_function\n",
-    "\n",
     "import logging\n",
     "import os\n",
     "\n",

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -24,7 +24,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "import os\n",
     "from collections import defaultdict\n",
     "import numpy as np\n",

--- a/tutorial/source/gp.ipynb
+++ b/tutorial/source/gp.ipynb
@@ -51,7 +51,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import torch\n",

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -4,8 +4,6 @@ Inference algorithms and utilities used in the RSA example models.
 Adapted from: http://dippl.org/chapters/03-enumeration.html
 """
 
-from __future__ import absolute_import, division, print_function
-
 import torch
 
 import pyro

--- a/tutorial/source/svi_part_i.ipynb
+++ b/tutorial/source/svi_part_i.ipynb
@@ -251,7 +251,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "import math\n",
     "import os\n",
     "import torch\n",

--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -271,7 +271,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "import os\n",
     "import torch\n",
     "import torch.distributions.constraints as constraints\n",

--- a/tutorial/source/tracking_1d.ipynb
+++ b/tutorial/source/tracking_1d.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import absolute_import, division, print_function\n",
     "import math\n",
     "import os\n",
     "import torch\n",


### PR DESCRIPTION
#1963

this took longer than i thought because sed cant properly handle the newline variations that follow `from __future__ import ...` so i had to learn perl then write a perl script to do the job. just to remove the extra newline.