### PR TITLE
Move mcmc predictive to infer

### DIFF
--- a/docs/source/inference_algos.rst
+++ b/docs/source/inference_algos.rst
@@ -86,6 +86,11 @@ Discrete Inference
 Inference Utilities
 -------------------
 
+.. automodule:: pyro.infer.predictive
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. automodule:: pyro.infer.abstract_infer
     :members:
     :undoc-members:

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -7,6 +7,7 @@ from pyro.infer.importance import Importance
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.nuts import NUTS
+from pyro.infer.predictive import predictive
 from pyro.infer.renyi_elbo import RenyiELBO
 from pyro.infer.smcfilter import SMCFilter
 from pyro.infer.svi import SVI
@@ -36,6 +37,7 @@ __all__ = [
     "JitTrace_ELBO",
     "MCMC",
     "NUTS",
+    "predictive",
     "RBFSteinKernel",
     "RenyiELBO",
     "SMCFilter",

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -7,7 +7,7 @@ from pyro.infer.importance import Importance
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.nuts import NUTS
-from pyro.infer.predictive import predictive
+from pyro.infer.predictive import Predictive
 from pyro.infer.renyi_elbo import RenyiELBO
 from pyro.infer.smcfilter import SMCFilter
 from pyro.infer.svi import SVI
@@ -37,7 +37,7 @@ __all__ = [
     "JitTrace_ELBO",
     "MCMC",
     "NUTS",
-    "predictive",
+    "Predictive",
     "RBFSteinKernel",
     "RenyiELBO",
     "SMCFilter",

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -1,0 +1,152 @@
+from functools import reduce
+import warnings
+
+import torch
+
+import pyro
+import pyro.poutine as poutine
+from pyro.poutine.util import prune_subsample_sites
+
+
+def _guess_max_plate_nesting(model, args, kwargs):
+    """
+    Guesses max_plate_nesting by running the model once
+    without enumeration. This optimistically assumes static model
+    structure.
+    """
+    with poutine.block():
+        model_trace = poutine.trace(model).get_trace(*args, **kwargs)
+    sites = [site for site in model_trace.nodes.values()
+             if site["type"] == "sample"]
+
+    dims = [frame.dim
+            for site in sites
+            for frame in site["cond_indep_stack"]
+            if frame.vectorized]
+    max_plate_nesting = -min(dims) if dims else 0
+    return max_plate_nesting
+
+
+def _predictive_sequential(model, posterior_samples, model_args, model_kwargs,
+                           num_samples, sample_sites, return_trace=False):
+    collected = []
+    samples = [{k: v[i] for k, v in posterior_samples.items()} for i in range(num_samples)]
+    for i in range(num_samples):
+        trace = poutine.trace(poutine.condition(model, samples[i])).get_trace(*model_args, **model_kwargs)
+        if return_trace:
+            collected.append(trace)
+        else:
+            collected.append({site: trace.nodes[site]['value'] for site in sample_sites})
+
+    return collected if return_trace else {site: torch.stack([s[site] for s in collected])
+                                           for site in sample_sites}
+
+
+def predictive(model, posterior_samples, *args, num_samples=None, return_sites=None,
+               return_trace=False, parallel=False, **kwargs):
+    """
+    Run model by sampling latent parameters from `posterior_samples`, and return
+    values at sample sites from the forward run. By default, only sites not contained in
+    `posterior_samples` are returned. This can be modified by changing the `return_sites`
+    keyword argument.
+
+    .. note:: Using empty dict `posterior_samples={}` for prior predictive or getting posterior
+        samples from `guide` in SVI. In those predictive, the number of samples `num_samples`
+        should be specified.
+
+    .. warning::
+        The interface for the `predictive` class is experimental, and
+        might change in the future.
+
+    :param model: Python callable containing Pyro primitives.
+    :param dict posterior_samples: dictionary of samples from the posterior.
+    :param args: model arguments.
+    :param kwargs: model kwargs; and other keyword arguments (see below).
+
+    :Keyword Arguments:
+        * **num_samples** (``int``) - number of samples to draw from the predictive distribution.
+          This argument has no effect if ``posterior_samples`` is non-empty, in which case, the
+          leading dimension size of samples in ``posterior_samples`` is used.
+        * **return_sites** (``list``) - sites to return; by default only sample sites not present
+          in `posterior_samples` are returned.
+        * **return_trace** (``bool``) - whether to return the full trace. Note that this is
+          vectorized over `num_samples`.
+        * **parallel** (``bool``) - predict in parallel by wrapping the existing model
+          in an outermost `plate` messenger. Note that this requires that the model has
+          all batch dims correctly annotated via :class:`~pyro.plate`. Default is `False`.
+
+    :return: dict of samples from the predictive distribution, or a single vectorized
+        `trace` (if `return_trace=True`).
+    """
+    # num_samples = kwargs.pop('num_samples', None)
+    # return_sites = kwargs.pop('return_sites', None)
+    # return_trace = kwargs.pop('return_trace', False)
+    # parallel = kwargs.pop('parallel', False)
+
+    max_plate_nesting = _guess_max_plate_nesting(model, args, kwargs)
+    model_trace = prune_subsample_sites(poutine.trace(model).get_trace(*args, **kwargs))
+    reshaped_samples = {}
+
+    for name, sample in posterior_samples.items():
+
+        batch_size, sample_shape = sample.shape[0], sample.shape[1:]
+
+        if num_samples is None:
+            num_samples = batch_size
+
+        elif num_samples != batch_size:
+            warnings.warn("Sample's leading dimension size {} is different from the "
+                          "provided {} num_samples argument. Defaulting to {}."
+                          .format(batch_size, num_samples, batch_size), UserWarning)
+            num_samples = batch_size
+
+        sample = sample.reshape((num_samples,) + (1,) * (max_plate_nesting - len(sample_shape)) + sample_shape)
+        reshaped_samples[name] = sample
+
+    if num_samples is None:
+        raise ValueError("No sample sites in model to infer `num_samples`.")
+
+    return_site_shapes = {}
+    for site in model_trace.stochastic_nodes + model_trace.observation_nodes:
+        site_shape = (num_samples,) + model_trace.nodes[site]['value'].shape
+        if return_sites:
+            if site in return_sites:
+                return_site_shapes[site] = site_shape
+        else:
+            if site not in reshaped_samples:
+                return_site_shapes[site] = site_shape
+
+    if not parallel:
+        return _predictive_sequential(model, posterior_samples, args, kwargs, num_samples,
+                                      return_site_shapes.keys(), return_trace)
+
+    def _vectorized_fn(fn):
+        """
+        Wraps a callable inside an outermost :class:`~pyro.plate` to parallelize
+        sampling from the posterior predictive.
+
+        :param fn: arbitrary callable containing Pyro primitives.
+        :return: wrapped callable.
+        """
+
+        def wrapped_fn(*args, **kwargs):
+            with pyro.plate("_num_predictive_samples", num_samples, dim=-max_plate_nesting-1):
+                return fn(*args, **kwargs)
+
+        return wrapped_fn
+
+    trace = poutine.trace(poutine.condition(_vectorized_fn(model), reshaped_samples))\
+        .get_trace(*args, **kwargs)
+
+    if return_trace:
+        return trace
+
+    predictions = {}
+    for site, shape in return_site_shapes.items():
+        value = trace.nodes[site]['value']
+        if value.numel() < reduce((lambda x, y: x * y), shape):
+            predictions[site] = value.expand(shape)
+        else:
+            predictions[site] = value.reshape(shape)
+
+    return predictions

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -1,0 +1,92 @@
+import torch
+
+import pyro
+import pyro.distributions as dist
+import pyro.optim as optim
+import pyro.poutine as poutine
+from pyro.infer.autoguide import AutoDelta, AutoDiagonalNormal
+from pyro.infer import SVI, TracePredictive, Trace_ELBO, predictive
+from tests.common import assert_close
+
+
+def model(num_trials):
+    with pyro.plate("data", num_trials.size(0)):
+        phi_prior = dist.Uniform(num_trials.new_tensor(0.), num_trials.new_tensor(1.))
+        success_prob = pyro.sample("phi", phi_prior)
+        return pyro.sample("obs", dist.Binomial(num_trials, success_prob))
+
+
+def one_hot_model(pseudocounts, classes=None):
+    probs_prior = dist.Dirichlet(pseudocounts)
+    probs = pyro.sample("probs", probs_prior)
+    with pyro.plate("classes", classes.size(0) if classes is not None else 1, dim=-1):
+        return pyro.sample("obs", dist.OneHotCategorical(probs), obs=classes)
+
+
+def beta_guide(num_trials):
+    phi_c0 = pyro.param("phi_c0", num_trials.new_tensor(5.0).expand([num_trials.size(0)]))
+    phi_c1 = pyro.param("phi_c1", num_trials.new_tensor(5.0).expand([num_trials.size(0)]))
+    with pyro.plate("data", num_trials.size(0)):
+        phi_posterior = dist.Beta(concentration0=phi_c0, concentration1=phi_c1)
+        pyro.sample("phi", phi_posterior)
+
+
+def test_posterior_predictive_svi_manual_guide():
+    true_probs = torch.ones(5) * 0.7
+    num_trials = torch.ones(5) * 1000
+    num_success = dist.Binomial(num_trials, true_probs).sample()
+    conditioned_model = poutine.condition(model, data={"obs": num_success})
+    svi = SVI(conditioned_model, beta_guide, optim.Adam(dict(lr=1.0)), Trace_ELBO())
+    for i in range(1000):
+        svi.step(num_trials)
+    posterior_samples = predictive(beta_guide, {}, num_trials[:3], num_samples=100)
+    posterior_predictive = predictive(model, posterior_samples, num_trials[:3], num_samples=10000)
+    #     svi.step(num_trials[:3])
+    # posterior_samples = predictive(beta_guide, {}, num_trials, num_samples=100)
+    # posterior_predictive = predictive(model, posterior_samples, num_trials, num_samples=10000)
+    marginal_return_vals = posterior_predictive["_RETURN"]
+    assert_close(marginal_return_vals.mean, torch.ones(3) * 700, rtol=0.05)
+
+
+def test_posterior_predictive_svi_auto_delta_guide():
+    true_probs = torch.ones(5) * 0.7
+    num_trials = torch.ones(5) * 1000
+    num_success = dist.Binomial(num_trials, true_probs).sample()
+    conditioned_model = poutine.condition(model, data={"obs": num_success})
+    guide = AutoDelta(conditioned_model)
+    svi = SVI(conditioned_model, guide, optim.Adam(dict(lr=1.0)), Trace_ELBO())
+    for i in range(1000):
+        svi.step(num_trials)
+    posterior_samples = predictive(guide, {}, num_trials, num_samples=10000)
+    posterior_predictive = predictive(model, posterior_samples, num_trials)
+    marginal_return_vals = posterior_predictive["obs"]
+    assert_close(marginal_return_vals.mean(dim=0), torch.ones(5) * 700, rtol=0.05)
+
+
+def test_posterior_predictive_svi_auto_diag_normal_guide():
+    true_probs = torch.ones(5) * 0.7
+    num_trials = torch.ones(5) * 1000
+    num_success = dist.Binomial(num_trials, true_probs).sample()
+    conditioned_model = poutine.condition(model, data={"obs": num_success})
+    guide = AutoDiagonalNormal(conditioned_model)
+    svi = SVI(conditioned_model, guide, optim.Adam(dict(lr=1.0)), Trace_ELBO())
+    for i in range(1000):
+        svi.step(num_trials)
+    posterior_samples = predictive(guide, {}, num_trials, num_samples=10000)
+    posterior_predictive = predictive(model, posterior_samples, num_trials)
+    marginal_return_vals = posterior_predictive["obs"]
+    assert_close(marginal_return_vals.mean(dim=0), torch.ones(5) * 700, rtol=0.05)
+
+
+def test_posterior_predictive_svi_one_hot():
+    pseudocounts = torch.ones(3) * 0.1
+    true_probs = torch.tensor([0.15, 0.6, 0.25])
+    classes = dist.OneHotCategorical(true_probs).sample((10000,))
+    guide = AutoDelta(one_hot_model)
+    svi = SVI(one_hot_model, guide, optim.Adam(dict(lr=0.1)), Trace_ELBO())
+    for i in range(1000):
+        svi.step(pseudocounts, classes=classes)
+    posterior_samples = predictive(guide, {}, pseudocounts, num_samples=10000)
+    posterior_predictive = predictive(one_hot_model, posterior_samples, pseudocounts)
+    marginal_return_vals = posterior_predictive["obs"]
+    assert_close(marginal_return_vals.mean(dim=0), true_probs.unsqueeze(0), rtol=0.1)


### PR DESCRIPTION
This PR attempts to make `predictive` utility work for SVI, which is part of issue #1930.

There are some issues, which are not addressed yet:

#### "_RETURN" site

+ Former behavior: "_RETURN" site is skipped in `guide` predictive and collected in `model` predictive

+ This PR behavior: "_RETURN" site is skipped for both model and guide.

This difference can be resolved by allowing collecting the "_RETURN" site through the `return_sites` keyword. But "_RETURN" is not visible in model/guide, so supporting this or not will depend on reviewers' opinion.

#### num_samples

+ Former behavior: num_samples is different for collecting samples from the guide and collecting samples from the model. Trace predictive will resample samples from guide to predict model.

I think that it is not necessary to have this distinction (maybe it is useful for important sampling). Posterior samples with important weights can be obtained separately. Then for posterior predictive, we just use those "resampled" samples for prediction.

#### param site

+ Former behavior: we can train guides with param_shape = num_data and get posterior samples with shape = num_samples x num_data. Then for prediction with data_new, we can get predictions with shape `num_samples x num_data_new` (by resampling indices?).

I don't understand the theoretical aspect of this pattern. Would it be more reasonable to have `param_shape` that does not depend on `num_data`? I think I need more explanation from reviewers.

cc @ahmadsalim