### PR TITLE
Reorganize docs in pyro.contrib.timeseries

### DIFF
--- a/docs/source/contrib.timeseries.rst
+++ b/docs/source/contrib.timeseries.rst
@@ -3,7 +3,25 @@ Time Series
 
 See the `GP example <http://pyro.ai/examples/independent_gps.html>`_ for example usage. 
 
-.. automodule:: pyro.contrib.timeseries
+Abstract Models
+---------------
+.. automodule:: pyro.contrib.timeseries.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+Gaussian Processes
+------------------
+.. automodule:: pyro.contrib.timeseries.gp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
+Linear Gaussian State Space Models
+----------------------------------
+.. automodule:: pyro.contrib.timeseries.lgssm
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pyro/contrib/timeseries/__init__.py
+++ b/pyro/contrib/timeseries/__init__.py
@@ -2,11 +2,13 @@
 The :mod:`pyro.contrib.timeseries` module provides a collection of Bayesian time series
 models useful for forecasting applications.
 """
+from pyro.contrib.timeseries.base import TimeSeriesModel
 from pyro.contrib.timeseries.gp import IndependentMaternGP, LinearlyCoupledMaternGP
 from pyro.contrib.timeseries.lgssm import GenericLGSSM
 
 __all__ = [
     "GenericLGSSM",
-    "LinearlyCoupledMaternGP",
     "IndependentMaternGP",
+    "LinearlyCoupledMaternGP",
+    "TimeSeriesModel",
 ]


### PR DESCRIPTION
- adds `TimeSeriesModel` to __init__.py
- adds sections to docs index:
![image](https://user-images.githubusercontent.com/648532/67879527-5ec13880-fafa-11e9-8e52-7d4a95131029.png)
