### PR TITLE
Make some gp likelihoods more stable

### DIFF
--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -143,7 +143,7 @@ def main(args):
     # Turns on "whiten" flag will help optimization for variational models.
     gpmodule = gp.models.VariationalSparseGP(X=Xu, y=None, kernel=deep_kernel, Xu=Xu,
                                              likelihood=likelihood, latent_shape=latent_shape,
-                                             num_data=60000, whiten=True)
+                                             num_data=60000, whiten=True, jitter=2e-6)
     if args.cuda:
         gpmodule.cuda()
 

--- a/pyro/contrib/gp/likelihoods/binary.py
+++ b/pyro/contrib/gp/likelihoods/binary.py
@@ -40,9 +40,11 @@ class Binary(Likelihood):
         """
         # calculates Monte Carlo estimate for E_q(f) [logp(y | f)]
         f = dist.Normal(f_loc, f_var.sqrt())()
-        f_res = self.response_function(f)
-
-        y_dist = dist.Bernoulli(f_res)
+        if self.response_function is torch.sigmoid:
+            y_dist = dist.Bernoulli(logits=f)
+        else:
+            f_res = self.response_function(f)
+            y_dist = dist.Bernoulli(f_res)
         if y is not None:
-            y_dist = y_dist.expand_by(y.shape[:-f_res.dim()]).to_event(y.dim())
+            y_dist = y_dist.expand_by(y.shape[:-f.dim()]).to_event(y.dim())
         return pyro.sample("y", y_dist, obs=y)

--- a/pyro/contrib/gp/likelihoods/multi_class.py
+++ b/pyro/contrib/gp/likelihoods/multi_class.py
@@ -57,9 +57,11 @@ class MultiClass(Likelihood):
             raise ValueError("Number of Gaussian processes should be equal to the "
                              "number of classes. Expected {} but got {}."
                              .format(self.num_classes, f_swap.size(-1)))
-        f_res = self.response_function(f_swap)
-
-        y_dist = dist.Categorical(f_res)
+        if self.response_function is _softmax:
+            y_dist = dist.Categorical(logits=f_swap)
+        else:
+            f_res = self.response_function(f_swap)
+            y_dist = dist.Categorical(f_res)
         if y is not None:
-            y_dist = y_dist.expand_by(y.shape[:-f_res.dim() + 1]).to_event(y.dim())
+            y_dist = y_dist.expand_by(y.shape[:-f.dim() + 1]).to_event(y.dim())
         return pyro.sample("y", y_dist, obs=y)


### PR DESCRIPTION
Addresses #1996. When `response_function` takes its default value, what it does is to convert `logits` to `probs` in Binary/Categorical distributions. This PR skips applying `response_function` for the default case to take advantage of the numerical stability when using these distributions with `logits` arg.