### PR TITLE
Change parametrization of AutoLowRankMultivariateNormal

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -603,7 +603,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         scale = pyro.param("{}_scale".format(self.prefix))
         factor = pyro.param("{}_cov_factor".format(self.prefix))
         scale = scale * (factor.pow(2).sum(-1) + 1).sqrt()
-        return loc, scale * 2
+        return loc, scale
 
 
 class AutoIAFNormal(AutoContinuous):

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -589,11 +589,11 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         """
         loc = pyro.param("{}_loc".format(self.prefix), self._init_loc)
         scale = pyro.param("{}_scale".format(self.prefix),
-                           lambda: loc.new_full((self.latent_dim,), self._init_scale),
+                           lambda: loc.new_full((self.latent_dim,), 0.5 ** 0.5 * self._init_scale),
                            constraint=constraints.positive)
         factor = pyro.param("{}_cov_factor".format(self.prefix),
                             lambda: loc.new_empty(self.latent_dim, self.rank).normal_(
-                                0, self._init_scale / self.rank ** 0.5))
+                                0, 1 / self.rank ** 0.5))
         factor = factor * scale.unsqueeze(-1)
         diagonal = scale * scale
         return dist.LowRankMultivariateNormal(loc, factor, diagonal)


### PR DESCRIPTION
Addresses #2120 

This aims to improve convergence of `AutoLowRankMultivariateNormal` by separating "noise scale" parameters from "noise direction" parameters. Intuitively this allows the uncertainty to grow slowly early in learning, when the autoguide is still learning the loc parameter; thus this PR is a smooth way to accomplish the staged learning of #2113 .

The old parametrization was:
```py
cov = diagonal + cov_factor @ cov_factor.T
```
The new parametrization is:
```py
cov = scale.unsqueeze(-1) * (eye + cov_factor @ cov_factor.T) * scale
    = scale.pow(2).diag_embed() + scaled_cov_factor @ scaled_cov_factor
```
where
```py
scaled_cov_factor = scale.unsqueeze(-1) * cov_factor
```
## Experiments

### Experiment 1

I have tested this on a high-dimensional variational inference problem (dim=22407, rank=100, real world data) and found this PR to stabilize training:
<details>

old loss curve (which required custom per-parameter learning rates):
![image](https://user-images.githubusercontent.com/648532/68346986-796f5080-00aa-11ea-8570-9d7915320fc2.png)
new loss curve (with higher learning rate):
![image](https://user-images.githubusercontent.com/648532/68349576-74ae9a80-00b2-11ea-9a9e-2d4969772c8f.png)

</details>

## Experiment 2

This example demonstrates more stable convergence on a synthetic dataset:
https://github.com/pyro-ppl/sandbox/blob/auto-lowrank-mvn/2019-11-lowrank/experiment.ipynb

<details>

![image](https://user-images.githubusercontent.com/648532/68403945-a36c5580-0132-11ea-8fc9-2378920066ac.png)

![image](https://user-images.githubusercontent.com/648532/68404006-bc750680-0132-11ea-9d81-955deb7ad035.png)

</details>

## Experiment 3

This example demonstrates identification of true low rank structure when the model matches the guide. https://github.com/pyro-ppl/sandbox/blob/auto-lowrank-mvn/2019-11-lowrank/exact.ipynb

<details>

![image](https://user-images.githubusercontent.com/648532/68423555-256e7580-0157-11ea-96f3-44e847c64971.png)

</details>

## Experiment 4

This is like experiment 3, but when dimensions are randomly scaled by a scale in [exp(-1), exp(1)]. https://github.com/pyro-ppl/sandbox/blob/auto-lowrank-mvn/2019-11-lowrank/exact-scaled.ipynb

<details>

![image](https://user-images.githubusercontent.com/648532/68424444-da556200-0158-11ea-82f9-7793581897af.png)

</details>

## Tested
- tested on experiments
- existing behavior is covered by unit tests