### PR TITLE
Removed a misleading comment

### DIFF
--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -194,7 +194,7 @@ def apply_stack(initial_msg):
 
     default_process_message(msg)
 
-    for frame in stack[-pointer:]:  # reversed(stack[0:pointer])
+    for frame in stack[-pointer:]:
         frame._postprocess_message(msg)
 
     cont = msg["continuation"]


### PR DESCRIPTION
The comment said that stack[-pointer:] is same as reversed(stack[0:pointer]). This is not the case. For example:
```
stack = [1, 2, 3, 4, 5]
stack[-3:]  # this is [3, 4, 5]
reversed(stack[0:3])  # this is [3, 2, 1]
```
This seemed minor enough to directly create the pull request without opening an issue