### PR TITLE
Implement GaussianMRF distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -98,9 +98,9 @@ GammaPoisson
     :undoc-members:
     :show-inheritance:
 
-GaussianMRF
+GaussianGaussianMRF
 --------------------
-.. autoclass:: pyro.distributions.GaussianMRF
+.. autoclass:: pyro.distributions.GaussianGaussianMRF
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -98,6 +98,13 @@ GammaPoisson
     :undoc-members:
     :show-inheritance:
 
+GaussianMRF
+--------------------
+.. autoclass:: pyro.distributions.GaussianMRF
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 GaussianScaleMixture
 ------------------------------------
 .. autoclass:: pyro.distributions.GaussianScaleMixture

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -98,9 +98,9 @@ GammaPoisson
     :undoc-members:
     :show-inheritance:
 
-GaussianGaussianMRF
+GaussianMRF
 --------------------
-.. autoclass:: pyro.distributions.GaussianGaussianMRF
+.. autoclass:: pyro.distributions.GaussianMRF
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -64,6 +64,7 @@ Gaussian Contraction
     :undoc-members:
     :show-inheritance:
     :member-order: bysource
+    :special-members: __add__,__getitem__
 
 Statistical Utilities
 ---------------------

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -7,7 +7,7 @@ from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNorma
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
-from pyro.distributions.hmm import DiscreteHMM
+from pyro.distributions.hmm import DiscreteHMM, GaussianMRF
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
@@ -35,6 +35,7 @@ __all__ = [
     "Distribution",
     "Empirical",
     "GammaPoisson",
+    "GaussianMRF",
     "GaussianScaleMixture",
     "InverseGamma",
     "LKJCorrCholesky",

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -7,7 +7,7 @@ from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNorma
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
-from pyro.distributions.hmm import DiscreteHMM, GaussianMRF
+from pyro.distributions.hmm import DiscreteHMM, GaussianGaussianMRF
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
@@ -35,7 +35,7 @@ __all__ = [
     "Distribution",
     "Empirical",
     "GammaPoisson",
-    "GaussianMRF",
+    "GaussianGaussianMRF",
     "GaussianScaleMixture",
     "InverseGamma",
     "LKJCorrCholesky",

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -7,7 +7,7 @@ from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNorma
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
-from pyro.distributions.hmm import DiscreteHMM, GaussianGaussianMRF
+from pyro.distributions.hmm import DiscreteHMM, GaussianMRF
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
@@ -35,7 +35,7 @@ __all__ = [
     "Distribution",
     "Empirical",
     "GammaPoisson",
-    "GaussianGaussianMRF",
+    "GaussianMRF",
     "GaussianScaleMixture",
     "InverseGamma",
     "LKJCorrCholesky",

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -46,8 +46,9 @@ def _sequential_gaussian_tensordot(gaussian):
         x[..., 0] @ x[..., 1] @ ... @ x[..., T-1]
     """
     assert isinstance(gaussian, Gaussian)
+    assert gaussian.dim() % 2 == 0, "dim is not even"
     batch_shape = gaussian.batch_shape[:-1]
-    state_dim = gaussian.precision.size(-1) // 2
+    state_dim = gaussian.dim() // 2
     while gaussian.batch_shape[-1] > 1:
         time = gaussian.batch_shape[-1]
         even_time = time // 2 * 2
@@ -199,7 +200,7 @@ class GaussianMRF(TorchDistribution):
         assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
         assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
         hidden_dim = initial_dist.event_shape[0]
-        assert transition_dist.event_shape[0] == (hidden_dim, hidden_dim)
+        assert transition_dist.event_shape[0] == hidden_dim + hidden_dim
         obs_dim = observation_dist.event_shape[0] - hidden_dim
 
         shape = broadcast_shape(initial_dist.batch_shape + (1,),

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -155,7 +155,7 @@ class DiscreteHMM(TorchDistribution):
         return result
 
 
-class GaussianGaussianMRF(TorchDistribution):
+class GaussianMRF(TorchDistribution):
     """
     Temporal Markov Random Field with Gaussian factors for initial, transition,
     and observation distributions. This adapts [1] to parallelize over time to
@@ -210,7 +210,7 @@ class GaussianGaussianMRF(TorchDistribution):
                                 observation_dist.batch_shape)
         batch_shape, time_shape = shape[:-1], shape[-1:]
         event_shape = time_shape + (obs_dim,)
-        super(GaussianGaussianMRF, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super(GaussianMRF, self).__init__(batch_shape, event_shape, validate_args=validate_args)
         self.hidden_dim = hidden_dim
         self.obs_dim = obs_dim
         self._init = mvn_to_gaussian(initial_dist)
@@ -218,7 +218,7 @@ class GaussianGaussianMRF(TorchDistribution):
         self._obs = mvn_to_gaussian(observation_dist)
 
     def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(GaussianGaussianMRF, _instance)
+        new = self._get_checked_instance(GaussianMRF, _instance)
         batch_shape = torch.Size(broadcast_shape(self.batch_shape, batch_shape))
         # We only need to expand one of the inputs, since batch_shape is determined
         # by broadcasting all three. To save computation in _sequential_gaussian_tensordot(),
@@ -226,7 +226,7 @@ class GaussianGaussianMRF(TorchDistribution):
         new._init = self._init.expand(batch_shape)
         new._trans = self._trans
         new._obs = self._obs
-        super(GaussianGaussianMRF, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        super(GaussianMRF, new).__init__(batch_shape, self.event_shape, validate_args=False)
         new.validate_args = self.__dict__.get('_validate_args')
         return new
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -155,7 +155,7 @@ class DiscreteHMM(TorchDistribution):
         return result
 
 
-class GaussianMRF(TorchDistribution):
+class GaussianGaussianMRF(TorchDistribution):
     """
     Temporal Markov Random Field with Gaussian factors for initial, transition,
     and observation distributions. This adapts [1] to parallelize over time to
@@ -210,7 +210,7 @@ class GaussianMRF(TorchDistribution):
                                 observation_dist.batch_shape)
         batch_shape, time_shape = shape[:-1], shape[-1:]
         event_shape = time_shape + (obs_dim,)
-        super(GaussianMRF, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        super(GaussianGaussianMRF, self).__init__(batch_shape, event_shape, validate_args=validate_args)
         self.hidden_dim = hidden_dim
         self.obs_dim = obs_dim
         self._init = mvn_to_gaussian(initial_dist)
@@ -218,7 +218,7 @@ class GaussianMRF(TorchDistribution):
         self._obs = mvn_to_gaussian(observation_dist)
 
     def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(GaussianMRF, _instance)
+        new = self._get_checked_instance(GaussianGaussianMRF, _instance)
         batch_shape = torch.Size(broadcast_shape(self.batch_shape, batch_shape))
         # We only need to expand one of the inputs, since batch_shape is determined
         # by broadcasting all three. To save computation in _sequential_gaussian_tensordot(),
@@ -226,7 +226,7 @@ class GaussianMRF(TorchDistribution):
         new._init = self._init.expand(batch_shape)
         new._trans = self._trans
         new._obs = self._obs
-        super(GaussianMRF, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        super(GaussianGaussianMRF, new).__init__(batch_shape, self.event_shape, validate_args=False)
         new.validate_args = self.__dict__.get('_validate_args')
         return new
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -237,8 +237,7 @@ class GaussianGaussianMRF(TorchDistribution):
 
         # Combine observation and transition factors.
         logp_oh += self._obs.condition(value).event_pad(left=self.hidden_dim)
-        logp_h += self._obs.marginalize(slice(self.hidden_dim)) \
-                           .event_pad(left=self.hidden_dim)
+        logp_h += self._obs.marginalize(right=self.obs_dim).event_pad(left=self.hidden_dim)
 
         # Concatenate p(obs,hidden) and p(hidden) into a single Gaussian.
         batch_shape = (1,) + logp_oh.batch_shape

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -233,7 +233,7 @@ class GaussianMRF(TorchDistribution):
     def log_prob(self, value):
         # Combine observation and transition factors.
         result = self._trans
-        result += self._obs.condition(value).pad(left=self.hidden_dim)
+        result += self._obs.condition(value).event_pad(left=self.hidden_dim)
 
         # Eliminate time dimension.
         result = result.expand(result.batch_shape)  # required by later .reshape()s
@@ -243,5 +243,5 @@ class GaussianMRF(TorchDistribution):
         result = gaussian_tensordot(self._init, result, dims=self.hidden_dim)
 
         # Marginalize out final state.
-        result = result.logsumexp()
+        result = result.event_logsumexp()
         return result

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -236,6 +236,7 @@ class GaussianMRF(TorchDistribution):
         result += self._obs.condition(value).pad(left=self.hidden_dim)
 
         # Eliminate time dimension.
+        result = result.expand(result.batch_shape)  # required by later .reshape()s
         result = _sequential_gaussian_tensordot(result)
 
         # Combine initial factor.

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -239,7 +239,7 @@ class GaussianMRF(TorchDistribution):
         result = _sequential_gaussian_tensordot(result)
 
         # Combine initial factor.
-        result += self._init.pad(right=self.hidden_dim)
+        result = gaussian_tensordot(self._init, result, dims=self.hidden_dim)
 
         # Marginalize out final state.
         result = result.logsumexp()

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -73,6 +73,22 @@ class Gaussian(object):
                 for attr in ["log_normalizer", "info_vec", "precision"]]
         return Gaussian(*args)
 
+    def pad(self, left=0, right=0):
+        """
+        Pad along event dimension.
+        """
+        lr = (left, right)
+        log_normalizer = self.log_normalizer
+        info_vec = pad(self.info_vec, lr)
+        precision = pad(self.precision, lr + lr)
+        return Gaussian(log_normalizer, info_vec, precision)
+
+    def __add__(self, other):
+        assert self.dim() == other.dim()
+        return Gaussian(self.log_normalizer + other.log_normalizer,
+                        self.info_vec + other.info_vec,
+                        self.precision + other.precision)
+
     def log_density(self, value):
         """
         Evaluate the log density of this Gaussian at a point value.
@@ -179,6 +195,4 @@ def gaussian_tensordot(x, y, dims=0):
         diff = 0.5 * nb * math.log(2 * math.pi) + 0.5 * Linvb.squeeze(-1).pow(2).sum(-1) - logdet
         log_normalizer = log_normalizer + diff
 
-    result = Gaussian(log_normalizer, info_vec, precision)
-    assert result.dim() == x.dim() + y.dim() - 2 * dims
-    return result
+    return Gaussian(log_normalizer, info_vec, precision)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -180,5 +180,5 @@ def gaussian_tensordot(x, y, dims=0):
         log_normalizer = log_normalizer + diff
 
     result = Gaussian(log_normalizer, info_vec, precision)
-    assert result.dim() == x.dim() + y.dim() - dims
+    assert result.dim() == x.dim() + y.dim() - 2 * dims
     return result

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -179,4 +179,6 @@ def gaussian_tensordot(x, y, dims=0):
         diff = 0.5 * nb * math.log(2 * math.pi) + 0.5 * Linvb.squeeze(-1).pow(2).sum(-1) - logdet
         log_normalizer = log_normalizer + diff
 
-    return Gaussian(log_normalizer, info_vec, precision)
+    result = Gaussian(log_normalizer, info_vec, precision)
+    assert result.dim() == x.dim() + y.dim() - dims
+    return result

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -191,7 +191,8 @@ class Gaussian(object):
 
         log_normalizer = (self.log_normalizer +
                           0.5 * n_b * math.log(2 * math.pi) -
-                          P_b.diagonal(dim1=-2, dim2=-1).log().sum(-1))
+                          P_b.diagonal(dim1=-2, dim2=-1).log().sum(-1) +
+                          0.5 * b_tmp.squeeze(-1).pow(2).sum(-1))
         return Gaussian(log_normalizer, info_vec, precision)
 
     def event_logsumexp(self):

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -56,6 +56,9 @@ class Gaussian(object):
         return Gaussian(log_normalizer, info_vec, precision)
 
     def __getitem__(self, index):
+        """
+        Index into the batch_shape of a Gaussian.
+        """
         assert isinstance(index, tuple)
         log_normalizer = self.log_normalizer[index]
         info_vec = self.info_vec[index + (slice(None),)]
@@ -84,6 +87,9 @@ class Gaussian(object):
         return Gaussian(log_normalizer, info_vec, precision)
 
     def __add__(self, other):
+        """
+        Adds two Gaussians in log-density space.
+        """
         assert self.dim() == other.dim()
         return Gaussian(self.log_normalizer + other.log_normalizer,
                         self.info_vec + other.info_vec,
@@ -136,7 +142,7 @@ def mvn_to_gaussian(mvn):
 
     :param ~torch.distributions.MultivariateNormal mvn: A multivariate normal distribution.
     :return: An equivalent Gaussian object.
-    :rtype: Gaussian
+    :rtype: ~pyro.ops.gaussian.Gaussian
     """
     assert isinstance(mvn, torch.distributions.MultivariateNormal)
     n = mvn.loc.size(-1)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -42,14 +42,14 @@ class Gaussian(object):
                                self.precision.shape[:-2])
 
     def expand(self, batch_shape):
-        n = self.info_vec.size(-1)
+        n = self.dim()
         log_normalizer = self.log_normalizer.expand(batch_shape)
         info_vec = self.info_vec.expand(batch_shape + (n,))
         precision = self.precision.expand(batch_shape + (n, n))
         return Gaussian(log_normalizer, info_vec, precision)
 
     def reshape(self, batch_shape):
-        n = self.info_vec.size(-1)
+        n = self.dim()
         log_normalizer = self.log_normalizer.reshape(batch_shape)
         info_vec = self.info_vec.reshape(batch_shape + (n,))
         precision = self.precision.reshape(batch_shape + (n, n))
@@ -180,8 +180,8 @@ def mvn_to_gaussian(mvn):
     precision = mvn.precision_matrix
     info_vec = precision.matmul(mvn.loc.unsqueeze(-1)).squeeze(-1)
     log_normalizer = (-0.5 * n * math.log(2 * math.pi) +
-                      -0.5 * (info_vec * mvn.loc).sum(-1) +
-                      precision.cholesky().diagonal(dim1=-2, dim2=-1).log().sum(-1))
+                      -0.5 * (info_vec * mvn.loc).sum(-1) -
+                      mvn.scale_tril.diagonal(dim1=-2, dim2=-1).log().sum(-1))
     return Gaussian(log_normalizer, info_vec, precision)
 
 

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -127,7 +127,15 @@ class Gaussian(object):
         Condition this Gaussian on a trailing subset of its state.
         This should satisfy::
 
-            x.condition(y).dim() == x.dim() - y.size(-1)
+            g.condition(y).dim() == g.dim() - y.size(-1)
+
+        Note that since this is a non-normalized Gaussian, we include the
+        density of ``y`` in the result. Thus :meth:`condition` is similar to a
+        ``functools.partial`` binding of arguments::
+
+            left = x[..., :n]
+            right = x[..., n:]
+            g.log_density(x) == g.condition(right).log_density(left)
         """
         assert isinstance(value, torch.Tensor)
         assert value.size(-1) <= self.info_vec.size(-1)

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -267,7 +267,7 @@ def test_gaussian_mrf_log_prob(sample_shape, batch_shape, num_steps, hidden_dim,
     assert unrolled_obs.dim() == T * (hidden_dim + obs_dim)
     logp_h = gaussian_tensordot(init, unrolled_trans, hidden_dim)
     logp_oh = gaussian_tensordot(logp_h, unrolled_obs, T * hidden_dim)
-    logp_h += unrolled_obs.marginalize(slice(T * hidden_dim))
+    logp_h += unrolled_obs.marginalize(right=T * obs_dim)
     expected_log_prob = logp_oh.log_density(unrolled_data) - logp_h.event_logsumexp()
     assert_close(actual_log_prob, expected_log_prob)
 

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -1,3 +1,6 @@
+import operator
+from functools import reduce
+
 import opt_einsum
 import pytest
 import torch
@@ -7,7 +10,7 @@ import pyro.distributions as dist
 from pyro.distributions.hmm import _sequential_gaussian_tensordot, _sequential_logmatmulexp
 from pyro.distributions.util import broadcast_shape
 from pyro.infer import TraceEnum_ELBO, config_enumerate
-from pyro.ops.gaussian import gaussian_tensordot
+from pyro.ops.gaussian import gaussian_tensordot, mvn_to_gaussian
 from pyro.ops.indexing import Vindex
 from tests.common import assert_close
 from tests.ops.gaussian import assert_close_gaussian, random_gaussian, random_mvn
@@ -216,3 +219,47 @@ def test_gaussian_mrf_shape(init_shape, trans_shape, obs_shape, hidden_dim, obs_
     assert data.shape == d.shape()
     actual = d.log_prob(data)
     assert actual.shape == expected_batch_shape
+
+
+@pytest.mark.parametrize('sample_shape', [(), (5,)], ids=str)
+@pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize('obs_dim', [1, 2])
+@pytest.mark.parametrize('hidden_dim', [1, 2])
+@pytest.mark.parametrize('num_steps', [1, 2, 3, 4])
+def test_gaussian_mrf_log_prob(sample_shape, batch_shape, num_steps, hidden_dim, obs_dim):
+    init_dist = random_mvn(batch_shape, hidden_dim)
+    trans_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + hidden_dim)
+    obs_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + obs_dim)
+    d = dist.GaussianMRF(init_dist, trans_dist, obs_dist)
+    data = obs_dist.sample(sample_shape)[..., hidden_dim:]
+    assert data.shape == sample_shape + d.shape()
+    actual_log_prob = d.log_prob(data)
+
+    # Compare against hand-computed density.
+    # We will construct enormous unrolled joint gaussians.
+    T = num_steps
+    init = mvn_to_gaussian(init_dist)
+    trans = mvn_to_gaussian(trans_dist)
+    obs = mvn_to_gaussian(obs_dist)
+
+    unrolled_trans = reduce(operator.add, [
+        trans[..., t].event_pad(left=t * hidden_dim, right=(T - t - 1) * hidden_dim)
+        for t in range(T)
+    ])
+    unrolled_obs = reduce(operator.add, [
+        obs[..., t].event_pad(left=t * obs.dim(), right=(T - t - 1) * obs.dim())
+        for t in range(T)
+    ])
+    # Permute from HOHOHO to HHHOOO.
+    perm = torch.cat([torch.arange(hidden_dim) + t * obs.dim() for t in range(T)] +
+                     [torch.arange(obs_dim) + hidden_dim + t * obs.dim() for t in range(T)])
+    unrolled_obs = unrolled_obs.event_permute(perm)
+    unrolled_data = data.reshape(data.shape[:-2] + (T * obs_dim,))
+
+    assert init.dim() == hidden_dim
+    assert unrolled_trans.dim() == (1 + T) * hidden_dim
+    assert unrolled_obs.dim() == T * (hidden_dim + obs_dim)
+    joint = gaussian_tensordot(init, unrolled_trans, hidden_dim)
+    joint = gaussian_tensordot(joint, unrolled_obs, T * hidden_dim)
+    expected_log_prob = joint.log_density(unrolled_data)
+    assert_close(actual_log_prob, expected_log_prob)

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -207,7 +207,7 @@ def test_gaussian_mrf_shape(init_shape, trans_shape, obs_shape, hidden_dim, obs_
     init_dist = random_mvn(init_shape, hidden_dim)
     trans_dist = random_mvn(trans_shape, hidden_dim + hidden_dim)
     obs_dist = random_mvn(obs_shape, hidden_dim + obs_dim)
-    d = dist.GaussianGaussianMRF(init_dist, trans_dist, obs_dist)
+    d = dist.GaussianMRF(init_dist, trans_dist, obs_dist)
 
     shape = broadcast_shape(init_shape + (1,), trans_shape, obs_shape)
     expected_batch_shape, time_shape = shape[:-1], shape[-1:]
@@ -230,7 +230,7 @@ def test_gaussian_mrf_log_prob(sample_shape, batch_shape, num_steps, hidden_dim,
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + hidden_dim)
     obs_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + obs_dim)
-    d = dist.GaussianGaussianMRF(init_dist, trans_dist, obs_dist)
+    d = dist.GaussianMRF(init_dist, trans_dist, obs_dist)
     data = obs_dist.sample(sample_shape)[..., hidden_dim:]
     assert data.shape == sample_shape + d.shape()
     actual_log_prob = d.log_prob(data)
@@ -290,7 +290,7 @@ def test_gaussian_mrf_log_prob_block_diag(sample_shape, batch_shape, num_steps, 
 
     init_dist = random_mvn(batch_shape, hidden_dim)
     trans_dist = random_mvn(batch_shape + (num_steps,), hidden_dim + hidden_dim)
-    d = dist.GaussianGaussianMRF(init_dist, trans_dist, obs_dist)
+    d = dist.GaussianMRF(init_dist, trans_dist, obs_dist)
     data = obs_dist.sample(sample_shape)[..., hidden_dim:]
     assert data.shape == sample_shape + d.shape()
     actual_log_prob = d.log_prob(data)

--- a/tests/ops/gaussian.py
+++ b/tests/ops/gaussian.py
@@ -1,0 +1,42 @@
+import torch
+
+import pyro.distributions as dist
+from pyro.ops.gaussian import Gaussian
+from tests.common import assert_close
+
+
+def random_gaussian(batch_shape, dim, rank=None):
+    """
+    Generate a random Gaussian for testing.
+    """
+    if rank is None:
+        rank = dim + dim
+    log_normalizer = torch.randn(batch_shape)
+    info_vec = torch.randn(batch_shape + (dim,))
+    samples = torch.randn(batch_shape + (dim, rank))
+    precision = torch.matmul(samples, samples.transpose(-2, -1))
+    result = Gaussian(log_normalizer, info_vec, precision)
+    assert result.dim() == dim
+    assert result.batch_shape == batch_shape
+    return result
+
+
+def random_mvn(batch_shape, dim):
+    """
+    Generate a random MultivariateNormal distribution for testing.
+    """
+    rank = dim + dim
+    loc = torch.randn(batch_shape + (dim,))
+    cov = torch.randn(batch_shape + (dim, rank))
+    cov = cov.matmul(cov.transpose(-1, -2))
+    return dist.MultivariateNormal(loc, cov)
+
+
+def assert_close_gaussian(actual, expected):
+    assert isinstance(actual, Gaussian)
+    assert isinstance(expected, Gaussian)
+    assert actual.dim() == expected.dim()
+    assert actual.batch_shape == expected.batch_shape
+    assert_close(actual.log_normalizer, expected.log_normalizer)
+    assert_close(actual.info_vec, expected.info_vec)
+    assert_close(actual.precision, expected.precision)

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -103,12 +103,22 @@ def test_add(shape, dim):
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])
+def test_marginalize_shape(batch_shape, left, right):
+    dim = left + right
+    g = random_gaussian(batch_shape, dim)
+    assert g.marginalize(left=left).dim() == right
+    assert g.marginalize(right=right).dim() == left
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("left", [1, 2, 3])
+@pytest.mark.parametrize("right", [1, 2, 3])
 def test_marginalize(batch_shape, left, right):
     dim = left + right
     g = random_gaussian(batch_shape, dim)
-    assert_close(g.marginalize(slice(left)).event_logsumexp(),
+    assert_close(g.marginalize(left=left).event_logsumexp(),
                  g.event_logsumexp())
-    assert_close(g.marginalize(slice(0, left)).event_logsumexp(),
+    assert_close(g.marginalize(right=right).event_logsumexp(),
                  g.event_logsumexp())
 
 
@@ -120,7 +130,7 @@ def test_marginalize_condition(sample_shape, batch_shape, left, right):
     dim = left + right
     g = random_gaussian(batch_shape, dim)
     x = torch.randn(sample_shape + (1,) * len(batch_shape) + (right,))
-    assert_close(g.marginalize(slice(left)).log_prob(x),
+    assert_close(g.marginalize(left=left).log_density(x),
                  g.condition(x).event_logsumexp())
 
 

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -83,7 +83,7 @@ def test_cat(shape, cat_dim, split, dim):
 @pytest.mark.parametrize("right", [0, 1, 2])
 def test_pad(shape, left, right, dim):
     expected = random_gaussian(shape, dim)
-    padded = expected.pad(left=left, right=right)
+    padded = expected.event_pad(left=left, right=right)
     assert padded.batch_shape == expected.batch_shape
     assert padded.dim() == left + expected.dim() + right
     mid = slice(left, padded.dim() - right)
@@ -131,7 +131,7 @@ def test_logsumexp(batch_shape, dim):
     scale = 10
     samples = torch.rand((num_samples,) + (1,) * len(batch_shape) + (dim,)) * scale - scale / 2
     expected = gaussian.log_density(samples).logsumexp(0) + math.log(scale ** dim / num_samples)
-    actual = gaussian.logsumexp()
+    actual = gaussian.event_logsumexp()
     assert_close(actual, expected, atol=0.05, rtol=0.05)
 
 

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -4,7 +4,8 @@ import pytest
 import torch
 from torch.nn.functional import pad
 
-from pyro.ops.gaussian import Gaussian, gaussian_tensordot
+from pyro.distributions.util import broadcast_shape
+from pyro.ops.gaussian import Gaussian, gaussian_tensordot, mvn_to_gaussian
 from tests.common import assert_close
 
 
@@ -21,6 +22,108 @@ def random_gaussian(batch_shape, dim, rank):
     assert result.dim() == dim
     assert result.batch_shape == batch_shape
     return result
+
+
+@pytest.mark.parametrize("extra_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("log_normalizer_shape,info_vec_shape,precision_shape", [
+    ((), (), ()),
+    ((5,), (), ()),
+    ((), (5,), ()),
+    ((), (), (5,)),
+    ((3, 1, 1), (1, 4, 1), (1, 1, 5)),
+], ids=str)
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_expand(extra_shape, log_normalizer_shape, info_vec_shape, precision_shape, dim):
+    rank = dim + dim
+    log_normalizer = torch.randn(log_normalizer_shape)
+    info_vec = torch.randn(info_vec_shape + (dim,))
+    precision = torch.randn(info_vec_shape + (dim, rank))
+    precision = precision.matmul(precision.transpose(-1, -2))
+    gaussian = Gaussian(log_normalizer, info_vec, precision)
+
+    expected_shape = extra_shape + broadcast_shape(
+        log_normalizer_shape, info_vec_shape, precision_shape)
+    actual = gaussian.expand(expected_shape)
+    assert actual.batch_shape == expected_shape
+
+
+@pytest.mark.parametrize("old_shape,new_shape", [
+    ((6,), (3, 2)),
+    ((5, 6), (5, 3, 2)),
+], ids=str)
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_reshape(old_shape, new_shape, dim):
+    gaussian = random_gaussian(old_shape, dim, rank=dim + dim)
+
+    # reshape to new
+    new = gaussian.reshape(new_shape)
+    assert new.batch_shape == new_shape
+
+    # reshape back to old
+    g = new.reshape(old_shape)
+    assert g.batch_shape == gaussian.batch_shape
+    assert_close(g.log_normalizer, gaussian.log_normalizer)
+    assert_close(g.info_vec, gaussian.info_vec)
+    assert_close(g.precision, gaussian.precision)
+
+
+@pytest.mark.parametrize("shape,cat_dim,split", [
+    ((4, 7, 6), -1, (2, 1, 3)),
+    ((4, 7, 6), -2, (1, 1, 2, 3)),
+    ((4, 7, 6), 1, (1, 1, 2, 3)),
+])
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_cat(shape, cat_dim, split, dim):
+    assert sum(split) == shape[cat_dim]
+    gaussian = random_gaussian(shape, dim, rank=dim + dim)
+    parts = []
+    end = 0
+    for size in split:
+        beg, end = end, end + size
+        if cat_dim == -1:
+            part = gaussian[..., beg: end]
+        elif cat_dim == -2:
+            part = gaussian[..., beg: end, :]
+        elif cat_dim == 1:
+            part = gaussian[:, beg: end]
+        else:
+            raise ValueError
+        parts.append(part)
+
+    actual = Gaussian.cat(parts, cat_dim)
+    assert actual.batch_shape == gaussian.batch_shape
+    assert_close(actual.log_normalizer, gaussian.log_normalizer)
+    assert_close(actual.info_vec, gaussian.info_vec)
+    assert_close(actual.precision, gaussian.precision)
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_logsumexp(batch_shape, dim):
+    gaussian = random_gaussian(batch_shape, dim, rank=dim + 1)
+    gaussian.info_vec.fill_(0)  # centered
+
+    num_samples = 10000
+    scale = 10
+    samples = torch.rand((num_samples, dim)) * scale - scale / 2
+    expected = gaussian.log_density(samples).mean() * scale ** dim
+    actual = gaussian.logsumexp()
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_mvn_to_gaussian(sample_shape, batch_shape, dim):
+    loc = torch.randn(batch_shape + (dim,))
+    cov = torch.randn(batch_shape + (dim, dim))
+    cov = torch.matmul(cov, cov.transpose(-1, -2))
+    mvn = torch.distributions.MultivariateNormal(loc, cov)
+    gaussian = mvn_to_gaussian(mvn)
+    value = mvn.sample(sample_shape)
+    actual_log_prob = gaussian.log_density(value)
+    expected_log_prob = mvn.log_prob(value)
+    assert_close(actual_log_prob, expected_log_prob)
 
 
 @pytest.mark.parametrize("x_batch_shape,y_batch_shape", [

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -124,7 +124,7 @@ def test_condition(sample_shape, batch_shape, left, right):
 @pytest.mark.parametrize("dim", [1, 2, 3])
 def test_logsumexp(batch_shape, dim):
     gaussian = random_gaussian(batch_shape, dim)
-    gaussian.info_vec.fill_(0)  # centered
+    gaussian.info_vec *= 0.1  # approximately centered
     gaussian.precision += torch.eye(dim) * 0.1
 
     num_samples = 200000

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -23,7 +23,7 @@ def test_expand(extra_shape, log_normalizer_shape, info_vec_shape, precision_sha
     rank = dim + dim
     log_normalizer = torch.randn(log_normalizer_shape)
     info_vec = torch.randn(info_vec_shape + (dim,))
-    precision = torch.randn(info_vec_shape + (dim, rank))
+    precision = torch.randn(precision_shape + (dim, rank))
     precision = precision.matmul(precision.transpose(-1, -2))
     gaussian = Gaussian(log_normalizer, info_vec, precision)
 

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -100,6 +100,30 @@ def test_add(shape, dim):
     assert_close((x + y).log_density(value), x.log_density(value) + y.log_density(value))
 
 
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("left", [1, 2, 3])
+@pytest.mark.parametrize("right", [1, 2, 3])
+def test_marginalize(batch_shape, left, right):
+    dim = left + right
+    g = random_gaussian(batch_shape, dim)
+    assert_close(g.marginalize(slice(left)).event_logsumexp(),
+                 g.event_logsumexp())
+    assert_close(g.marginalize(slice(0, left)).event_logsumexp(),
+                 g.event_logsumexp())
+
+
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("left", [1, 2, 3])
+@pytest.mark.parametrize("right", [1, 2, 3])
+def test_marginalize_condition(sample_shape, batch_shape, left, right):
+    dim = left + right
+    g = random_gaussian(batch_shape, dim)
+    x = torch.randn(sample_shape + (1,) * len(batch_shape) + (right,))
+    assert_close(g.marginalize(slice(left)).log_prob(x),
+                 g.condition(x).event_logsumexp())
+
+
 @pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -54,7 +54,7 @@ def test_reshape(old_shape, new_shape, dim):
     ((4, 7, 6), -1, (2, 1, 3)),
     ((4, 7, 6), -2, (1, 1, 2, 3)),
     ((4, 7, 6), 1, (1, 1, 2, 3)),
-])
+], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
 def test_cat(shape, cat_dim, split, dim):
     assert sum(split) == shape[cat_dim]
@@ -77,7 +77,7 @@ def test_cat(shape, cat_dim, split, dim):
     assert_close_gaussian(actual, gaussian)
 
 
-@pytest.mark.parametrize("shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
 @pytest.mark.parametrize("left", [0, 1, 2])
 @pytest.mark.parametrize("right", [0, 1, 2])
@@ -91,7 +91,7 @@ def test_pad(shape, left, right, dim):
     assert_close(padded.precision[..., mid, mid], expected.precision)
 
 
-@pytest.mark.parametrize("shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
 def test_add(shape, dim):
     x = random_gaussian(shape, dim)
@@ -100,22 +100,23 @@ def test_add(shape, dim):
     assert_close((x + y).log_density(value), x.log_density(value) + y.log_density(value))
 
 
-@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
 def test_logsumexp(batch_shape, dim):
     gaussian = random_gaussian(batch_shape, dim)
     gaussian.info_vec.fill_(0)  # centered
+    gaussian.precision += torch.eye(dim) * 0.1
 
-    num_samples = 10000
+    num_samples = 200000
     scale = 10
-    samples = torch.rand((num_samples, dim)) * scale - scale / 2
-    expected = gaussian.log_density(samples).mean() * scale ** dim
+    samples = torch.rand((num_samples,) + (1,) * len(batch_shape) + (dim,)) * scale - scale / 2
+    expected = gaussian.log_density(samples).logsumexp(0) + math.log(scale ** dim / num_samples)
     actual = gaussian.logsumexp()
-    assert_close(actual, expected)
+    assert_close(actual, expected, atol=0.05, rtol=0.05)
 
 
-@pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)])
-@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)], ids=str)
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
 def test_mvn_to_gaussian(sample_shape, batch_shape, dim):
     mvn = random_mvn(batch_shape, dim)

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -77,6 +77,29 @@ def test_cat(shape, cat_dim, split, dim):
     assert_close_gaussian(actual, gaussian)
 
 
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("dim", [1, 2, 3])
+@pytest.mark.parametrize("left", [0, 1, 2])
+@pytest.mark.parametrize("right", [0, 1, 2])
+def test_pad(shape, left, right, dim):
+    expected = random_gaussian(shape, dim)
+    padded = expected.pad(left=left, right=right)
+    assert padded.batch_shape == expected.batch_shape
+    assert padded.dim() == left + expected.dim() + right
+    mid = slice(left, padded.dim() - right)
+    assert_close(padded.info_vec[..., mid], expected.info_vec)
+    assert_close(padded.precision[..., mid, mid], expected.precision)
+
+
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_add(shape, dim):
+    x = random_gaussian(shape, dim)
+    y = random_gaussian(shape, dim)
+    value = torch.randn(dim)
+    assert_close((x + y).log_density(value), x.log_density(value) + y.log_density(value))
+
+
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)])
 @pytest.mark.parametrize("dim", [1, 2, 3])
 def test_logsumexp(batch_shape, dim):


### PR DESCRIPTION
Addresses #1970 

This implements a `GaussianMRF` that uses time-parallel filtering to compute a differentiable `.log_prob()`.

Note this Markov Random Field model involves an underlying factor graph, whereas the more standard Hidden Markov Model involves conditional normal distributions. This MRF implementation is simpler to implement than an HMM and is closer in code to the `DiscreteHMM`. In practice provides similar modeling capabilities, but requires slightly different interpretation of factors. We may add an additional `GaussianHMM` distribution in the future.

The main parts to review are: new methods of the `Gaussian` class, the `_sequential_gaussian_tensordot()` function, and the `GaussianMRF` class.

## Tested
- [x] unit tests for new `Gaussian` methods
- [x] math test for the recursive `_sequential_gaussian_tensordot()`
- [x] shape tests for `GaussianMRF`
- [x] density tests for `GaussianMRF`