### PR TITLE
Fix preditive shapes

### DIFF
--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -28,7 +28,7 @@ def _guess_max_plate_nesting(model, args, kwargs):
 
 
 def _predictive_sequential(model, posterior_samples, model_args, model_kwargs,
-                           num_samples, sample_sites, return_trace=False):
+                           num_samples, return_site_shapes, return_trace=False):
     collected = []
     samples = [{k: v[i] for k, v in posterior_samples.items()} for i in range(num_samples)]
     for i in range(num_samples):
@@ -36,16 +36,18 @@ def _predictive_sequential(model, posterior_samples, model_args, model_kwargs,
         if return_trace:
             collected.append(trace)
         else:
-            collected.append({site: trace.nodes[site]['value'] for site in sample_sites})
+            collected.append({site: trace.nodes[site]['value'] for site in return_site_shapes})
 
-    return collected if return_trace else {site: torch.stack([s[site] for s in collected])
-                                           for site in sample_sites}
+    if return_trace:
+        return collected
+    else:
+        return {site: torch.stack([s[site] for s in collected]).reshape(shape)
+                for site, shape in return_site_shapes.items()}
 
 
 def _predictive(model, posterior_samples, num_samples, return_sites=None,
                 return_trace=False, parallel=False, model_args=(), model_kwargs={}):
     max_plate_nesting = _guess_max_plate_nesting(model, model_args, model_kwargs)
-    vectorize = pyro.plate("_num_predictive_samples", num_samples, dim=-max_plate_nesting-1)
     model_trace = prune_subsample_sites(poutine.trace(model).get_trace(*model_args, **model_kwargs))
     reshaped_samples = {}
 
@@ -54,14 +56,30 @@ def _predictive(model, posterior_samples, num_samples, return_sites=None,
         sample = sample.reshape((num_samples,) + (1,) * (max_plate_nesting - len(sample_shape)) + sample_shape)
         reshaped_samples[name] = sample
 
+    def _vectorized_fn(fn):
+        """
+        Wraps a callable inside an outermost :class:`~pyro.plate` to parallelize
+        sampling from the posterior predictive.
+
+        :param fn: arbitrary callable containing Pyro primitives.
+        :return: wrapped callable.
+        """
+
+        def wrapped_fn(*args, **kwargs):
+            with pyro.plate("_num_predictive_samples", num_samples, dim=-max_plate_nesting-1):
+                return fn(*args, **kwargs)
+
+        return wrapped_fn
+
     if return_trace:
-        trace = poutine.trace(poutine.condition(vectorize(model), reshaped_samples))\
+        trace = poutine.trace(poutine.condition(_vectorized_fn(model), reshaped_samples))\
             .get_trace(*model_args, **model_kwargs)
         return trace
 
     return_site_shapes = {}
     for site in model_trace.stochastic_nodes + model_trace.observation_nodes:
-        site_shape = (num_samples,) + model_trace.nodes[site]['value'].shape
+        append_ndim = max_plate_nesting - len(model_trace.nodes[site]["fn"].batch_shape)
+        site_shape = (num_samples,) + (1,) * append_ndim + model_trace.nodes[site]['value'].shape
         if isinstance(return_sites, (list, tuple, set)):
             if site in return_sites:
                 return_site_shapes[site] = site_shape
@@ -77,9 +95,9 @@ def _predictive(model, posterior_samples, num_samples, return_sites=None,
 
     if not parallel:
         return _predictive_sequential(model, posterior_samples, model_args, model_kwargs, num_samples,
-                                      return_site_shapes.keys(), return_trace=False)
+                                      return_site_shapes, return_trace=False)
 
-    trace = poutine.trace(poutine.condition(vectorize(model), reshaped_samples))\
+    trace = poutine.trace(poutine.condition(_vectorized_fn(model), reshaped_samples))\
         .get_trace(*model_args, **model_kwargs)
     predictions = {}
     for site, shape in return_site_shapes.items():
@@ -95,7 +113,7 @@ def _predictive(model, posterior_samples, num_samples, return_sites=None,
     return predictions
 
 
-class Predictive:
+class Predictive(object):
     """
     This class is used to construct predictive distribution. The predictive distribution is obtained
     by running model conditioned on latent samples from `posterior_samples`.

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -48,6 +48,7 @@ def _predictive_sequential(model, posterior_samples, model_args, model_kwargs,
 def _predictive(model, posterior_samples, num_samples, return_sites=None,
                 return_trace=False, parallel=False, model_args=(), model_kwargs={}):
     max_plate_nesting = _guess_max_plate_nesting(model, model_args, model_kwargs)
+    vectorize = pyro.plate("_num_predictive_samples", num_samples, dim=-max_plate_nesting-1)
     model_trace = prune_subsample_sites(poutine.trace(model).get_trace(*model_args, **model_kwargs))
     reshaped_samples = {}
 
@@ -56,23 +57,8 @@ def _predictive(model, posterior_samples, num_samples, return_sites=None,
         sample = sample.reshape((num_samples,) + (1,) * (max_plate_nesting - len(sample_shape)) + sample_shape)
         reshaped_samples[name] = sample
 
-    def _vectorized_fn(fn):
-        """
-        Wraps a callable inside an outermost :class:`~pyro.plate` to parallelize
-        sampling from the posterior predictive.
-
-        :param fn: arbitrary callable containing Pyro primitives.
-        :return: wrapped callable.
-        """
-
-        def wrapped_fn(*args, **kwargs):
-            with pyro.plate("_num_predictive_samples", num_samples, dim=-max_plate_nesting-1):
-                return fn(*args, **kwargs)
-
-        return wrapped_fn
-
     if return_trace:
-        trace = poutine.trace(poutine.condition(_vectorized_fn(model), reshaped_samples))\
+        trace = poutine.trace(poutine.condition(vectorize(model), reshaped_samples))\
             .get_trace(*model_args, **model_kwargs)
         return trace
 
@@ -97,7 +83,7 @@ def _predictive(model, posterior_samples, num_samples, return_sites=None,
         return _predictive_sequential(model, posterior_samples, model_args, model_kwargs, num_samples,
                                       return_site_shapes, return_trace=False)
 
-    trace = poutine.trace(poutine.condition(_vectorized_fn(model), reshaped_samples))\
+    trace = poutine.trace(poutine.condition(vectorize(model), reshaped_samples))\
         .get_trace(*model_args, **model_kwargs)
     predictions = {}
     for site, shape in return_site_shapes.items():
@@ -113,7 +99,7 @@ def _predictive(model, posterior_samples, num_samples, return_sites=None,
     return predictions
 
 
-class Predictive(object):
+class Predictive:
     """
     This class is used to construct predictive distribution. The predictive distribution is obtained
     by running model conditioned on latent samples from `posterior_samples`.

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -94,7 +94,8 @@ def test_posterior_predictive_svi_one_hot():
     assert_close(marginal_return_vals.mean(dim=0), true_probs.unsqueeze(0), rtol=0.1)
 
 
-def test_shapes():
+@pytest.mark.parametrize("parallel", [False, True])
+def test_shapes(parallel):
     num_samples = 10
 
     def model():
@@ -113,7 +114,7 @@ def test_shapes():
 
     # Use Predictive.
     predictive = Predictive(model, guide=guide, return_sites=["x", "y"],
-                            num_samples=num_samples, parallel=True)
+                            num_samples=num_samples, parallel=parallel)
     actual = predictive.get_samples()
     assert set(actual) == set(expected)
     assert actual["x"].shape == expected["x"].shape

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -92,3 +92,29 @@ def test_posterior_predictive_svi_one_hot():
     posterior_predictive = Predictive(one_hot_model, posterior_samples)
     marginal_return_vals = posterior_predictive.get_samples(pseudocounts)["obs"]
     assert_close(marginal_return_vals.mean(dim=0), true_probs.unsqueeze(0), rtol=0.1)
+
+
+def test_shapes():
+    num_samples = 10
+
+    def model():
+        x = pyro.sample("x", dist.Normal(0, 1).expand([2]).to_event(1))
+        with pyro.plate("plate", 5):
+            loc, log_scale = x.unbind(-1)
+            y = pyro.sample("y", dist.Normal(loc, log_scale.exp()))
+        return dict(x=x, y=y)
+
+    guide = AutoDiagonalNormal(model)
+
+    # Compute by hand.
+    vectorize = pyro.plate("_vectorize", num_samples, dim=-2)
+    trace = poutine.trace(vectorize(guide)).get_trace()
+    expected = poutine.replay(vectorize(model), trace)()
+
+    # Use Predictive.
+    predictive = Predictive(model, guide=guide, return_sites=["x", "y"],
+                            num_samples=num_samples, parallel=True)
+    actual = predictive.get_samples()
+    assert set(actual) == set(expected)
+    assert actual["x"].shape == expected["x"].shape
+    assert actual["y"].shape == expected["y"].shape


### PR DESCRIPTION
Resolves #2122

Consider the model
```py
    def model():
        x = pyro.sample("x", dist.Normal(0, 1).expand([2]).to_event())
        with pyro.plate("plate", 5):
            y = pyro.sample("y", dist.Normal(0, 1))
```
, the latent variable `x` has shape `(2,)`. However, in "vectorized" semantic, its shape actually is `(1, 2)`, where the appended dim is to match the plate `"plate"`. So
```py
vectorize = pyro.plate("_vectorize", 10, dim=-2)
trace = poutine.trace(vectorize(model)).get_trace()
```
will give us a trace with `x.shape = (10, 1, 2)`, `y.shape = (10, 5)`.

This PR makes Predictive class follow that convention: that is 10 samples at `x` site will have shape `(10, 1, 2)` instead of `(10, 2)`. This change makes the behavior of `get_vectorized_trace` and `get_samples` with `parallel=True/False` consistent. The only downside I can think about is users might wonder why their samples have additional singleton dimensions. WDYT?
