### PR TITLE
Implement ReflectedDistribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -175,6 +175,13 @@ OMTMultivariateNormal
     :undoc-members:
     :show-inheritance:
 
+ReflectedDistribution
+---------------------
+.. autoclass:: pyro.distributions.ReflectedDistribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 RelaxedBernoulliStraightThrough
 -------------------------------
 .. autoclass:: pyro.distributions.RelaxedBernoulliStraightThrough

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -14,6 +14,7 @@ from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.lkj import LKJCorrCholesky
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
+from pyro.distributions.reflected import ReflectedDistribution
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.relaxed_straight_through import (RelaxedBernoulliStraightThrough,
                                                          RelaxedOneHotCategoricalStraightThrough)
@@ -52,6 +53,7 @@ __all__ = [
     "MixtureOfDiagNormals",
     "MixtureOfDiagNormalsSharedCovariance",
     "OMTMultivariateNormal",
+    "ReflectedDistribution",
     "Rejector",
     "RelaxedBernoulliStraightThrough",
     "RelaxedOneHotCategoricalStraightThrough",

--- a/pyro/distributions/reflected.py
+++ b/pyro/distributions/reflected.py
@@ -24,6 +24,8 @@ class ReflectedDistribution(TransformedDistribution):
         return super().expand(batch_shape, _instance=new)
 
     def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
         dim = max(len(self.batch_shape), value.dim())
         plus_minus = value.new_tensor([1., -1.]).reshape((2,) + (1,) * dim)
         return self.base_dist.log_prob(plus_minus * value).logsumexp(0)

--- a/pyro/distributions/reflected.py
+++ b/pyro/distributions/reflected.py
@@ -1,0 +1,29 @@
+from torch.distributions import constraints
+from torch.distributions.transforms import AbsTransform
+
+from pyro.distributions.torch import TransformedDistribution
+
+
+class ReflectedDistribution(TransformedDistribution):
+    """
+    Equivalent to ``TransformedDistribution(base_dist, AbsTransform())``,
+    but additionally supports :meth:`log_prob` .
+
+    :param ~torch.distributions.Distribution base_dist: The distribution to
+        reflect.
+    """
+    support = constraints.positive
+
+    def __init__(self, base_dist):
+        if base_dist.event_shape:
+            raise ValueError("Only univariate distributions can be reflected.")
+        super().__init__(base_dist, AbsTransform())
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(type(self), _instance)
+        return super().expand(batch_shape, _instance=new)
+
+    def log_prob(self, value):
+        dim = max(len(self.batch_shape), value.dim())
+        plus_minus = value.new_tensor([1., -1.]).reshape((2,) + (1,) * dim)
+        return self.base_dist.log_prob(plus_minus * value).logsumexp(0)

--- a/pyro/distributions/reflected.py
+++ b/pyro/distributions/reflected.py
@@ -14,10 +14,10 @@ class ReflectedDistribution(TransformedDistribution):
     """
     support = constraints.positive
 
-    def __init__(self, base_dist):
+    def __init__(self, base_dist, validate_args=None):
         if base_dist.event_shape:
             raise ValueError("Only univariate distributions can be reflected.")
-        super().__init__(base_dist, AbsTransform())
+        super().__init__(base_dist, AbsTransform(), validate_args)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(type(self), _instance)

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -10,6 +10,12 @@ from pyro.distributions.testing.rejection_exponential import RejectionExponentia
 from pyro.distributions.testing.rejection_gamma import ShapeAugmentedBeta, ShapeAugmentedDirichlet, ShapeAugmentedGamma
 from tests.distributions.dist_fixture import Fixture
 
+
+class ReflectedNormal(dist.ReflectedDistribution):
+    def __init__(self, loc, scale):
+        super().__init__(dist.Normal(loc, scale))
+
+
 continuous_dists = [
     Fixture(pyro_dist=dist.Uniform,
             scipy_dist=sp.uniform,
@@ -158,6 +164,17 @@ continuous_dists = [
                 ((), {"mean": np.array(loc), "cov": np.array([[1.5, 0.5], [0.5, 0.75]])}),
             prec=0.01,
             min_samples=500000),
+    Fixture(pyro_dist=ReflectedNormal,
+            examples=[
+                {'loc': [2.0], 'scale': [4.0],
+                 'test_data': [2.0]},
+                {'loc': [[2.0]], 'scale': [[4.0]],
+                 'test_data': [[2.0]]},
+                {'loc': [[[2.0]]], 'scale': [[[4.0]]],
+                 'test_data': [[[2.0]]]},
+                {'loc': [2.0, 50.0], 'scale': [4.0, 100.0],
+                 'test_data': [[2.0, 50.0], [2.0, 50.0]]},
+            ]),
     Fixture(pyro_dist=dist.Dirichlet,
             scipy_dist=sp.dirichlet,
             examples=[


### PR DESCRIPTION
This implements a `ReflectedDistribution` which is like `TransformedDistribution(-, AbsTransform())` but also supports `.log_prob()`. Unlike truncating or censoring, reflecting leads to generic tractable `.rasample()` and `.log_prob()` methods. Unlike the [similar implementation](https://github.com/tensorflow/probability/blob/r0.8/tensorflow_probability/python/distributions/transformed_distribution.py#L407) in tensorflow distributions, I have not attempted to generalize Bijectors to multivalued functions, since this one case gets us quite far.

The motivation is in count-valued time series forecasting, where @slaweku recommends modeling positive data as power-transformed with a robust noise distribution. We'd like to use something like
```py
TransformedDistribution(StudentT(...),
                        PowerTransform(...))
```
which works in Stan, but fails in PyTorch because `PowerTransform` assumes positive data. In the past I've tried to replace the `PowerTransform` with an `ExpTransform`, but this ends up being less robust to zeros. Instead we can wrap with `ReflectedDistribution` to get a working Pyro version.
```py
TransformedDistribution(ReflectedDistribution(StudentT(...)),
                        PowerTransform(...))
```
I have tested this version for both SVI training and data generation.

## Tested
- added unit tests
- tested in a real time series application