### PR TITLE
Fix RuntimeException in MCMC when number of cores is less than num_chains

### DIFF
--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -316,10 +316,11 @@ class MCMC(object):
                               .format(num_chains, available_cpu))
                 num_chains = available_cpu
                 # adjust initial_params accordingly
-                if num_chains == 1:
-                    initial_params = {k: v[0] for k, v in initial_params.items()}
-                else:
-                    initial_params = {k: v[:num_chains] for k, v in initial_params.items()}
+                if initial_params:
+                    if num_chains == 1:
+                        initial_params = {k: v[0] for k, v in initial_params.items()}
+                    else:
+                        initial_params = {k: v[:num_chains] for k, v in initial_params.items()}
 
         self.num_chains = num_chains
         self._diagnostics = [None] * num_chains


### PR DESCRIPTION
If the number of available cores is less than the number of chains, MCMC should just raise a warning and reset the number of chains. There was a bug due to which it was instead raising an exception when trying to access `initial_params` which may not have been provided by the users. This fixes the bug so that we continue with sampling after raising an initial warning.

Modified existing test to catch this bug.