### PR TITLE
Bump version to 0.5.1 that is python 3.5 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     include:
         - stage: lint
           name: lint
-          python: 3.6
+          python: 3.5
           before_install: pip install flake8 nbstripout nbformat
           install:
           script:
@@ -48,36 +48,36 @@ jobs:
               #  git diff-index --quiet HEAD
         - stage: auxiliary modules
           name: docs
-          python: 3.6
+          python: 3.5
           script:
               - pip install -r docs/requirements.txt
               - make docs
               - make doctest
         - name: perf
-          python: 3.6
+          python: 3.5
           script:
               - pip install -e .[profile]
               - pytest -vs --benchmark-disable tests/perf/test_benchmark.py
         - name: profiler
-          python: 3.6
+          python: 3.5
           script:
               - pip install -e .[profile]
               - python -m profiler.distributions
         - stage: unit test
           name: unit
-          python: 3.6
+          python: 3.5
           script: pytest -vs --cov=pyro --cov-config .coveragerc --stage unit --durations 20
         - name: examples
-          python: 3.6
+          python: 3.5
           script:
               - CI=1 pytest -vs --cov=pyro --cov-config .coveragerc --stage test_examples --durations 10
               - grep -l smoke_test tutorial/source/*.ipynb | xargs grep -L 'smoke_test = False' \
                   | CI=1 xargs pytest -vx --nbval-lax --current-env
         - name: integration batch_1
-          python: 3.6
+          python: 3.5
           script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_1 --durations 10
         - name: integration batch_2
-          python: 3.6
+          python: 3.5
           script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_2 --durations 10
 
 after_success:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ graphviz>=0.8
 numpy>=1.7
 observations>=0.1.4
 opt_einsum>=2.3.2
-pyro-api>=0.1.0
+pyro-api>=0.1.1
 tqdm>=4.36

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,4 @@ numpy>=1.7
 observations>=0.1.4
 opt_einsum>=2.3.2
 pyro-api>=0.1.0
-tqdm>=4.31
+tqdm>=4.36

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -204,4 +204,4 @@ def setup(app):
 
 # @jpchen's hack to get rtd builder to install latest pytorch
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')
+    os.system('pip install torch==1.3.0+cpu -f https://download.pytorch.org/whl/torch_stable.html')

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -245,7 +245,7 @@ def main(**kwargs):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="Pyro AIR example", argument_default=argparse.SUPPRESS)
     parser.add_argument('-n', '--num-steps', type=int, default=int(1e8),
                         help='number of optimization steps to take')

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -359,7 +359,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="Baseball batting average using HMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=200, type=int)
     parser.add_argument("--num-chains", nargs='?', default=4, type=int)

--- a/examples/bayesian_regression.py
+++ b/examples/bayesian_regression.py
@@ -137,7 +137,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=1000, type=int)
     parser.add_argument('-b', '--batch-size', default=N, type=int)

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -72,7 +72,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=200, type=int)
     parser.add_argument('--jit', action='store_true')

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -64,7 +64,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=200, type=int)
     args = parser.parse_args()

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -102,7 +102,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=100, type=int)
     args = parser.parse_args()

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -162,7 +162,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description='Pyro GP MNIST Example')
     parser.add_argument('--data-dir', type=str, default=None, metavar='PATH',
                         help='default directory to cache MNIST data')

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -112,7 +112,7 @@ def main(num_vi_steps, num_bo_steps, seed):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="A/B test experiment design using VI")
     parser.add_argument("-n", "--num-vi-steps", nargs="?", default=5000, type=int)
     parser.add_argument('--num-bo-steps', nargs="?", default=5, type=int)

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -433,7 +433,7 @@ def main(args):
 
 # parse command-line arguments and execute the main method
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
 
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', type=int, default=5000)

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -40,7 +40,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description='Eight Schools MCMC')
     parser.add_argument('--num-samples', type=int, default=1000,
                         help='number of MCMC samples (default: 1000)')

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -72,7 +72,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description='Eight Schools SVI')
     parser.add_argument('--lr', type=float, default=0.01,
                         help='learning rate (default: 0.01)')

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -626,7 +626,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="MAP Baum-Welch learning Bach Chorales")
     parser.add_argument("-m", "--model", default="1", type=str,
                         help="one of: {}".format(", ".join(sorted(models.keys()))))

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -121,7 +121,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=500, type=int)
     args = parser.parse_args()

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -135,7 +135,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="Amortized Latent Dirichlet Allocation")
     parser.add_argument("-t", "--num-topics", default=8, type=int)
     parser.add_argument("-w", "--num-words", default=1024, type=int)

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -46,7 +46,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="Demonstrate the use of an LKJ Prior")
     parser.add_argument("--num-samples", nargs="?", default=200, type=int)
     parser.add_argument("--n", nargs="?", default=500, type=int)

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -62,7 +62,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="Mini Pyro demo")
     parser.add_argument("-b", "--backend", default="minipyro")
     parser.add_argument("-n", "--num-steps", default=1001, type=int)

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -154,7 +154,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     args = parser.parse_args()

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -151,7 +151,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--price', default=10000, type=int)

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -73,7 +73,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--depth', default=2, type=int)

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -86,7 +86,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--depth', default=3, type=int)

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -337,7 +337,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     args = parser.parse_args()

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -231,7 +231,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=1500, type=int, help='number of training epochs')

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -306,7 +306,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description='Krylov KIT')
     parser.add_argument('--num-data', type=int, default=750)
     parser.add_argument('--num-steps', type=int, default=1000)

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -380,7 +380,7 @@ EXAMPLE_RUN = "example run: python ss_vae_M2.py --seed 0 --cuda -n 2 --aux-loss 
               "-sup 3000 -zd 50 -hl 500 -lr 0.00042 -b1 0.95 -bs 200 -log ./tmp.log"
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
 
     parser = argparse.ArgumentParser(description="SS-VAE\n{}".format(EXAMPLE_RUN))
 

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -198,7 +198,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=101, type=int, help='number of training epochs')

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -243,7 +243,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('0.5.0')
+    assert pyro.__version__.startswith('0.5.1')
     parser = argparse.ArgumentParser(description='VAE using MNIST dataset')
     parser.add_argument('-n', '--num-epochs', nargs='?', default=10, type=int)
     parser.add_argument('--batch_size', nargs='?', default=128, type=int)

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -5,7 +5,7 @@ from pyro.primitives import (clear_param_store, enable_validation, factor, get_p
                              param, plate, plate_stack, random_module, sample, validation_enabled)
 from pyro.util import set_rng_seed
 
-version_prefix = '0.5.0'
+version_prefix = '0.5.1'
 
 # Get the __version__ string from the auto-generated _version.py file, if exists.
 try:

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -58,9 +58,7 @@ class ProgressBar(object):
         # Disable progress bar in "CI"
         # (see https://github.com/travis-ci/travis-ci/issues/1337).
         disable = disable or "CI" in os.environ or "PYTEST_XDIST_WORKER" in os.environ
-        bar_format = None
-        if not ipython_env:
-            bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"
+        bar_format = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"
         pbar_cls = tqdm_nb if num_bars > 1 and ipython_env else tqdm
         self.progress_bars = []
         for i in range(num_bars):

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         # numpy is necessary for some functionality of PyTorch
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
-        'pyro-api>=0.1.0',
+        'pyro-api>=0.1.1',
         'torch>=1.3.0',
         'tqdm>=4.36',
     ],

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
             'yapf',
         ],
     },
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     keywords='machine learning statistics probabilistic programming bayesian modeling pytorch',
     license='MIT License',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -35,17 +35,18 @@ if commit_sha:
 with open(os.path.join(PROJECT_PATH, 'pyro', '_version.py'), 'w') as f:
     f.write(VERSION.format(version))
 
-# Populate long description from README.md
+
+# READ README.md for long description on PyPi.
+# This requires uploading via twine, e.g.:
+# $ python setup.py sdist bdist_wheel
+# $ twine upload --repository-url https://test.pypi.org/legacy/ dist/*  # test version
+# $ twine upload dist/*
 try:
     long_description = open('README.md', encoding='utf-8').read()
 except Exception as e:
     sys.stderr.write('Failed to read README.md\n'.format(e))
     sys.stderr.flush()
     long_description = ''
-
-# Remove badges since they will always be obsolete.
-# This assumes the first 10 lines contain badge info.
-long_description = '\n'.join([str(line) for line in long_description.split('\n')[10:]])
 
 # examples/tutorials
 EXTRAS_REQUIRE = [
@@ -58,9 +59,6 @@ EXTRAS_REQUIRE = [
     'seaborn',
     'wget',
 ]
-
-if sys.version_info[0] == 2:
-    EXTRAS_REQUIRE.append('functools32')
 
 setup(
     name='pyro-ppl',
@@ -122,6 +120,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     # yapf
 )

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,10 @@ except Exception as e:
     sys.stderr.flush()
     long_description = ''
 
+# Remove badges since they will always be obsolete.
+# This assumes the first 12 lines contain badge info.
+long_description = '\n'.join([str(line) for line in long_description.split('\n')[12:]])
+
 # examples/tutorials
 EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
@@ -120,7 +124,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     # yapf
 )

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.0',
         'torch>=1.3.0',
-        'tqdm>=4.31',
+        'tqdm>=4.36',
     ],
     extras_require={
         'extras': EXTRAS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -35,18 +35,13 @@ if commit_sha:
 with open(os.path.join(PROJECT_PATH, 'pyro', '_version.py'), 'w') as f:
     f.write(VERSION.format(version))
 
-# Convert README.md to rst for display at https://pypi.python.org/pypi/pyro-ppl
-# When releasing on pypi, make sure pandoc is on your system:
-# $ brew install pandoc          # OS X
-# $ sudo apt-get install pandoc  # Ubuntu Linux
+# Populate long description from README.md
 try:
-    import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-    print(long_description)
+    long_description = open('README.md', encoding='utf-8').read()
 except Exception as e:
-    sys.stderr.write('Failed to convert README.md to rst:\n  {}\n'.format(e))
+    sys.stderr.write('Failed to read README.md\n'.format(e))
     sys.stderr.flush()
-    long_description = open('README.md').read()
+    long_description = ''
 
 # Remove badges since they will always be obsolete.
 # This assumes the first 10 lines contain badge info.
@@ -72,6 +67,7 @@ setup(
     version=version,
     description='A Python library for probabilistic modeling and inference',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=find_packages(include=['pyro', 'pyro.*']),
     package_data={"pyro.distributions": ["*.cpp"]},
     url='http://pyro.ai',
@@ -85,7 +81,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.0',
-        'torch>=1.2.0',
+        'torch>=1.3.0',
         'tqdm>=4.31',
     ],
     extras_require={
@@ -114,6 +110,7 @@ setup(
             'yapf',
         ],
     },
+    python_requires='>=3.4',
     keywords='machine learning statistics probabilistic programming bayesian modeling pytorch',
     license='MIT License',
     classifiers=[
@@ -122,7 +119,9 @@ setup(
         'Intended Audience :: Science/Research',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     # yapf
 )

--- a/tutorial/source/air.ipynb
+++ b/tutorial/source/air.ipynb
@@ -41,7 +41,7 @@
     "import numpy as np\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/bayesian_regression.ipynb
+++ b/tutorial/source/bayesian_regression.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "# for CI testing\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(1)\n",
     "pyro.enable_validation(True)\n",

--- a/tutorial/source/bayesian_regression_ii.ipynb
+++ b/tutorial/source/bayesian_regression_ii.ipynb
@@ -39,7 +39,7 @@
     "import pyro.optim as optim\n",
     "\n",
     "pyro.set_rng_seed(1)\n",
-    "assert pyro.__version__.startswith('0.5.0')"
+    "assert pyro.__version__.startswith('0.5.1')"
    ]
   },
   {

--- a/tutorial/source/bo.ipynb
+++ b/tutorial/source/bo.ipynb
@@ -54,7 +54,7 @@
     "import pyro\n",
     "import pyro.contrib.gp as gp\n",
     "\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)  # can help with debugging\n",
     "pyro.set_rng_seed(1)"
    ]

--- a/tutorial/source/easyguide.ipynb
+++ b/tutorial/source/easyguide.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "pyro.enable_validation(True)\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')"
+    "assert pyro.__version__.startswith('0.5.1')"
    ]
   },
   {

--- a/tutorial/source/ekf.ipynb
+++ b/tutorial/source/ekf.ipynb
@@ -98,7 +98,7 @@
     "from pyro.contrib.tracking.measurements import PositionMeasurement\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -50,7 +50,7 @@
     "from pyro.ops.indexing import Vindex\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation()\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -41,7 +41,7 @@
     "from pyro.infer import SVI, TraceEnum_ELBO, config_enumerate, infer_discrete\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/gp.ipynb
+++ b/tutorial/source/gp.ipynb
@@ -60,7 +60,7 @@
     "import pyro.distributions as dist\n",
     "\n",
     "smoke_test = ('CI' in os.environ)  # ignore; used to check code integrity in the Pyro repo\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/gplvm.ipynb
+++ b/tutorial/source/gplvm.ipynb
@@ -39,7 +39,7 @@
     "import pyro.ops.stats as stats\n",
     "\n",
     "smoke_test = ('CI' in os.environ)  # ignore; used to check code integrity in the Pyro repo\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(1)"
    ]

--- a/tutorial/source/jit.ipynb
+++ b/tutorial/source/jit.ipynb
@@ -48,7 +48,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!"
    ]
   },

--- a/tutorial/source/svi_part_i.ipynb
+++ b/tutorial/source/svi_part_i.ipynb
@@ -265,7 +265,7 @@
     "n_steps = 2 if smoke_test else 2000\n",
     "\n",
     "# enable validation (e.g. validate parameters of distributions)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)\n",
     "\n",
     "# clear the param store in case we're in a REPL\n",

--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -284,7 +284,7 @@
     "import sys\n",
     "\n",
     "# enable validation (e.g. validate parameters of distributions)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)\n",
     "\n",
     "# this is for running the notebook in our testing framework\n",

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -52,7 +52,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!\n",
     "\n",
     "# We'll ue this helper to check our models are correct.\n",

--- a/tutorial/source/tracking_1d.ipynb
+++ b/tutorial/source/tracking_1d.ipynb
@@ -30,7 +30,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)\n",
     "smoke_test = ('CI' in os.environ)"
    ]

--- a/tutorial/source/vae.ipynb
+++ b/tutorial/source/vae.ipynb
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert pyro.__version__.startswith('0.5.0')\n",
+    "assert pyro.__version__.startswith('0.5.1')\n",
     "pyro.enable_validation(True)\n",
     "pyro.distributions.enable_validation(False)\n",
     "pyro.set_rng_seed(0)\n",


### PR DESCRIPTION
Preparing to cut a 0.5.1 release that is compatible with python 3.5:
 - Moving travis to using python 3.5 instead. If this is really slow, we can still use python 3.6 for testing and separately test release candidates locally.
 - Updated readme to remove conversion to .rst, since twine can publish markdown based long description. Also updated `python_requires`.
 - Updating PyTorch to 1.3 in setup.py. I had missed doing that in the earlier version and while the last released changes are compatible with PyTorch 1.2 as well, I think it is better to bump up the PyTorch version to what has been tested. 

Also, fix included for #2091. 