### PR TITLE
Implement Gaussian ops

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -56,6 +56,15 @@ Tensor Contraction
 
 .. autofunction:: pyro.ops.contract.ubersum
 
+Gaussian Contraction
+--------------------
+
+.. automodule:: pyro.ops.gaussian
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 Statistical Utilities
 ---------------------
 

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -63,6 +63,7 @@ def gaussian_contract_base(yz, xy, nx):
     #          inv(Px.bb) + inv(Py.bb))
     # Cp(a)q(c) = ...
     # It seems complicated to represent in terms of N((a, c); mz.a, mz.c, ...)
+    # We might follow Proposition 8, https://arxiv.org/abs/1905.13002 here.
     ny = xy.size(-1) - nx
     Ayz, byz, Cyz, etayz, Jyz = mean_precision_to_filtering_parameters(yz.mean, yz.precision, ny)
     Axy, bxy, Cxy, etaxy, Jxy = mean_precision_to_filtering_parameters(xy.mean, xy.precision, nx)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -91,7 +91,7 @@ def mean_precision_to_filtering_parameters(mean, precision, nx):
     :param precision: precision of Gaussian
     :param nx: size of x
     """
-    # TODO: explore precision_tril alternative
+    # TODO: explore prec_factor alternative to resolve rank deficient problem
     # TODO: use ellipsis for batching
     mx, mz = mean[:i], mean[i:]
     Pxx, Pxz, Pzx, Pzz = precision[:i, :i], precision[:i, i:], precision[i:, :i], precision[i:, i:]

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -1,0 +1,74 @@
+import torch
+
+from pyro.distributions.util import broadcast_shape
+
+
+class Gaussian(object):
+    """
+    Non-normalized Gaussian distribution.
+
+    This represents an arbitrary semidefinite quadratic function, which can be
+    interpreted as a rank-deficient scaled Gaussian distribution. The precision
+    matrix may have zero eigenvalues, thus it may be impossible to work
+    directly with the covariance matrix.
+
+    TODO(fehiepsi) Possibly change precision to another more numerically stable
+    representation.
+    """
+    def __init__(self, log_normalizer, mean, precision):
+        assert mean.dim() >= 1
+        assert precision.dim() >= 2
+        assert precision.shape[-2:] == mean.shape[-1:] * 2
+        self.log_normalizer = log_normalizer
+        self.mean = mean
+        self.precision = precision
+
+    def dim(self):
+        return self.mean.size(-1)
+
+    @property
+    def batch_shape(self):
+        return broadcast_shape(self.log_normalizer.shape,
+                               self.mean.shape[:-1],
+                               self.precision.shape[:-2])
+
+    def log_density(self, value):
+        """
+        Evaluate the log density of this Gaussian at a point value.
+        This is mainly used for testing.
+        """
+        diff = value - self.mean
+        result = torch.matmul(diff.unsqueeze(-2), self.precision)
+        result = torch.matmul(result, diff.unsqueeze(-1))
+        return result.sum(-1).sum(-1) + self.log_normalizer
+
+
+def gaussian_contract(equation, x, y):
+    """
+    Compute the integral over two gaussians:
+
+        (x @ y)(a,c) = log(integral(exp(x(a,b) + y(b,c)), c))
+
+    where x is a gaussian over variables a,b, y is a gaussian over variables
+    b,c, and a,b,c can each be sets of zero or more variables.
+    """
+    assert isinstance(x, Gaussian)
+    assert isinstance(y, Gaussian)
+    inputs, output = equation.split("->")
+    x_input, y_input = inputs.split(",")
+    assert set(output) <= set(x_input + y_input)
+    assert len(x_input) == x.dim()
+    assert len(y_input) == y.dim()
+
+    # TODO(fehiepsi) Compute fused gaussian.
+    raise NotImplementedError("TODO")
+    result = "TODO"
+
+    # Sketch of precision computation:
+    # full_precision = (x.precision.pad(...) + y.precision.pad(...))
+    # full_cov = torch.inv(full_precision)
+    # cov = full_cov[selected_indices, selected_indices]
+    # precision = torch.inv(cov)
+
+    assert len(output) == result.dim()
+    return result

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -14,9 +14,6 @@ class Gaussian(object):
     interpreted as a rank-deficient scaled Gaussian distribution. The precision
     matrix may have zero eigenvalues, thus it may be impossible to work
     directly with the covariance matrix.
-
-    TODO(fehiepsi) Possibly change precision to another more numerically stable
-    representation.
     """
     def __init__(self, log_normalizer, info_vec, precision):
         # NB: using info_vec instead of mean to deal with rank-deficient problem
@@ -99,34 +96,3 @@ def gaussian_tensordot(x, y, dims=0):
         log_normalizer = log_normalizer + diff
 
     return Gaussian(log_normalizer, info_vec, precision)
-
-
-def gaussian_contract(equation, x, y):
-    """
-    Compute the integral over two gaussians:
-
-        (x @ y)(a,c) = log(integral(exp(x(a,b) + y(b,c)), b))
-
-    where x is a gaussian over variables a,b, y is a gaussian over variables
-    b,c, and a,b,c can each be sets of zero or more variables.
-    """
-    assert isinstance(x, Gaussian)
-    assert isinstance(y, Gaussian)
-    inputs, output = equation.split("->")
-    x_input, y_input = inputs.split(",")
-    assert set(output) <= set(x_input + y_input)
-    assert len(x_input) == x.dim()
-    assert len(y_input) == y.dim()
-
-    # TODO(fehiepsi) Compute fused gaussian.
-    raise NotImplementedError("TODO")
-    result = "TODO"
-
-    # Sketch of precision computation:
-    # full_precision = (x.precision.pad(...) + y.precision.pad(...))
-    # full_cov = torch.inv(full_precision)
-    # cov = full_cov[selected_indices, selected_indices]
-    # precision = torch.inv(cov)
-
-    assert len(output) == result.dim()
-    return result

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -14,6 +14,13 @@ class Gaussian(object):
     interpreted as a rank-deficient scaled Gaussian distribution. The precision
     matrix may have zero eigenvalues, thus it may be impossible to work
     directly with the covariance matrix.
+
+    :param torch.Tensor log_normalizer: a normalization constant, which is mainly used to keep
+        track of normalization terms during contractions.
+    :param torch.Tensor info_vec: information vector, which is a scaled version of the mean
+        ``info_vec = precision @ mean``. We use this represention to make gaussian contraction
+        fast and stable.
+    :param torch.Tensor precision: precision matrix of this gaussian.
     """
     def __init__(self, log_normalizer, info_vec, precision):
         # NB: using info_vec instead of mean to deal with rank-deficient problem
@@ -36,6 +43,9 @@ class Gaussian(object):
     def log_density(self, value):
         """
         Evaluate the log density of this Gaussian at a point value.
+
+            `-0.5 * value.T @ precision @ value + value.T @ info_vec + log_normalizer`
+
         This is mainly used for testing.
         """
         if value.size(-1) == 0:
@@ -51,7 +61,7 @@ def gaussian_tensordot(x, y, dims=0):
     """
     Computes the integral over two gaussians:
 
-        (x @ y)(a,c) = log(integral(exp(x(a,b) + y(b,c)), b)),
+        `(x @ y)(a,c) = log(integral(exp(x(a,b) + y(b,c)), b))`,
 
     where `x` is a gaussian over variables (a,b), `y` is a gaussian over variables
     (b,c), (a,b,c) can each be sets of zero or more variables, and `dims` is the size of b.

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -79,7 +79,7 @@ def test_gaussian_tensordot(dot_dims,
 
     # Assume a = c = 0, integrate out b
     # FIXME: this might be not a stable way to compute integral
-    num_samples = 200000
+    num_samples = 300000
     scale = 20
     # generate samples in [-10, 10]
     value_b = torch.rand((num_samples,) + z.batch_shape + (nb,)) * scale - scale / 2

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -79,7 +79,7 @@ def test_gaussian_tensordot(dot_dims,
 
     # Assume a = c = 0, integrate out b
     # FIXME: this might be not a stable way to compute integral
-    num_samples = 300000
+    num_samples = 200000
     scale = 20
     # generate samples in [-10, 10]
     value_b = torch.rand((num_samples,) + z.batch_shape + (nb,)) * scale - scale / 2
@@ -88,4 +88,6 @@ def test_gaussian_tensordot(dot_dims,
     expect = torch.logsumexp(x.log_density(value_x) + y.log_density(value_y), dim=0)
     expect += math.log(scale ** nb / num_samples)
     actual = z.log_density(torch.zeros(z.batch_shape + (z.dim(),)))
-    assert_close(actual, expect, atol=0.1, rtol=0.1)
+    # TODO(fehiepsi): find some condition to make this test stable, so we can compare large value
+    # log densities.
+    assert_close(actual.clamp(max=10.), expect.clamp(max=10.), atol=0.1, rtol=0.1)

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -1,7 +1,9 @@
 import pytest
 import torch
+from torch.nn.functional import pad
 
-from pyro.ops.gaussian import Gaussian, gaussian_contract
+from pyro.ops.gaussian import Gaussian, gaussian_contract, gaussian_tensordot
+from tests.common import assert_close
 
 
 def random_gaussian(batch_shape, dim, rank):
@@ -9,13 +11,71 @@ def random_gaussian(batch_shape, dim, rank):
     Generate a random Gaussian for testing.
     """
     log_normalizer = torch.randn(batch_shape)
-    mean = torch.randn(batch_shape + (dim,))
+    info_vec = torch.randn(batch_shape + (dim,))
+    rank = min(dim, rank)
     samples = torch.randn(batch_shape + (dim, rank))
-    precision = torch.matmul(samples, samples.transpose(-1, -1))
-    result = Gaussian(log_normalizer, mean, precision)
+    precision = torch.matmul(samples, samples.transpose(-2, -1))
+    result = Gaussian(log_normalizer, info_vec, precision)
     assert result.dim() == dim
     assert result.batch_shape == batch_shape
     return result
+
+
+@pytest.mark.parametrize("x_batch_shape,y_batch_shape", [
+    ((), ()),
+    ((3,), ()),
+    ((), (3,)),
+    ((2, 1), (3,)),
+    ((2, 3), (2, 3,)),
+], ids=str)
+@pytest.mark.parametrize("x_dim,y_dim,dot_dims", [
+    (0, 0, 0),
+    (0, 2, 0),
+    (1, 0, 0),
+    (2, 1, 0),
+    (3, 3, 3),
+    (3, 2, 1),
+    (3, 2, 2),
+    (5, 4, 2),
+], ids=str)
+@pytest.mark.parametrize("x_rank,y_rank", [
+    (1, 1), (4, 1), (1, 4), (4, 4)
+], ids=str)
+def test_gaussian_tensordot(dot_dims,
+                            x_batch_shape, x_dim, x_rank,
+                            y_batch_shape, y_dim, y_rank):
+    x = random_gaussian(x_batch_shape, x_dim, x_rank)
+    y = random_gaussian(y_batch_shape, y_dim, y_rank)
+    na = x_dim - dot_dims
+    nb = dot_dims
+    nc = y_dim - dot_dims
+    try:
+        torch.cholesky(x.precision[..., na:, na:] + y.precision[..., :nb, :nb])
+    except RuntimeError:
+        pytest.skip("Cannot marginalize the common variables of two Gaussians.")
+
+    z = gaussian_tensordot(x, y, dot_dims)
+    assert z.dim() == x_dim + y_dim - 2 * dot_dims
+
+    # We make these precision matrices positive definite to test the math
+    x.precision = x.precision + 1e-4 * torch.eye(x.dim())
+    y.precision = y.precision + 1e-4 * torch.eye(y.dim())
+    z = gaussian_tensordot(x, y, dot_dims)
+    # compare against broadcasting, adding, and marginalizing
+    precision = pad(x.precision, (0, nc, 0, nc)) + pad(y.precision, (na, 0, na, 0))
+    info_vec = pad(x.info_vec, (0, nc)) + pad(y.info_vec, (na, 0))
+    covariance = torch.inverse(precision)
+    loc = covariance.matmul(info_vec.unsqueeze(-1)).squeeze(-1) if info_vec.size(-1) > 0 else info_vec
+    z_covariance = torch.inverse(z.precision)
+    z_loc = z_covariance.matmul(z.info_vec.view(z.info_vec.shape + (int(z.dim() > 0),))).sum(-1)
+    assert_close(loc[..., :na], z_loc[..., :na])
+    assert_close(loc[..., x_dim:], z_loc[..., na:])
+    assert_close(covariance[..., :na, :na], z_covariance[..., :na, :na])
+    assert_close(covariance[..., :na, x_dim:], z_covariance[..., :na, na:])
+    assert_close(covariance[..., x_dim:, :na], z_covariance[..., na:, :na])
+    assert_close(covariance[..., x_dim:, x_dim:], z_covariance[..., na:, na:])
+
+    # FIXME: add test for log_normalizer
 
 
 @pytest.mark.parametrize("x_batch_shape,y_batch_shape", [

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from torch.nn.functional import pad
 
-from pyro.ops.gaussian import Gaussian, gaussian_contract, gaussian_tensordot
+from pyro.ops.gaussian import Gaussian, gaussian_tensordot
 from tests.common import assert_close
 
 
@@ -89,35 +89,3 @@ def test_gaussian_tensordot(dot_dims,
     expect += math.log(scale ** nb / num_samples)
     actual = z.log_density(torch.zeros(z.batch_shape + (z.dim(),)))
     assert_close(actual, expect, atol=0.1, rtol=0.1)
-
-
-@pytest.mark.parametrize("x_batch_shape,y_batch_shape", [
-    ((), ()),
-    ((3,), ()),
-    ((), (3,)),
-    ((2, 1), (3,)),
-    ((2, 3), (2, 3,)),
-], ids=str)
-@pytest.mark.parametrize("equation", [
-    "a,ab->b",
-    "a,abc->bc",
-    "ab,abc->c",
-    "ac,abcd->bd",
-    "ab,bc->ac",
-    "abc,bcd->ad",
-    "abcde,bdfgh->bd",
-])
-@pytest.mark.parametrize("x_rank,y_rank", [
-    (1, 1), (4, 1), (1, 4), (4, 4)
-], ids=str)
-def test_gaussian_contract(equation,
-                           x_batch_shape, x_rank,
-                           y_batch_shape, y_rank):
-    inputs, output = equation.split("->")
-    x_input, y_input = inputs.split(",")
-    x = random_gaussian(x_batch_shape, len(x_input), x_rank)
-    y = random_gaussian(y_batch_shape, len(y_input), y_rank)
-
-    gaussian_contract(equation, x, y)
-    # TODO(fehiepsi) Design a test for this.
-    # One thing we could do is test against funsor in case that is installed.

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+from pyro.ops.gaussian import Gaussian, gaussian_contract
+
+
+def random_gaussian(batch_shape, dim, rank):
+    """
+    Generate a random Gaussian for testing.
+    """
+    log_normalizer = torch.randn(batch_shape)
+    mean = torch.randn(batch_shape + (dim,))
+    samples = torch.randn(batch_shape + (dim, rank))
+    precision = torch.matmul(samples, samples.transpose(-1, -1))
+    result = Gaussian(log_normalizer, mean, precision)
+    assert result.dim() == dim
+    assert result.batch_shape == batch_shape
+    return result
+
+
+@pytest.mark.parametrize("x_batch_shape,y_batch_shape", [
+    ((), ()),
+    ((3,), ()),
+    ((), (3,)),
+    ((2, 1), (3,)),
+    ((2, 3), (2, 3,)),
+], ids=str)
+@pytest.mark.parametrize("equation", [
+    "a,ab->b",
+    "a,abc->bc",
+    "ab,abc->c",
+    "ac,abcd->bd",
+    "ab,bc->ac",
+    "abc,bcd->ad",
+    "abcde,bdfgh->bd",
+])
+@pytest.mark.parametrize("x_rank,y_rank", [
+    (1, 1), (4, 1), (1, 4), (4, 4)
+], ids=str)
+def test_gaussian_contract(equation,
+                           x_batch_shape, x_rank,
+                           y_batch_shape, y_rank):
+    inputs, output = equation.split("->")
+    x_input, y_input = inputs.split(",")
+    x = random_gaussian(x_batch_shape, len(x_input), x_rank)
+    y = random_gaussian(y_batch_shape, len(y_input), y_rank)
+
+    gaussian_contract(equation, x, y)
+    # TODO(fehiepsi) Design a test for this.
+    # One thing we could do is test against funsor in case that is installed.


### PR DESCRIPTION
This PR implements Gaussian ops as suggested in https://github.com/pyro-ppl/pyro/issues/1970.

The trickiest part is to deal with rank-deficient precision matrix. I have tried considering various representatives of Gaussian but most of them involve taking inverse of precision matrices. My solution is to use canonical representation as in [information filter](https://en.wikipedia.org/wiki/Kalman_filter#Information_filter). To integrate out joined variables, the condition is the precision matrix part restricted on those variables has to be positive definite.

Alternative, we can follow [Sarrka & Garcia-Fernandez](https://arxiv.org/pdf/1905.13002.pdf) but their methods do not keep track of `log_normalizer` term. Instead, they use an additional parallel scan pass, which seems do not applicable outside bayesian filtering context.

TODO:
- [x] implement gaussian tensordot
- ~[ ] generate gaussian tensordot for general contraction~ defer to later PRs
- [x] test gaussian tensordot
- ~[ ] test gaussian contract~ defer to later PRs