### PR TITLE
Fix autoguide's init_to_median strategy for multivariate distributions

### DIFF
--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -95,6 +95,9 @@ def test_shapes(auto_class, init_loc_fn, Elbo):
         pyro.sample("z2", dist.Normal(torch.zeros(2), torch.ones(2)).to_event(1))
         with pyro.plate("plate", 3):
             pyro.sample("z3", dist.Normal(torch.zeros(3), torch.ones(3)))
+        pyro.sample("z4", dist.MultivariateNormal(torch.zeros(2), torch.eye(2)))
+        pyro.sample("z5", dist.Dirichlet(torch.ones(3)))
+        pyro.sample("z6", dist.Normal(0, 1).expand((2,)).mask(torch.arange(2) > 0).to_event(1))
 
     guide = auto_class(model, init_loc_fn=init_loc_fn)
     elbo = Elbo(strict_enumeration_warning=False)


### PR DESCRIPTION
This checks whether median can actually be computed for `init_to_median`, as discussed in https://github.com/pyro-ppl/pyro/pull/2079

For multivariate distributions, it does not make sense to compute medians independently for each component. This is problematic for e.g. Dirichlet distributions since the median will not satisfy the normalization constraint. Dirichlet was actually succeeding previous to this PR because the normalization constraint failed in `_validate_sample(value)`, but `init_to_median` caught the error and fell back to `init_to_feasible`. For `MultivariateNormal`, the error was silent and led to possibly-bad initialization.

## Tested
- added more distributions to `test_shapes()`