### PR TITLE
Implement CRPS for empirical distributions

### DIFF
--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -397,3 +397,42 @@ def fit_generalized_pareto(X):
     k = k * N / (N + 10.0) + 5.0 / (N + 10.0)
 
     return k, sigma
+
+
+def crps_empirical(pred, truth):
+    """
+    Computes negative Continuous Ranked Probability Score CRPS* [1] between a
+    set of samples ``pred`` and true data ``truth``. This uses an ``n log(n)``
+    time algorithm to compute a quantity equal that would naively have
+    complexity quadratic in the number of samples ``n``::
+
+        CRPS* = E|pred - truth| - 1/2 E|pred - pred'|
+              = (pred - truth).abs().mean(0)
+              - (pred - pred.unsqueeze(1)).abs().mean([0, 1]) / 2
+
+    Note that for a single sample this reduces to absolute error.
+
+    References
+    [1] `Strictly Proper Scoring Rules, Prediction, and Estimation`
+    Tilmann Gneiting, Adrian E. Raftery (2007)
+    https://www.stat.washington.edu/raftery/Research/PDF/Gneiting2007jasa.pdf
+
+    :param torch.Tensor pred: A set of sample predictions batched on rightmost dim.
+        This should have shape ``(num_samples,) + truth.shape``.
+    :param torch.Tensor truth: A true tensor.
+    """
+    if pred.dim() != 1 + truth.dim() or pred.shape[1:] != truth.shape:
+        raise ValueError(f"Expected pred to have one extra sample dim on left. "
+                         f"Actual shapes: {pred.shape} versus {truth.shape}")
+    opts = dict(device=pred.device, dtype=pred.dtype)
+    num_samples = pred.size(0)
+    if num_samples == 1:
+        return (pred[0] - truth).abs()
+
+    pred = pred.sort(dim=0).values
+    diff = pred[1:] - pred[:-1]
+    weight = (torch.arange(1, num_samples, **opts) *
+              torch.arange(num_samples - 1, 0, -1, **opts))
+    weight = weight.reshape(weight.shape + (1,) * truth.dim())
+
+    return (pred - truth).abs().mean(0) - (diff * weight).sum(0) / num_samples**2

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -420,6 +420,8 @@ def crps_empirical(pred, truth):
     :param torch.Tensor pred: A set of sample predictions batched on rightmost dim.
         This should have shape ``(num_samples,) + truth.shape``.
     :param torch.Tensor truth: A true tensor.
+    :return: A tensor of shape ``truth.shape``.
+    :rtype: torch.Tensor
     """
     if pred.dim() != 1 + truth.dim() or pred.shape[1:] != truth.shape:
         raise ValueError(f"Expected pred to have one extra sample dim on left. "

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -419,7 +419,7 @@ def crps_empirical(pred, truth):
 
     :param torch.Tensor pred: A set of sample predictions batched on rightmost dim.
         This should have shape ``(num_samples,) + truth.shape``.
-    :param torch.Tensor truth: A true tensor.
+    :param torch.Tensor truth: A tensor of true observations.
     :return: A tensor of shape ``truth.shape``.
     :rtype: torch.Tensor
     """

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -4,10 +4,10 @@ import warnings
 import pytest
 import torch
 
-from pyro.ops.stats import (autocorrelation, autocovariance, effective_sample_size, gelman_rubin,
-                            hpdi, pi, quantile, resample, split_gelman_rubin, waic, _cummin,
-                            _fft_next_good_size, fit_generalized_pareto)
-from tests.common import assert_equal, xfail_if_not_implemented
+from pyro.ops.stats import (_cummin, _fft_next_good_size, autocorrelation, autocovariance, crps_empirical,
+                            effective_sample_size, fit_generalized_pareto, gelman_rubin, hpdi, pi, quantile, resample,
+                            split_gelman_rubin, waic)
+from tests.common import assert_close, assert_equal, xfail_if_not_implemented
 
 
 @pytest.mark.parametrize('replacement', [True, False])
@@ -250,3 +250,14 @@ def test_fit_generalized_pareto(k, sigma, n_samples=5000):
     fit_k, fit_sigma = fit_generalized_pareto(torch.tensor(X))
     assert_equal(k, fit_k, prec=0.02)
     assert_equal(sigma, fit_sigma, prec=0.02)
+
+
+@pytest.mark.parametrize('event_shape', [(), (4,), (3, 2)])
+@pytest.mark.parametrize('num_samples', [1, 2, 3, 4, 10])
+def test_crps_empirical(num_samples, event_shape):
+    truth = torch.randn(event_shape)
+    pred = truth + 0.1 * torch.randn((num_samples,) + event_shape)
+    actual = crps_empirical(pred, truth)
+    expected = ((pred - truth).abs().mean(0)
+                - 0.5 * (pred - pred.unsqueeze(1)).abs().mean([0, 1]))
+    assert_close(actual, expected)

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -257,7 +257,10 @@ def test_fit_generalized_pareto(k, sigma, n_samples=5000):
 def test_crps_empirical(num_samples, event_shape):
     truth = torch.randn(event_shape)
     pred = truth + 0.1 * torch.randn((num_samples,) + event_shape)
+
     actual = crps_empirical(pred, truth)
+    assert actual.shape == truth.shape
+
     expected = ((pred - truth).abs().mean(0)
                 - 0.5 * (pred - pred.unsqueeze(1)).abs().mean([0, 1]))
     assert_close(actual, expected)


### PR DESCRIPTION
This implements an `n log(n)`-time algorithm for the (negative) [Continuous Ranked Probability Score](https://www.stat.washington.edu/raftery/Research/PDF/Gneiting2007jasa.pdf) between an unweighted set of samples and truth. This is a nice "strictly proper" evaluation metric that favors uncertainty but reduces to absolute error for degenerate distributions. This is worth adding to `pyro.ops.stats` because the naive version is quadratic-time and it's nice to have the slightly more subtle `n log(n)` version implemented with unit tests.

## Tested
- added unit tests
- verified fast running time on a largish BART forecasting dataset ([code](https://github.com/pyro-ppl/sandbox/blob/df7813d/2019-08-time-series/bart/evaluate.py#L79))