### PR TITLE
Support Independent(Normal) observations in GaussianHMM

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -205,10 +205,12 @@ class GaussianHMM(TorchDistribution):
     :param ~torch.Tensor observation_matrix: A linear transformation from hidden
         to observed state. This should have shape broadcastable to
         ``self.batch_shape + (num_steps, hidden_dim, obs_dim)``.
-    :param ~torch.distributions.MultivariateNormal observation_dist: An
+    :param observation_dist: An
         observation noise distribution. This should have batch_shape
         broadcastable to ``self.batch_shape + (num_steps,)``.  This should have
         event_shape ``(obs_dim,)``.
+    :type observation_dist: ~torch.distributions.MultivariateNormal or
+        ~torch.distributions.Independent of ~torch.distributions.Normal
     """
     arg_constraints = {}
 
@@ -218,7 +220,9 @@ class GaussianHMM(TorchDistribution):
         assert isinstance(transition_matrix, torch.Tensor)
         assert isinstance(transition_dist, torch.distributions.MultivariateNormal)
         assert isinstance(observation_matrix, torch.Tensor)
-        assert isinstance(observation_dist, torch.distributions.MultivariateNormal)
+        assert (isinstance(observation_dist, torch.distributions.MultivariateNormal) or
+                (isinstance(observation_dist, torch.distributions.Independent) and
+                 isinstance(observation_dist.base_dist, torch.distributions.Normal)))
         hidden_dim, obs_dim = observation_matrix.shape[-2:]
         assert initial_dist.event_shape == (hidden_dim,)
         assert transition_matrix.shape[-2:] == (hidden_dim, hidden_dim)

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -7,7 +7,7 @@ from torch.nn.functional import pad
 from pyro.distributions.util import broadcast_shape
 
 
-class Gaussian(object):
+class Gaussian:
     """
     Non-normalized Gaussian distribution.
 
@@ -213,7 +213,7 @@ class AffineNormal:
     variable ``Y`` whose mean is an affine function of a random variable ``X``.
     The likelihood of ``X`` is thus::
 
-        LinearNormal(matrix, loc, scale).condition(y).log_density(x)
+        AffineNormal(matrix, loc, scale).condition(y).log_density(x)
 
     which is equivalent to::
 

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -207,6 +207,49 @@ class Gaussian(object):
                 chol_P.diagonal(dim1=-2, dim2=-1).log().sum(-1))
 
 
+class AffineNormal:
+    """
+    Represents a conditional diagonal normal distribution over a random
+    variable ``Y`` whose mean is an affine function of a random variable ``X``.
+    The likelihood of ``X`` is thus::
+
+        LinearNormal(matrix, loc, scale).condition(y).log_density(x)
+
+    which is equivalent to::
+
+        Normal(x @ matrix + loc, scale).to_event(1).log_prob(y)
+
+    :param torch.Tensor matrix: A transformation from ``X`` to ``Y``.
+        Should have rightmost shape ``(x_dim, y_dim)``.
+    :param torch.Tensor loc: A constant offset for ``Y``'s mean.
+        Should have rightmost shape ``(y_dim,)``.
+    :param torch.Tensor scale: Standard deviation for ``Y``.
+        Should have rightmost shape ``(y_dim,)``.
+    """
+    def __init__(self, matrix, loc, scale):
+        assert loc.shape == scale.shape
+        x_dim, y_dim = matrix.shape[-2:]
+        self.matrix = matrix
+        self.loc = loc
+        self.scale = scale
+
+    def condition(self, value):
+        """
+        Condition on a ``Y`` value.
+
+        :param torch.Tensor value: A value of ``Y``.
+        :return Gaussian: A gaussian likelihood over ``X``.
+        """
+        assert value.size(-1) == self.loc.size(-1)
+        prec_sqrt = self.matrix / self.scale.unsqueeze(-2)
+        precision = prec_sqrt.matmul(prec_sqrt.transpose(-1, -2))
+        delta = (value - self.loc) / self.scale
+        info_vec = prec_sqrt.matmul(delta.unsqueeze(-1)).squeeze(-1)
+        log_normalizer = (-0.5 * self.loc.size(-1) * math.log(2 * math.pi)
+                          - 0.5 * delta.pow(2).sum(-1) - self.scale.log().sum(-1))
+        return Gaussian(log_normalizer, info_vec, precision)
+
+
 def mvn_to_gaussian(mvn):
     """
     Convert a MultivaiateNormal distribution to a Gaussian.
@@ -236,13 +279,19 @@ def matrix_and_mvn_to_gaussian(matrix, mvn):
     :return: A Gaussian with broadcasted batch shape and ``.dim() == x_dim + y_dim``.
     :rtype: ~pyro.ops.gaussian.Gaussian
     """
-    assert isinstance(mvn, torch.distributions.MultivariateNormal)
+    assert (isinstance(mvn, torch.distributions.MultivariateNormal) or
+            (isinstance(mvn, torch.distributions.Independent) and
+             isinstance(mvn.base_dist, torch.distributions.Normal)))
     assert isinstance(matrix, torch.Tensor)
     x_dim, y_dim = matrix.shape[-2:]
     assert mvn.event_shape == (y_dim,)
     batch_shape = broadcast_shape(matrix.shape[:-2], mvn.batch_shape)
     matrix = matrix.expand(batch_shape + (x_dim, y_dim))
     mvn = mvn.expand(batch_shape)
+
+    # Handle diagonal normal distributions as an efficient special case.
+    if isinstance(mvn, torch.distributions.Independent):
+        return AffineNormal(matrix, mvn.base_dist.loc, mvn.base_dist.scale)
 
     y_gaussian = mvn_to_gaussian(mvn)
     P_yy = y_gaussian.precision


### PR DESCRIPTION
This adds support for diagonal observation covariances in `GaussianHMM`.

My use case is an HMM with very large observation space, say latent dimension of M=32 but observed dimension of N=2000. This PR reduces complexity from `M^3+N^3` to `M^3+MN`.

## Tested
- unit test for `matrix_and_mvn_to_gaussian()` with `AffineNormal`
- added diag versions of shape tests to `GaussianHMM` tests