### PR TITLE
Added 1x1 invertible convolution as a transform (Glow, Kingma 2018)

### DIFF
--- a/pyro/distributions/transforms/glow.py
+++ b/pyro/distributions/transforms/glow.py
@@ -1,0 +1,97 @@
+import torch
+import torch.nn as nn
+from torch.distributions import constraints
+
+from pyro.distributions.torch_transform import TransformModule
+from pyro.distributions.util import copy_docs_from
+from pyro.distributions.transforms.utils import clamp_preserve_gradients
+
+import numpy as np
+
+
+@copy_docs_from(TransformModule)
+class GlowFlow(TransformModule):
+    """
+    An implementation of Glow: Generative Flow with Invertible 1×1 Convolutions, using Eq (9) from Kingma Et Al., 2018.
+    Together with `TransformedDistribution` and `AffineCoupling` this provides a way to sample images from a latent distirbution (à la VAE).
+    Example usage:
+    >>> import torch
+    >>> c = 3 # assume 3 x 32 x 32 RGB inputs
+    >>> base_dist = dist.Normal(torch.zeros(c*32*32), torch.ones(c*32*32))
+    >>> glow = GlowFlow(torch.nn.Conv2d(c,c,1))
+    >>> pyro.module("my_glow", glow)  # doctest: +SKIP
+    >>> glow_dist = dist.TransformedDistribution(base_dist, [ReshapeTransform([32,32,c]),glow])
+    >>> glow_dist.sample(torch.Size([1])).shape  # doctest: +SKIP
+        torch.Size([1, 3, 32, 32])
+
+    :param cnn: a convolutional neural network with 1x1 kernel size
+    :type cnn: nn.Module
+    :param initialized: if False, use Kingma's orthogonal initialization
+    :type initialized: bool
+    References:
+    1. Glow: Generative Flow with Invertible 1×1 Convolutions [arXiv:1807.03039]
+    Diederik P. Kingma, Prafulla Dhariwal
+    2. Variational Inference with Normalizing Flows [arXiv:1505.05770]
+    Danilo Jimenez Rezende, Shakir Mohamed
+    """
+
+    domain = constraints.real
+    codomain = constraints.real
+    bijective = True
+    event_dim = 0
+    autoregressive = False
+
+    def __init__(self, cnn, initialized=True):
+        super(GlowFlow, self).__init__(cache_size=1)
+        self.cnn = cnn
+        self._cached_log_det = None
+        self.initialized = initialized
+
+    def _call(self, x):
+        """
+        :param x: the input into the bijection
+        :type x: torch.Tensor
+        Invokes the bijection x=>y; in the prototypical context of a TransformedDistribution `x` is a
+        sample from the base distribution (or the output of a previous flow)
+        """
+        h,w,c = x.shape[1:]
+        if not self.initialized:
+            w_init = torch.FloatTensor(np.linalg.qr(np.random.randn(*[c,c]))[0]) # c x c
+            self.cnn.weight.data[:,:,0,0] = w_init
+            self.initialized = True
+
+        log_det = h * w * torch.log(torch.abs(torch.det(self.cnn.weight)))
+        self._cached_log_det = log_det
+
+        y = self.cnn(x)
+        return y
+
+    def _inverse(self, y):
+        """
+        :param y: the output of the bijection
+        :type y: torch.Tensor
+        Inverts y => x. Uses a previously cached inverse if available, otherwise performs the inversion afresh.
+        """
+        h,w,c = y.shape[1:]
+        if not self.initialized:
+            w_init = torch.FloatTensor(np.linalg.qr(np.random.randn(*[c,c]))[0]) # c x c
+            self.cnn.weight.data[:,:,0,0] = w_init
+            self.initialized = True
+
+        log_det = - (h * w * torch.log(torch.abs(torch.det(self.cnn.weight))) )
+        self._cached_log_det = log_det
+
+        self.cnn.weight = torch.inverse(self.cnn.weight)
+
+        x = self.cnn(y)
+        return x
+
+    def log_abs_det_jacobian(self, x, y):
+        """
+        Calculates the elementwise determinant of the log jacobian
+        """
+        if self._cached_log_det is not None:
+            log_det = self._cached_log_det
+        else:
+            log_det = h * w * torch.log(torch.abs(torch.det(self.cnn.weight)))
+        return log_det.sum(-1)

--- a/pyro/distributions/transforms/reshape.py
+++ b/pyro/distributions/transforms/reshape.py
@@ -1,0 +1,69 @@
+import torch
+from torch.distributions.utils import lazy_property
+from torch.distributions import constraints
+from torch.distributions.transforms import Transform
+
+from pyro.distributions.util import copy_docs_from
+
+
+@copy_docs_from(Transform)
+class ReshapeTransform(Transform):
+    """
+    A bijection that reshapes the inputs into an arbitrary-size Tensor. In conjunction with `GlowFlow`, this can be used
+    to apply `nn.Conv2d` to any supported distribution.
+
+    Example usage:
+    >>> import torch
+    >>> c = 3 # assume 3 x 32 x 32 RGB inputs
+    >>> base_dist = dist.Normal(torch.zeros(c*32*32), torch.ones(c*32*32))
+    >>> glow = GlowFlow(torch.nn.Conv2d(c,c,1))
+    >>> pyro.module("my_glow", glow)  # doctest: +SKIP
+    >>> glow_dist = dist.TransformedDistribution(base_dist, [ReshapeTransform([32,32,c]),glow])
+    >>> glow_dist.sample(torch.Size([1])).shape  # doctest: +SKIP
+        torch.Size([1, 3, 32, 32])
+
+    :param shape: the desired shape of y, for the bijection x=>y.
+    :type shape: list
+
+    """
+
+    codomain = constraints.real
+    bijective = True
+    event_dim = 1
+    volume_preserving = True
+
+    def __init__(self, shape):
+        super(ReshapeTransform, self).__init__(cache_size=1)
+
+        self._cached_forward_shape = shape
+
+    def _call(self, x):
+        """
+        :param x: the input into the bijection
+        :type x: torch.Tensor
+
+        Invokes the bijection x=>y; in the prototypical context of a TransformedDistribution `x` is a
+        sample from the base distribution (or the output of a previous transform)
+        """
+        self._cached_inverse_shape = x.shape[1:]
+        return x.view([x.size(0)]+self._cached_forward_shape)
+
+    def _inverse(self, y):
+        """
+        :param y: the output of the bijection
+        :type y: torch.Tensor
+
+        Inverts y => x.
+        """
+        self._cached_forward_shape = y.shape[1:]
+        return y.view([y.size(0)]+self._cached_inverse_shape)
+
+    def log_abs_det_jacobian(self, x, y):
+        """
+        Calculates the elementwise determinant of the log Jacobian, i.e. log(abs([dy_0/dx_0, ..., dy_{N-1}/dx_{N-1}])).
+        Note that this type of transform is not autoregressive, so the log Jacobian is not the sum of the previous
+        expression. However, it turns out it's always 0 (since the determinant is -1 or +1), and so returning a
+        vector of zeros works.
+        """
+
+        return torch.zeros(x.size()[:-1], dtype=x.dtype, layout=x.layout, device=x.device)


### PR DESCRIPTION
This PR implements 1x1 invertible convolutions (which boils down to multiple `nn.Linear` stacked together, but nevertheless useful when mixed with `AffineCoupling`) from [this paper](https://arxiv.org/abs/1807.03039), Eq. 9.