### PR TITLE
Exclude seed handler from the PYRO_STACK

### DIFF
--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -124,6 +124,9 @@ class seed(Messenger):
         except ImportError:
             pass
 
+    def __exit__(self, type, value, traceback):
+        pass
+
 
 # This limited implementation of PlateMessenger only implements broadcasting.
 class PlateMessenger(Messenger):
@@ -229,7 +232,9 @@ def param(name, init_value=None, constraint=torch.distributions.constraints.real
 
 
 # boilerplate to match the syntax of actual pyro.plate:
-def plate(name, size, dim):
+def plate(name, size, dim=None):
+    if dim is None:
+        raise NotImplementedError("minipyro.plate requires a dim arg")
     return PlateMessenger(fn=None, size=size, dim=dim)
 
 

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -116,16 +116,22 @@ class seed(Messenger):
         super(seed, self).__init__(fn)
 
     def __enter__(self):
+        self.old_state = {'torch': torch.get_rng_state(), 'random': random.getstate()}
         torch.manual_seed(self.rng_seed)
         random.seed(self.rng_seed)
         try:
             import numpy as np
             np.random.seed(self.rng_seed)
+            self.old_state['numpy'] = np.random.get_state()
         except ImportError:
             pass
 
     def __exit__(self, type, value, traceback):
-        pass
+        torch.set_rng_state(self.old_state['torch'])
+        random.setstate(self.old_state['random'])
+        if 'numpy' in self.old_state:
+            import numpy as np
+            np.random.set_state(self.old_state['numpy'])
 
 
 # This limited implementation of PlateMessenger only implements broadcasting.

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -509,7 +509,9 @@ class _SeedMessenger(Messenger):
 
     def __enter__(self):
         set_rng_seed(self.rng_seed)
-        super(_SeedMessenger, self).__enter__()
+
+    def __exit__(self, type, value, traceback):
+        pass
 
 
 def seed(fn=None, rng_seed=None):

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -50,7 +50,8 @@ import functools
 
 from pyro.poutine import util
 from pyro.poutine.messenger import Messenger
-from pyro.util import set_rng_seed
+from pyro.util import get_rng_state, set_rng_seed, set_rng_state
+
 from .block_messenger import BlockMessenger
 from .broadcast_messenger import BroadcastMessenger
 from .condition_messenger import ConditionMessenger
@@ -66,7 +67,6 @@ from .runtime import NonlocalExit
 from .scale_messenger import ScaleMessenger
 from .trace_messenger import TraceMessenger
 from .uncondition_messenger import UnconditionMessenger
-
 
 ############################################
 # Begin primitive operations
@@ -508,10 +508,11 @@ class _SeedMessenger(Messenger):
         super(_SeedMessenger, self).__init__()
 
     def __enter__(self):
+        self.old_state = get_rng_state()
         set_rng_seed(self.rng_seed)
 
     def __exit__(self, type, value, traceback):
-        pass
+        set_rng_state(self.old_state)
 
 
 def seed(fn=None, rng_seed=None):

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -28,6 +28,24 @@ def set_rng_seed(rng_seed):
         pass
 
 
+def get_rng_state():
+    state = {'torch': torch.get_rng_state(), 'random': random.getstate()}
+    try:
+        import numpy as np
+        state['numpy'] = np.random.get_state()
+    except ImportError:
+        pass
+    return state
+
+
+def set_rng_state(state):
+    torch.set_rng_state(state['torch'])
+    random.setstate(state['random'])
+    if 'numpy' in state:
+        import numpy as np
+        np.random.set_state(state['numpy'])
+
+
 def torch_isnan(x):
     """
     A convenient function to check if a Tensor contains any nan; also works with numbers

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,7 +1,8 @@
 import pytest
-
 from pyro.generic import handlers, infer, pyro, pyro_backend
 from pyro.generic.testing import MODELS
+
+from tests.common import xfail_if_not_implemented
 
 pytestmark = pytest.mark.stage('unit')
 
@@ -30,9 +31,8 @@ def test_not_implemented(backend):
 
 @pytest.mark.parametrize('model', MODELS)
 @pytest.mark.parametrize('backend', ['minipyro', 'pyro'])
-@pytest.mark.xfail(reason='Not supported by backend.')
 def test_model_sample(model, backend):
-    with pyro_backend(backend), handlers.seed(rng_seed=2):
+    with pyro_backend(backend), handlers.seed(rng_seed=2), xfail_if_not_implemented():
         f = MODELS[model]()
         model, model_args = f['model'], f.get('model_args', ())
         model(*model_args)
@@ -40,9 +40,8 @@ def test_model_sample(model, backend):
 
 @pytest.mark.parametrize('model', MODELS)
 @pytest.mark.parametrize('backend', ['minipyro', 'pyro'])
-@pytest.mark.xfail(reason='Not supported by backend.')
 def test_trace_handler(model, backend):
-    with pyro_backend(backend), handlers.seed(rng_seed=2):
+    with pyro_backend(backend), handlers.seed(rng_seed=2), xfail_if_not_implemented():
         f = MODELS[model]()
         model, model_args, model_kwargs = f['model'], f.get('model_args', ()), f.get('model_kwargs', {})
         # should be implemented


### PR DESCRIPTION
The seed handler is special in Pyro and Minipyro in that it affects state in the global rng seed, rather than in Pyro. Moreover we would like to use this handler globally, as is done in Numpyro. One thing that makes this difficult is that much of our code tests `if not PYRO_STACK: ...do shortcut...`. This PR omits the `Seed` handler from the `PYRO_STACK`, thus making it possible to use that handler globally while preserving old shortcuts.

This PR also makes the seed handler restore previous state on exit, thereby providing compatibility with the numpyro backend.

For motivation, see https://github.com/pyro-ppl/numpyro/pull/396/files#r334110296