### PR TITLE
Raise NotImplementedError on missing backend functionality

### DIFF
--- a/pyro/generic/dispatch.py
+++ b/pyro/generic/dispatch.py
@@ -23,7 +23,10 @@ class GenericModule(object):
         except KeyError:
             module = importlib.import_module(backend)
             GenericModule._modules[backend] = module
-        return getattr(module, name)
+        try:
+            return getattr(module, name)
+        except AttributeError:
+            raise NotImplementedError(f'This Pyro backend does not implement {module_name}.{name}')
 
 
 @contextmanager

--- a/pyro/generic/dispatch.py
+++ b/pyro/generic/dispatch.py
@@ -23,6 +23,8 @@ class GenericModule(object):
         except KeyError:
             module = importlib.import_module(backend)
             GenericModule._modules[backend] = module
+        if name.startswith('__'):
+            return getattr(module, name)  # allow magic attributes to return AttributeError
         try:
             return getattr(module, name)
         except AttributeError:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,5 +1,4 @@
 import pytest
-import torch
 
 from pyro.generic import handlers, infer, pyro, pyro_backend
 from pyro.generic.testing import MODELS
@@ -7,6 +6,7 @@ from pyro.generic.testing import MODELS
 pytestmark = pytest.mark.stage('unit')
 
 
+@pytest.mark.filterwarnings("ignore", category=UserWarning)
 @pytest.mark.parametrize('model', MODELS)
 @pytest.mark.parametrize('backend', ['pyro'])
 def test_mcmc_interface(model, backend):
@@ -16,8 +16,7 @@ def test_mcmc_interface(model, backend):
         nuts_kernel = infer.NUTS(model=model)
         mcmc = infer.MCMC(nuts_kernel, num_samples=10, warmup_steps=10)
         mcmc.run(*args, **kwargs)
-        if torch.backends.mkl.is_available():
-            mcmc.summary()
+        mcmc.summary()
 
 
 @pytest.mark.parametrize('backend', ['pyro', 'minipyro'])
@@ -26,4 +25,4 @@ def test_not_implemented(backend):
         pyro.sample  # should be implemented
         pyro.param  # should be implemented
         with pytest.raises(NotImplementedError):
-            pyro.nonexistant_primitive
+            pyro.nonexistent_primitive

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,8 +1,8 @@
 import pytest
+import torch
 
-from pyro.generic import infer, pyro_backend, handlers
+from pyro.generic import handlers, infer, pyro, pyro_backend
 from pyro.generic.testing import MODELS
-
 
 pytestmark = pytest.mark.stage('unit')
 
@@ -16,4 +16,14 @@ def test_mcmc_interface(model, backend):
         nuts_kernel = infer.NUTS(model=model)
         mcmc = infer.MCMC(nuts_kernel, num_samples=10, warmup_steps=10)
         mcmc.run(*args, **kwargs)
-        mcmc.summary()
+        if torch.backends.mkl.is_available():
+            mcmc.summary()
+
+
+@pytest.mark.parametrize('backend', ['pyro', 'minipyro'])
+def test_not_implemented(backend):
+    with pyro_backend(backend):
+        pyro.sample  # should be implemented
+        pyro.param  # should be implemented
+        with pytest.raises(NotImplementedError):
+            pyro.nonexistant_primitive


### PR DESCRIPTION
Addresses #2053 

~~Note I've been having mkl errors when using `.summary()`. It would be nice to find a non-mkl workaround `if not torch.backends.mkl.is_available()`.~~

## Tested
- added a unit test