### PR TITLE
Support pickling of easyguides

### DIFF
--- a/tests/contrib/easyguide/test_easyguide.py
+++ b/tests/contrib/easyguide/test_easyguide.py
@@ -1,12 +1,14 @@
+import warnings
+
 import pytest
 import torch
 from torch.distributions import constraints
 
 import pyro
 import pyro.distributions as dist
-from pyro.infer.autoguide.initialization import init_to_mean, init_to_median
-from pyro.contrib.easyguide import easy_guide
+from pyro.contrib.easyguide import EasyGuide, easy_guide
 from pyro.infer import SVI, Trace_ELBO
+from pyro.infer.autoguide.initialization import init_to_mean, init_to_median
 from pyro.optim import Adam
 from pyro.util import ignore_jit_warnings
 
@@ -61,6 +63,31 @@ def test_delta_smoke(init_fn):
         guide.init = init_fn
 
     check_guide(guide)
+
+
+class PickleGuide(EasyGuide):
+    def __init__(self, model):
+        super().__init__(model)
+        self.init = init_to_median
+
+    def guide(self, batch, subsample, full_size):
+        self.map_estimate("drift")
+        with self.plate("data", full_size, subsample=subsample):
+            self.group(match="state_[0-9]*").map_estimate()
+
+
+def test_serialize():
+    guide = PickleGuide(model)
+    check_guide(guide)
+
+    # Work around https://github.com/pytorch/pytorch/issues/27972
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        torch.save(guide, "/tmp/test_easyguide.pkl")
+        actual = torch.load("/tmp/test_easyguide.pkl")
+
+    assert type(actual) == type(guide)
+    check_guide(actual)
 
 
 @pytest.mark.parametrize("init_fn", [None, init_to_mean, init_to_median])


### PR DESCRIPTION
1. Pickle does not handle weakref. This works around by temporarily strengthening the ref.
2. Pickle does not handle `@easyguide` magic. This adds a note to use `EasyGuide` instead if pickling is desired.

## Tested
- added a serialization test
- tested in an application