### PR TITLE
Remove f string.

### DIFF
--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -424,8 +424,8 @@ def crps_empirical(pred, truth):
     :rtype: torch.Tensor
     """
     if pred.dim() != 1 + truth.dim() or pred.shape[1:] != truth.shape:
-        raise ValueError(f"Expected pred to have one extra sample dim on left. "
-                         f"Actual shapes: {pred.shape} versus {truth.shape}")
+        raise ValueError("Expected pred to have one extra sample dim on left. "
+                         "Actual shapes: {} versus {}".format(pred.shape, truth.shape))
     opts = dict(device=pred.device, dtype=pred.dtype)
     num_samples = pred.size(0)
     if num_samples == 1:


### PR DESCRIPTION
It looks like an f-string snuck into 0.5.0 breaking compatibility with python <3.6. I imagine this was an accident as it looks like there's only this single occurrence and I don't see the docs updated to require 3.6+