### PR TITLE
Improve contrib.oed documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    ?= -E -W
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python3 -msphinx
 APIDOC        = sphinx-apidoc
 SPHINXPROJ    = Pyro
 SOURCEDIR     = source

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    ?= -E -W
-SPHINXBUILD   = python3 -msphinx
+SPHINXBUILD   = python -msphinx
 APIDOC        = sphinx-apidoc
 SPHINXPROJ    = Pyro
 SOURCEDIR     = source

--- a/pyro/contrib/oed/__init__.py
+++ b/pyro/contrib/oed/__init__.py
@@ -17,8 +17,8 @@ In the BOED framework, we choose the design that optimizes the expected informat
 
 where :math:`H[·]` represents the entropy and :math:`p(\\theta|y, d) \\propto p(\\theta)p(y|\\theta, d)` is the
 posterior we get from
-running the experiment with design :math:`d` and observing :math:`y`. In other words, the optimal design is the one that,
-in expectation over possible future observations, most reduces posterior entropy
+running the experiment with design :math:`d` and observing :math:`y`. In other words, the optimal design is the one
+that, in expectation over possible future observations, most reduces posterior entropy
 over the target latent variables. If the predictive model is correct, this forms a design strategy that is
 (one-step) optimal from an information-theoretic viewpoint. For further details, see [1, 2].
 
@@ -26,17 +26,23 @@ The :mod:`pyro.contrib.oed` module provides tools to create optimal experimental
 designs for Pyro models. In particular, it provides estimators for the
 expected information gain (EIG).
 
-To estimate the EIG for a particular design, first set up a model, for example::
+To estimate the EIG for a particular design, we first set up our Pyro model. For example::
 
     def model(design):
-        with pyro.plate_stack("plate_stack", design.shape[:-1]):
-            theta = pyro.sample("theta", dist.Normal(prior_mean, prior_sd))
-            theta = theta.unsqueeze(-1)
-            logit_p = sensitivity * (theta - design)
-            y = pyro.sample("y", dist.Bernoulli(logits=logit_p).to_event(1))
+
+        # This line allows batching of designs, treating all batch dimensions as independent
+        with pyro.plate_stack("plate_stack", design.shape):
+
+            # We use a Normal prior for theta
+            theta = pyro.sample("theta", dist.Normal(torch.tensor(0.0), torch.tensor(1.0)))
+
+            # We use a simple logistic regression model for the likelihood
+            logit_p = theta - design
+            y = pyro.sample("y", dist.Bernoulli(logits=logit_p))
+
             return y
 
-Then select an appropriate EIG estimator, such as::
+We then select an appropriate EIG estimator, such as::
 
     eig = nmc_eig(model, design, observation_labels=["y"], target_labels=["theta"], N=2500, M=50)
 
@@ -46,7 +52,8 @@ It is possible to estimate the EIG across a grid of designs::
 
 to find the best design from a number of options.
 
-[1] Chaloner, Kathryn, and Isabella Verdinelli. "Bayesian experimental design: A review." Statistical Science (1995): 273-304.
+[1] Chaloner, Kathryn, and Isabella Verdinelli. "Bayesian experimental design: A review."
+Statistical Science (1995): 273-304.
 
 [2] Foster, Adam, et al. "Variational Bayesian Optimal Experimental Design." arXiv preprint arXiv:1903.05480 (2019).
 

--- a/pyro/contrib/oed/__init__.py
+++ b/pyro/contrib/oed/__init__.py
@@ -1,17 +1,55 @@
-"""
-The :mod:`pyro.contrib.oed` module provides tools to create optimal experiment
-designs for pyro models. In particular, it provides estimators for the
-expected information gain (EIG) criterion.
+"""Tasks such as choosing the next question to ask in a psychology study, designing an election polling
+strategy, and deciding which compounds to synthesize and test in biological sciences are all fundamentally asking the
+same question: how do we design an experiment to maximize the information gathered? Bayesian
+optimal experimental design (BOED) is a powerful methodology for tackling such
+problems.
 
-To estimate the EIG for a particular design, use::
+In the BOED framework, we begin with a Bayesian model with a likelihood :math:`p(y|\\theta,d)` and a prior
+:math:`p(\\theta)` on the target latent variables. In Pyro, any fully Bayesian model can be used in the BOED framework.
+The sample sites corresponding to experimental outcomes are the *observation* sites, those corresponding to
+latent variables of interest are the *target* sites. The design :math:`d` is the argument to the model, and is not
+a random variable.
+
+In the BOED framework, we choose the design that optimizes the expected information gain (EIG) on the targets
+:math:`\\theta` from running the experiment
+
+    :math:`\\text{EIG}(d) = \\mathbf{E}_{p(y|d)} [H[p(\\theta)] − H[p(\\theta|y, d)]]` ,
+
+where :math:`H[·]` represents the entropy and :math:`p(\\theta|y, d) \\propto p(\\theta)p(y|\\theta, d)` is the
+posterior we get from
+running the experiment with design :math:`d` and observing :math:`y`. In other words, the optimal design is the one that,
+in expectation over possible future observations, most reduces posterior entropy
+over the target latent variables. If the predictive model is correct, this forms a design strategy that is
+(one-step) optimal from an information-theoretic viewpoint. For further details, see [1, 2].
+
+The :mod:`pyro.contrib.oed` module provides tools to create optimal experimental
+designs for Pyro models. In particular, it provides estimators for the
+expected information gain (EIG).
+
+To estimate the EIG for a particular design, first set up a model, for example::
 
     def model(design):
-        ...
+        with pyro.plate_stack("plate_stack", design.shape[:-1]):
+            theta = pyro.sample("theta", dist.Normal(prior_mean, prior_sd))
+            theta = theta.unsqueeze(-1)
+            logit_p = sensitivity * (theta - design)
+            y = pyro.sample("y", dist.Bernoulli(logits=logit_p).to_event(1))
+            return y
 
-    # Select an appropriate EIG estimator, such as
-    eig = vnmc_eig(model, design, ...)
+Then select an appropriate EIG estimator, such as::
 
-EIG can then be maximised using existing optimisers in :mod:`pyro.optim`.
+    eig = nmc_eig(model, design, observation_labels=["y"], target_labels=["theta"], N=2500, M=50)
+
+It is possible to estimate the EIG across a grid of designs::
+
+    designs = torch.stack([design1, design2], dim=0)
+
+to find the best design from a number of options.
+
+[1] Chaloner, Kathryn, and Isabella Verdinelli. "Bayesian experimental design: A review." Statistical Science (1995): 273-304.
+
+[2] Foster, Adam, et al. "Variational Bayesian Optimal Experimental Design." arXiv preprint arXiv:1903.05480 (2019).
+
 """
 
 from pyro.contrib.oed import search, eig

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -44,7 +44,7 @@ def laplace_eig(model, design, observation_labels, target_labels, guide, loss, o
     :param dict prior_entropy_kwargs: parameters for estimating the prior entropy: `num_prior_samples` indicating the
         number of samples for a MC estimate of prior entropy, and `mean_field` indicating if an analytic form for
         a mean-field prior should be tried.
-    :return: EIG estimate
+    :return: EIG estimate, optionally includes full optimization history
     :rtype: torch.Tensor
     """
 
@@ -105,7 +105,10 @@ def _laplace_vi_ape(model, design, observation_labels, target_labels, guide, los
 # Deprecated
 def vi_eig(model, design, observation_labels, target_labels, vi_parameters, is_parameters, y_dist=None,
            eig=True, **prior_entropy_kwargs):
-    """Estimates the expected information gain (EIG) using variational inference (VI).
+    """.. deprecated:: 0.4.1
+        Use `posterior_eig` instead.
+
+    Estimates the expected information gain (EIG) using variational inference (VI).
 
     The APE is defined as
 
@@ -142,8 +145,8 @@ def vi_eig(model, design, observation_labels, target_labels, vi_parameters, is_p
     :param dict prior_entropy_kwargs: parameters for estimating the prior entropy: `num_prior_samples` indicating the
         number of samples for a MC estimate of prior entropy, and `mean_field` indicating if an analytic form for
         a mean-field prior should be tried.
-    :return: EIG estimate
-    :rtype: `torch.Tensor`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor
 
     """
 
@@ -185,8 +188,7 @@ def _vi_ape(model, design, observation_labels, target_labels, vi_parameters, is_
 
 def nmc_eig(model, design, observation_labels, target_labels=None,
             N=100, M=10, M_prime=None, independent_priors=False):
-    """
-   Nested Monte Carlo estimate of the expected information
+    """Nested Monte Carlo estimate of the expected information
     gain (EIG). The estimate is, when there are not any random effects,
 
     .. math::
@@ -194,7 +196,8 @@ def nmc_eig(model, design, observation_labels, target_labels=None,
         \\frac{1}{N}\\sum_{n=1}^N \\log p(y_n | \\theta_n, d) -
         \\frac{1}{N}\\sum_{n=1}^N \\log \\left(\\frac{1}{M}\\sum_{m=1}^M p(y_n | \\theta_m, d)\\right)
 
-    The estimate is, in the presence of random effects,
+    where :math:`\\theta_n, y_n \\sim p(\\theta, y | d)` and :math:`\\theta_m \\sim p(\\theta)`.
+    The estimate in the presence of random effects is
 
     .. math::
 
@@ -203,6 +206,9 @@ def nmc_eig(model, design, observation_labels, target_labels=None,
         \\frac{1}{N}\\sum_{n=1}^N \\log \\left(\\frac{1}{M}\\sum_{m=1}^{M}
         p(y_n | \\theta_m, \\widetilde{\\theta}_{m}, d)\\right)
 
+    where :math:`\\widetilde{\\theta}` are the random effects with
+    :math:`\\widetilde{\\theta}_{nm} \\sim p(\\widetilde{\\theta}|\\theta=\\theta_n)` and
+    :math:`\\theta_m,\\widetilde{\\theta}_m \\sim p(\\theta,\\widetilde{\\theta})`.
     The latter form is used when `M_prime != None`.
 
     :param function model: A pyro model accepting `design` as only argument.
@@ -219,8 +225,8 @@ def nmc_eig(model, design, observation_labels, target_labels=None,
     :param bool independent_priors: Only used when `M_prime` is not `None`. Indicates whether the prior distributions
         for the target variables and the nuisance variables are independent. In this case, it is not necessary to
         sample the targets conditional on the nuisance variables.
-    :return: EIG estimate
-    :rtype: `torch.Tensor`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor
     """
 
     if isinstance(observation_labels, str):  # list of strings instead of strings
@@ -300,18 +306,18 @@ def donsker_varadhan_eig(model, design, observation_labels, target_labels,
     :param list target_labels: A subset of the sample sites over which the posterior
         entropy is to be measured.
     :param int num_samples: Number of samples per iteration.
-    :param int num_steps: Number of optimisation steps.
+    :param int num_steps: Number of optimization steps.
     :param function or torch.nn.Module T: optimisable function `T` for use in the
         Donsker-Varadhan loss function.
     :param pyro.optim.Optim optim: Optimiser to use.
     :param bool return_history: If `True`, also returns a tensor giving the loss function
-        at each step of the optimisation.
+        at each step of the optimization.
     :param torch.Tensor final_design: The final design tensor to evaluate at. If `None`, uses
         `design`.
     :param int final_num_samples: The number of samples to use at the final evaluation, If `None,
         uses `num_samples`.
     :return: EIG estimate, optionally includes full optimisatio history
-    :rtype: `torch.Tensor` or `tuple`
+    :rtype: torch.Tensor or tuple
     """
     if isinstance(observation_labels, str):
         observation_labels = [observation_labels]
@@ -327,16 +333,15 @@ def posterior_eig(model, design, observation_labels, target_labels, num_samples,
                   *args, **kwargs):
     """
     Posterior estimate of expected information gain (EIG) computed from the average posterior entropy (APE)
-    using `EIG = prior entropy - APE`. See [1] for full details.
+    using :math:`EIG(d) = H[p(\\theta)] - APE(d)`. See [1] for full details.
 
     The posterior representation of APE is
 
-        :math:`sup_{q}E_{p(y, \\theta | d)}[\\log q(\\theta | y, d)]`
+        :math:`\\sup_{q}\\ E_{p(y, \\theta | d)}[\\log q(\\theta | y, d)]`
 
     where :math:`q` is any distribution on :math:`\\theta`.
 
-    This method optimises the loss over a given guide family `guide`
-    representing :math:`q`.
+    This method optimises the loss over a given `guide` family representing :math:`q`.
 
     [1] Foster, Adam, et al. "Variational Bayesian Optimal Experimental Design." arXiv preprint arXiv:1903.05480 (2019).
 
@@ -349,13 +354,13 @@ def posterior_eig(model, design, observation_labels, target_labels, num_samples,
     :param list target_labels: A subset of the sample sites over which the posterior
         entropy is to be measured.
     :param int num_samples: Number of samples per iteration.
-    :param int num_steps: Number of optimisation steps.
+    :param int num_steps: Number of optimization steps.
     :param function guide: guide family for use in the (implicit) posterior estimation.
         The parameters of `guide` are optimised to maximise the posterior
         objective.
     :param pyro.optim.Optim optim: Optimiser to use.
     :param bool return_history: If `True`, also returns a tensor giving the loss function
-        at each step of the optimisation.
+        at each step of the optimization.
     :param torch.Tensor final_design: The final design tensor to evaluate at. If `None`, uses
         `design`.
     :param int final_num_samples: The number of samples to use at the final evaluation, If `None,
@@ -366,8 +371,8 @@ def posterior_eig(model, design, observation_labels, target_labels, num_samples,
     :param dict prior_entropy_kwargs: parameters for estimating the prior entropy: `num_prior_samples` indicating the
         number of samples for a MC estimate of prior entropy, and `mean_field` indicating if an analytic form for
         a mean-field prior should be tried.
-    :return: EIG estimate, optionally includes full optimisation history
-    :rtype: `torch.Tensor` or `tuple`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor or tuple
     """
     if isinstance(observation_labels, str):
         observation_labels = [observation_labels]
@@ -396,11 +401,11 @@ def marginal_eig(model, design, observation_labels, target_labels,
 
     The marginal representation of EIG is
 
-        :math:`inf_{q}E_{p(y, \\theta | d)}\\left[\\log \\frac{p(y | \\theta, d)}{q(y | d)} \\right]`
+        :math:`\\inf_{q}\\ E_{p(y, \\theta | d)}\\left[\\log \\frac{p(y | \\theta, d)}{q(y | d)} \\right]`
 
-    where :math:`q` is any distribution on :math:`y`.
+    where :math:`q` is any distribution on :math:`y`. A variational family for :math:`q` is specified in the `guide`.
 
-    .. warning :: this method does **not** estimate the correct quantity in the presence of random effects.
+    .. warning :: This method does **not** estimate the correct quantity in the presence of random effects.
 
     [1] Foster, Adam, et al. "Variational Bayesian Optimal Experimental Design." arXiv preprint arXiv:1903.05480 (2019).
 
@@ -413,18 +418,18 @@ def marginal_eig(model, design, observation_labels, target_labels,
     :param list target_labels: A subset of the sample sites over which the posterior
         entropy is to be measured.
     :param int num_samples: Number of samples per iteration.
-    :param int num_steps: Number of optimisation steps.
+    :param int num_steps: Number of optimization steps.
     :param function guide: guide family for use in the marginal estimation.
         The parameters of `guide` are optimised to maximise the log-likelihood objective.
     :param pyro.optim.Optim optim: Optimiser to use.
     :param bool return_history: If `True`, also returns a tensor giving the loss function
-        at each step of the optimisation.
+        at each step of the optimization.
     :param torch.Tensor final_design: The final design tensor to evaluate at. If `None`, uses
         `design`.
     :param int final_num_samples: The number of samples to use at the final evaluation, If `None,
         uses `num_samples`.
-    :return: EIG estimate, optionally includes full optimisation history
-    :rtype: `torch.Tensor` or `tuple`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor or tuple
     """
 
     if isinstance(observation_labels, str):
@@ -453,20 +458,20 @@ def marginal_likelihood_eig(model, design, observation_labels, target_labels,
     :param list target_labels: A subset of the sample sites over which the posterior
         entropy is to be measured.
     :param int num_samples: Number of samples per iteration.
-    :param int num_steps: Number of optimisation steps.
+    :param int num_steps: Number of optimization steps.
     :param function marginal_guide: guide family for use in the marginal estimation.
         The parameters of `guide` are optimised to maximise the log-likelihood objective.
     :param function cond_guide: guide family for use in the likelihood (conditional) estimation.
         The parameters of `guide` are optimised to maximise the log-likelihood objective.
     :param pyro.optim.Optim optim: Optimiser to use.
     :param bool return_history: If `True`, also returns a tensor giving the loss function
-        at each step of the optimisation.
+        at each step of the optimization.
     :param torch.Tensor final_design: The final design tensor to evaluate at. If `None`, uses
         `design`.
     :param int final_num_samples: The number of samples to use at the final evaluation, If `None,
         uses `num_samples`.
-    :return: EIG estimate, optionally includes full optimisation history
-    :rtype: `torch.Tensor` or `tuple`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor or tuple
     """
 
     if isinstance(observation_labels, str):
@@ -498,18 +503,18 @@ def lfire_eig(model, design, observation_labels, target_labels,
     :param int num_y_samples: Number of samples to take in :math:`y` for each :math:`\\theta`.
     :param: int num_theta_samples: Number of initial samples in :math:`\\theta` to take. The likelihood ratio
                                    is estimated by LFIRE for each sample.
-    :param int num_steps: Number of optimisation steps.
+    :param int num_steps: Number of optimization steps.
     :param function classifier: a Pytorch or Pyro classifier used to distinguish between samples of :math:`y` under
                                 :math:`p(y|d)` and samples under :math:`p(y|\\theta,d)` for some :math:`\\theta`.
     :param pyro.optim.Optim optim: Optimiser to use.
     :param bool return_history: If `True`, also returns a tensor giving the loss function
-        at each step of the optimisation.
+        at each step of the optimization.
     :param torch.Tensor final_design: The final design tensor to evaluate at. If `None`, uses
         `design`.
     :param int final_num_samples: The number of samples to use at the final evaluation, If `None,
         uses `num_samples`.
-    :return: EIG estimate, optionally includes full optimisation history
-    :rtype: `torch.Tensor` or `tuple`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor or tuple
     """
     if isinstance(observation_labels, str):
         observation_labels = [observation_labels]
@@ -549,6 +554,8 @@ def vnmc_eig(model, design, observation_labels, target_labels,
     As :math:`N \\to \\infty` this is an upper bound on EIG. We minimise this upper bound by stochastic gradient
     descent.
 
+    .. warning :: This method cannot be used in the presence of random effects.
+
     [1] Foster, Adam, et al. "Variational Bayesian Optimal Experimental Design." arXiv preprint arXiv:1903.05480 (2019).
 
     :param function model: A pyro model accepting `design` as only argument.
@@ -560,18 +567,18 @@ def vnmc_eig(model, design, observation_labels, target_labels,
     :param list target_labels: A subset of the sample sites over which the posterior
         entropy is to be measured.
     :param tuple num_samples: Number of (:math:`N, M`) samples per iteration.
-    :param int num_steps: Number of optimisation steps.
+    :param int num_steps: Number of optimization steps.
     :param function guide: guide family for use in the posterior estimation.
         The parameters of `guide` are optimised to minimise the VNMC upper bound.
     :param pyro.optim.Optim optim: Optimiser to use.
     :param bool return_history: If `True`, also returns a tensor giving the loss function
-        at each step of the optimisation.
+        at each step of the optimization.
     :param torch.Tensor final_design: The final design tensor to evaluate at. If `None`, uses
         `design`.
     :param tuple final_num_samples: The number of (:math:`N, M`) samples to use at the final evaluation, If `None,
         uses `num_samples`.
-    :return: EIG estimate, optionally includes full optimisation history
-    :rtype: `torch.Tensor` or `tuple`
+    :return: EIG estimate, optionally includes full optimization history
+    :rtype: torch.Tensor or tuple
     """
     if isinstance(observation_labels, str):
         observation_labels = [observation_labels]

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -316,7 +316,7 @@ def donsker_varadhan_eig(model, design, observation_labels, target_labels,
         `design`.
     :param int final_num_samples: The number of samples to use at the final evaluation, If `None,
         uses `num_samples`.
-    :return: EIG estimate, optionally includes full optimisatio history
+    :return: EIG estimate, optionally includes full optimization history
     :rtype: torch.Tensor or tuple
     """
     if isinstance(observation_labels, str):


### PR DESCRIPTION
I glanced over the documentation for `pyro.contrib.oed` which I'll shortly be linking as part of my NeurIPS paper. It looked a bit light on docs and there were some formatting issues. In this PR  I have
 - added a fuller introduction to EIG. This replicates things we added to the tutorials, but I think it's useful to have it on the landing page
 - fixed documentation for the methods