### PR TITLE
Make autoguides derive from nn.Module

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -178,6 +178,10 @@ class AutoGuideList(AutoGuide):
         if self.prototype_trace is None:
             self._setup_prototype(*args, **kwargs)
 
+        # Needed to capture autoguide parameters as pyro.param statements in the
+        # guide trace
+        if self.master is None:
+            pyro.module(self.prefix, self)
         # create all plates
         self.plates = {frame.name: pyro.plate(frame.name, frame.size, dim=frame.dim)
                        for frame in sorted(self._plates.values())}
@@ -303,7 +307,8 @@ class AutoDelta(AutoGuide):
 
         # Needed to capture autoguide parameters as pyro.param statements in the
         # guide trace
-        pyro.module(self.prefix, self)
+        if self.master is None:
+            pyro.module(self.prefix, self)
 
         plates = self._create_plates()
         result = {}
@@ -434,7 +439,8 @@ class AutoContinuous(AutoGuide):
 
         # Needed to capture autoguide parameters as pyro.param statements in the
         # guide trace
-        pyro.module(self.prefix, self)
+        if self.master is None:
+            pyro.module(self.prefix, self)
 
         latent = self.sample_latent(*args, **kwargs)
         plates = self._create_plates()
@@ -804,7 +810,8 @@ class AutoDiscreteParallel(AutoGuide):
 
         # Needed to capture autoguide parameters as pyro.param statements in the
         # guide trace
-        pyro.module(self.prefix, self)
+        if self.master is None:
+            pyro.module(self.prefix, self)
 
         plates = self._create_plates()
 

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -688,9 +688,10 @@ class AutoIAFNormal(AutoContinuous):
             self.hidden_dim = self.latent_dim
         if self.arn is None:
             self.arn = AutoRegressiveNN(self.latent_dim, [self.hidden_dim])
+        if self.master is None:
+            pyro.module(self.prefix, self)
 
         iaf = transforms.InverseAutoregressiveFlow(self.arn)
-        pyro.module("{}_iaf".format(self.prefix), iaf)
         iaf_dist = dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]), [iaf])
         return iaf_dist
 

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -45,6 +45,7 @@ class AutoGuide(nn.Module):
 
     :param callable model: a pyro model
     :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def __init__(self, model, prefix="auto"):
@@ -129,6 +130,7 @@ class AutoGuideList(AutoGuide):
 
     :param callable model: a Pyro model
     :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def __init__(self, model, prefix="auto"):
@@ -513,8 +515,8 @@ class AutoMultivariateNormal(AutoContinuous):
         See :ref:`autoguide-initialization` section for available functions.
     :param float init_scale: Initial scale for the standard deviation of each
         (unconstrained transformed) latent variable.
-    :param str prefix: A prefix that will be prefixed to all param internal
-        sites.
+    :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def __init__(self, model, prefix="auto", init_loc_fn=init_to_median,
@@ -561,8 +563,8 @@ class AutoDiagonalNormal(AutoContinuous):
         See :ref:`autoguide-initialization` section for available functions.
     :param float init_scale: Initial scale for the standard deviation of each
         (unconstrained transformed) latent variable.
-    :param str prefix: A prefix that will be prefixed to all param internal
-        sites.
+    :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def __init__(self, model, prefix="auto", init_loc_fn=init_to_median,
@@ -612,8 +614,8 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         See :ref:`autoguide-initialization` section for available functions.
     :param float init_scale: Approximate initial scale for the standard
         deviation of each (unconstrained transformed) latent variable.
-    :param str prefix: A prefix that will be prefixed to all param internal
-        sites.
+    :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def __init__(self, model, prefix="auto", init_loc_fn=init_to_median, init_scale=1.0, rank=1):
@@ -668,6 +670,7 @@ class AutoIAFNormal(AutoContinuous):
     :param callable init_loc_fn: A per-site initialization function.
         See :ref:`autoguide-initialization` section for available functions.
     :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def __init__(self, model, hidden_dim=None, prefix="auto", init_loc_fn=init_to_median):
@@ -715,6 +718,7 @@ class AutoLaplaceApproximation(AutoContinuous):
     :param callable init_loc_fn: A per-site initialization function.
         See :ref:`autoguide-initialization` section for available functions.
     :param str prefix: a prefix that will be prefixed to all param internal sites
+        as part of the module name.
     """
 
     def get_posterior(self, *args, **kwargs):

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -17,7 +17,7 @@ import weakref
 from contextlib import ExitStack  # python 3
 
 import torch
-from torch.distributions import biject_to, constraints
+from torch.distributions import biject_to, constraints, transform_to
 from torch import nn
 
 import pyro
@@ -751,7 +751,7 @@ class AutoLaplaceApproximation(AutoContinuous):
         gaussian_guide._setup_prototype(*args, **kwargs)
         # Set loc, scale_tril parameters as computed above.
         gaussian_guide.loc.data = loc
-        gaussian_guide.scale_tril.data = scale_tril
+        gaussian_guide.scale_tril_unconstrained.data = transform_to(constraints.lower_cholesky).inv(scale_tril)
         return gaussian_guide
 
 

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -165,7 +165,7 @@ class AutoGuideList(AutoGuide):
         for part in self.parts:
             part._setup_prototype(*args, **kwargs)
             for param, value in part.named_parameters():
-                setattr(self, param, value)
+                setattr(self, '{}_{}'.format(part.prefix, param), value)
 
     def forward(self, *args, **kwargs):
         """

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -34,7 +34,7 @@ from pyro.params import constraint, ConstrainedModule, ConstrainedParameter
 from pyro.poutine.util import prune_subsample_sites
 
 
-class AutoGuide(nn.Module):
+class AutoGuide(object):
     """
     Base class for automatic guides.
 
@@ -117,7 +117,7 @@ class AutoGuide(nn.Module):
         raise NotImplementedError
 
 
-class AutoGuideList(AutoGuide):
+class AutoGuideList(AutoGuide, nn.Module):
     """
     Container class to combine multiple automatic guides.
 
@@ -320,7 +320,7 @@ class AutoDelta(AutoGuide, ConstrainedModule):
         return self(*args, **kwargs)
 
 
-class AutoContinuous(AutoGuide):
+class AutoContinuous(AutoGuide, nn.Module):
     """
     Base class for implementations of continuous-valued Automatic
     Differentiation Variational Inference [1].


### PR DESCRIPTION
Addresses #2078, using the machinery from @fritzo's #2102, #2104. 

This makes AutoGuide derive from `nn.Module` instances, where optimizable parameters are stored as `nn.Parameter` attributes of the instance.
 - The `_setup_prototyp` method is used to initialize autoguide parameters. 
 - We need to call `pyro.module(self.prefix, self)` inside `__call__` so that guide parameters can be captured as `pyro.param` values in the guide trace for SVI. 

**Additional notes:**
 - I had to create a new `call` method that returns the result from `__call__` in the form of a tuple of tensors. This is because functions with the `dict` return type are not currently supported by the JIT tracer. This method can be removed once this restriction is lifted.
 - Note that this requires setting the `constraint` for all static guide parameters even if they are unconstrained. e.g. `self.loc`. Otherwise, these will not be registered as `nn.Parameter`s and won't be registered into the param store by `pyro.module`. **Update** Changed to using `nn.Parameter` for unconstrained parameters.
 - We are using `self.prefix` as the module name so the parameters in the param store will have names like `guide.auto$$$loc_unconstrained`. I think it might be better to use the autoguide name as the module name and append the prefix to the parameter name instead, which will have fewer clashes even with the default prefix?
 - It is the responsibility of the user to ensure that they are storing all autoguide parameters as `nn.Parameter` in their custom autoguides that they pass in to `AutoguideList`. Even otherwise, it should work fine, but those parameters will likely cause issues during serialization. 

**Tests:**
 - Existing tests pass without any modification.
 - New test added for testing guide serialization.

**TODOs:**
 - [x] Fix failing guide serialization tests.