### PR TITLE
Implement constraints for nn.Parameters of nn.Modules

### DIFF
--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -7,4 +7,20 @@ via the Pyro primitive `pyro.param`. Parameters play a central role in stochasti
 where they are used to represent point estimates for the parameters in parameterized families of 
 models and guides.
 
-.. include:: pyro.params.txt
+ParamStore
+----------
+
+.. automodule:: pyro.params.param_store
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+ConstrainedParameter
+--------------------
+
+.. automodule:: pyro.params.constrained_parameter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource

--- a/docs/source/pyro.params.txt
+++ b/docs/source/pyro.params.txt
@@ -1,8 +1,0 @@
-ParamStore
-----------
-
-.. automodule:: pyro.params.param_store
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :member-order: bysource

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,8 +1,9 @@
-from .constrained_parameter import ConstrainedParameter
+from .constrained_parameter import ConstrainedParameter, constraint
 from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
 
 __all__ = [
     "ConstrainedParameter",
+    "constraint",
     "module_from_param_with_module_name",
     "param_with_module_name",
     "user_param_name",

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,6 +1,8 @@
-from pyro.params.param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
+from .constrained_parameter import ConstrainedParameter
+from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
 
 __all__ = [
+    "ConstrainedParameter",
     "module_from_param_with_module_name",
     "param_with_module_name",
     "user_param_name",

--- a/pyro/params/constrained_parameter.py
+++ b/pyro/params/constrained_parameter.py
@@ -1,0 +1,106 @@
+import weakref
+
+import torch
+from torch.distributions import transform_to
+from torch.distributions.constraints import Constraint
+
+
+class ConstrainedParameter:
+    """
+    Constrained wrapper around a :class:`~torch.nn.Parameter` that obeys a
+    :class:`~torch.distributions.constraints.Constraint` .
+
+    Like :class:`~torch.nn.Parameter` , this can be accessed directly as an
+    attribute of an enclosing :class:`~torch.nn.Module` . Unlike a
+    :class:`~torch.nn.Parameter` , the ``.data`` attribute cannot be set
+    directly; instead set data via the :meth:`unconstrained` method::
+
+        my_module.scale = ConstrainedParameter(torch.ones(2,3,4),
+                                               constraint=constraints.positive)
+        assert isinstance(my_module.scale, torch.Tensor)
+        my_module.scale.unconstrained().data.normal_()
+
+    ConstrainedParameters can be owned by only one object.
+
+    :param torch.Tensor constrained_data: Initial data in constrained space.
+    :param ~torch.distributions.constraints.Constraint constraint: A
+        constraint.
+    """
+
+    def __init__(self, constrained_data, constraint):
+        assert isinstance(constrained_data, torch.Tensor)
+        assert isinstance(constraint, Constraint)
+        self.constraint = constraint
+        self._owner = None
+        self._name = None
+
+        super().__init__()
+        self.set(constrained_data)
+
+    def unconstrained(self):
+        """
+        Provides access to the underlying unconstrained data.
+
+        :rtype: torch.Tensor
+        """
+        if self._owner is not None:
+            self._unconstrained_value = getattr(self._owner, self._name)
+        return self._unconstrained_value
+
+    def get(self):
+        """
+        Gets the current constrained value.
+
+        :rtype: torch.Tensor
+        """
+        return self.__get__(None)
+
+    def set(self, constrained_data):
+        """
+        Sets a new constrained value.
+
+        :param torch.Tensor constrained_data: A new constrained value.
+        """
+        with torch.no_grad():
+            constrained_data = constrained_data.detach()
+            unconstrained_data = transform_to(self.constraint).inv(constrained_data)
+            unconstrained_data = unconstrained_data.contiguous()
+        self._unconstrained_value = torch.nn.Parameter(unconstrained_data)
+        if self._owner is not None:
+            setattr(owner, self._name, self._unconstrained_value)
+
+    def _update_owner(self, owner):
+        if owner is not self._owner:
+            self._owner = owner
+            for name, attr in owner.__dict__.items():
+                if attr is self:
+                    self._name = name + "_unconstrained"
+                    return
+        raise ValueError("ConstrainedParameter is not owned by {}".format(owner))
+
+    def __get__(self, owner, obj_type=None):
+        if owner is not None:
+            self._update_owner(owner)
+        unconstrained_value = self.unconstrained()
+        constrained_value = transform_to(self.constraint)(unconstrained_value)
+
+        # We add a weakref to the constrained result to provide uniform access
+        # to the underlying data:
+        # 1. When called on a free-standing instance, .unconstrained() will
+        #    call the above unconstrained() method.
+        # 2. When called on an attribute of an enclosing object, that object's
+        #    getattr will trigger, __get__, returning a constrained
+        #    torch.Tensor (not a ConsterainedParameter), and .unconstrained()
+        #    will dereference the following weakref:
+        constrained_value.unconstrained = weakref.ref(unconstrained_value)
+
+        return constrained_value
+
+    # These must be defined to ensure this is a data attribute,
+    # but cannot be implemented because torch.nn.Module implements
+    # custom .__setattr__() and .__delattr__() methods.
+    def __set__(self, owner, constrained_data):
+        raise AttributeError('Not Implemented')
+
+    def __delete__(self, owner):
+        raise AttributeError('Not Implemented')

--- a/pyro/params/constrained_parameter.py
+++ b/pyro/params/constrained_parameter.py
@@ -4,7 +4,7 @@ from torch.distributions import transform_to
 
 class ConstrainedParameter:
     """
-    Descriptor to add a constraint to a
+    Descriptor to add a
     :class:`~torch.distributions.constraints.Constraint` to a
     :class:`~torch.nn.Parameter` of a :class:`~torch.nn.Module` .
     These are typically created via the :func:`constraint` decorator.
@@ -17,6 +17,7 @@ class ConstrainedParameter:
 
         class MyModule(nn.Module):
             def __init__(self, x):
+                super().__init__()
                 self.x = x
 
             @constraint
@@ -30,6 +31,19 @@ class ConstrainedParameter:
 
         # XXX Wrong way to initialize XXX
         # my_module.x.data.normal_()  # has no effect.
+
+    Constraints may depend on other parameters (of course not cyclically), for
+    example::
+
+        class Interval(nn.Module):
+            def __init__(self, lb, ub):
+                super().__init__()
+                self.lb = lb
+                self.ub = ub
+
+            @constraint
+            def ub(self):
+                return constraints.greater_than(self.lb)
 
     :param str name: The name of the constrained parameter.
     :param callable constraint: A function that inputs a

--- a/tests/params/test_constrained_parameter.py
+++ b/tests/params/test_constrained_parameter.py
@@ -1,0 +1,95 @@
+import pytest
+import torch
+from torch.distributions import constraints
+
+from pyro.params import ConstrainedParameter
+
+
+SHAPE_CONSTRAINT = [
+    ((), constraints.real),
+    ((4,), constraints.real),
+    ((3, 2), constraints.real),
+    ((), constraints.positive),
+    ((4,), constraints.positive),
+    ((3, 2), constraints.positive),
+    ((5,), constraints.simplex),
+    ((2, 5,), constraints.simplex),
+    ((5, 5), constraints.lower_cholesky),
+    ((2, 5, 5), constraints.lower_cholesky),
+    ((10, ), constraints.greater_than(-torch.randn(10).exp())),
+    ((4, 10), constraints.greater_than(-torch.randn(10).exp())),
+    ((4, 10), constraints.greater_than(-torch.randn(4, 10).exp())),
+    ((3, 2, 10), constraints.greater_than(-torch.randn(10).exp())),
+    ((3, 2, 10), constraints.greater_than(-torch.randn(2, 10).exp())),
+    ((3, 2, 10), constraints.greater_than(-torch.randn(3, 1, 10).exp())),
+    ((3, 2, 10), constraints.greater_than(-torch.randn(3, 2, 10).exp())),
+    ((5,), constraints.real_vector),
+    ((2, 5,), constraints.real_vector),
+    ((), constraints.unit_interval),
+    ((4, ), constraints.unit_interval),
+    ((3, 2), constraints.unit_interval),
+    ((10,), constraints.interval(-torch.randn(10).exp(),
+                                 torch.randn(10).exp())),
+    ((4, 10), constraints.interval(-torch.randn(10).exp(),
+                                   torch.randn(10).exp())),
+    ((3, 2, 10), constraints.interval(-torch.randn(10).exp(),
+                                      torch.randn(10).exp())),
+]
+
+
+@pytest.mark.parametrize('shape,constraint', SHAPE_CONSTRAINT)
+def test_attr_of_object(shape, constraint):
+    obj = type("Foo", (), {})
+    p = ConstrainedParameter(torch.full(shape, 1e-4), constraint)
+    obj.x = p
+
+    assert isinstance(obj.__dict__['x'], ConstrainedParameter)
+    assert isinstance(obj.x, torch.Tensor)
+    assert obj.x.shape == shape
+    assert constraint.check(obj.x).all()
+
+    p.set(torch.randn(shape).exp() * 1e-6)
+    assert isinstance(obj.__dict__['x'], ConstrainedParameter)
+    assert isinstance(obj.x, torch.Tensor)
+    assert obj.x.shape == shape
+    assert constraint.check(obj.x).all()
+
+    assert isinstance(obj.x.unconstrained(), torch.Tensor)
+    obj.x.unconstrained().data.normal_()
+    assert constraint.check(obj.x).all()
+
+
+@pytest.mark.parametrize('shape,constraint', SHAPE_CONSTRAINT)
+def test_attr_of_module(shape, constraint):
+    module = type("Foo", (), {})
+    p = ConstrainedParameter(torch.full(shape, 1e-4), constraint)
+    module.x = p
+
+    assert isinstance(module.__dict__['x'], ConstrainedParameter)
+    assert isinstance(module.x, torch.Tensor)
+    assert module.x.shape == shape
+    assert constraint.check(module.x).all()
+
+    p.set(torch.randn(shape).exp() * 1e-6)
+    assert isinstance(module.__dict__['x'], ConstrainedParameter)
+    assert isinstance(module.x, torch.Tensor)
+    assert module.x.shape == shape
+    assert constraint.check(module.x).all()
+
+    assert isinstance(module.x.unconstrained(), torch.Tensor)
+    module.x.unconstrained().data.normal_()
+    assert constraint.check(module.x).all()
+
+
+@pytest.mark.parametrize('shape,constraint', SHAPE_CONSTRAINT)
+def test_free_object(shape, constraint):
+    p = ConstrainedParameter(torch.full(shape, 1e-4), constraint)
+
+    p.set(torch.randn(shape).exp() * 1e-6)
+    assert isinstance(p.get(), torch.Tensor)
+    assert p.get().shape == shape
+    assert constraint.check(p.get()).all()
+
+    assert isinstance(p.unconstrained(), torch.Tensor)
+    p.unconstrained().data.normal_()
+    assert constraint.check(p.get()).all()


### PR DESCRIPTION
Addresses #2078 

This implements a surprisingly succinct syntax for constraints of module parameters, e.g.
```py
from torch import nn
from torch.distributions import constraints
from pyro.params import constraint

class Normal(nn.Module):
    def __init__(self, loc, scale):
        super().__init__()
        self.loc = loc                 # this will be unconstrained
        self.scale = scale             # this will be constrained

    @constraint
    def scale(self):                   # must match name of attribute
        return constraints.positive    # a constraint object,
                                       # can even depend on other params
```
Hopefully this moves us towards making the Pyro param store a nn.Module. Currently this is not used by the ParamStore, but this PR will unblock later refactoring.

In the nearer term, @martinjankowiak might want to use this for constrained parameters in pyro.contrib.timeseries, e.g. this could simplify #2099.

## How does this work?

For each constrained parameter `x`, this creates an unconstrained parameter with name `x_unconstrained`, which is accessible in the usual way. The name `x` then points to a Python descriptor (like a property) that transforms to/from `unconstrained_x` to a user-defined value. Thus all the usual `nn.Module` magic should continue to work correctly, with only the addition of this `transform_to()` layer.

## Tested
- [x] tested with a variety of constraints
- [x] tested chaining, where one param's constraint might depend on another param (e.g. for lower bound)
- [x] tested serialization