### PR TITLE
Allow setting of @constraint descriptors to nn.Parameters

### DIFF
--- a/pyro/params/constrained_parameter.py
+++ b/pyro/params/constrained_parameter.py
@@ -152,17 +152,17 @@ class ConstraintDescriptor:
         if obj is None:
             return self
 
+        # In case setattr(obj, self.name, constrained_value) accidentally
+        # bypassed self.__set__(obj, constrained_value), attempt to repair
+        # the situation.
         try:
             unconstrained_value = getattr(obj, self._unconstrained_name)
         except AttributeError:
-            print("DEBUG repairing")
-            # In case setattr(obj, self.name, constrained_value) accidentally
-            # bypassed self.__set__(obj, constrained_value), attempt to repair
-            # the situation.
             # The following may safely raise another AttributeError.
             constrained_value = obj.__getattr__(self.name)
-            delattr(obj, self.name)
+            # But further AttributeErrors indicate a real problem.
             try:
+                delattr(obj, self.name)
                 self.__set__(obj, constrained_value)
                 unconstrained_value = getattr(obj, self._unconstrained_name)
             except AttributeError:

--- a/pyro/params/constrained_parameter.py
+++ b/pyro/params/constrained_parameter.py
@@ -152,8 +152,23 @@ class ConstraintDescriptor:
         if obj is None:
             return self
 
+        try:
+            unconstrained_value = getattr(obj, self._unconstrained_name)
+        except AttributeError:
+            print("DEBUG repairing")
+            # In case setattr(obj, self.name, constrained_value) accidentally
+            # bypassed self.__set__(obj, constrained_value), attempt to repair
+            # the situation.
+            # The following may safely raise another AttributeError.
+            constrained_value = obj.__getattr__(self.name)
+            delattr(obj, self.name)
+            try:
+                self.__set__(obj, constrained_value)
+                unconstrained_value = getattr(obj, self._unconstrained_name)
+            except AttributeError:
+                raise RuntimeError("Failed to lazily constrain {}.{}".format(obj, self.name))
+
         constraint = self._constraint_fn(obj)
-        unconstrained_value = getattr(obj, self._unconstrained_name)
         constrained_value = transform_to(constraint)(unconstrained_value)
         return constrained_value
 


### PR DESCRIPTION
Addresses #2126, #2120 

In Python `__get__` takes [precedence](https://docs.python.org/3/howto/descriptor.html#invoking-descriptors) over `__getattr__`, but `__setattr__` takes precedence over `__set__`. This makes it error-prone to set `@constraint`ed parameters of an `nn.Module`, since `nn.Module.__setattr__` can steal control from `ConstraintDescriptor.__set__`.

This PR implements a workaround whereby, after a constrained parameter has been incorrectly set directly in `nn.Module._params`, at the first read of `ConstraintDescriptor.__get__` the parameter will be moved into the correct position.

This solution is a little dangerous, e.g. `pyro.module()` might record incorrect parameters in the first iteration, before the parameter is read. However in typical autoguide use, we can ensure parameters are read before `pyro.module()` is called.

## Tested
- added a unit test
- verified that this allows setting to `nn.Parameter` in #2126