### PR TITLE
Use torch.jit.script in DiscreteHMM

### DIFF
--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -585,7 +585,7 @@ def main(args):
     Elbo = JitTraceEnum_ELBO if args.jit else TraceEnum_ELBO
     elbo = Elbo(max_plate_nesting=1 if model is model_0 else 2,
                 strict_enumeration_warning=(model is not model_7),
-                jit_options={"optimize": model is model_7, "time_compilation": args.time_compilation})
+                jit_options={"time_compilation": args.time_compilation})
     optim = Adam({'lr': args.learning_rate})
     svi = SVI(model, guide, optim, elbo)
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -17,6 +17,7 @@ def _logmatmulexp(x, y):
     return xy + x_shift + y_shift
 
 
+@torch.jit.script
 def _sequential_logmatmulexp(logits):
     """
     For a tensor ``x`` whose time dimension is -3, computes::


### PR DESCRIPTION
This converts `_sequential_logmatmulexp()` to a torch script, enabling dynamic size computations even when jitted. Thus this allows the jitted code to be run on time series of different length. Note that `_sequential_gaussian_tensordot()` is much more difficult to convert to a script.

This also removes the deprecated `optimize` setting from examples/hmm.py.

## Performance

`examples/hmm.py -m 7 --jit` (best of three runs)

Before this PR: 4.7 sec

After this: PR 3.7 sec

## Tested
- exercised by existing tests