### PR TITLE
Add docs for ZeroInflatedPoisson

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -203,6 +203,13 @@ VonMises3D
     :undoc-members:
     :show-inheritance:
 
+ZeroInflatedPoisson
+-------------------
+.. autoclass:: pyro.distributions.ZeroInflatedPoisson
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Transformed Distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
We've had this distribution for a while, and I just realized its docs were missing.