### PR TITLE
Warn if importing pyro.contrib.autoguide rather than pyro.infer.autoguide

### DIFF
--- a/pyro/contrib/autoguide.py
+++ b/pyro/contrib/autoguide.py
@@ -1,4 +1,5 @@
 import warnings
+
 from pyro.infer.autoguide import *  # noqa F403
 
 warnings.warn("pyro.contrib.autoguide has moved to pyro.infer.autoguide. "

--- a/pyro/contrib/autoguide.py
+++ b/pyro/contrib/autoguide.py
@@ -1,2 +1,6 @@
-# DEPRECATED pyro.contrib.autoguide has moved to pyro.infer.autoguide
+import warnings
 from pyro.infer.autoguide import *  # noqa F403
+
+warnings.warn("pyro.contrib.autoguide has moved to pyro.infer.autoguide. "
+              "The contrib alias will stop working in Pyro 0.5.",
+              DeprecationWarning)


### PR DESCRIPTION
Following #1989 , this adds a `DeprecationWarning`