### PR TITLE
drop remaining python 2 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ For more information, check out our [blog post](http://eng.uber.com/pyro).
 
 **Install using pip:**
 
+Pyro supports Python 3.4+.
+
 ```sh
 pip install pyro-ppl
 ```

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,7 +14,7 @@ DOCKER_WORK_DIR=/home/${USER}/workspace/shared
 pyro_git_url=https://github.com/pyro-ppl/pyro.git
 
 # Optional args
-python_version?=2.7
+python_version?=3.6
 pytorch_branch?=release
 pyro_branch?=release
 cmd?=bash
@@ -41,7 +41,7 @@ build: ##
 	## Build a docker image for running Pyro on a CPU.
 	## Requires nvidia-docker (https://github.com/NVIDIA/nvidia-docker).
 	## Args:
-	##   python_version: version of python to use. default - python 2.7
+	##   python_version: version of python to use. default - python 3.6
 	##   pytorch_branch: whether to build PyTorch from conda or from source
 	##   (git branch specified by pytorch_branch)
 	##     default - latest pytorch version on conda
@@ -62,7 +62,7 @@ build-gpu: ##
 	## Build a docker image for running Pyro on a GPU.
 	## Requires nvidia-docker (https://github.com/NVIDIA/nvidia-docker).
 	## Args:
-	##   python_version: version of python to use. default - python 2.7
+	##   python_version: version of python to use. default - python 3.6
 	##   pytorch_branch: whether to build PyTorch from conda or from source
 	##   (git branch specified by pytorch_branch)
 	##     default - latest pytorch version on conda

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Install from Source
 -------------------
-Pyro supports Python 2.7.* and Python 3.  To setup, install `PyTorch <http://pytorch.org>`_ then run::
+Pyro supports 3.4+.  To setup, install `PyTorch <http://pytorch.org>`_ then run::
 
    pip install pyro-ppl
 


### PR DESCRIPTION
missed a few in the last PR:

- docker makefile
- docs setup

this should wrap up all the python 2 changes AFAICT