### PR TITLE
Implement KL divergence for delta and independent distributions

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -27,6 +27,8 @@ from pyro.distributions.zero_inflated_poisson import ZeroInflatedPoisson
 from pyro.distributions.lkj import CorrLCholeskyTransform, LKJCorrCholesky, corr_cholesky_constraint
 from pyro.distributions.transforms import *  # noqa F403
 
+import pyro.distributions.kl  # noqa F403 isort:skip
+
 __all__ = [
     "AVFMultivariateNormal",
     "BetaBinomial",

--- a/pyro/distributions/kl.py
+++ b/pyro/distributions/kl.py
@@ -18,8 +18,8 @@ def _kl_independent_independent(p, q):
     shared_ndims = min(p.reinterpreted_batch_ndims, q.reinterpreted_batch_ndims)
     p_ndims = p.reinterpreted_batch_ndims - shared_ndims
     q_ndims = q.reinterpreted_batch_ndims - shared_ndims
-    p = Independent(p, p_ndims) if p_ndims else p
-    q = Independent(q, q_ndims) if q_ndims else q
+    p = Independent(p.base_dist, p_ndims) if p_ndims else p.base_dist
+    q = Independent(q.base_dist, q_ndims) if q_ndims else q.base_dist
     kl = kl_divergence(p, q)
     if shared_ndims:
         kl = sum_rightmost(kl, shared_ndims)

--- a/pyro/distributions/kl.py
+++ b/pyro/distributions/kl.py
@@ -1,0 +1,46 @@
+import math
+
+from torch.distributions import kl_divergence, register_kl
+
+from pyro.distributions.delta import Delta
+from pyro.distributions.distribution import Distribution
+from pyro.distributions.torch import Independent, MultivariateNormal, Normal
+from pyro.distributions.util import sum_rightmost
+
+
+@register_kl(Delta, Distribution)
+def _kl_delta(p, q):
+    return -q.log_prob(p.v)
+
+
+@register_kl(Independent, Independent)
+def _kl_independent_independent(p, q):
+    shared_ndims = min(p.reinterpreted_batch_ndims, q.reinterpreted_batch_ndims)
+    p_ndims = p.reinterpreted_batch_ndims - shared_ndims
+    q_ndims = q.reinterpreted_batch_ndims - shared_ndims
+    p = Independent(p, p_ndims) if p_ndims else p
+    q = Independent(q, q_ndims) if q_ndims else q
+    kl = kl_divergence(p, q)
+    if shared_ndims:
+        kl = sum_rightmost(kl, shared_ndims)
+    return kl
+
+
+@register_kl(Independent, MultivariateNormal)
+def _kl_independent_mvn(p, q):
+    if isinstance(p.base_dist, Delta) and p.reinterpreted_batch_ndims == 1:
+        return -q.log_prob(p.base_dist.v)
+
+    if isinstance(p.base_dist, Normal) and p.reinterpreted_batch_ndims == 1:
+        dim = q.event_shape[0]
+        p_cov = p.base_dist.scale ** 2
+        q_precision = q.precision_matrix.diagonal(dim1=-2, dim2=-1)
+        return (0.5 * (p_cov * q_precision).sum(-1)
+                - 0.5 * dim * (1 + math.log(2 * math.pi))
+                - q.log_prob(p.base_dist.loc)
+                - p.base_dist.scale.log().sum(-1))
+
+    raise NotImplementedError
+
+
+__all__ = []

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,8 +1,7 @@
 import torch
-from torch.distributions import constraints, kl_divergence, register_kl
+from torch.distributions import constraints
 
 from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistributionMixin
-from pyro.distributions.util import sum_rightmost
 
 
 # This overloads .log_prob() and .enumerate_support() to speed up evaluating
@@ -50,16 +49,6 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
     @_validate_args.setter
     def _validate_args(self, value):
         self.base_dist._validate_args = value
-
-
-@register_kl(Independent, Independent)
-def _kl_independent_independent(p, q):
-    if p.reinterpreted_batch_ndims != q.reinterpreted_batch_ndims:
-        raise NotImplementedError
-    kl = kl_divergence(p.base_dist, q.base_dist)
-    if p.reinterpreted_batch_ndims:
-        kl = sum_rightmost(kl, p.reinterpreted_batch_ndims)
-    return kl
 
 
 # Programmatically load all distributions from PyTorch.

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -100,9 +100,7 @@ class TraceMeanField_ELBO(Trace_ELBO):
                         kl_qp = scale_and_mask(kl_qp, scale=guide_site["scale"], mask=guide_site["mask"])
                         assert kl_qp.shape == guide_site["fn"].batch_shape
                         elbo_particle = elbo_particle - kl_qp.sum()
-                        print('EXACT: {} {}'.format(type(guide_site["fn"]), type(model_site["fn"])))
                     except NotImplementedError:
-                        print('APPROX: {} {}'.format(type(guide_site["fn"]), type(model_site["fn"])))
                         entropy_term = guide_site["score_parts"].entropy_term
                         elbo_particle = elbo_particle + model_site["log_prob_sum"] - entropy_term.sum()
 

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -100,7 +100,9 @@ class TraceMeanField_ELBO(Trace_ELBO):
                         kl_qp = scale_and_mask(kl_qp, scale=guide_site["scale"], mask=guide_site["mask"])
                         assert kl_qp.shape == guide_site["fn"].batch_shape
                         elbo_particle = elbo_particle - kl_qp.sum()
+                        print('EXACT: {} {}'.format(type(guide_site["fn"]), type(model_site["fn"])))
                     except NotImplementedError:
+                        print('APPROX: {} {}'.format(type(guide_site["fn"]), type(model_site["fn"])))
                         entropy_term = guide_site["score_parts"].entropy_term
                         elbo_particle = elbo_particle + model_site["log_prob_sum"] - entropy_term.sum()
 

--- a/tests/distributions/test_kl.py
+++ b/tests/distributions/test_kl.py
@@ -1,0 +1,60 @@
+import pytest
+import torch
+from torch.distributions import kl_divergence
+
+import pyro.distributions as dist
+from tests.common import assert_close
+
+
+@pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
+def test_kl_delta_normal_shape(batch_shape):
+    v = torch.randn(batch_shape)
+    loc = torch.randn(batch_shape)
+    scale = torch.randn(batch_shape).exp()
+    p = dist.Delta(v)
+    q = dist.Normal(loc, scale)
+    assert kl_divergence(p, q).shape == batch_shape
+
+
+@pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
+@pytest.mark.parametrize('size', [1, 2, 3])
+def test_kl_delta_mvn_shape(batch_shape, size):
+    v = torch.randn(batch_shape + (size,))
+    p = dist.Delta(v, event_dim=1)
+
+    loc = torch.randn(batch_shape + (size,))
+    cov = torch.randn(batch_shape + (size, size))
+    cov = cov @ cov.transpose(-1, -2) + 0.01 * torch.eye(size)
+    q = dist.MultivariateNormal(loc, covariance_matrix=cov)
+    assert kl_divergence(p, q).shape == batch_shape
+
+
+@pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
+@pytest.mark.parametrize('size', [1, 2, 3])
+def test_kl_independent_delta_mvn_shape(batch_shape, size):
+    v = torch.randn(batch_shape + (size,))
+    p = dist.Independent(dist.Delta(v), 1)
+
+    loc = torch.randn(batch_shape + (size,))
+    cov = torch.randn(batch_shape + (size, size))
+    cov = cov @ cov.transpose(-1, -2) + 0.01 * torch.eye(size)
+    q = dist.MultivariateNormal(loc, covariance_matrix=cov)
+    assert kl_divergence(p, q).shape == batch_shape
+
+
+@pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
+@pytest.mark.parametrize('size', [1, 2, 3])
+def test_kl_independent_normal_mvn(batch_shape, size):
+    loc = torch.randn(batch_shape + (size,))
+    scale = torch.randn(batch_shape + (size,)).exp()
+    p1 = dist.Normal(loc, scale).to_event(1)
+    p2 = dist.MultivariateNormal(loc, scale_tril=scale.diag_embed())
+
+    loc = torch.randn(batch_shape + (size,))
+    cov = torch.randn(batch_shape + (size, size))
+    cov = cov @ cov.transpose(-1, -2) + 0.01 * torch.eye(size)
+    q = dist.MultivariateNormal(loc, covariance_matrix=cov)
+
+    actual = kl_divergence(p1, q)
+    expected = kl_divergence(p2, q)
+    assert_close(actual, expected)


### PR DESCRIPTION
This implements `kl_divergence()` for some new pairs, useful in `TraceMeanField_ELBO`:
- (Delta, *)
- (Independent, Independent) in a more general way
- (Independent(Delta), MultivariateNormal)
- (Independent(Normal), MultivariateNormal)

I've also moved our custom kl registrations into a new file. Some of these can eventually be moved to PyTorch.

## Future work

I'd next like to implement `kl_divergence(Independent(Normal(...), 2), GaussianHMM(...))`. I believe this requires computing the diagonal of the posterior precision matrix, i.e. marginalizing out all hidden variables. In theory this can be done cheaply via parallel-scan, but would require both a forward and backward pass.

@fehiepsi any ideas how to simplify the `GaussianHMM` version?

## Tested
- added unit tests