### PR TITLE
Reorganize constraints and transforms modules

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -369,3 +369,11 @@ TransformModule
     :members:
     :undoc-members:
     :show-inheritance:
+
+Constraints
+~~~~~~~~~~~
+.. automodule:: pyro.distributions.constraints
+    :members:
+    :member-order: bysource
+    :undoc-members:
+    :show-inheritance:

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -24,7 +24,8 @@ import polyphonic_data_loader as poly
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.distributions import InverseAutoregressiveFlow, TransformedDistribution
+from pyro.distributions import TransformedDistribution
+from pyro.distributions.transforms import InverseAutoregressiveFlow
 from pyro.infer import SVI, JitTrace_ELBO, Trace_ELBO
 from pyro.nn import AutoRegressiveNN
 from pyro.optim import ClippedAdam

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -22,8 +22,6 @@ from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.torch_transform import TransformModule
-from pyro.distributions.transforms import *  # noqa F403
-from pyro.distributions.transforms import __all__ as pyro_transforms
 from pyro.distributions.unit import Unit
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 from pyro.distributions.von_mises import VonMises
@@ -72,7 +70,3 @@ __all__ = [
 # Import all torch distributions from `pyro.distributions.torch_distribution`
 __all__.extend(torch_dists)
 del torch_dists
-
-# For backwards compatibility, import all transforms into distributions module
-__all__.extend(pyro_transforms)  # noqa
-del pyro_transforms

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,5 +1,7 @@
 import pyro.distributions.torch_patch  # noqa F403
 from pyro.distributions.avf_mvn import AVFMultivariateNormal
+from pyro.distributions.conditional import (ConditionalDistribution, ConditionalTransform,
+                                            ConditionalTransformedDistribution, ConditionalTransformModule)
 from pyro.distributions.conjugate import BetaBinomial, DirichletMultinomial, GammaPoisson
 from pyro.distributions.delta import Delta
 from pyro.distributions.diag_normal_mixture import MixtureOfDiagNormals
@@ -9,6 +11,7 @@ from pyro.distributions.empirical import Empirical
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
 from pyro.distributions.hmm import DiscreteHMM, GaussianHMM, GaussianMRF
 from pyro.distributions.inverse_gamma import InverseGamma
+from pyro.distributions.lkj import LKJCorrCholesky
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
 from pyro.distributions.rejector import Rejector
@@ -19,15 +22,13 @@ from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.torch_transform import TransformModule
-from pyro.distributions.conditional import (ConditionalDistribution, ConditionalTransform, ConditionalTransformModule,
-                                            ConditionalTransformedDistribution)
-from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
+from pyro.distributions.transforms import *  # noqa F403
+from pyro.distributions.transforms import __all__ as pyro_transforms
 from pyro.distributions.unit import Unit
+from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D
 from pyro.distributions.zero_inflated_poisson import ZeroInflatedPoisson
-from pyro.distributions.lkj import (LKJCorrCholesky, CorrLCholeskyTransform, corr_cholesky_constraint)
-from pyro.distributions.transforms import *  # noqa F403
 
 import pyro.distributions.kl  # noqa F403 isort:skip
 
@@ -49,8 +50,6 @@ __all__ = [
     "GaussianScaleMixture",
     "InverseGamma",
     "LKJCorrCholesky",
-    "CorrLCholeskyTransform",
-    "corr_cholesky_constraint",
     "MaskedMixture",
     "MixtureOfDiagNormals",
     "MixtureOfDiagNormalsSharedCovariance",
@@ -75,4 +74,5 @@ __all__.extend(torch_dists)
 del torch_dists
 
 # For backwards compatibility, import all transforms into distributions module
-__all__.extend(transforms.__all__)  # noqa
+__all__.extend(pyro_transforms)  # noqa
+del pyro_transforms

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -28,15 +28,15 @@ from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D
 from pyro.distributions.zero_inflated_poisson import ZeroInflatedPoisson
 
-import pyro.distributions.kl  # noqa F403 isort:skip
+from . import constraints, kl, transforms
 
 __all__ = [
     "AVFMultivariateNormal",
     "BetaBinomial",
     "ConditionalDistribution",
     "ConditionalTransform",
-    "ConditionalTransformedDistribution",
     "ConditionalTransformModule",
+    "ConditionalTransformedDistribution",
     "Delta",
     "DirichletMultinomial",
     "DiscreteHMM",
@@ -62,8 +62,11 @@ __all__ = [
     "VonMises",
     "VonMises3D",
     "ZeroInflatedPoisson",
+    "constraints",
     "enable_validation",
     "is_validation_enabled",
+    "kl",
+    "transforms",
     "validation_enabled",
 ]
 

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -1,0 +1,50 @@
+from torch.distributions.constraints import *  # noqa F403
+from torch.distributions.constraints import Constraint
+from torch.distributions.constraints import __all__ as torch_constraints
+from torch.distributions.constraints import lower_cholesky
+
+
+# TODO move this upstream to torch.distributions
+class IndependentConstraint(Constraint):
+    """
+    Wraps a constraint by aggregating over ``reinterpreted_batch_ndims``-many
+    dims in :meth:`check`, so that an event is valid only if all its
+    independent entries are valid.
+
+    :param torch.distributions.constraints.Constraint base_constraint: A base
+        constraint whose entries are incidentally indepenent.
+    :param int reinterpreted_batch_ndims: The number of extra event dimensions that will
+        be considered dependent.
+    """
+    def __init__(self, base_constraint, reinterpreted_batch_ndims):
+        self.base_constraint = base_constraint
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+
+    def check(self, value):
+        result = self.base_constraint.check(value)
+        result = result.reshape(result.shape[:result.dim() - self.reinterpreted_batch_ndims] + (-1,))
+        result = result.min(-1)[0]
+        return result
+
+
+class _CorrCholesky(Constraint):
+    """
+    Constrains to lower-triangular square matrices with positive diagonals and
+    Euclidean norm of each row is 1, such that `torch.mm(omega, omega.t())` will
+    have unit diagonal.
+    """
+
+    def check(self, value):
+        unit_norm_row = (value.norm(dim=-1).sub(1) < 1e-4).min(-1)[0]
+        return lower_cholesky.check(value) & unit_norm_row
+
+
+corr_cholesky_constraint = _CorrCholesky()
+
+__all__ = [
+    'IndependentConstraint',
+    'corr_cholesky_constraint',
+]
+
+__all__.extend(torch_constraints)
+del torch_constraints

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,8 +1,9 @@
 import math
 
 import torch
+from torch.distributions import constraints
 
-import pyro.distributions.constraints as constraints
+from pyro.distributions.constraints import corr_cholesky_constraint
 from pyro.distributions.torch import Beta
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.transforms.cholesky import _vector_to_l_cholesky
@@ -35,7 +36,7 @@ class LKJCorrCholesky(TorchDistribution):
     :param torch.Tensor eta: A single positive number parameterizing the distribution.
     """
     arg_constraints = {"eta": constraints.positive}
-    support = constraints.corr_cholesky_constraint
+    support = corr_cholesky_constraint
     has_rsample = False
 
     def __init__(self, d, eta, validate_args=None):

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,117 +1,12 @@
 import math
 
 import torch
-from torch.distributions import biject_to, constraints, transform_to
-from torch.distributions.constraints import Constraint
-from torch.distributions.transforms import Transform
 
-from pyro.distributions import Beta, TorchDistribution
+import pyro.distributions.constraints as constraints
+from pyro.distributions.torch import Beta
+from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.transforms.cholesky import _vector_to_l_cholesky
 
-
-########################################
-# Define constraint
-########################################
-
-
-class _CorrCholesky(Constraint):
-    """
-    Constrains to lower-triangular square matrices with positive diagonals and
-    Euclidean norm of each row is 1, such that `torch.mm(omega, omega.t())` will
-    have unit diagonal.
-    """
-
-    def check(self, value):
-        unit_norm_row = (value.norm(dim=-1).sub(1) < 1e-4).min(-1)[0]
-        return constraints.lower_cholesky.check(value) & unit_norm_row
-
-
-corr_cholesky_constraint = _CorrCholesky()
-
-
-########################################
-# Define transforms
-########################################
-
-def _vector_to_l_cholesky(z):
-    D = (1.0 + math.sqrt(1.0 + 8.0 * z.shape[-1])) / 2.0
-    if D % 1 != 0:
-        raise ValueError("Correlation matrix transformation requires d choose 2 inputs")
-    D = int(D)
-    x = torch.zeros(z.shape[:-1] + (D, D), dtype=z.dtype, device=z.device)
-
-    x[..., 0, 0] = 1
-    x[..., 1:, 0] = z[..., :(D - 1)]
-    i = D - 1
-    last_squared_x = torch.zeros(z.shape[:-1] + (D,), dtype=z.dtype, device=z.device)
-    for j in range(1, D):
-        distance_to_copy = D - 1 - j
-        last_squared_x = last_squared_x[..., 1:] + x[..., j:, (j - 1)].clone()**2
-        x[..., j, j] = (1 - last_squared_x[..., 0]).sqrt()
-        x[..., (j + 1):, j] = z[..., i:(i + distance_to_copy)] * (1 - last_squared_x[..., 1:]).sqrt()
-        i += distance_to_copy
-    return x
-
-
-class CorrLCholeskyTransform(Transform):
-    """
-    Transforms a vector into the cholesky factor of a correlation matrix.
-
-    The input should have shape `[batch_shape] + [d * (d-1)/2]`. The output will have
-    shape `[batch_shape] + [d, d]`.
-
-    Reference:
-
-    [1] `Cholesky Factors of Correlation Matrices`, Stan Reference Manual v2.18, Section 10.12
-    """
-    domain = constraints.real
-    codomain = corr_cholesky_constraint
-    bijective = True
-    sign = +1
-    event_dim = 1
-
-    def __eq__(self, other):
-        return isinstance(other, CorrLCholeskyTransform)
-
-    def _call(self, x):
-        z = x.tanh()
-        return _vector_to_l_cholesky(z)
-
-    def _inverse(self, y):
-        if (y.shape[-2] != y.shape[-1]):
-            raise ValueError("A matrix that isn't square can't be a Cholesky factor of a correlation matrix")
-        D = y.shape[-1]
-
-        z_tri = torch.zeros(y.shape[:-2] + (D - 2, D - 2), dtype=y.dtype, device=y.device)
-        z_stack = [
-            y[..., 1:, 0]
-        ]
-
-        for i in range(2, D):
-            z_tri[..., i - 2, 0:(i - 1)] = y[..., i, 1:i] / (1 - y[..., i, 0:(i - 1)].pow(2).cumsum(-1)).sqrt()
-        for j in range(D - 2):
-            z_stack.append(z_tri[..., j:, j])
-
-        z = torch.cat(z_stack, -1)
-        return torch.log1p((2 * z) / (1 - z)) / 2
-
-    def log_abs_det_jacobian(self, x, y):
-        # Note dependence on pytorch 1.0.1 for batched tril
-        tanpart = x.cosh().log().sum(-1).mul(-2)
-        matpart = (1 - y.pow(2).cumsum(-1).tril(diagonal=-2)).log().div(2).sum(-1).sum(-1)
-        return tanpart + matpart
-
-# register transform to global store
-
-
-@biject_to.register(corr_cholesky_constraint)
-@transform_to.register(corr_cholesky_constraint)
-def _transform_to_corr_cholesky(constraint):
-    return CorrLCholeskyTransform()
-
-
-########################################
-# Define distribution
-########################################
 
 # TODO: Modify class to support more than one eta value at a time?
 class LKJCorrCholesky(TorchDistribution):
@@ -140,7 +35,7 @@ class LKJCorrCholesky(TorchDistribution):
     :param torch.Tensor eta: A single positive number parameterizing the distribution.
     """
     arg_constraints = {"eta": constraints.positive}
-    support = corr_cholesky_constraint
+    support = constraints.corr_cholesky_constraint
     has_rsample = False
 
     def __init__(self, d, eta, validate_args=None):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,7 +1,8 @@
 import torch
 from torch.distributions import constraints
 
-from pyro.distributions.torch_distribution import IndependentConstraint, TorchDistributionMixin
+from pyro.distributions.constraints import IndependentConstraint
+from pyro.distributions.torch_distribution import TorchDistributionMixin
 
 
 # This overloads .log_prob() and .enumerate_support() to speed up evaluating

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,9 +1,9 @@
 import warnings
 
 import torch
+from torch.distributions import constraints
 from torch.distributions.kl import kl_divergence, register_kl
 
-import pyro.distributions.constraints as constraints
 import pyro.distributions.torch
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.util import broadcast_shape, scale_and_mask

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,9 +1,9 @@
 import warnings
 
 import torch
-from torch.distributions import biject_to, constraints, transform_to
 from torch.distributions.kl import kl_divergence, register_kl
 
+import pyro.distributions.constraints as constraints
 import pyro.distributions.torch
 from pyro.distributions.distribution import Distribution
 from pyro.distributions.util import broadcast_shape, scale_and_mask
@@ -196,33 +196,6 @@ class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin
     ``.has_enumerate_support = True``.
     """
     pass
-
-
-# TODO move this upstream to torch.distributions
-class IndependentConstraint(constraints.Constraint):
-    """
-    Wraps a constraint by aggregating over ``reinterpreted_batch_ndims``-many
-    dims in :meth:`check`, so that an event is valid only if all its
-    independent entries are valid.
-
-    :param torch.distributions.constraints.Constraint base_constraint: A base
-        constraint whose entries are incidentally indepenent.
-    :param int reinterpreted_batch_ndims: The number of extra event dimensions that will
-        be considered dependent.
-    """
-    def __init__(self, base_constraint, reinterpreted_batch_ndims):
-        self.base_constraint = base_constraint
-        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
-
-    def check(self, value):
-        result = self.base_constraint.check(value)
-        result = result.reshape(result.shape[:result.dim() - self.reinterpreted_batch_ndims] + (-1,))
-        result = result.min(-1)[0]
-        return result
-
-
-biject_to.register(IndependentConstraint, lambda c: biject_to(c.base_constraint))
-transform_to.register(IndependentConstraint, lambda c: transform_to(c.base_constraint))
 
 
 class MaskedDistribution(TorchDistribution):

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -2,7 +2,7 @@ from torch.distributions import biject_to, transform_to
 from torch.distributions.transforms import *  # noqa F403
 from torch.distributions.transforms import __all__ as torch_transforms
 
-import pyro.distributions.constraints as constraints
+from pyro.distributions.constraints import IndependentConstraint, corr_cholesky_constraint
 from pyro.distributions.transforms.affine_coupling import AffineCoupling
 from pyro.distributions.transforms.batch_norm import BatchNormTransform
 from pyro.distributions.transforms.block_autoregressive import BlockAutoregressive
@@ -20,14 +20,12 @@ from pyro.distributions.transforms.sylvester import SylvesterFlow
 ########################################
 # register transforms
 
-biject_to.register(constraints.IndependentConstraint,
-                   lambda c: biject_to(c.base_constraint))
-transform_to.register(constraints.IndependentConstraint,
-                      lambda c: transform_to(c.base_constraint))
+biject_to.register(IndependentConstraint, lambda c: biject_to(c.base_constraint))
+transform_to.register(IndependentConstraint, lambda c: transform_to(c.base_constraint))
 
 
-@biject_to.register(constraints.corr_cholesky_constraint)
-@transform_to.register(constraints.corr_cholesky_constraint)
+@biject_to.register(corr_cholesky_constraint)
+@transform_to.register(corr_cholesky_constraint)
 def _transform_to_corr_cholesky(constraint):
     return CorrLCholeskyTransform()
 

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -1,33 +1,56 @@
-from __future__ import absolute_import
+from torch.distributions import biject_to, transform_to
+from torch.distributions.transforms import *  # noqa F403
+from torch.distributions.transforms import __all__ as torch_transforms
 
+import pyro.distributions.constraints as constraints
 from pyro.distributions.transforms.affine_coupling import AffineCoupling
 from pyro.distributions.transforms.batch_norm import BatchNormTransform
 from pyro.distributions.transforms.block_autoregressive import BlockAutoregressive
+from pyro.distributions.transforms.cholesky import CorrLCholeskyTransform
 from pyro.distributions.transforms.householder import HouseholderFlow
 from pyro.distributions.transforms.iaf import InverseAutoregressiveFlow, InverseAutoregressiveFlowStable
-from pyro.distributions.transforms.neural_autoregressive import (ELUTransform, LeakyReLUTransform,
-                                                                 TanhTransform, NeuralAutoregressive)
+from pyro.distributions.transforms.neural_autoregressive import (ELUTransform, LeakyReLUTransform, NeuralAutoregressive,
+                                                                 TanhTransform)
 from pyro.distributions.transforms.permute import PermuteTransform
+from pyro.distributions.transforms.planar import ConditionalPlanarFlow, PlanarFlow
 from pyro.distributions.transforms.polynomial import PolynomialFlow
-from pyro.distributions.transforms.planar import PlanarFlow, ConditionalPlanarFlow
 from pyro.distributions.transforms.radial import RadialFlow
 from pyro.distributions.transforms.sylvester import SylvesterFlow
+
+########################################
+# register transforms
+
+biject_to.register(constraints.IndependentConstraint,
+                   lambda c: biject_to(c.base_constraint))
+transform_to.register(constraints.IndependentConstraint,
+                      lambda c: transform_to(c.base_constraint))
+
+
+@biject_to.register(constraints.corr_cholesky_constraint)
+@transform_to.register(constraints.corr_cholesky_constraint)
+def _transform_to_corr_cholesky(constraint):
+    return CorrLCholeskyTransform()
+
 
 __all__ = [
     'AffineCoupling',
     'BatchNormTransform',
     'BlockAutoregressive',
-    'ELUTransform',
     'ConditionalPlanarFlow',
+    'CorrLCholeskyTransform',
+    'ELUTransform',
     'HouseholderFlow',
     'InverseAutoregressiveFlow',
     'InverseAutoregressiveFlowStable',
     'LeakyReLUTransform',
     'NeuralAutoregressive',
     'PermuteTransform',
-    'PolynomialFlow',
     'PlanarFlow',
+    'PolynomialFlow',
     'RadialFlow',
     'SylvesterFlow',
-    'TanhTransform'
+    'TanhTransform',
 ]
+
+__all__.extend(torch_transforms)
+del torch_transforms

--- a/pyro/distributions/transforms/batch_norm.py
+++ b/pyro/distributions/transforms/batch_norm.py
@@ -34,7 +34,7 @@ class BatchNormTransform(TransformModule):
     Example usage:
 
     >>> from pyro.nn import AutoRegressiveNN
-    >>> from pyro.distributions import InverseAutoregressiveFlow
+    >>> from pyro.distributions.transforms import InverseAutoregressiveFlow
     >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
     >>> iafs = [InverseAutoregressiveFlow(AutoRegressiveNN(10, [40])) for _ in range(2)]
     >>> bn = BatchNormTransform(10)

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -1,0 +1,74 @@
+import math
+
+import torch
+from torch.distributions.transforms import Transform
+import pyro.distributions.constraints as constraints
+
+
+def _vector_to_l_cholesky(z):
+    D = (1.0 + math.sqrt(1.0 + 8.0 * z.shape[-1])) / 2.0
+    if D % 1 != 0:
+        raise ValueError("Correlation matrix transformation requires d choose 2 inputs")
+    D = int(D)
+    x = torch.zeros(z.shape[:-1] + (D, D), dtype=z.dtype, device=z.device)
+
+    x[..., 0, 0] = 1
+    x[..., 1:, 0] = z[..., :(D - 1)]
+    i = D - 1
+    last_squared_x = torch.zeros(z.shape[:-1] + (D,), dtype=z.dtype, device=z.device)
+    for j in range(1, D):
+        distance_to_copy = D - 1 - j
+        last_squared_x = last_squared_x[..., 1:] + x[..., j:, (j - 1)].clone()**2
+        x[..., j, j] = (1 - last_squared_x[..., 0]).sqrt()
+        x[..., (j + 1):, j] = z[..., i:(i + distance_to_copy)] * (1 - last_squared_x[..., 1:]).sqrt()
+        i += distance_to_copy
+    return x
+
+
+class CorrLCholeskyTransform(Transform):
+    """
+    Transforms a vector into the cholesky factor of a correlation matrix.
+
+    The input should have shape `[batch_shape] + [d * (d-1)/2]`. The output will have
+    shape `[batch_shape] + [d, d]`.
+
+    Reference:
+
+    [1] `Cholesky Factors of Correlation Matrices`, Stan Reference Manual v2.18, Section 10.12
+    """
+    domain = constraints.real
+    codomain = constraints.corr_cholesky_constraint
+    bijective = True
+    sign = +1
+    event_dim = 1
+
+    def __eq__(self, other):
+        return isinstance(other, CorrLCholeskyTransform)
+
+    def _call(self, x):
+        z = x.tanh()
+        return _vector_to_l_cholesky(z)
+
+    def _inverse(self, y):
+        if (y.shape[-2] != y.shape[-1]):
+            raise ValueError("A matrix that isn't square can't be a Cholesky factor of a correlation matrix")
+        D = y.shape[-1]
+
+        z_tri = torch.zeros(y.shape[:-2] + (D - 2, D - 2), dtype=y.dtype, device=y.device)
+        z_stack = [
+            y[..., 1:, 0]
+        ]
+
+        for i in range(2, D):
+            z_tri[..., i - 2, 0:(i - 1)] = y[..., i, 1:i] / (1 - y[..., i, 0:(i - 1)].pow(2).cumsum(-1)).sqrt()
+        for j in range(D - 2):
+            z_stack.append(z_tri[..., j:, j])
+
+        z = torch.cat(z_stack, -1)
+        return torch.log1p((2 * z) / (1 - z)) / 2
+
+    def log_abs_det_jacobian(self, x, y):
+        # Note dependence on pytorch 1.0.1 for batched tril
+        tanpart = x.cosh().log().sum(-1).mul(-2)
+        matpart = (1 - y.pow(2).cumsum(-1).tril(diagonal=-2)).log().div(2).sum(-1).sum(-1)
+        return tanpart + matpart

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -1,8 +1,10 @@
 import math
 
 import torch
+from torch.distributions import constraints
 from torch.distributions.transforms import Transform
-import pyro.distributions.constraints as constraints
+
+from pyro.distributions.constraints import corr_cholesky_constraint
 
 
 def _vector_to_l_cholesky(z):
@@ -37,7 +39,7 @@ class CorrLCholeskyTransform(Transform):
     [1] `Cholesky Factors of Correlation Matrices`, Stan Reference Manual v2.18, Section 10.12
     """
     domain = constraints.real
-    codomain = constraints.corr_cholesky_constraint
+    codomain = corr_cholesky_constraint
     bijective = True
     sign = +1
     event_dim = 1

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -20,7 +20,7 @@ class PermuteTransform(Transform):
     Example usage:
 
     >>> from pyro.nn import AutoRegressiveNN
-    >>> from pyro.distributions import InverseAutoregressiveFlow, PermuteTransform
+    >>> from pyro.distributions.transforms import InverseAutoregressiveFlow, PermuteTransform
     >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
     >>> iaf1 = InverseAutoregressiveFlow(AutoRegressiveNN(10, [40]))
     >>> ff = PermuteTransform(torch.randperm(10, dtype=torch.long))

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -23,12 +23,13 @@ from torch.distributions import biject_to, constraints
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
+from pyro.distributions import transforms
+from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
 from pyro.infer.autoguide.initialization import InitMessenger, init_to_median
 from pyro.infer.autoguide.utils import _product
-from pyro.ops.hessian import hessian
-from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
 from pyro.infer.enum import config_enumerate
 from pyro.nn import AutoRegressiveNN
+from pyro.ops.hessian import hessian
 from pyro.poutine.util import prune_subsample_sites
 
 
@@ -585,9 +586,10 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
 class AutoIAFNormal(AutoContinuous):
     """
     This implementation of :class:`AutoContinuous` uses a Diagonal Normal
-    distribution transformed via a :class:`~pyro.distributions.iaf.InverseAutoregressiveFlow`
-    to construct a guide over the entire latent space. The guide does not depend on the model's
-    ``*args, **kwargs``.
+    distribution transformed via a
+    :class:`~pyro.distributions.transforms.iaf.InverseAutoregressiveFlow`
+    to construct a guide over the entire latent space. The guide does not
+    depend on the model's ``*args, **kwargs``.
 
     Usage::
 
@@ -609,7 +611,7 @@ class AutoIAFNormal(AutoContinuous):
     def get_posterior(self, *args, **kwargs):
         """
         Returns a diagonal Normal posterior distribution transformed by
-        :class:`~pyro.distributions.iaf.InverseAutoregressiveFlow`.
+        :class:`~pyro.distributions.transforms.iaf.InverseAutoregressiveFlow`.
         """
         if self.latent_dim == 1:
             raise ValueError('latent dim = 1. Consider using AutoDiagonalNormal instead')
@@ -618,7 +620,7 @@ class AutoIAFNormal(AutoContinuous):
         if self.arn is None:
             self.arn = AutoRegressiveNN(self.latent_dim, [self.hidden_dim])
 
-        iaf = dist.InverseAutoregressiveFlow(self.arn)
+        iaf = transforms.InverseAutoregressiveFlow(self.arn)
         pyro.module("{}_iaf".format(self.prefix), iaf)
         iaf_dist = dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]), [iaf])
         return iaf_dist

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -1,9 +1,12 @@
+import math
+
 import pytest
 import torch
-import math
-from torch.distributions import biject_to, transform_to, TransformedDistribution, Beta, AffineTransform
-from pyro.distributions.lkj import (corr_cholesky_constraint, CorrLCholeskyTransform, LKJCorrCholesky)
-from tests.common import assert_tensors_equal, assert_equal
+from torch.distributions import AffineTransform, Beta, TransformedDistribution, biject_to, transform_to
+
+from pyro.distributions import constraints, transforms
+from pyro.distributions.lkj import LKJCorrCholesky
+from tests.common import assert_equal, assert_tensors_equal
 
 
 @pytest.mark.parametrize("value_shape", [(1, 1), (3, 3), (5, 5)])
@@ -12,7 +15,7 @@ def test_constraint(value_shape):
     value.diagonal(dim1=-2, dim2=-1).exp_()
     value = value / value.norm(2, dim=-1, keepdim=True)
 
-    assert (corr_cholesky_constraint.check(value) == 1).all()
+    assert (constraints.corr_cholesky_constraint.check(value) == 1).all()
 
 
 def _autograd_log_det(ys, x):
@@ -23,7 +26,7 @@ def _autograd_log_det(ys, x):
 
 @pytest.mark.parametrize("y_shape", [(1,), (3, 1), (6,), (1, 6), (2, 6)])
 def test_unconstrained_to_corr_cholesky_transform(y_shape):
-    transform = CorrLCholeskyTransform()
+    transform = transforms.CorrLCholeskyTransform()
     y = torch.empty(y_shape).uniform_(-4, 4).requires_grad_()
     x = transform(y)
 
@@ -56,7 +59,7 @@ def test_unconstrained_to_corr_cholesky_transform(y_shape):
 @pytest.mark.parametrize("x_shape", [(1,), (3, 1), (6,), (1, 6), (5, 6)])
 @pytest.mark.parametrize("mapping", [biject_to, transform_to])
 def test_corr_cholesky_transform(x_shape, mapping):
-    transform = mapping(corr_cholesky_constraint)
+    transform = mapping(constraints.corr_cholesky_constraint)
     x = torch.randn(x_shape, requires_grad=True).clamp(-2, 2)
     y = transform(x)
 

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -181,6 +181,8 @@ def test_mcmc_diagnostics(num_chains):
     mcmc = MCMC(kernel, num_samples=10, warmup_steps=10, num_chains=num_chains,
                 initial_params=initial_params, transforms=transforms)
     mcmc.run(data)
+    if not torch.backends.mkl.is_available():
+        pytest.skip()
     diagnostics = mcmc.diagnostics()
     assert diagnostics["y"]["n_eff"].shape == data.shape
     assert diagnostics["y"]["r_hat"].shape == data.shape


### PR DESCRIPTION
Addresses issues in #2049
 
This reorganizes the `constraints` and `transforms` modules such that:
- pyro.distributions strictly extends torch.distributions
- pyro.distributions.constraints strictly extends torch.distributions.constaints
- pyro.distributions.transforms strictly extends torch.distributions.transforms

This is important for `pyro.generic` so all constraints and transforms are accessible, both those from PyTorch and those from Pyro.

After this PR we can idiomatically:
```py
import pyro.distributions as dist
from pyro.distributions import constraints, transforms
```
or more generically, following #2049 ,
```py
from pyro.generic import distributions as dist
from pyro.generic import constraints, transforms
```

cc @stefanwebb 