### PR TITLE
Implement *HMM.filter() methods for forecasting

### DIFF
--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -111,6 +111,7 @@ def test_discrete_hmm_shape(ok, init_shape, trans_shape, obs_shape, event_shape,
     assert isinstance(final, dist.Categorical)
     assert final.batch_shape == d.batch_shape
     assert final.event_shape == ()
+    assert final.support.upper_bound == state_dim - 1
 
 
 @pytest.mark.parametrize('event_shape', [(), (5,), (2, 3)], ids=str)


### PR DESCRIPTION
This adds `Discrete-` and `GaussianHMM.filter()` methods for for forecasting.

Currently the `DiscreteHMM` and `GaussianHMM` methods are fast for training but cannot be used for forecasting, i.e. for sampling posterior observations `x[t],...,x[t+w-1] | x[0],...,x[t-1]`. The solution proposed in this PR is to:
1. use `*HMM.log_prob()` to train parameters; then
2. use `*HMM.filter()` to compute a posterior `z[t-1] | x[0],...,x[t-1]`; and finally
3. use a standard sequential Pyro model to sample `z[t],...,z[t+w-1]` and `x[t],...,x[t+w-1]` from the posterior.

This solution benefits from parallel scan in the filter (typically long-window `[0,...,t-1]`), but does not use parallel scan for the forecast (typically short-window `[t,...,t+w-1]`) forecast. However that forecast phase usually benefits from parallelization over samples rather than time.

@martinjankowiak `funsor.pyro.SwitchingLinearHMM` is implemented in https://github.com/pyro-ppl/funsor/pull/191

## Documentation

- added docstrings
- I plan to add examples to both the viterbi tutorial #1802 and Pyro [workshop tutorials](https://github.com/pyro-ppl/sandbox/pull/3)

## Tested
- added shape tests (math is nearly identical to `.log_prob()`)