### PR TITLE
Remove prefixes from autoguides

### DIFF
--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -546,7 +546,7 @@ def test_nested_autoguide(Elbo):
         infer.step()
 
     tr = poutine.trace(guide).get_trace()
-    assert all(p.startswith("AutoGuideList$$$x") or p.startswith("AutoGuideList$$$y") for p in tr.param_nodes)
+    assert all(p.startswith("AutoGuideList$$$x") or p.startswith("AutoGuideList$$$y.z") for p in tr.param_nodes)
     assert "x" in tr
     assert "y" in tr
     # Only latent sampled is for the IAF.


### PR DESCRIPTION
Attempts to address #2131. 
 - This removes prefixes from all autoguides.
 - For `AutoGuideList`, this allows us to set autoguides as below. In this case, `x` and `y` are registered as submodules of `autoguide_list` and their parameters are not immediately set as attributes of `autoguide_list`. However, these attributes are accessible in the same manner as for `nn.Modules`. e.g. `autoguide_list.x.x_unconstrained` gives us the AutoDelta params. The values in the param store will be stored as `AutoGuideList$$$x.x_unconstrained`, where the module name is given by the guide class name.

```python
autoguide_list = AutoGuideList(model)
autoguide_list.x = AutoDelta(poutine.block(model, expose='x'))
autoguide_list.y = AutoDiagonalNormal(poutine.block(model, expose='y'))
```
 - `AutoGuideList.add` is also supported and simply calls `setattr` under the hood. In this case, the names of the submodules are "guide_0", "guide_1", etc.
 - Also, fixes a bug in `AutoGuideList` (I think) where we need to use `poutine.block` when creating plates.

Tested the naming / serialization for a nested autoguide.

