### PR TITLE
Support python bool in TorchDistribution.mask() w/ short circuit for log_prob

### DIFF
--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -205,6 +205,10 @@ class MaskedDistribution(TorchDistribution):
     Masks a distribution by a boolean tensor that is broadcastable to the
     distribution's :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
 
+    In the special case ``mask is False``, computation of :meth:`log_prob` ,
+    :meth:`score_parts` , and ``kl_divergence()`` is skipped, and constant zero
+    values are returned instead.
+
     :param mask: A boolean or boolean-valued tensor.
     :type mask: torch.Tensor or bool
     """

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -206,7 +206,7 @@ class MaskedDistribution(TorchDistribution):
     distribution's :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
 
     :param mask: A boolean or boolean-valued tensor.
-    :type mask: torch.Tensor or book
+    :type mask: torch.Tensor or bool
     """
     arg_constraints = {}
 

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -124,10 +124,12 @@ class TorchDistributionMixin(Distribution):
 
     def mask(self, mask):
         """
-        Masks a distribution by a zero-one tensor that is broadcastable to the
-        distributions :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
+        Masks a distribution by a boolean or boolean-valued tensor that is
+        broadcastable to the distributions
+        :attr:`~torch.distributions.distribution.Distribution.batch_shape` .
 
-        :param torch.Tensor mask: A zero-one valued float tensor.
+        :param mask: A boolean or boolean valued tensor.
+        :type mask: bool or torch.Tensor
         :return: A masked copy of this distribution.
         :rtype: :class:`MaskedDistribution`
         """
@@ -200,26 +202,32 @@ class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin
 
 class MaskedDistribution(TorchDistribution):
     """
-    Masks a distribution by a zero-one tensor that is broadcastable to the
+    Masks a distribution by a boolean tensor that is broadcastable to the
     distribution's :attr:`~torch.distributions.distribution.Distribution.batch_shape`.
 
-    :param torch.Tensor mask: A zero-one valued tensor.
+    :param mask: A boolean or boolean-valued tensor.
+    :type mask: torch.Tensor or book
     """
     arg_constraints = {}
 
     def __init__(self, base_dist, mask):
-        if broadcast_shape(mask.shape, base_dist.batch_shape) != base_dist.batch_shape:
-            raise ValueError("Expected mask.shape to be broadcastable to base_dist.batch_shape, "
-                             "actual {} vs {}".format(mask.shape, base_dist.batch_shape))
-        self.base_dist = base_dist
-        self._mask = mask.bool()
+        if isinstance(mask, bool):
+            self._mask = mask
+        else:
+            if broadcast_shape(mask.shape, base_dist.batch_shape) != base_dist.batch_shape:
+                raise ValueError("Expected mask.shape to be broadcastable to base_dist.batch_shape, "
+                                 "actual {} vs {}".format(mask.shape, base_dist.batch_shape))
+            self.base_dist = base_dist
+            self._mask = mask.bool()
         super(MaskedDistribution, self).__init__(base_dist.batch_shape, base_dist.event_shape)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(MaskedDistribution, _instance)
         batch_shape = torch.Size(batch_shape)
         new.base_dist = self.base_dist.expand(batch_shape)
-        new._mask = self._mask.expand(batch_shape)
+        new._mask = self._mask
+        if isinstance(new._mask, torch.Tensor):
+            new._mask = new._mask.expand(batch_shape)
         super(MaskedDistribution, new).__init__(batch_shape, self.event_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new
@@ -243,9 +251,17 @@ class MaskedDistribution(TorchDistribution):
         return self.base_dist.rsample(sample_shape)
 
     def log_prob(self, value):
+        if self._mask is False:
+            shape = broadcast_shape(self.base_dist.batch_shape,
+                                    value.shape[:value.dim() - self.event_dim])
+            return torch.zeros((), device=value.device).expand(shape)
+        if self._mask is True:
+            return self.base_dist.log_prob(value)
         return scale_and_mask(self.base_dist.log_prob(value), mask=self._mask)
 
     def score_parts(self, value):
+        if isinstance(self._mask, bool):
+            return super().score_parts(self, value)  # calls self.log_prob()
         return self.base_dist.score_parts(value).scale_and_mask(mask=self._mask)
 
     def enumerate_support(self, expand=True):
@@ -262,6 +278,20 @@ class MaskedDistribution(TorchDistribution):
 
 @register_kl(MaskedDistribution, MaskedDistribution)
 def _kl_masked_masked(p, q):
-    mask = p._mask if p._mask is q._mask else p._mask & q._mask
+    if p._mask is False or q._mask is False:
+        mask = False
+    elif p._mask is True:
+        mask = q._mask
+    elif q._mask is True:
+        mask = p._mask
+    elif p._mask is q._mask:
+        mask = p._mask
+    else:
+        mask = p._mask & q._mask
+
+    if mask is False:
+        return 0.  # We cannot generically determine device, so we return a float.
+    if mask is True:
+        return kl_divergence(p.base_dist, q.base_dist)
     kl = kl_divergence(p.base_dist, q.base_dist)
     return scale_and_mask(kl, mask=mask)

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -49,6 +49,26 @@ def test_mask(batch_dim, event_dim, mask_dim):
         assert_equal(dist.enumerate_support(expand=False), base_dist.enumerate_support(expand=False))
 
 
+@pytest.mark.parametrize("mask", [False, True, torch.tensor(False), torch.tensor(True)])
+def test_mask_type(mask):
+    p = Normal(torch.randn(2, 2), torch.randn(2, 2).exp())
+    p_masked = p.mask(mask)
+    if isinstance(mask, bool):
+        mask = torch.tensor(mask)
+
+    x = p.sample()
+    actual = p_masked.log_prob(x)
+    expected = p.log_prob(x) * mask.float()
+    assert_equal(actual, expected)
+
+    actual = p_masked.score_parts(x)
+    expected = p.score_parts(x)
+    for a, e in zip(actual, expected):
+        if isinstance(e, torch.Tensor):
+            e = e * mask.float()
+        assert_equal(a, e)
+
+
 @pytest.mark.parametrize('batch_shape,mask_shape', [
     ([], [1]),
     ([], [2]),
@@ -74,3 +94,43 @@ def test_kl_divergence():
               kl_divergence(p.mask(~mask).to_event(2),
                             q.mask(~mask).to_event(2)))
     assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize("p_mask", [False, True, torch.tensor(False), torch.tensor(True)])
+@pytest.mark.parametrize("q_mask", [False, True, torch.tensor(False), torch.tensor(True)])
+def test_kl_divergence_type(p_mask, q_mask):
+    p = Normal(torch.randn(2, 2), torch.randn(2, 2).exp())
+    q = Normal(torch.randn(2, 2), torch.randn(2, 2).exp())
+    mask = ((torch.tensor(p_mask) if isinstance(p_mask, bool) else p_mask) &
+            (torch.tensor(q_mask) if isinstance(q_mask, bool) else q_mask)).expand(2, 2)
+
+    expected = kl_divergence(p, q)
+    expected[~mask] = 0
+
+    actual = kl_divergence(p.mask(p_mask), q.mask(q_mask))
+    if p_mask is False or q_mask is False:
+        assert isinstance(actual, float) and actual == 0.
+    else:
+        assert_equal(actual, expected)
+
+
+class NormalBomb(Normal):
+    def log_prob(self, value):
+        raise ValueError("Should not be called")
+
+    def score_parts(self, value):
+        raise ValueError("Should not be called")
+
+
+@pytest.mark.parametrize("shape", [None, (), (4,), (3, 2)], ids=str)
+def test_mask_noop(shape):
+    d = NormalBomb(0, 1).mask(False)
+    if shape is not None:
+        d = d.expand(shape)
+    x = d.sample()
+
+    actual = d.log_prob(x)
+    assert_equal(actual, torch.zeros(shape if shape else ()))
+
+    actual = d.score_parts(x)
+    assert_equal(actual.log_prob, torch.zeros(shape if shape else ()))


### PR DESCRIPTION
This implements a feature requested by @martinjankowiak and @gpleiss, allowing distribution `.log_prob()` values to be masked with zero computation cost, i.e. to avoid computation in `Trace.compute_log_prob()` or `Trace.compute_score_parts()`. For example the following are nearly* equivalent but the second is cheaper:
```py
# Version 1. triggers a call to .log_prob() inside Trace_ELBO()
with pyro.mask(False):
    pyro.sample("x", MultivariateNormal(loc, scale_tril=scale_tril))

# Version 2. short circuits
pyro.sample("x", MultivariateNormal(loc, scale_tril=scale_tril).mask(False))
```
*Since we don't have full access to `.dtype` and `.device` information for values that have not been computed, we implement best-effort results as follows:
1. Return `torch.zeros((), device=value.device)` from`.log_prob()`, which may sometimes return a tensor of incorrect precision (e.g. double vs float)
2. Return a Python `0.` from `kl_divergence` which may break some downstream logic, however we have no generic access to device, and this was the simplest device-agnostic solution I could find.

Note we chose to implement this short-circuit in `MaskedDistribution` rather than in `poutine.mask` or `Trace.compute_*()` because `MaskedDistribution` has fewer users and because this solution touches fewer pieces of tricky logic.

## Tested
- tested short circuit logic
- tests for mask types
- tests for kl_divergence types