### PR TITLE
Implement a staged Delta -> DiagNormal -> LowRankMVN autoguide

### DIFF
--- a/docs/source/infer.autoguide.rst
+++ b/docs/source/infer.autoguide.rst
@@ -73,6 +73,7 @@ AutoProgressive
     :members:
     :undoc-members:
     :special-members: __call__
+    :member-order: bysource
     :show-inheritance:
 
 AutoIAFNormal

--- a/docs/source/infer.autoguide.rst
+++ b/docs/source/infer.autoguide.rst
@@ -67,6 +67,14 @@ AutoLowRankMultivariateNormal
     :special-members: __call__
     :show-inheritance:
 
+AutoProgressive
+---------------
+.. autoclass:: pyro.infer.autoguide.AutoProgressive
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+
 AutoIAFNormal
 -----------------------------
 .. autoclass:: pyro.infer.autoguide.AutoIAFNormal

--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -1,9 +1,9 @@
 from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta, AutoDiagonalNormal,
                                          AutoDiscreteParallel, AutoGuide, AutoGuideList, AutoIAFNormal,
                                          AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
-                                         AutoMultivariateNormal)
-from pyro.infer.autoguide.utils import mean_field_entropy
+                                         AutoMultivariateNormal, AutoProgressive)
 from pyro.infer.autoguide.initialization import init_to_feasible, init_to_mean, init_to_median, init_to_sample
+from pyro.infer.autoguide.utils import mean_field_entropy
 
 __all__ = [
     'AutoCallable',
@@ -17,6 +17,7 @@ __all__ = [
     'AutoLaplaceApproximation',
     'AutoLowRankMultivariateNormal',
     'AutoMultivariateNormal',
+    'AutoProgressive',
     'init_to_feasible',
     'init_to_mean',
     'init_to_median',

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -638,7 +638,8 @@ class AutoProgressive(AutoContinuous):
     @property
     def rank(self):
         if self._rank is None:
-            self._rank = int(round(self.latent_dim))
+            # This heuristic chooses rank close to sqrt(latent_dim).
+            self._rank = int(round(self.latent_dim ** 0.5))
         return self._rank
 
     def init_scale(self, scale=0.1):

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -17,17 +17,19 @@ from pyro.optim import Adam
 from tests.common import assert_close, assert_equal
 
 
+# Test helper to test stage 2 of AutoProgressive.
 class AutoProgressive2(AutoProgressive):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.init_scale()
+        self.init_scale()  # Advance to stage 2.
 
 
+# Test helper to test stage 3 of AutoProgressive.
 class AutoProgressive3(AutoProgressive):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.init_scale()
-        self.init_cov()
+        self.init_scale()  # Advance to stage 2.
+        self.init_cov()  # Advance to stage 3.
 
 
 @pytest.mark.parametrize("auto_class", [


### PR DESCRIPTION
Addresses #2120 

This implements a new autoguide whose complexity can be increased through three stages of training. This captures an inference motif I often use in practice.
1. train an AutoDelta guide
2. train an AutoDiagonalNormal guide
3. train an AutoLowRankMultivariateNormal guide

Additionally this implementation uses previous models to warm-start subsequent stages.

## Tested
- [x] added unit tests
- [ ] validate heuristics on real data