### PR TITLE
 Profile compilation time in profiler.hmm

### DIFF
--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -34,6 +34,7 @@ Neeraj Pradhan, Alexander Rush, Noah Goodman. https://arxiv.org/abs/1902.03210
 """
 import argparse
 import logging
+import sys
 
 import torch
 import torch.nn as nn
@@ -49,8 +50,15 @@ from pyro.ops.indexing import Vindex
 from pyro.optim import Adam
 from pyro.util import ignore_jit_warnings
 
-logging.basicConfig(format='%(relativeCreated) 9d %(message)s', level=logging.INFO)
+logging.basicConfig(format='%(relativeCreated) 9d %(message)s', level=logging.DEBUG)
 
+# Add another handler for logging debugging events (e.g. for profiling)
+# in a separate stream that can be captured.
+log = logging.getLogger()
+debug_handler = logging.StreamHandler(sys.stdout)
+debug_handler.setLevel(logging.DEBUG)
+debug_handler.addFilter(filter=lambda record: record.levelno <= logging.DEBUG)
+log.addHandler(debug_handler)
 
 # Let's start with a simple Hidden Markov Model.
 #
@@ -576,7 +584,7 @@ def main(args):
     Elbo = JitTraceEnum_ELBO if args.jit else TraceEnum_ELBO
     elbo = Elbo(max_plate_nesting=1 if model is model_0 else 2,
                 strict_enumeration_warning=(model is not model_7),
-                jit_options={"optimize": model is model_7})
+                jit_options={"optimize": model is model_7, "time_compilation": args.time_compilation})
     optim = Adam({'lr': args.learning_rate})
     svi = SVI(model, guide, optim, elbo)
 
@@ -585,6 +593,9 @@ def main(args):
     for step in range(args.num_steps):
         loss = svi.step(sequences, lengths, args=args, batch_size=args.batch_size)
         logging.info('{: >5d}\t{}'.format(step, loss / num_observations))
+
+    if args.jit and args.time_compilation:
+        logging.debug('time to compile: {} s.'.format(elbo._differentiable_loss.compile_time))
 
     # We evaluate on the entire training dataset,
     # excluding the prior term so our results are comparable across models.
@@ -629,6 +640,7 @@ if __name__ == '__main__':
     parser.add_argument("--seed", default=0, type=int)
     parser.add_argument('--cuda', action='store_true')
     parser.add_argument('--jit', action='store_true')
+    parser.add_argument('--time-compilation', action='store_true')
     parser.add_argument('-rp', '--raftery-parameterization', action='store_true')
     args = parser.parse_args()
     main(args)

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -60,6 +60,7 @@ debug_handler.setLevel(logging.DEBUG)
 debug_handler.addFilter(filter=lambda record: record.levelno <= logging.DEBUG)
 log.addHandler(debug_handler)
 
+
 # Let's start with a simple Hidden Markov Model.
 #
 #     x[t-1] --> x[t] --> x[t+1]

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -4,52 +4,52 @@ import sys
 import torchvision
 import torchvision.datasets as datasets
 from torch.utils.data import DataLoader
-from torchvision import transforms
-from torchvision.datasets import MNIST
-
-from pyro.distributions.torch_patch import patch_dependency
-
-
-@patch_dependency('torchvision.datasets.MNIST', torchvision)
-class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
-    urls = [
-        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz",
-        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz",
-        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz",
-        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz",
-    ]
-
-
-def get_data_loader(dataset_name,
-                    data_dir,
-                    batch_size=1,
-                    dataset_transforms=None,
-                    is_training_set=True,
-                    shuffle=True):
-    if not dataset_transforms:
-        dataset_transforms = []
-    trans = transforms.Compose([transforms.ToTensor()] + dataset_transforms)
-    dataset = getattr(datasets, dataset_name)
-    print("downloading data")
-    dset = dataset(root=data_dir,
-                   train=is_training_set,
-                   transform=trans,
-                   download=True)
-    print("download complete.")
-    return DataLoader(
-        dset,
-        batch_size=batch_size,
-        shuffle=shuffle
-    )
-
-
-def print_and_log(logger, msg):
-    # print and log a message (if a logger is present)
-    print(msg)
-    sys.stdout.flush()
-    if logger is not None:
-        logger.write("{}\n".format(msg))
-        logger.flush()
+# from torchvision import transforms
+# from torchvision.datasets import MNIST
+#
+# from pyro.distributions.torch_patch import patch_dependency
+#
+#
+# @patch_dependency('torchvision.datasets.MNIST', torchvision)
+# class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
+#     urls = [
+#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz",
+#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz",
+#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz",
+#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz",
+#     ]
+#
+#
+# def get_data_loader(dataset_name,
+#                     data_dir,
+#                     batch_size=1,
+#                     dataset_transforms=None,
+#                     is_training_set=True,
+#                     shuffle=True):
+#     if not dataset_transforms:
+#         dataset_transforms = []
+#     trans = transforms.Compose([transforms.ToTensor()] + dataset_transforms)
+#     dataset = getattr(datasets, dataset_name)
+#     print("downloading data")
+#     dset = dataset(root=data_dir,
+#                    train=is_training_set,
+#                    transform=trans,
+#                    download=True)
+#     print("download complete.")
+#     return DataLoader(
+#         dset,
+#         batch_size=batch_size,
+#         shuffle=shuffle
+#     )
+#
+#
+# def print_and_log(logger, msg):
+#     # print and log a message (if a logger is present)
+#     print(msg)
+#     sys.stdout.flush()
+#     if logger is not None:
+#         logger.write("{}\n".format(msg))
+#         logger.flush()
 
 
 def get_data_directory(filepath=None):

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -4,52 +4,52 @@ import sys
 import torchvision
 import torchvision.datasets as datasets
 from torch.utils.data import DataLoader
-# from torchvision import transforms
-# from torchvision.datasets import MNIST
-#
-# from pyro.distributions.torch_patch import patch_dependency
-#
-#
-# @patch_dependency('torchvision.datasets.MNIST', torchvision)
-# class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
-#     urls = [
-#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz",
-#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz",
-#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz",
-#         "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz",
-#     ]
-#
-#
-# def get_data_loader(dataset_name,
-#                     data_dir,
-#                     batch_size=1,
-#                     dataset_transforms=None,
-#                     is_training_set=True,
-#                     shuffle=True):
-#     if not dataset_transforms:
-#         dataset_transforms = []
-#     trans = transforms.Compose([transforms.ToTensor()] + dataset_transforms)
-#     dataset = getattr(datasets, dataset_name)
-#     print("downloading data")
-#     dset = dataset(root=data_dir,
-#                    train=is_training_set,
-#                    transform=trans,
-#                    download=True)
-#     print("download complete.")
-#     return DataLoader(
-#         dset,
-#         batch_size=batch_size,
-#         shuffle=shuffle
-#     )
-#
-#
-# def print_and_log(logger, msg):
-#     # print and log a message (if a logger is present)
-#     print(msg)
-#     sys.stdout.flush()
-#     if logger is not None:
-#         logger.write("{}\n".format(msg))
-#         logger.flush()
+from torchvision import transforms
+from torchvision.datasets import MNIST
+
+from pyro.distributions.torch_patch import patch_dependency
+
+
+@patch_dependency('torchvision.datasets.MNIST', torchvision)
+class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
+    urls = [
+        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz",
+        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz",
+        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz",
+        "https://d2fefpcigoriu7.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz",
+    ]
+
+
+def get_data_loader(dataset_name,
+                    data_dir,
+                    batch_size=1,
+                    dataset_transforms=None,
+                    is_training_set=True,
+                    shuffle=True):
+    if not dataset_transforms:
+        dataset_transforms = []
+    trans = transforms.Compose([transforms.ToTensor()] + dataset_transforms)
+    dataset = getattr(datasets, dataset_name)
+    print("downloading data")
+    dset = dataset(root=data_dir,
+                   train=is_training_set,
+                   transform=trans,
+                   download=True)
+    print("download complete.")
+    return DataLoader(
+        dset,
+        batch_size=batch_size,
+        shuffle=shuffle
+    )
+
+
+def print_and_log(logger, msg):
+    # print and log a message (if a logger is present)
+    print(msg)
+    sys.stdout.flush()
+    if logger is not None:
+        logger.write("{}\n".format(msg))
+        logger.flush()
 
 
 def get_data_directory(filepath=None):

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -408,8 +408,8 @@ def deep_getattr(obj, name):
 
 
 class timed(object):
-    def __enter__(self):
-        self.start = timeit.default_timer()
+    def __enter__(self, timer=timeit.default_timer):
+        self.start = timer()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,6 +1,7 @@
 import functools
 import numbers
 import random
+import timeit
 import warnings
 from collections import defaultdict
 from itertools import zip_longest
@@ -370,16 +371,21 @@ def jit_iter(tensor):
         return list(tensor)
 
 
-@contextmanager
-def optional(context_manager, condition):
+class optional(object):
     """
     Optionally wrap inside `context_manager` if condition is `True`.
     """
-    if condition:
-        with context_manager:
-            yield
-    else:
-        yield
+    def __init__(self, context_manager, condition):
+        self.context_manager = context_manager
+        self.condition = condition
+
+    def __enter__(self):
+        if self.condition:
+            return self.context_manager.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.condition:
+            return self.context_manager.__exit__(exc_type, exc_val, exc_tb)
 
 
 class ExperimentalWarning(UserWarning):
@@ -399,6 +405,17 @@ def deep_getattr(obj, name):
     Throws an AttributeError if bad attribute
     """
     return functools.reduce(getattr, name.split("."), obj)
+
+
+class timed(object):
+    def __enter__(self):
+        self.start = timeit.default_timer()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end = timeit.default_timer()
+        self.elapsed = self.end - self.start
+        return self.elapsed
 
 
 # work around https://github.com/pytorch/pytorch/issues/11829


### PR DESCRIPTION
This adds a few utilities to profile JIT compilation time for SVI given user reports that this has increased substantially between `torch==1.0.0` and `torch==1.1.0`. I am using @fritzo's `profiler.hmm` script for this.

 - Added a `timed` context manager, and modified the `optional` context manager so as to allow for usage like `with optional(timed, True) as t` (previous implementation would return None for `t`).
 - The `ops.jit.CompiledFunction` takes in a `time_compilation=False` arg, which when set to `True` times the compilation and sets the `compile_time` attribute. This can be set to True by passing `time_compilation=True` to the `jit_options` kwarg to `ELBO`.
 - The `profiler/hmm.py` script reads this compilation time from the dumped output when run with the `--jit` option.

**Output**

**PyTorch nightly** 

| Min (sec) | Mean (sec) | Max (sec) | python -O examples/hmm.py ... |
| -: | -: | -: | - |
| 16.9 | 17.3 | 18.2 | --model=4 --num-steps=50 |
| 39.1 | 40.1 | 42.7 | --model=4 --num-steps=50 --jit --time-compilation |
| 14.4 | 15.3 | 15.6 | --model=4 --num-steps=50 --jit --time-compilation (compilation time) |

**PyTorch 1.0.0**

| Min (sec) | Mean (sec) | Max (sec) | python -O examples/hmm.py ... |
| -: | -: | -: | - |
| 15.7 | 16.1 | 17.5 | --model=4 --num-steps=50 |
| 30.1 | 30.7 | 32.7 | --model=4 --num-steps=50 --jit --time-compilation |
| 13.0 | 13.2 | 14.6 | --model=4 --num-steps=50 --jit --time-compilation (compilation time) |

Compilation time on `torch==1.1.0` is quite high, and I didn't profile that. While it seems to be much improved in the nightly build, the execution time is actually slower than `1.0.0`.
