### PR TITLE
Avoid in-place ops in a few places

### DIFF
--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -555,7 +555,7 @@ def main(args):
     sequences = sequences[..., present_notes]
 
     if args.truncate:
-        lengths.clamp_(max=args.truncate)
+        lengths = lengths.clamp(max=args.truncate)
         sequences = sequences[:, :args.truncate]
     num_observations = float(lengths.sum())
     pyro.set_rng_seed(args.seed)
@@ -609,7 +609,7 @@ def main(args):
     sequences = data['test']['sequences'][..., present_notes]
     lengths = data['test']['sequence_lengths']
     if args.truncate:
-        lengths.clamp_(max=args.truncate)
+        lengths = lengths.clamp(max=args.truncate)
     num_observations = float(lengths.sum())
 
     # note that since we removed unseen notes above (to make the problem a bit easier and for

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -224,10 +224,7 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
         return tensor
     if mask is None:
         return tensor * scale
-    tensor, mask = broadcast_all(tensor, mask)
-    tensor = tensor * scale  # triggers a copy, avoiding in-place op errors
-    tensor.masked_fill_(mask == 0, 0.)
-    return tensor
+    return torch.where(mask, tensor * scale, tensor.new_zeros(()))
 
 
 def scalar_like(prototype, fill_value):

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -184,7 +184,7 @@ def _compute_marginals(model_trace, guide_trace):
             logits = packed.unpack(logits, model_trace.symbol_to_dim)
             logits = logits.unsqueeze(-1).transpose(-1, enum_dim - 1)
             while logits.shape[0] == 1:
-                logits.squeeze_(0)
+                logits = logits.squeeze(0)
             marginal_dists[name] = _make_dist(site["fn"], logits)
     return marginal_dists
 
@@ -225,7 +225,7 @@ class BackwardSampleMessenger(pyro.poutine.messenger.Messenger):
             logits = packed.unpack(logits, self.enum_trace.symbol_to_dim)
             logits = logits.unsqueeze(-1).transpose(-1, enum_dim - 1)
             while logits.shape[0] == 1:
-                logits.squeeze_(0)
+                logits = logits.squeeze(0)
         msg["fn"] = _make_dist(msg["fn"], logits)
 
     def _pyro_post_sample(self, msg):

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -120,7 +120,7 @@ class MultiFrameTensor(dict):
                 if f not in target_frames and value.shape[f.dim] != 1:
                     value = value.sum(f.dim, True)
             while value.shape and value.shape[0] == 1:
-                value.squeeze_(0)
+                value = value.squeeze(0)
             total = value if total is None else total + value
         return total
 

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -135,8 +135,7 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
         result._pyro_dims = tensor._pyro_dims
         return result
     tensor, mask = broadcast_all(tensor, mask)
-    result = tensor * scale  # triggers a copy, avoiding in-place op errors
-    result.masked_fill_(mask == 0, 0.)
+    result = torch.where(mask, tensor, tensor.new_zeros(()))
     result._pyro_dims = tensor._pyro_dims
     return result
 

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -162,7 +162,7 @@ class LinearRing(Ring):
             return self._cache[key]
 
         result = term.reciprocal()
-        result.clamp_(max=torch.finfo(result.dtype).max)  # avoid nan due to inf / inf
+        result = result.clamp(max=torch.finfo(result.dtype).max)  # avoid nan due to inf / inf
         result._pyro_dims = term._pyro_dims
         self._cache[key] = result
         return result
@@ -213,7 +213,7 @@ class LogRing(Ring):
             return self._cache[key]
 
         result = -term
-        result.clamp_(max=torch.finfo(result.dtype).max)  # avoid nan due to inf - inf
+        result = result.clamp(max=torch.finfo(result.dtype).max)  # avoid nan due to inf - inf
         result._pyro_dims = term._pyro_dims
         self._cache[key] = result
         return result


### PR DESCRIPTION
This avoids in-place ops in a few places, e.g. replacing `.masked_fill_()` with `torch.where()`.

The goal is to reduce `torch.jit.trace` compilation time in a future version of the PyTorch jit, where purely functional blocks of code can be compiled more quickly by neglecting aliasing information.