### PR TITLE
Remove obsolete torch patches

### DIFF
--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -11,16 +11,6 @@ from pyro.distributions.util import sum_rightmost
 # Pyro models that use enumeration.
 class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
 
-    # This fixes a bug in expanded samples, and can be removed after publication of
-    # https://github.com/pytorch/pytorch/pull/23328
-    def sample(self, sample_shape=torch.Size()):
-        sample_shape = self._extended_shape(sample_shape)
-        param_shape = sample_shape + torch.Size((self._num_events,))
-        probs = self.probs.expand(param_shape)
-        probs_2d = probs.reshape(-1, self._num_events)
-        sample_2d = torch.multinomial(probs_2d, 1, True)
-        return sample_2d.contiguous().view(sample_shape)
-
     def log_prob(self, value):
         if getattr(value, '_pyro_categorical_support', None) == id(self):
             # Assume value is a reshaped torch.arange(event_shape[0]).

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -36,19 +36,6 @@ def _Transform__getstate__(self):
     return attrs
 
 
-@patch_dependency('torch.linspace')
-def _torch_linspace(*args, **kwargs):
-    unpatched_fn = _torch_linspace._pyro_unpatched
-    template = torch.Tensor()
-    if template.is_cuda:
-        kwargs["device"] = "cpu"
-        ret = unpatched_fn(*args, **kwargs).to(device=template.device)
-        kwargs.pop("device", None)
-    else:
-        ret = unpatched_fn(*args, **kwargs)
-    return ret
-
-
 # Fixes a shape error in Multinomial.support with inhomogeneous .total_count
 @patch_dependency('torch.distributions.Multinomial.support')
 @torch.distributions.constraints.dependent_property

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -32,20 +32,6 @@ def _torch_dirichlet_grad(x, concentration, total):
     return unpatched_fn(x, concentration, total)
 
 
-# This can be removed when super(...).__init__() is added upstream
-@patch_dependency('torch.distributions.transforms.Transform.__init__')
-def _Transform__init__(self, cache_size=0):
-    self._cache_size = cache_size
-    self._inv = None
-    if cache_size == 0:
-        pass  # default behavior
-    elif cache_size == 1:
-        self._cached_x_y = None, None
-    else:
-        raise ValueError('cache_size must be 0 or 1')
-    super(torch.distributions.transforms.Transform, self).__init__()
-
-
 # TODO: Move upstream to allow for pickle serialization of transforms
 @patch_dependency('torch.distributions.transforms.Transform.__getstate__')
 def _Transform__getstate__(self):

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -24,14 +24,6 @@ def patch_dependency(target, root_module=torch):
     return decorator
 
 
-@patch_dependency('torch._dirichlet_grad')
-def _torch_dirichlet_grad(x, concentration, total):
-    unpatched_fn = _torch_dirichlet_grad._pyro_unpatched
-    if x.is_cuda:
-        return unpatched_fn(x.cpu(), concentration.cpu(), total.cpu()).cuda(x.get_device())
-    return unpatched_fn(x, concentration, total)
-
-
 # TODO: Move upstream to allow for pickle serialization of transforms
 @patch_dependency('torch.distributions.transforms.Transform.__getstate__')
 def _Transform__getstate__(self):

--- a/tests/distributions/test_torch_patch.py
+++ b/tests/distributions/test_torch_patch.py
@@ -13,4 +13,4 @@ def test_dirichlet_grad_cuda():
 @requires_cuda
 def test_linspace():
     x = torch.linspace(-1., 1., 100, device="cuda")
-    assert x.device == "cuda"
+    assert x.device.type == "cuda"

--- a/tests/distributions/test_torch_patch.py
+++ b/tests/distributions/test_torch_patch.py
@@ -1,0 +1,16 @@
+import torch
+
+import pyro.distributions as dist
+from tests.common import requires_cuda
+
+
+@requires_cuda
+def test_dirichlet_grad_cuda():
+    concentration = torch.ones(3, requires_grad=True)
+    dist.Dirichlet(concentration).rsample().sum().backward()
+
+
+@requires_cuda
+def test_linspace():
+    x = torch.linspace(-1., 1., 100, device="cuda")
+    assert x.device == "cuda"


### PR DESCRIPTION
##Tested

- [x] Test `Transform.__init__()` patch
- [x] Test `Categorical.sample()` patch
- [x] Test dirichlet grad patch on CUDA
- [x] Test `linspace` patch on CUDA