### PR TITLE
Implement 1d convolution via fft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,14 @@ branches:
 
 jobs:
     include:
+        # TODO remove these before merging
+        - stage: debug
+          python: 3.6
+          script:
+              - pytest -vs tests/ops/test_tensor_utils.py
+        - stage: fail
+          script: test ''  # will fail
+
         - stage: lint
           name: lint
           python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,6 @@ branches:
 
 jobs:
     include:
-        # TODO remove these before merging
-        - stage: debug
-          python: 3.6
-          script:
-              - pytest -vs tests/ops/test_tensor_utils.py
-        - stage: fail
-          script: test ''  # will fail
-
         - stage: lint
           name: lint
           python: 3.5

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -53,7 +53,7 @@ def convolve(signal, kernel, mode='full'):
         raise ValueError('Unknown mode: {}'.format(mode))
 
     # Compute convolution using fft.
-    padded_size = m + n
+    padded_size = m + n - 1
     # Round up to next power of 2 for cheaper fft.
     padded_size = 2 ** int(math.ceil(math.log2(padded_size)))
     f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, padded_size - m)), 1)

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 
 
@@ -23,7 +25,7 @@ def _complex_mul(a, b):
     return torch.stack([ar * br - ai * bi, ar * bi + ai * br], dim=-1)
 
 
-def conv1d_fft(signal, kernel):
+def convolve(signal, kernel, mode='full'):
     """
     Computes the 1-d convolution of signal by kernel using FFTs.
     The two arguments should have the same rightmost dim, but may otherwise be
@@ -31,12 +33,32 @@ def conv1d_fft(signal, kernel):
 
     :param torch.Tensor signal: A signal to convolve.
     :param torch.Tensor kernel: A convolution kernel.
-    :return: A tensor of shape
-        ``broadcast_shape(convolve, kernel.shape)``
+    :param str mode: One of: 'full', 'valid', 'same'.
+    :return: A tensor with broadcasted shape. Letting ``m = signal.size(-1)``
+        and ``n = kernel.size(-1)``, the rightmost size of the result will be:
+        ``m + n - 1`` if mode is 'full';
+        ``max(m, n) - min(m, n) + 1`` if mode is 'valid'; or
+        ``m`` if mode is 'same'.
     :rtype torch.Tensor:
     """
-    assert signal.size(-1) == kernel.size(-1)
-    f_signal = torch.rfft(torch.cat([signal, torch.zeros_like(signal)], dim=-1), 1)
-    f_kernel = torch.rfft(torch.cat([kernel, torch.zeros_like(kernel)], dim=-1), 1)
+    m = signal.size(-1)
+    n = kernel.size(-1)
+    if mode == 'full':
+        truncate = m + n - 1
+    elif mode == 'valid':
+        truncate = max(m, n) - min(m, n) + 1
+    elif mode == 'same':
+        truncate = m
+    else:
+        raise ValueError('Unknown mode: {}'.format(mode))
+
+    # Compute convolution using fft.
+    padded_size = m + n
+    # Round up to next power of 2 for cheaper fft.
+    padded_size = 2 ** int(math.ceil(math.log2(padded_size)))
+    f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, padded_size - m)), 1)
+    f_kernel = torch.rfft(torch.nn.functional.pad(kernel, (0, padded_size - n)), 1)
     f_result = _complex_mul(f_signal, f_kernel)
-    return torch.irfft(f_result, 1)[..., :signal.size(-1)]
+    result = torch.irfft(f_result, 1)
+
+    return result[..., :truncate]

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -53,12 +53,11 @@ def convolve(signal, kernel, mode='full'):
     # Compute convolution using fft.
     padded_size = m + n - 1
     # Round up to next power of 2 for cheaper fft.
-    fast_ftt_size = 2 ** int(math.ceil(math.log2(padded_size)))
+    fast_ftt_size = 2 ** math.ceil(math.log2(padded_size))
     f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, fast_ftt_size - m)), 1, onesided=False)
     f_kernel = torch.rfft(torch.nn.functional.pad(kernel, (0, fast_ftt_size - n)), 1, onesided=False)
     f_result = _complex_mul(f_signal, f_kernel)
     result = torch.irfft(f_result, 1, onesided=False)
 
-    result = result[..., :padded_size]
     start_idx = (padded_size - truncate) // 2
     return result[..., start_idx: start_idx + truncate]

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -20,8 +20,6 @@ def block_diag(m):
 def _complex_mul(a, b):
     ar, ai = a.unbind(-1)
     br, bi = b.unbind(-1)
-    # FIXME should b be conjugated?
-    # bi = -bi  # Conjugates b.
     return torch.stack([ar * br - ai * bi, ar * bi + ai * br], dim=-1)
 
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -36,7 +36,7 @@ def convolve(signal, kernel, mode='full'):
         and ``n = kernel.size(-1)``, the rightmost size of the result will be:
         ``m + n - 1`` if mode is 'full';
         ``max(m, n) - min(m, n) + 1`` if mode is 'valid'; or
-        ``m`` if mode is 'same'.
+        ``max(m, n)`` if mode is 'same'.
     :rtype torch.Tensor:
     """
     m = signal.size(-1)
@@ -46,7 +46,7 @@ def convolve(signal, kernel, mode='full'):
     elif mode == 'valid':
         truncate = max(m, n) - min(m, n) + 1
     elif mode == 'same':
-        truncate = m
+        truncate = max(m, n)
     else:
         raise ValueError('Unknown mode: {}'.format(mode))
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -13,3 +13,30 @@ def block_diag(m):
     B, M, N = m.shape
     eye = torch.eye(B, dtype=m.dtype, device=m.device).reshape(B, 1, B, 1)
     return (m.unsqueeze(-2) * eye).reshape(B * M, B * N)
+
+
+def _complex_mul(a, b):
+    ar, ai = a.unbind(-1)
+    br, bi = b.unbind(-1)
+    # FIXME should b be conjugated?
+    # bi = -bi  # Conjugates b.
+    return torch.stack([ar * br - ai * bi, ar * bi + ai * br], dim=-1)
+
+
+def conv1d_fft(signal, kernel):
+    """
+    Computes the 1-d convolution of signal by kernel using FFTs.
+    The two arguments should have the same rightmost dim, but may otherwise be
+    arbitrarily broadcastable.
+
+    :param torch.Tensor signal: A signal to convolve.
+    :param torch.Tensor kernel: A convolution kernel.
+    :return: A tensor of shape
+        ``broadcast_shape(convolve, kernel.shape)``
+    :rtype torch.Tensor:
+    """
+    assert signal.size(-1) == kernel.size(-1)
+    f_signal = torch.rfft(torch.cat([signal, torch.zeros_like(signal)], dim=-1), 1)
+    f_kernel = torch.rfft(torch.cat([kernel, torch.zeros_like(kernel)], dim=-1), 1)
+    f_result = _complex_mul(f_signal, f_kernel)
+    return torch.irfft(f_result, 1)[..., :signal.size(-1)]

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -54,9 +54,9 @@ def convolve(signal, kernel, mode='full'):
     padded_size = m + n - 1
     # Round up to next power of 2 for cheaper fft.
     padded_size = 2 ** int(math.ceil(math.log2(padded_size)))
-    f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, padded_size - m)), 1)
-    f_kernel = torch.rfft(torch.nn.functional.pad(kernel, (0, padded_size - n)), 1)
+    f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, padded_size - m)), 1, onesided=False)
+    f_kernel = torch.rfft(torch.nn.functional.pad(kernel, (0, padded_size - n)), 1, onesided=False)
     f_result = _complex_mul(f_signal, f_kernel)
-    result = torch.irfft(f_result, 1)
+    result = torch.irfft(f_result, 1, onesided=False)
 
     return result[..., :truncate]

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -53,10 +53,12 @@ def convolve(signal, kernel, mode='full'):
     # Compute convolution using fft.
     padded_size = m + n - 1
     # Round up to next power of 2 for cheaper fft.
-    padded_size = 2 ** int(math.ceil(math.log2(padded_size)))
-    f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, padded_size - m)), 1, onesided=False)
-    f_kernel = torch.rfft(torch.nn.functional.pad(kernel, (0, padded_size - n)), 1, onesided=False)
+    fast_ftt_size = 2 ** int(math.ceil(math.log2(padded_size)))
+    f_signal = torch.rfft(torch.nn.functional.pad(signal, (0, fast_ftt_size - m)), 1, onesided=False)
+    f_kernel = torch.rfft(torch.nn.functional.pad(kernel, (0, fast_ftt_size - n)), 1, onesided=False)
     f_result = _complex_mul(f_signal, f_kernel)
     result = torch.irfft(f_result, 1, onesided=False)
 
-    return result[..., :truncate]
+    result = result[..., :padded_size]
+    start_idx = (padded_size - truncate) // 2
+    return result[..., start_idx: start_idx + truncate]

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -1,5 +1,5 @@
 import pytest
-import scipy.signal
+import numpy as np
 import torch
 
 from pyro.ops.tensor_utils import block_diag, convolve
@@ -31,7 +31,7 @@ def test_convolve_shape(m, n, mode):
     signal = torch.randn(m)
     kernel = torch.randn(n)
     actual = convolve(signal, kernel, mode)
-    expected = scipy.signal.convolve(signal, kernel, mode=mode)
+    expected = np.convolve(signal, kernel, mode=mode)
     assert actual.shape == expected.shape
 
 
@@ -44,7 +44,7 @@ def test_convolve(batch_shape, m, n, mode):
     kernel = torch.randn(*batch_shape, n)
     actual = convolve(signal, kernel, mode)
     expected = torch.stack([
-        torch.tensor(scipy.signal.convolve(s, k, mode=mode))
+        torch.tensor(np.convolve(s, k, mode=mode))
         for s, k in zip(signal.reshape(-1, m), kernel.reshape(-1, n))
     ]).reshape(*batch_shape, -1)
     assert_close(actual, expected)

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -26,6 +26,17 @@ def test_block_diag(batch_size, block_size):
 
 @pytest.mark.parametrize('m', [2, 3, 4, 5, 6, 10])
 @pytest.mark.parametrize('n', [2, 3, 4, 5, 6, 10])
+@pytest.mark.parametrize('mode', ['full', 'valid', 'same'])
+def test_convolve_shape(m, n, mode):
+    signal = torch.randn(m)
+    kernel = torch.randn(n)
+    actual = convolve(signal, kernel, mode)
+    expected = scipy.signal.convolve(signal, kernel, mode=mode)
+    assert actual.shape == expected.shape
+
+
+@pytest.mark.parametrize('m', [2, 3, 4, 5, 6, 10])
+@pytest.mark.parametrize('n', [2, 3, 4, 5, 6, 10])
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
 @pytest.mark.parametrize('mode', ['full', 'valid', 'same'])
 def test_convolve(batch_shape, m, n, mode):

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -38,9 +38,7 @@ def test_convolve_shape(m, n, mode):
 @pytest.mark.parametrize('m', [2, 3, 4, 5, 6, 10])
 @pytest.mark.parametrize('n', [2, 3, 4, 5, 6, 10])
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
-@pytest.mark.parametrize('mode', ['full', 
-    #'valid',
-    'same'])
+@pytest.mark.parametrize('mode', ['full', 'valid', 'same'])
 def test_convolve(batch_shape, m, n, mode):
     signal = torch.randn(*batch_shape, m)
     kernel = torch.randn(*batch_shape, n)

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -2,7 +2,7 @@ import pytest
 from tests.common import assert_equal
 
 import torch
-from pyro.ops.tensor_utils import block_diag
+from pyro.ops.tensor_utils import block_diag, conv1d_fft
 
 
 pytestmark = pytest.mark.stage('unit')
@@ -22,3 +22,18 @@ def test_block_diag(batch_size, block_size):
         bottom, top = k * block_size[0], (k + 1) * block_size[0]
         left, right = k * block_size[1], (k + 1) * block_size[1]
         assert_equal(b[bottom:top, left:right], m[k])
+
+
+@pytest.mark.parametrize('T', [2, 3, 4, 5, 10])
+@pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
+def test_conv1d_fft(batch_shape, T):
+    signal = torch.randn(T)  # not batched
+    kernel = torch.randn(*batch_shape, T).exp()  # batched
+    actual = conv1d_fft(signal, kernel)
+
+    # FIXME is this correct?
+    padded = torch.cat([torch.zeros_like(signal), signal])
+    expected = torch.stack([kernel @ padded[t:t+T]
+                            for t in range(1, 1+T)], dim=-1)
+    assert actual.shape == expected.shape
+    assert torch.allclose(actual, expected), (actual, expected)

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -38,7 +38,9 @@ def test_convolve_shape(m, n, mode):
 @pytest.mark.parametrize('m', [2, 3, 4, 5, 6, 10])
 @pytest.mark.parametrize('n', [2, 3, 4, 5, 6, 10])
 @pytest.mark.parametrize('batch_shape', [(), (4,), (2, 3)], ids=str)
-@pytest.mark.parametrize('mode', ['full', 'valid', 'same'])
+@pytest.mark.parametrize('mode', ['full', 
+    #'valid',
+    'same'])
 def test_convolve(batch_shape, m, n, mode):
     signal = torch.randn(*batch_shape, m)
     kernel = torch.randn(*batch_shape, n)


### PR DESCRIPTION
This adds a helper to do long time convolution, as common in signal processing.
The interface matches [np.convolve](https://docs.scipy.org/doc/numpy/reference/generated/numpy.convolve.html) but supports batching and gradients.

## Tested
- added unit tests