### PR TITLE
Add ops module to pyro.generic interface

### DIFF
--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -11,7 +11,7 @@ import torch
 # We use the pyro.generic interface to support dynamic choice of backend.
 from pyro.generic import pyro_backend
 from pyro.generic import distributions as dist
-from pyro.generic import infer, optim, pyro
+from pyro.generic import infer, optim, pyro, ops
 
 
 def main(args):
@@ -26,7 +26,7 @@ def main(args):
     # distribution over the latent random variable `loc`.
     def guide(data):
         guide_loc = pyro.param("guide_loc", torch.tensor(0.))
-        guide_scale = pyro.param("guide_scale_log", torch.tensor(0.)).exp()
+        guide_scale = ops.exp(pyro.param("guide_scale_log", torch.tensor(0.)))
         pyro.sample("loc", dist.Normal(guide_loc, guide_scale))
 
     # Generate some data.

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -8,10 +8,9 @@ import argparse
 
 import torch
 
-# We use the pyro.generic interface to support dynamic choice of backend.
-from pyro.generic import pyro_backend
 from pyro.generic import distributions as dist
-from pyro.generic import infer, optim, pyro, ops
+# We use the pyro.generic interface to support dynamic choice of backend.
+from pyro.generic import infer, ops, optim, pyro, pyro_backend
 
 
 def main(args):

--- a/pyro/generic.py
+++ b/pyro/generic.py
@@ -58,23 +58,27 @@ _ALIASES = {
         'distributions': 'pyro.distributions',
         'infer': 'pyro.infer',
         'optim': 'pyro.optim',
+        'ops': 'torch',
     },
     'minipyro': {
         'pyro': 'pyro.contrib.minipyro',
         'infer': 'pyro.contrib.minipyro',
         'optim': 'pyro.contrib.minipyro',
+        'ops': 'torch',
     },
     'funsor': {
         'pyro': 'funsor.minipyro',
         'infer': 'funsor.minipyro',
         'optim': 'funsor.minipyro',
         'distributions': 'funsor.distributions',
+        'ops': 'funsor.ops',
     },
     'numpy': {
         'pyro': 'numpyro.compat.pyro',
         'distributions': 'numpyro.compat.distributions',
         'infer': 'numpyro.compat.infer',
         'optim': 'numpyro.compat.optim',
+        'ops': 'numpy',
     },
 }
 
@@ -83,3 +87,4 @@ pyro = GenericModule('pyro', 'pyro')
 distributions = GenericModule('distributions', 'pyro.distributions')
 infer = GenericModule('infer', 'pyro.infer')
 optim = GenericModule('optim', 'pyro.optim')
+ops = GenericModule('ops', 'torch')

--- a/tests/contrib/test_minipyro.py
+++ b/tests/contrib/test_minipyro.py
@@ -5,7 +5,7 @@ import torch
 from torch.distributions import constraints
 
 from pyro.generic import distributions as dist
-from pyro.generic import infer, optim, pyro, pyro_backend
+from pyro.generic import infer, ops, optim, pyro, pyro_backend
 from tests.common import assert_close, xfail_param
 
 # This file tests a variety of model,guide pairs with valid and invalid structure.
@@ -78,7 +78,7 @@ def test_generate_data_plate(backend):
     with pyro_backend(backend):
         data = model().data
         assert data.shape == (num_points,)
-        mean = data.sum().item() / num_points
+        mean = float(ops.sum(data)) / num_points
         assert 1.9 <= mean <= 2.1
 
 
@@ -185,13 +185,13 @@ def test_constraints(backend, jit):
 
     def model():
         locs = pyro.param("locs", torch.randn(3), constraint=constraints.real)
-        scales = pyro.param("scales", torch.randn(3).exp(), constraint=constraints.positive)
+        scales = pyro.param("scales", ops.exp(torch.randn(3)), constraint=constraints.positive)
         p = torch.tensor([0.5, 0.3, 0.2])
         x = pyro.sample("x", dist.Categorical(p))
         pyro.sample("obs", dist.Normal(locs[x], scales[x]), obs=data)
 
     def guide():
-        q = pyro.param("q", torch.randn(3).exp(), constraint=constraints.simplex)
+        q = pyro.param("q", ops.exp(torch.randn(3)), constraint=constraints.simplex)
         pyro.sample("x", dist.Categorical(q))
 
     with pyro_backend(backend):


### PR DESCRIPTION
This aims to make Pyro model code more generic.

Funsor already has a `funsor.ops` module that mimics torch but dispatches to torch/funsor/numpy depending on argument type. I've set the NumPyro backend ops to point to `numpy` in this PR, but @neerajprad may want to switch to a more-torch-compatible `numpyro.ops` library in a follow-up PR.

I have not replaced `torch.randn(...)` and `torch.tensor(...)` in this PR; I think we can do this in follow-up PRs once numpyro and funsor add wrappers. After that.

## Tested
- added a couple unit tests
- updated examples/minipyro.py
- locally ran `examples/minipyro.py --backend=funsor`