### PR TITLE
First pass at adding `clip_args` to PyroOptim

### DIFF
--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -9,6 +9,8 @@ class PyroLRScheduler(PyroOptim):
     :param scheduler_constructor: a :class:`~torch.optim.lr_scheduler`
     :param optim_args: a dictionary of learning arguments for the optimizer or a callable that returns
         such dictionaries. must contain the key 'optimizer' with pytorch optimizer value
+    :param clip_args: a dictionary of clip_norm and/or clip_value args or a callable that returns
+        such dictionaries.
 
     Example::
 

--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -20,7 +20,7 @@ class PyroLRScheduler(PyroOptim):
                 svi.step(minibatch)
             scheduler.step(epoch=i)
     """
-    def __init__(self, scheduler_constructor, optim_args):
+    def __init__(self, scheduler_constructor, optim_args, clip_args=None):
         # pytorch scheduler
         self.pt_scheduler_constructor = scheduler_constructor
         # torch optimizer
@@ -28,7 +28,7 @@ class PyroLRScheduler(PyroOptim):
         # kwargs for the torch optimizer
         optim_kwargs = optim_args.pop('optim_args')
         self.kwargs = optim_args
-        super(PyroLRScheduler, self).__init__(pt_optim_constructor, optim_kwargs)
+        super(PyroLRScheduler, self).__init__(pt_optim_constructor, optim_kwargs, clip_args)
 
     def __call__(self, params, *args, **kwargs):
         super(PyroLRScheduler, self).__call__(params, *args, **kwargs)

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -1,4 +1,5 @@
 import torch
+from torch.nn.utils import clip_grad_norm_, clip_grad_value_
 
 import pyro
 from pyro.optim.adagrad_rmsprop import AdagradRMSProp as pt_AdagradRMSProp
@@ -13,19 +14,30 @@ class PyroOptim(object):
     :param optim_constructor: a torch.optim.Optimizer
     :param optim_args: a dictionary of learning arguments for the optimizer or a callable that returns
         such dictionaries
+    :param clip_args: a dictionary of clip_norm and/or clip_value args or a callable that return
+        such dictionaries
     """
-    def __init__(self, optim_constructor, optim_args):
+    def __init__(self, optim_constructor, optim_args, clip_args=None):
         self.pt_optim_constructor = optim_constructor
 
         # must be callable or dict
         assert callable(optim_args) or isinstance(
             optim_args, dict), "optim_args must be function that returns defaults or a defaults dictionary"
 
+        if clip_args is None:
+            clip_args = {}
+
+        # must be callable or dict
+        assert callable(clip_args) or isinstance(
+            clip_args, dict), "clip_args must be function that returns defaults or a defaults dictionary"
+
         # hold our args to be called/used
         self.pt_optim_args = optim_args
+        self.pt_clip_args = clip_args
 
         # holds the torch optimizer objects
         self.optim_objs = {}
+        self.grad_clip = {}
 
         # any optimizer state that's waiting to be consumed (because that parameter hasn't been seen before)
         self._state_waiting_to_be_consumed = {}
@@ -39,10 +51,12 @@ class PyroOptim(object):
         initialize an optimizer for it.
         """
         for p in params:
-            # if we have not seen this param before, we instantiate and optim object to deal with it
+            # if we have not seen this param before, we instantiate an optim object to deal with it
             if p not in self.optim_objs:
                 # create a single optim object for that param
                 self.optim_objs[p] = self._get_optim(p)
+                # create a gradient clipping function if specified
+                self.grad_clip[p] = self._get_grad_clip(p)
                 # set state from _state_waiting_to_be_consumed if present
                 param_name = pyro.get_param_store().param_name(p)
                 if param_name in self._state_waiting_to_be_consumed:
@@ -52,8 +66,10 @@ class PyroOptim(object):
             if isinstance(self.optim_objs[p], torch.optim.lr_scheduler._LRScheduler) or \
                     isinstance(self.optim_objs[p], torch.optim.lr_scheduler.ReduceLROnPlateau):
                 # if optim object was a scheduler, perform an optimizer step
+                self.grad_clip[p](p)
                 self.optim_objs[p].optimizer.step(*args, **kwargs)
             else:
+                self.grad_clip[p](p)
                 self.optim_objs[p].step(*args, **kwargs)
 
     def get_state(self):
@@ -77,7 +93,7 @@ class PyroOptim(object):
     def save(self, filename):
         """
         :param filename: file name to save to
-        :type name: str
+        :type filename: str
 
         Save optimizer state to disk
         """
@@ -87,7 +103,7 @@ class PyroOptim(object):
     def load(self, filename):
         """
         :param filename: file name to load from
-        :type name: str
+        :type filename: str
 
         Load optimizer state from disk
         """
@@ -117,6 +133,40 @@ class PyroOptim(object):
             return opt_dict
         else:
             return self.pt_optim_args
+
+    def _get_grad_clip(self, param):
+        grad_clip_args = self._get_grad_clip_args(param)
+
+        def _clip_grad(params):
+            self._clip_grad(params, **grad_clip_args)
+
+        return _clip_grad
+
+    def _get_grad_clip_args(self, param):
+        # if we were passed a fct, we call fct with param info
+        # arguments are (module name, param name) e.g. ('mymodule', 'bias')
+        if callable(self.pt_clip_args):
+
+            # get param name
+            param_name = pyro.get_param_store().param_name(param)
+            module_name = module_from_param_with_module_name(param_name)
+            stripped_param_name = user_param_name(param_name)
+
+            # invoke the user-provided callable
+            clip_dict = self.pt_clip_args(module_name, stripped_param_name)
+
+            # must be dictionary
+            assert isinstance(clip_dict, dict), "per-param clip arg must return defaults dictionary"
+            return clip_dict
+        else:
+            return self.pt_clip_args
+
+    @staticmethod
+    def _clip_grad(params, clip_norm=None, clip_value=None):
+        if clip_norm is not None:
+            clip_grad_norm_(params, clip_norm)
+        if clip_value is not None:
+            clip_grad_value_(params, clip_value)
 
 
 def AdagradRMSProp(optim_args):

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -63,15 +63,14 @@ class PyroOptim(object):
                     state = self._state_waiting_to_be_consumed.pop(param_name)
                     self.optim_objs[p].load_state_dict(state)
 
+            if self.grad_clip[p] is not None:
+                self.grad_clip[p](p)
+
             if isinstance(self.optim_objs[p], torch.optim.lr_scheduler._LRScheduler) or \
                     isinstance(self.optim_objs[p], torch.optim.lr_scheduler.ReduceLROnPlateau):
                 # if optim object was a scheduler, perform an optimizer step
-                if self.grad_clip[p] is not None:
-                    self.grad_clip[p](p)
                 self.optim_objs[p].optimizer.step(*args, **kwargs)
             else:
-                if self.grad_clip[p] is not None:
-                    self.grad_clip[p](p)
                 self.optim_objs[p].step(*args, **kwargs)
 
     def get_state(self):

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -16,7 +16,7 @@ for _name, _Optim in torch.optim.__dict__.items():
         # XXX LBFGS is not supported for SVI yet
         continue
 
-    _PyroOptim = (lambda _Optim: lambda optim_args: PyroOptim(_Optim, optim_args))(_Optim)
+    _PyroOptim = (lambda _Optim: lambda optim_args, clip_args=None: PyroOptim(_Optim, optim_args, clip_args))(_Optim)
     _PyroOptim.__name__ = _name
     _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with :class:`~pyro.optim.optim.PyroOptim`.'.format(_name)
 
@@ -33,7 +33,7 @@ for _name, _Optim in torch.optim.lr_scheduler.__dict__.items():
     if _Optim is torch.optim.Optimizer:
         continue
 
-    _PyroOptim = (lambda _Optim: lambda optim_args: PyroLRScheduler(_Optim, optim_args))(_Optim)
+    _PyroOptim = (lambda _Optim: lambda optim_args, clip_args=None: PyroLRScheduler(_Optim, optim_args, clip_args))(_Optim)
     _PyroOptim.__name__ = _name
     _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with '.format(_name) +\
                          ':class:`~pyro.optim.lr_scheduler.PyroLRScheduler`.'

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -33,7 +33,9 @@ for _name, _Optim in torch.optim.lr_scheduler.__dict__.items():
     if _Optim is torch.optim.Optimizer:
         continue
 
-    _PyroOptim = (lambda _Optim: lambda optim_args, clip_args=None: PyroLRScheduler(_Optim, optim_args, clip_args))(_Optim)
+    _PyroOptim = (
+        lambda _Optim: lambda optim_args, clip_args=None: PyroLRScheduler(_Optim, optim_args, clip_args)
+    )(_Optim)
     _PyroOptim.__name__ = _name
     _PyroOptim.__doc__ = 'Wraps :class:`torch.optim.{}` with '.format(_name) +\
                          ':class:`~pyro.optim.lr_scheduler.PyroLRScheduler`.'

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -131,6 +131,24 @@ def test_autowrap(factory):
     assert instance.pt_optim_constructor.__name__ == factory.__name__
 
 
+@pytest.mark.parametrize('pyro_optim', [optim.Adam, optim.SGD])
+@pytest.mark.parametrize('clip', ['clip_norm', 'clip_value'])
+@pytest.mark.parametrize('value', [1., 3., 5.])
+def test_clip_norm(pyro_optim, clip, value):
+    x1 = torch.tensor(0., requires_grad=True)
+    x2 = torch.tensor(0., requires_grad=True)
+    opt_c = pyro_optim({"lr": 1.}, {clip: value})
+    opt = pyro_optim({"lr": 1.})
+    for step in range(3):
+        x1.backward(Uniform(value, value + 3.).sample())
+        x2.backward(torch.tensor(value))
+        opt_c([x1])
+        opt([x2])
+        assert_equal(x1, x2)
+        opt_c.optim_objs[x1].zero_grad()
+        opt.optim_objs[x2].zero_grad()
+
+
 @pytest.mark.parametrize('clip_norm', [1., 3., 5.])
 def test_clippedadam_clip(clip_norm):
     x1 = torch.tensor(0., requires_grad=True)

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -144,6 +144,8 @@ def test_clip_norm(pyro_optim, clip, value):
         x2.backward(torch.tensor(value))
         opt_c([x1])
         opt([x2])
+        assert_equal(x1.grad, torch.tensor(value))
+        assert_equal(x2.grad, torch.tensor(value))
         assert_equal(x1, x2)
         opt_c.optim_objs[x1].zero_grad()
         opt.optim_objs[x2].zero_grad()

--- a/tutorial/source/custom_objectives.ipynb
+++ b/tutorial/source/custom_objectives.ipynb
@@ -229,20 +229,13 @@
     "svi.step(other_args, annealing_factor=0.2, latents_to_anneal=[\"my_latent\"])\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pyro-dev]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-pyro-dev-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -254,9 +247,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/tutorial/source/custom_objectives.ipynb
+++ b/tutorial/source/custom_objectives.ipynb
@@ -91,6 +91,21 @@
     "+ loss = loss_fn(model, guide) + my_custom_L2_regularizer(my_parameters)\n",
     "```\n",
     "\n",
+    "## Example: Clipping Gradients\n",
+    "\n",
+    "For some models the loss gradient can explode during training, leading to overflow and \n",
+    "`NaN` values. One way to protect against this is with gradient clipping. The optimizers\n",
+    "in `pyro.optim` take an optional dictionary of `clip_args` which allows clipping either\n",
+    "the gradient norm or the gradient value to fall within the given limit.\n",
+    "\n",
+    "To change the basic example above:\n",
+    "\n",
+    "```diff\n",
+    "- optimizer = pyro.optim.Adam({\"lr\": 0.001, \"betas\": (0.90, 0.999)})\n",
+    "+ optimizer = pyro.optim.Adam({\"lr\": 0.001, \"betas\": (0.90, 0.999)}, {\"clip_norm\": 10.0})\n",
+    "```\n",
+    "\n",
+    "\n",
     "## Example: Scaling the Loss\n",
     "\n",
     "Depending on the optimization algorithm, the scale of the loss may or not matter. Suppose \n",
@@ -214,13 +229,20 @@
     "svi.step(other_args, annealing_factor=0.2, latents_to_anneal=[\"my_latent\"])\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:pyro-dev]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-pyro-dev-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -232,9 +254,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This is a WIP to spur discussion on #2109. This code runs but I didn't test it very well–I will use one of the existing tutorials I know will train quickly, so that I can verify the gradients are being clipped as expected.

In terms of the API I'm not in love with how I did this but I'm not sure what would be better. The main trade-off to me is a) adding an argument to the `PyroOptim` initializer versus b) adding keywords to the existing `optim_args` argument. a) feels a little clunky and requires more code changes (in `pytorch_optimizers.py` and `lr_scheduler.py`, maybe in other places I didn't catch). b) feels cleaner (and for people who don't care about this feature, is invisible) but might be confusing, as the user is passing keywords to the optimizer that don't really exist (I would pop them out in the `PyroOptim` class). 

Another question is what to do with the existing `ClippedAdam` optimizer. It's not exactly the same as "`Adam` + `clip_norm`" because it also has learning-rate decay built into it. That should be done by an `LRScheduler`, though. If the powers that be agree I will add a deprecation warning to `ClippedAdam` that tells people to use `Adam` with a clipping parameter and/or a scheduler.