### PR TITLE
Implement GaussianHMM distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -98,6 +98,13 @@ GammaPoisson
     :undoc-members:
     :show-inheritance:
 
+GaussianHMM
+--------------------
+.. autoclass:: pyro.distributions.GaussianHMM
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 GaussianMRF
 --------------------
 .. autoclass:: pyro.distributions.GaussianMRF

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -7,7 +7,7 @@ from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNorma
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
-from pyro.distributions.hmm import DiscreteHMM, GaussianMRF
+from pyro.distributions.hmm import DiscreteHMM, GaussianHMM, GaussianMRF
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
@@ -23,8 +23,8 @@ from pyro.distributions.util import enable_validation, is_validation_enabled, va
 from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D
 from pyro.distributions.zero_inflated_poisson import ZeroInflatedPoisson
-from pyro.distributions.lkj import (LKJCorrCholesky, CorrLCholeskyTransform, corr_cholesky_constraint)
-from pyro.distributions.transforms import * # noqa F403
+from pyro.distributions.lkj import CorrLCholeskyTransform, LKJCorrCholesky, corr_cholesky_constraint
+from pyro.distributions.transforms import *  # noqa F403
 
 __all__ = [
     "AVFMultivariateNormal",
@@ -35,6 +35,7 @@ __all__ = [
     "Distribution",
     "Empirical",
     "GammaPoisson",
+    "GaussianHMM",
     "GaussianMRF",
     "GaussianScaleMixture",
     "InverseGamma",

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -3,7 +3,7 @@ from torch.distributions import constraints
 
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import broadcast_shape
-from pyro.ops.gaussian import Gaussian, gaussian_tensordot, mvn_to_gaussian
+from pyro.ops.gaussian import Gaussian, gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
 
 
 def _logmatmulexp(x, y):
@@ -152,6 +152,117 @@ class DiscreteHMM(TorchDistribution):
 
         # Marginalize out final state.
         result = result.logsumexp(-1)
+        return result
+
+
+class GaussianHMM(TorchDistribution):
+    """
+    Hidden Markov Model with Gaussians for initial, transition, and observation
+    distributions. This adapts [1] to parallelize over time to achieve
+    O(log(time)) parallel complexity, however it differs in that it tracks the
+    log normalizer to ensure :meth:`log_prob` is differentiable.
+
+    This corresponds to the generative model::
+
+        z = initial_distribution.sample()
+        x = []
+        for t in range(num_events):
+            z = z @ transition_matrix + transition_dist.sample()
+            x.append(z @ observation_matrix + observation_dist.sample())
+
+    The event_shape of this distribution includes time on the left::
+
+        event_shape = (num_steps,) + observation_dist.event_shape
+
+    This distribution supports any combination of homogeneous/heterogeneous
+    time dependency of ``transition_dist`` and ``observation_dist``. However,
+    because time is included in this distribution's event_shape, the
+    homogeneous+homogeneous case will have a broadcastable event_shape with
+    ``num_steps = 1``, allowing :meth:`log_prob` to work with arbitrary length
+    data::
+
+        event_shape = (1, obs_dim)  # homogeneous + homogeneous case
+
+    **References:**
+
+    [1] Simo Sarkka, Angel F. Garcia-Fernandez (2019)
+        "Temporal Parallelization of Bayesian Filters and Smoothers"
+        https://arxiv.org/pdf/1905.13002.pdf
+
+    :ivar int hidden_dim: The dimension of the hidden state.
+    :ivar int obs_dim: The dimension of the observed state.
+    :param ~torch.distributions.MultivariateNormal initial_dist: A distribution
+        over initial states. This should have batch_shape broadcastable to
+        ``self.batch_shape``.  This should have event_shape ``(hidden_dim,)``.
+    :param ~torch.Tensor transition_matrix: A linear transformation of hidden
+        state. This should have shape broadcastable to
+        ``self.batch_shape + (num_steps, hidden_dim, hidden_dim)`` where the
+        rightmost dims are ordered ``(old, new)``.
+    :param ~torch.distributions.MultivariateNormal transition_dist: A process
+        noise distribution. This should have batch_shape broadcastable to
+        ``self.batch_shape + (num_steps,)``.  This should have event_shape
+        ``(hidden_dim,)``.
+    :param ~torch.Tensor transition_matrix: A linear transformation from hidden
+        to observed state. This should have shape broadcastable to
+        ``self.batch_shape + (num_steps, hidden_dim, obs_dim)``.
+    :param ~torch.distributions.MultivariateNormal observation_dist: An
+        observation noise distribution. This should have batch_shape
+        broadcastable to ``self.batch_shape + (num_steps,)``.  This should have
+        event_shape ``(obs_dim,)``.
+    """
+    arg_constraints = {}
+
+    def __init__(self, initial_dist, transition_matrix, transition_dist,
+                 observation_matrix, observation_dist, validate_args=None):
+        assert isinstance(initial_dist, torch.distributions.MultivariateNormal)
+        assert isinstance(transition_matrix, torch.Tensor)
+        assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
+        assert isinstance(observation_matrix, torch.Tensor)
+        assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
+        hidden_dim, obs_dim = observation_matrix.shape[-2:]
+        assert initial_dist.event_shape == (hidden_dim,)
+        assert transition_matrix.shape[-2:] == (hidden_dim, hidden_dim)
+        assert transition_dist.event_shape == (hidden_dim,)
+        assert observation_dist.event_shape == (obs_dim,)
+        shape = broadcast_shape(initial_dist.batch_shape + (1,),
+                                transition_matrix.shape[-2:],
+                                transition_dist.batch_shape,
+                                observation_matrix.shape[-2:],
+                                observation_dist.batch_shape)
+        batch_shape, time_shape = shape[:-1], shape[-1:]
+        event_shape = time_shape + (obs_dim,)
+        super(GaussianHMM, self).__init__(batch_shape, event_shape, validate_args=validate_args)
+        self.hidden_dim = hidden_dim
+        self.obs_dim = obs_dim
+        self._init = mvn_to_gaussian(initial_dist)
+        self._trans = matrix_and_mvn_to_gaussian(transition_matrix, transition_dist)
+        self._obs = matrix_and_mvn_to_gaussian(observation_matrix, observation_dist)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(GaussianMRF, _instance)
+        batch_shape = torch.Size(broadcast_shape(self.batch_shape, batch_shape))
+        # We only need to expand one of the inputs, since batch_shape is determined
+        # by broadcasting all three. To save computation in _sequential_gaussian_tensordot(),
+        # we expand only _init, which is applied only after _sequential_gaussian_tensordot().
+        new._init = self._init.expand(batch_shape)
+        new._trans = self._trans
+        new._obs = self._obs
+        super(GaussianHMM, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new.validate_args = self.__dict__.get('_validate_args')
+        return new
+
+    def log_prob(self, value):
+        # Combine observation and transition factors.
+        result = self._trans + self._obs.condition(value).event_pad(left=self.hidden_dim)
+
+        # Eliminate time dimension.
+        result = _sequential_gaussian_tensordot(result)
+
+        # Combine initial factor.
+        result = gaussian_tensordot(self._init, result, dims=self.hidden_dim)
+
+        # Marginalize out final state.
+        result = result.event_logsumexp()
         return result
 
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -239,7 +239,7 @@ class GaussianHMM(TorchDistribution):
         self._obs = matrix_and_mvn_to_gaussian(observation_matrix, observation_dist)
 
     def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(GaussianMRF, _instance)
+        new = self._get_checked_instance(GaussianHMM, _instance)
         batch_shape = torch.Size(broadcast_shape(self.batch_shape, batch_shape))
         # We only need to expand one of the inputs, since batch_shape is determined
         # by broadcasting all three. To save computation in _sequential_gaussian_tensordot(),

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -256,7 +256,7 @@ class GaussianHMM(TorchDistribution):
         result = self._trans + self._obs.condition(value).event_pad(left=self.hidden_dim)
 
         # Eliminate time dimension.
-        result = _sequential_gaussian_tensordot(result)
+        result = _sequential_gaussian_tensordot(result.expand(result.batch_shape))
 
         # Combine initial factor.
         result = gaussian_tensordot(self._init, result, dims=self.hidden_dim)

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -225,9 +225,9 @@ class GaussianHMM(TorchDistribution):
         assert transition_dist.event_shape == (hidden_dim,)
         assert observation_dist.event_shape == (obs_dim,)
         shape = broadcast_shape(initial_dist.batch_shape + (1,),
-                                transition_matrix.shape[-2:],
+                                transition_matrix.shape[:-2],
                                 transition_dist.batch_shape,
-                                observation_matrix.shape[-2:],
+                                observation_matrix.shape[:-2],
                                 observation_dist.batch_shape)
         batch_shape, time_shape = shape[:-1], shape[-1:]
         event_shape = time_shape + (obs_dim,)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -249,6 +249,7 @@ def matrix_and_mvn_to_gaussian(matrix, mvn):
     P_yy = x_gaussian.precision
     P_xy = matrix
     P_yx = matrix.transpose(-1, -2)
+    # FIXME this math is incorrect:
     precision = torch.cat([torch.cat([P_xx, P_xy], -1),
                            torch.cat([P_yx, P_yy], -1)], -2)
     info_vec = torch.cat([matrix.new_zeros(batch_shape + (x_dim,)), x_gaussian.info_vec], -1)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -255,7 +255,6 @@ def matrix_and_mvn_to_gaussian(matrix, mvn):
     info_y = y_gaussian.info_vec
     info_x = -matrix.matmul(info_y.unsqueeze(-1)).squeeze(-1)
     info_vec = torch.cat([info_x, info_y], -1)
-    # FIXME this is incorrect:
     log_normalizer = y_gaussian.log_normalizer
 
     result = Gaussian(log_normalizer, info_vec, precision)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -225,6 +225,23 @@ def mvn_to_gaussian(mvn):
     return Gaussian(log_normalizer, info_vec, precision)
 
 
+def matrix_and_mvn_to_gaussian(matrix, mvn):
+    """
+    Convert a noisy affine function to a Gaussian. The noisy affine function is defined as::
+
+        y = x @ matrix + mvn.sample()
+
+    :param ~torch.Tensor matrix: A matrix with rightmost shape ``(x_dim, y_dim)``.
+    :param ~torch.distributions.MultivariateNormal mvn: A multivariate normal distribution.
+    :rtype: ~pyro.ops.gaussian.Gaussian
+    """
+    assert isinstance(mvn, torch.distributions.MultivariateNormal)
+    assert isinstance(matrix, torch.Tensor)
+    x_dim, y_dim = matrix.shape[-2:]
+    assert mvn.event_shape == (y_dim,)
+    raise NotImplementedError("TODO")
+
+
 def gaussian_tensordot(x, y, dims=0):
     """
     Computes the integral over two gaussians:

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -276,10 +276,9 @@ def test_gaussian_hmm_log_prob(sample_shape, batch_shape, num_steps, hidden_dim,
     assert init.dim() == hidden_dim
     assert unrolled_trans.dim() == (1 + T) * hidden_dim
     assert unrolled_obs.dim() == T * (hidden_dim + obs_dim)
-    logp_h = gaussian_tensordot(init, unrolled_trans, hidden_dim)
-    logp_oh = gaussian_tensordot(logp_h, unrolled_obs, T * hidden_dim)
-    logp_h += unrolled_obs.marginalize(right=T * obs_dim)
-    expected_log_prob = logp_oh.log_density(unrolled_data) - logp_h.event_logsumexp()
+    logp = gaussian_tensordot(init, unrolled_trans, hidden_dim)
+    logp = gaussian_tensordot(logp, unrolled_obs, T * hidden_dim)
+    expected_log_prob = logp.log_density(unrolled_data)
     assert_close(actual_log_prob, expected_log_prob)
 
 

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -10,7 +10,7 @@ import pyro.distributions as dist
 from pyro.distributions.hmm import _sequential_gaussian_tensordot, _sequential_logmatmulexp
 from pyro.distributions.util import broadcast_shape
 from pyro.infer import TraceEnum_ELBO, config_enumerate
-from pyro.ops.gaussian import gaussian_tensordot, mvn_to_gaussian
+from pyro.ops.gaussian import gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
 from pyro.ops.indexing import Vindex
 from tests.common import assert_close
 from tests.ops.gaussian import assert_close_gaussian, random_gaussian, random_mvn
@@ -228,6 +228,59 @@ def test_gaussian_hmm_shape(init_shape, trans_mat_shape, trans_mvn_shape,
     assert data.shape == d.shape()
     actual = d.log_prob(data)
     assert actual.shape == expected_batch_shape
+
+
+@pytest.mark.parametrize('sample_shape', [(), (5,)], ids=str)
+@pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize('obs_dim', [1, 2])
+@pytest.mark.parametrize('hidden_dim', [1, 2])
+@pytest.mark.parametrize('num_steps', [1, 2, 3, 4])
+def test_gaussian_hmm_log_prob(sample_shape, batch_shape, num_steps, hidden_dim, obs_dim):
+    init_dist = random_mvn(batch_shape, hidden_dim)
+    trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim))
+    trans_dist = random_mvn(batch_shape + (num_steps,), hidden_dim)
+    obs_mat = torch.randn(batch_shape + (num_steps, hidden_dim, obs_dim))
+    obs_dist = random_mvn(batch_shape + (num_steps,), obs_dim)
+    d = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    data = obs_dist.sample(sample_shape)
+    assert data.shape == sample_shape + d.shape()
+    actual_log_prob = d.log_prob(data)
+
+    # Compare against hand-computed density.
+    # We will construct enormous unrolled joint gaussians with shapes:
+    #       t | 0 1 2 3 1 2 3      T = 3 in this example
+    #   ------+-----------------------------------------
+    #    init | H
+    #   trans | H H H H            H = hidden
+    #     obs |   H H H O O O      O = observed
+    # and then combine these using gaussian_tensordot().
+    T = num_steps
+    init = mvn_to_gaussian(init_dist)
+    trans = matrix_and_mvn_to_gaussian(trans_mat, trans_dist)
+    obs = matrix_and_mvn_to_gaussian(obs_mat, obs_dist)
+
+    unrolled_trans = reduce(operator.add, [
+        trans[..., t].event_pad(left=t * hidden_dim, right=(T - t - 1) * hidden_dim)
+        for t in range(T)
+    ])
+    unrolled_obs = reduce(operator.add, [
+        obs[..., t].event_pad(left=t * obs.dim(), right=(T - t - 1) * obs.dim())
+        for t in range(T)
+    ])
+    # Permute obs from HOHOHO to HHHOOO.
+    perm = torch.cat([torch.arange(hidden_dim) + t * obs.dim() for t in range(T)] +
+                     [torch.arange(obs_dim) + hidden_dim + t * obs.dim() for t in range(T)])
+    unrolled_obs = unrolled_obs.event_permute(perm)
+    unrolled_data = data.reshape(data.shape[:-2] + (T * obs_dim,))
+
+    assert init.dim() == hidden_dim
+    assert unrolled_trans.dim() == (1 + T) * hidden_dim
+    assert unrolled_obs.dim() == T * (hidden_dim + obs_dim)
+    logp_h = gaussian_tensordot(init, unrolled_trans, hidden_dim)
+    logp_oh = gaussian_tensordot(logp_h, unrolled_obs, T * hidden_dim)
+    logp_h += unrolled_obs.marginalize(right=T * obs_dim)
+    expected_log_prob = logp_oh.log_density(unrolled_data) - logp_h.event_logsumexp()
+    assert_close(actual_log_prob, expected_log_prob)
 
 
 @pytest.mark.parametrize('obs_dim', [1, 2, 3])

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch.nn.functional import pad
 
+import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.gaussian import Gaussian, gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
 from tests.common import assert_close
@@ -196,6 +197,24 @@ def test_matrix_and_mvn_to_gaussian(sample_shape, batch_shape, x_dim, y_dim):
     actual_log_prob = gaussian.log_density(xy)
     expected_log_prob = xy_mvn.log_prob(xy) + y_mvn.log_prob(y - y_pred)
     assert_close(actual_log_prob, expected_log_prob)
+
+
+@pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)], ids=str)
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("x_dim", [1, 2, 3])
+@pytest.mark.parametrize("y_dim", [1, 2, 3])
+def test_matrix_and_mvn_to_gaussian_2(sample_shape, batch_shape, x_dim, y_dim):
+    matrix = torch.randn(batch_shape + (x_dim, y_dim))
+    y_mvn = random_mvn(batch_shape, y_dim)
+    x_mvn = random_mvn(batch_shape, x_dim)
+    Mx_cov = matrix.transpose(-2, -1).matmul(x_mvn.covariance_matrix).matmul(matrix)
+    Mx_loc = matrix.transpose(-2, -1).matmul(x_mvn.loc.unsqueeze(-1)).squeeze(-1)
+    mvn = dist.MultivariateNormal(Mx_loc + y_mvn.loc, Mx_cov + y_mvn.covariance_matrix)
+    expected = mvn_to_gaussian(mvn)
+
+    actual = gaussian_tensordot(mvn_to_gaussian(x_mvn),
+                                matrix_and_mvn_to_gaussian(matrix, y_mvn), dims=x_dim)
+    assert_close_gaussian(expected, actual)
 
 
 @pytest.mark.parametrize("x_batch_shape,y_batch_shape", [


### PR DESCRIPTION
Addresses #1970 
Joint work with @fehiepsi 

This implements a `GaussianHMM` distribution, similar to the `GaussianMRF` distribution. Unlike the MRF version, this version is normalized and permits cheaper inference.

## Tasks

- [x] fix `matrix_and_mvn_to_gaussian()`

## Tested
- [x] unit tests for `matrix_and_mvn_to_gaussian()`
- [x] test `GaussianHMM` shape broadcasting
- [x] test `GaussianHMM` against hand-computed `Gaussian`