### PR TITLE
Implement a ConstrainedModule for dynamic constraints

### DIFF
--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -16,8 +16,8 @@ ParamStore
     :show-inheritance:
     :member-order: bysource
 
-ConstrainedParameter
---------------------
+Constraints
+-----------
 
 .. automodule:: pyro.params.constrained_parameter
     :members:

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,7 +1,8 @@
-from .constrained_parameter import ConstrainedParameter, constraint
+from .constrained_parameter import ConstrainedModule, ConstrainedParameter, constraint
 from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
 
 __all__ = [
+    "ConstrainedModule",
     "ConstrainedParameter",
     "constraint",
     "module_from_param_with_module_name",

--- a/pyro/params/constrained_parameter.py
+++ b/pyro/params/constrained_parameter.py
@@ -1,10 +1,101 @@
+from collections import OrderedDict, namedtuple
+
 import torch
 from torch.distributions import transform_to
 
+ConstrainedParameter = namedtuple("ConstrainedParameter", ("data", "constraint"))
 
-class ConstrainedParameter:
+
+class ConstrainedModule(torch.nn.Module):
     """
-    Descriptor to add a
+    Subclass of :class:`~torch.nn.Module` that allows dynamically defined
+    :class:`~torch.distributions.constraints.Constraint` on its
+    :class:`~torch.nn.Parameter`. To declare a constrained parameter, use the
+    :class:`ConstrainedParameter` helper::
+
+        my_module = ConstrainedModule()
+        my_module.x = ConstrainedParameter(torch.tensor(1.),
+                                           constraints.positive)
+
+        # Now scale is a function of an unconstrained nn.Parameter.
+        assert isinstance(my_module.x, torch.Tensor)
+        assert isinstance(my_module.x_unconstrained, nn.Parameter)
+
+    Like an unconstrained :class:`~torch.nn.Parameter` ,
+    a :class:`ConstrainedParameter` can be accessed directly as an attribute of
+    its :class:`ConstrainedModule` . Unlike an unconstrained
+    :class:`~torch.nn.Parameter` , the ``.data`` attribute cannot be set
+    directly; instead set data of the correspondingly named parameter appended
+    with the string "_unconstrained"::
+
+        # Correct way to initialze:
+        my_module.x_unconstrained.data.normal_()
+
+        # XXX Wrong way to initialize XXX
+        # my_module.x.data.normal_()  # has no effect.
+    """
+    def __init__(self):
+        self._constraints = OrderedDict()
+        super().__init__()
+
+    def __setattr__(self, name, value):
+        if '_constraints' not in self.__dict__:
+            return super().__setattr__(name, value)
+        _constraints = self.__dict__['_constraints']
+
+        if isinstance(value, ConstrainedParameter):
+            constrained_value, constraint = value
+        elif name in _constraints:
+            constrained_value = value
+            constraint = _constraints[name]
+        else:
+            return super().__setattr__(name, value)
+
+        self._constraints[name] = constraint
+        with torch.no_grad():
+            constrained_value = constrained_value.detach()
+            unconstrained_value = transform_to(constraint).inv(constrained_value)
+            unconstrained_value = unconstrained_value.contiguous()
+        unconstrained_value = torch.nn.Parameter(unconstrained_value)
+        setattr(self, name + "_unconstrained", unconstrained_value)
+
+    def __getattr__(self, name):
+        if '_constraints' not in self.__dict__:
+            return super().__getattr__(name)
+        _constraints = self.__dict__['_constraints']
+
+        if name not in _constraints:
+            return super().__getattr__(name)
+
+        constraint = _constraints[name]
+        unconstrained_value = getattr(self, name + "_unconstrained")
+        return transform_to(constraint)(unconstrained_value)
+
+    def __delattr__(self, name):
+        if '_constraints' not in self.__dict__:
+            return super().__delattr__(name)
+        _constraints = self.__dict__['_constraints']
+
+        if name not in _constraints:
+            return super().__delattr__(name)
+
+        delattr(self, name + "_unconstrained")
+        del _constraints[name]
+
+
+    def constraints(self):
+        """
+        Returns an iterator over parameter (name,constraint) pairs.
+
+        :yields: (str, Constraint) Tuple containing the name and constraint.
+        """
+        for name, constraint in self._constraints.items():
+            yield name, constraint
+
+
+class ConstraintDescriptor:
+    """
+    Descriptor to add a static
     :class:`~torch.distributions.constraints.Constraint` to a
     :class:`~torch.nn.Parameter` of a :class:`~torch.nn.Module` .
     These are typically created via the :func:`constraint` decorator.
@@ -81,7 +172,7 @@ class ConstrainedParameter:
 
 def constraint(constraint_fn):
     """
-    Decorator for constrained parameters. For example::
+    Decorator for static constrained parameters. For example::
 
         class Normal(nn.Module):
             def __init__(self, loc, scale):
@@ -95,4 +186,4 @@ def constraint(constraint_fn):
     """
     assert callable(constraint_fn)
     name = constraint_fn.__name__
-    return ConstrainedParameter(name, constraint_fn)
+    return ConstraintDescriptor(name, constraint_fn)

--- a/pyro/params/constrained_parameter.py
+++ b/pyro/params/constrained_parameter.py
@@ -82,7 +82,6 @@ class ConstrainedModule(torch.nn.Module):
         delattr(self, name + "_unconstrained")
         del _constraints[name]
 
-
     def constraints(self):
         """
         Returns an iterator over parameter (name,constraint) pairs.

--- a/tests/params/test_constrained_parameter.py
+++ b/tests/params/test_constrained_parameter.py
@@ -5,7 +5,7 @@ import torch
 from torch.autograd import grad
 from torch.distributions import constraints, transform_to
 
-from pyro.params import ConstrainedParameter, constraint
+from pyro.params.constrained_parameter import ConstrainedModule, ConstrainedParameter, ConstraintDescriptor, constraint
 from tests.common import assert_equal
 
 SHAPE_CONSTRAINT = [
@@ -41,7 +41,34 @@ SHAPE_CONSTRAINT = [
 
 
 @pytest.mark.parametrize('shape,constraint_', SHAPE_CONSTRAINT)
-def test_constrained_parameter(shape, constraint_):
+def test_constrained_module(shape, constraint_):
+    module = ConstrainedModule()
+    module.x = ConstrainedParameter(torch.full(shape, 1e-4), constraint_)
+
+    assert isinstance(module.x, torch.Tensor)
+    assert isinstance(module.x_unconstrained, torch.nn.Parameter)
+    assert module.x.shape == shape
+    assert constraint_.check(module.x).all()
+
+    module.x = torch.randn(shape).exp() * 1e-6
+    assert isinstance(module.x_unconstrained, torch.nn.Parameter)
+    assert isinstance(module.x, torch.Tensor)
+    assert module.x.shape == shape
+    assert constraint_.check(module.x).all()
+
+    assert isinstance(module.x_unconstrained, torch.Tensor)
+    y = module.x_unconstrained.data.normal_()
+    assert_equal(module.x.data, transform_to(constraint_)(y))
+    assert constraint_.check(module.x).all()
+
+    del module.x
+    assert 'x' not in module._constraints
+    assert not hasattr(module, 'x')
+    assert not hasattr(module, 'x_unconstrained')
+
+
+@pytest.mark.parametrize('shape,constraint_', SHAPE_CONSTRAINT)
+def test_constraint_descriptor(shape, constraint_):
 
     class MyModule(torch.nn.Module):
         @constraint
@@ -51,13 +78,13 @@ def test_constrained_parameter(shape, constraint_):
     module = MyModule()
     module.x = torch.full(shape, 1e-4)
 
-    assert isinstance(MyModule.x, ConstrainedParameter)
+    assert isinstance(MyModule.x, ConstraintDescriptor)
     assert isinstance(module.x, torch.Tensor)
     assert module.x.shape == shape
     assert constraint_.check(module.x).all()
 
     module.x = torch.randn(shape).exp() * 1e-6
-    assert isinstance(MyModule.x, ConstrainedParameter)
+    assert isinstance(MyModule.x, ConstraintDescriptor)
     assert isinstance(module.x, torch.Tensor)
     assert module.x.shape == shape
     assert constraint_.check(module.x).all()
@@ -68,7 +95,7 @@ def test_constrained_parameter(shape, constraint_):
     assert constraint_.check(module.x).all()
 
 
-def test_chaining():
+def test_constraint_chaining():
 
     class ChainedModule(torch.nn.Module):
         def __init__(self):
@@ -97,20 +124,41 @@ def test_chaining():
     assert (dz_dx > 0).all()
 
 
+def test_constrained_module_serialization():
+
+    module = ConstrainedModule()
+    module.x = ConstrainedParameter(torch.tensor(1.234), constraints.positive)
+    assert isinstance(module.x, torch.Tensor)
+
+    # Work around https://github.com/pytorch/pytorch/issues/27972
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        torch.save(module, "/tmp/test_constrained_parameter.pkl")
+        actual = torch.load("/tmp/test_constrained_parameter.pkl")
+    assert_equal(actual.x, module.x)
+    actual_names = {name for name, _ in actual.named_parameters()}
+    expected_names = {name for name, _ in module.named_parameters()}
+    assert actual_names == expected_names
+
+
 class PositiveModule(torch.nn.Module):
     @constraint
     def x(self):
         return constraints.positive
 
 
-def test_serialization():
+def test_constraint_descriptor_serialization():
 
     module = PositiveModule()
     module.x = torch.tensor(1.234)
     assert isinstance(module.x, torch.Tensor)
 
+    # Work around https://github.com/pytorch/pytorch/issues/27972
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
         torch.save(module, "/tmp/test_constrained_parameter.pkl")
         actual = torch.load("/tmp/test_constrained_parameter.pkl")
     assert_equal(actual.x, module.x)
+    actual_names = {name for name, _ in actual.named_parameters()}
+    expected_names = {name for name, _ in module.named_parameters()}
+    assert actual_names == expected_names

--- a/tests/params/test_constrained_parameter.py
+++ b/tests/params/test_constrained_parameter.py
@@ -5,7 +5,8 @@ import torch
 from torch.autograd import grad
 from torch.distributions import constraints, transform_to
 
-from pyro.params.constrained_parameter import ConstrainedModule, ConstrainedParameter, ConstraintDescriptor, constraint
+from pyro.params import ConstrainedModule, ConstrainedParameter, constraint
+from pyro.params.constrained_parameter import ConstraintDescriptor
 from tests.common import assert_equal
 
 SHAPE_CONSTRAINT = [


### PR DESCRIPTION
Addresses #2078 

This implements a `ConstrainedModule` subclass of `torch.nn.Module`. Whereas the `@constraint` decorator of #2102 which stores constraints statically in the module definition, this version stores constraints dynamically in the module instance. (the two have different advantages).

This is one step in making the `ParamStore` and dynamic autoguides like `AutoDelta` and `AutoNormal` into `nn.Module`s (static autoguides like `AutoDiagonalNormal` could simply use `@constraint`).

## Tested
- [x] unit test for `__getattr__`, `__setattr__`, `__delattr__`
- [x] unit test for `torch.save()`/`torch.load()`