### PR TITLE
Handle -inf in einsum torch_log backend

### DIFF
--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -29,6 +29,8 @@ def einsum(equation, *operands):
         for i, dim in enumerate(dims):
             if dim not in output:
                 shift = shift.max(i, keepdim=True)[0]
+        # avoid nan due to -inf - -inf
+        shift = shift.clamp(min=torch.finfo(shift.dtype).min)
         exp_operands.append((operand - shift).exp())
 
         # permute shift to match output

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -32,14 +32,16 @@ from tests.common import assert_equal
     'ab,bc,cd->bc',
     'a,a,ab,b,b,b,b->a',
 ])
-def test_einsum(equation, min_size):
+@pytest.mark.parametrize('infinite', [False, True], ids=['finite', 'infinite'])
+def test_einsum(equation, min_size, infinite):
     inputs, output = equation.split('->')
     inputs = inputs.split(',')
     symbols = sorted(set(equation) - set(',->'))
     sizes = dict(zip(symbols, itertools.count(min_size)))
     shapes = [torch.Size(tuple(sizes[dim] for dim in dims))
               for dims in inputs]
-    operands = [torch.randn(shape) for shape in shapes]
+    operands = [torch.full(shape, -float('inf')) if infinite else torch.randn(shape)
+                for shape in shapes]
 
     expected = contract(equation, *(torch_exp(x) for x in operands), backend='torch').log()
     actual = contract(equation, *operands, backend='pyro.ops.einsum.torch_log')


### PR DESCRIPTION
Blocking https://github.com/pyro-ppl/funsor/pull/281

This adds support for correct handling of `-inf` in the `pyro.ops.einsum.torch_log` backend of `opt_einsum.contract`. Similar handling is already used in pyro.ops.rings.

## Tested
- added a unit test
- tested failing test in funsor