### PR TITLE
Add some features to minipyro for generic API coverage

### DIFF
--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -11,6 +11,7 @@ module.
 An accompanying example that makes use of this implementation can be
 found at examples/minipyro.py.
 """
+import random
 import warnings
 import weakref
 from collections import OrderedDict
@@ -108,6 +109,22 @@ class block(Messenger):
             msg["stop"] = True
 
 
+# seed is used to fix the RNG state when calling a model.
+class seed(Messenger):
+    def __init__(self, fn=None, rng_seed=None):
+        self.rng_seed = rng_seed
+        super(seed, self).__init__(fn)
+
+    def __enter__(self):
+        torch.manual_seed(self.rng_seed)
+        random.seed(self.rng_seed)
+        try:
+            import numpy as np
+            np.random.seed(self.rng_seed)
+        except ImportError:
+            pass
+
+
 # This limited implementation of PlateMessenger only implements broadcasting.
 class PlateMessenger(Messenger):
     def __init__(self, fn, size, dim):
@@ -150,18 +167,20 @@ def apply_stack(msg):
 
 # sample is an effectful version of Distribution.sample(...)
 # When any effect handlers are active, it constructs an initial message and calls apply_stack.
-def sample(name, fn, obs=None):
+def sample(name, fn, *args, **kwargs):
+    obs = kwargs.pop('obs', None)
 
     # if there are no active Messengers, we just draw a sample and return it as expected:
     if not PYRO_STACK:
-        return fn()
+        return fn(*args, **kwargs)
 
     # Otherwise, we initialize a message...
     initial_msg = {
         "type": "sample",
         "name": name,
         "fn": fn,
-        "args": (),
+        "args": args,
+        "kwargs": kwargs,
         "value": obs,
     }
 

--- a/pyro/generic/testing.py
+++ b/pyro/generic/testing.py
@@ -84,28 +84,3 @@ def beta_binomial():
                     pyro.sample("binomial", dist.Binomial(probs=probs, total_count=total_count), obs=data)
 
     return {'model': model, 'model_args': (N, D1, D2), 'model_kwargs': {'data': data}}
-
-
-def check_model(backend, name):
-    get_model = MODELS[name]
-    print('Running model "{}" on backend "{}".'.format(name, args.backend))
-    with pyro_backend(backend), handlers.seed(rng_seed=2):
-        f = get_model()
-        model, model_args, model_kwargs = f['model'], f.get('model_args', ()), f.get('model_kwargs', {})
-        print('Sample from prior...')
-        model(*model_args)
-        print('Trace model...')
-        handlers.trace(model).get_trace(*model_args, **model_kwargs)
-
-
-def main(args):
-    for name in MODELS:
-        check_model(args.backend, name)
-
-
-if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.4.1')
-    parser = argparse.ArgumentParser(description="Mini Pyro demo")
-    parser.add_argument("-b", "--backend", default="pyro")
-    args = parser.parse_args()
-    main(args)

--- a/pyro/generic/testing.py
+++ b/pyro/generic/testing.py
@@ -6,10 +6,9 @@ that positional arguments are inputs to the model and keyword arguments denote
 observed data.
 """
 
-import argparse
 from collections import OrderedDict
 
-from pyro.generic import distributions as dist, handlers, ops, pyro, pyro_backend
+from pyro.generic import distributions as dist, handlers, ops, pyro
 
 MODELS = OrderedDict()
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -33,7 +33,7 @@ def test_not_implemented(backend):
 def test_model_sample(model, backend):
     with pyro_backend(backend), handlers.seed(rng_seed=2):
         f = MODELS[model]()
-        model, model_args, model_kwargs = f['model'], f.get('model_args', ()), f.get('model_kwargs', {})
+        model, model_args = f['model'], f.get('model_args', ())
         model(*model_args)
 
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.stage('unit')
 
 @pytest.mark.filterwarnings("ignore", category=UserWarning)
 @pytest.mark.parametrize('model', MODELS)
-@pytest.mark.parametrize('backend', ['pyro'])
+@pytest.mark.parametrize('backend', ['pyro', 'numpy'])
 def test_mcmc_interface(model, backend):
     with pyro_backend(backend), handlers.seed(rng_seed=20):
         f = MODELS[model]()
@@ -26,3 +26,22 @@ def test_not_implemented(backend):
         pyro.param  # should be implemented
         with pytest.raises(NotImplementedError):
             pyro.nonexistent_primitive
+
+
+@pytest.mark.parametrize('model', MODELS)
+@pytest.mark.parametrize('backend', ['minipyro', 'pyro'])
+def test_model_sample(model, backend):
+    with pyro_backend(backend), handlers.seed(rng_seed=2):
+        f = MODELS[model]()
+        model, model_args, model_kwargs = f['model'], f.get('model_args', ()), f.get('model_kwargs', {})
+        model(*model_args)
+
+
+@pytest.mark.parametrize('model', MODELS)
+@pytest.mark.parametrize('backend', ['minipyro', 'pyro'])
+def test_trace_handler(model, backend):
+    with pyro_backend(backend), handlers.seed(rng_seed=2):
+        f = MODELS[model]()
+        model, model_args, model_kwargs = f['model'], f.get('model_args', ()), f.get('model_kwargs', {})
+        # should be implemented
+        handlers.trace(model).get_trace(*model_args, **model_kwargs)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.stage('unit')
 
 @pytest.mark.filterwarnings("ignore", category=UserWarning)
 @pytest.mark.parametrize('model', MODELS)
-@pytest.mark.parametrize('backend', ['pyro', 'numpy'])
+@pytest.mark.parametrize('backend', ['pyro'])
 def test_mcmc_interface(model, backend):
     with pyro_backend(backend), handlers.seed(rng_seed=20):
         f = MODELS[model]()
@@ -30,6 +30,7 @@ def test_not_implemented(backend):
 
 @pytest.mark.parametrize('model', MODELS)
 @pytest.mark.parametrize('backend', ['minipyro', 'pyro'])
+@pytest.mark.xfail(reason='Not supported by backend.')
 def test_model_sample(model, backend):
     with pyro_backend(backend), handlers.seed(rng_seed=2):
         f = MODELS[model]()
@@ -39,6 +40,7 @@ def test_model_sample(model, backend):
 
 @pytest.mark.parametrize('model', MODELS)
 @pytest.mark.parametrize('backend', ['minipyro', 'pyro'])
+@pytest.mark.xfail(reason='Not supported by backend.')
 def test_trace_handler(model, backend):
     with pyro_backend(backend), handlers.seed(rng_seed=2):
         f = MODELS[model]()


### PR DESCRIPTION
Added the following to minipyro:
 - seed handler to set the rng state for torch, numpy and python.
 - let `sample` take in arbitrary args, kwargs

Also added minipyro to some basic tests which are moved from testing. Currently, minipyro fails on 2 models because of limitations in the `plate` handler which requires an explicit dim argument in minipyro. I was thinking of specifying this in the model, but on second thoughts, it is good to have these failures as a demonstration of minipyro's limitations. 