### PR TITLE
Support saving of PyroModules in PyroParam store

### DIFF
--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -34,29 +34,26 @@ def _make_name(prefix, name):
     return "{}.{}".format(prefix, name) if prefix else name
 
 
-def _force_pyro_param(name, unconstrained_value, constraint=constraints.real, event_dim=None):
-    """
-    Force updates the Pyro param store with an unconstrained value.
-
-    This treats a PyroModule as source of truth, rather than the Pyro param store.
-    """
-    if _PYRO_PARAM_STORE._params.get(name) is not unconstrained_value:
-        _PYRO_PARAM_STORE._params[name] = unconstrained_value
-        _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = name
-        _PYRO_PARAM_STORE._constraints[name] = constraint
-    return pyro.param(name, event_dim=event_dim)
+def _unconstrain(constrained_value, constraint):
+    with torch.no_grad():
+        unconstrained_value = transform_to(constraint).inv(constrained_value.detach())
+        return torch.nn.Parameter(unconstrained_value)
 
 
-class _Cache:
+class _Context:
     """
     Sometimes-active cache for ``PyroModule.__call__()`` contexts.
     """
     def __init__(self):
         self.active = 0
         self.cache = {}
+        if __debug__:
+            self.used = False
 
     def __enter__(self):
         self.active += 1
+        if __debug__:
+            self.used = True
 
     def __exit__(self, type, value, traceback):
         self.active -= 1
@@ -95,8 +92,8 @@ class PyroModule(torch.nn.Module):
     :class:`PyroModule` s can contain normal :class:`torch.nn.Module` s, but not
     vice versa. Accessing a normal :class:`torch.nn.Module` attribute of
     a :class:`PyroModule` triggers a :func:`pyro.module` statement. Parameters
-    in :class:`PyroModule` s are considered the source of truth, and override
-    values in the Pyro param store.
+    in :class:`PyroModule` s are read from the param store if they exist there,
+    otherwise are written to the param store.
 
     To create a Pyro-managed random attribute, set that attribute using the
     :class:`PyroSample` helper, specifying a prior distribution. Reading that
@@ -129,29 +126,23 @@ class PyroModule(torch.nn.Module):
     """
     def __init__(self):
         self._pyro_name = ""
-        self._pyro_cache = _Cache()  # shared among sub-PyroModules
+        self._pyro_context = _Context()  # shared among sub-PyroModules
         self._pyro_params = OrderedDict()
         self._pyro_samples = OrderedDict()
         super().__init__()
 
-    def _pyro_set_supermodule(self, name, cache):
+    def _pyro_set_supermodule(self, name, context):
         self._pyro_name = name
-        self._pyro_cache = cache
+        self._pyro_context = context
         for key, value in self._modules.items():
             assert isinstance(value, PyroModule)
-            value._pyro_set_supermodule(_make_name(name, key), cache)
+            assert not value._pyro_context.used, \
+                "submodule {} has executed outside of supermodule".format(name)
+            value._pyro_set_supermodule(_make_name(name, key), context)
 
     def __call__(self, *args, **kwargs):
-        with self._pyro_cache:
+        with self._pyro_context:
             return super().__call__(*args, **kwargs)
-
-    def _pyro_sample(self, name, fn):
-        cache = self.__dict__['_pyro_cache']
-        value = cache.get(name)
-        if value is None:
-            value = pyro.sample(name, fn)
-            cache.set(name, value)
-        return value
 
     def __getattr__(self, name):
         # PyroParams trigger pyro.param statements.
@@ -160,8 +151,26 @@ class PyroModule(torch.nn.Module):
             if name in _pyro_params:
                 constraint, event_dim = _pyro_params[name]
                 unconstrained_value = getattr(self, name + "_unconstrained")
-                return _force_pyro_param(_make_name(self._pyro_name, name),
-                                         unconstrained_value, constraint, event_dim)
+                if self._pyro_context.active:
+                    fullname = _make_name(self._pyro_name, name)
+                    if fullname in _PYRO_PARAM_STORE:
+                        if _PYRO_PARAM_STORE._params[fullname] is not unconstrained_value:
+                            # Update PyroModule <--- ParamStore.
+                            unconstrained_value = _PYRO_PARAM_STORE._params[fullname]
+                            if not isinstance(unconstrained_value, torch.nn.Parameter):
+                                # Update PyroModule ---> ParamStore (type only; data is preserved).
+                                unconstrained_value = torch.nn.Parameter(unconstrained_value)
+                                _PYRO_PARAM_STORE._params[fullname] = unconstrained_value
+                                _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
+                            super().__setattr__(name + "_unconstrained", unconstrained_value)
+                    else:
+                        # Update PyroModule ---> ParamStore.
+                        _PYRO_PARAM_STORE._constraints[fullname] = constraint
+                        _PYRO_PARAM_STORE._params[fullname] = unconstrained_value
+                        _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
+                    return pyro.param(fullname, event_dim=event_dim)
+                else:  # Cannot determine supermodule and hence cannot compute fullname.
+                    return transform_to(constraint)(unconstrained_value)
 
         # PyroSample trigger pyro.sample statements.
         if '_pyro_samples' in self.__dict__:
@@ -170,17 +179,28 @@ class PyroModule(torch.nn.Module):
                 prior = _pyro_samples[name]
                 if not isinstance(prior, (dist.Distribution, torch.distributions.Distribution)):
                     prior = prior(self)
-                return self._pyro_sample(_make_name(self._pyro_name, name), prior)
+                context = self._pyro_context
+                if context.active:
+                    fullname = _make_name(self._pyro_name, name)
+                    value = context.get(fullname)
+                    if value is None:
+                        value = pyro.sample(fullname, prior)
+                        context.set(fullname, value)
+                    return value
+                else:  # Cannot determine supermodule and hence cannot compute fullname.
+                    return prior()
 
         result = super().__getattr__(name)
 
         # Regular nn.Parameters trigger pyro.param statements.
         if isinstance(result, torch.nn.Parameter) and not name.endswith("_unconstrained"):
-            _force_pyro_param(_make_name(self._pyro_name, name), result)
+            if self._pyro_context.active:
+                pyro.param(_make_name(self._pyro_name, name), result)
 
         # Regular nn.Modules trigger pyro.module statements.
         if isinstance(result, torch.nn.Module) and not isinstance(result, PyroModule):
-            pyro.module(_make_name(self._pyro_name, name), result)
+            if self._pyro_context.active:
+                pyro.module(_make_name(self._pyro_name, name), result)
 
         return result
 
@@ -191,7 +211,7 @@ class PyroModule(torch.nn.Module):
                 delattr(self, name)
             except AttributeError:
                 pass
-            value._pyro_set_supermodule(_make_name(self._pyro_name, name), self._pyro_cache)
+            value._pyro_set_supermodule(_make_name(self._pyro_name, name), self._pyro_context)
             super().__setattr__(name, value)
             return
 
@@ -201,19 +221,23 @@ class PyroModule(torch.nn.Module):
                 delattr(self, name)
             except AttributeError:
                 pass
-            fullname = _make_name(self._pyro_name, name)
-            if fullname in _PYRO_PARAM_STORE:
-                del _PYRO_PARAM_STORE[fullname]
-            _pyro_params = self.__dict__['_pyro_params']
             constrained_value, constraint, event_dim = value
-            _pyro_params[name] = constraint, event_dim
-            pyro.param(fullname, constrained_value, constraint=constraint, event_dim=event_dim)
-            unconstrained_param = _PYRO_PARAM_STORE._params[fullname]
-            if not isinstance(unconstrained_param, torch.nn.Parameter):
-                unconstrained_param = torch.nn.Parameter(unconstrained_param)
-                _PYRO_PARAM_STORE._params[fullname] = unconstrained_param
-                _PYRO_PARAM_STORE._param_to_name[unconstrained_param] = fullname
-            super().__setattr__(name + "_unconstrained", unconstrained_param)
+            self._pyro_params[name] = constraint, event_dim
+            if self._pyro_context.active:
+                fullname = _make_name(self._pyro_name, name)
+                if fullname in _PYRO_PARAM_STORE:
+                    # Update PyroModule <--- ParamStore.
+                    unconstrained_value = _PYRO_PARAM_STORE._params[fullname]
+                    if not isinstance(unconstrained_value, torch.nn.Parameter):
+                        # Update PyroModule ---> ParamStore (type only; data is preserved).
+                        unconstrained_value = torch.nn.Parameter(unconstrained_value)
+                        _PYRO_PARAM_STORE._params[fullname] = unconstrained_value
+                        _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
+                else:
+                    unconstrained_value = _unconstrain(constrained_value, constraint)
+            else:  # Cannot determine supermodule and hence cannot compute fullname.
+                unconstrained_value = _unconstrain(constrained_value, constraint)
+            super().__setattr__(name + "_unconstrained", unconstrained_value)
             return
 
         if isinstance(value, torch.nn.Parameter):
@@ -222,23 +246,25 @@ class PyroModule(torch.nn.Module):
                 delattr(self, name)
             except AttributeError:
                 pass
-            fullname = _make_name(self._pyro_name, name)
-            if fullname in _PYRO_PARAM_STORE:
-                del _PYRO_PARAM_STORE[fullname]
-            pyro.param(fullname, value)
+            if self._pyro_context.active:
+                fullname = _make_name(self._pyro_name, name)
+                value = pyro.param(fullname, value)
+                if not isinstance(value, torch.nn.Parameter):
+                    # Update PyroModule ---> ParamStore (type only; data is preserved).
+                    value = torch.nn.Parameter(value)
+                    _PYRO_PARAM_STORE._params[fullname] = value
+                    _PYRO_PARAM_STORE._param_to_name[value] = fullname
             super().__setattr__(name, value)
             return
 
         if isinstance(value, torch.Tensor):
-            if '_pyro_params' in self.__dict__:
-                _pyro_params = self.__dict__['_pyro_params']
-                if name in _pyro_params:
-                    # Update value of an existing PyroParam.
-                    constraint, event_dim = _pyro_params[name]
-                    unconstrained_value = getattr(self, name + "_unconstrained")
-                    with torch.no_grad():
-                        unconstrained_value.data = transform_to(constraint).inv(value.detach())
-                    return
+            if name in self._pyro_params:
+                # Update value of an existing PyroParam.
+                constraint, event_dim = self._pyro_params[name]
+                unconstrained_value = getattr(self, name + "_unconstrained")
+                with torch.no_grad():
+                    unconstrained_value.data = transform_to(constraint).inv(value.detach())
+                return
 
         if isinstance(value, PyroSample):
             # Create a new PyroSample, overwriting any old value.
@@ -253,18 +279,26 @@ class PyroModule(torch.nn.Module):
         super().__setattr__(name, value)
 
     def __delattr__(self, name):
-        if '_pyro_params' in self.__dict__:
-            _pyro_params = self.__dict__['_pyro_params']
-            if name in _pyro_params:
-                delattr(self, name + "_unconstrained")
-                del _pyro_params[name]
-                return
+        if name in self._parameters:
+            del self._parameters[name]
+            fullname = _make_name(self._pyro_name, name)
+            if fullname in _PYRO_PARAM_STORE:
+                # Update PyroModule ---> ParamStore.
+                del _PYRO_PARAM_STORE[fullname]
+            return
 
-        if '_pyro_samples' in self.__dict__:
-            _pyro_samples = self.__dict__['_pyro_samples']
-            if name in _pyro_samples:
-                del _pyro_samples[name]
-                return
+        if name in self._pyro_params:
+            delattr(self, name + "_unconstrained")
+            del self._pyro_params[name]
+            fullname = _make_name(self._pyro_name, name)
+            if fullname in _PYRO_PARAM_STORE:
+                # Update PyroModule ---> ParamStore.
+                del _PYRO_PARAM_STORE[fullname]
+            return
+
+        if name in self._pyro_samples:
+            del self._pyro_samples[name]
+            return
 
         super().__delattr__(name)
 
@@ -280,7 +314,7 @@ def pyro_method(fn):
 
     @functools.wraps(fn)
     def cached_fn(self, *args, **kwargs):
-        with self._pyro_cache:
+        with self._pyro_context:
             return fn(self, *args, **kwargs)
 
     return cached_fn

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -297,14 +297,15 @@ def test_pyro_serialize():
     actual = module()  # triggers saving in param store
     assert_equal(actual[0], module.x)
     assert_equal(actual[1], module.y)
-    assert len(pyro.get_param_store()) == 2
+    assert set(pyro.get_param_store().keys()) == {"x", "y"}
+    assert_equal(pyro.param("x").detach(), module.x.detach())
+    assert_equal(pyro.param("y").detach(), module.y.detach())
 
-    # Work around https://github.com/pytorch/pytorch/issues/27972
     pyro.get_param_store().save("/tmp/pyro_module.pt")
     pyro.clear_param_store()
     assert len(pyro.get_param_store()) == 0
     pyro.get_param_store().load("/tmp/pyro_module.pt")
-    assert len(pyro.get_param_store()) == 2
+    assert set(pyro.get_param_store().keys()) == {"x", "y"}
     actual = MyModule()
     actual()
 

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -62,14 +62,27 @@ def test_svi_smoke():
 
 
 def test_names():
-    root = PyroModule()
-    root.x = nn.Parameter(torch.tensor(0.))
-    root.y = PyroParam(torch.tensor(1.), constraint=constraints.positive)
-    root.m = nn.Module()
-    root.m.u = nn.Parameter(torch.tensor(2.0))
-    root.p = PyroModule()
-    root.p.v = nn.Parameter(torch.tensor(3.))
-    root.p.w = PyroParam(torch.tensor(4.), constraint=constraints.positive)
+
+    class Model(PyroModule):
+        def __init__(self):
+            super().__init__()
+            self.x = nn.Parameter(torch.tensor(0.))
+            self.y = PyroParam(torch.tensor(1.), constraint=constraints.positive)
+            self.m = nn.Module()
+            self.m.u = nn.Parameter(torch.tensor(2.0))
+            self.p = PyroModule()
+            self.p.v = nn.Parameter(torch.tensor(3.))
+            self.p.w = PyroParam(torch.tensor(4.), constraint=constraints.positive)
+
+        def forward(self):
+            # trigger .__getattr__()
+            self.x
+            self.y
+            self.m
+            self.p.v
+            self.p.w
+
+    model = Model()
 
     # Check named_parameters.
     expected = {
@@ -79,18 +92,13 @@ def test_names():
         "p.v",
         "p.w_unconstrained",
     }
-    actual = set(name for name, _ in root.named_parameters())
+    actual = set(name for name, _ in model.named_parameters())
     assert actual == expected
 
     # Check pyro.param names.
     expected = {"x", "y", "m$$$u", "p.v", "p.w"}
     with poutine.trace(param_only=True) as param_capture:
-        # trigger .__getattr__()
-        root.x
-        root.y
-        root.m
-        root.p.v
-        root.p.w
+        model()
     actual = {name for name, site in param_capture.trace.nodes.items()
               if site["type"] == "param"}
     assert actual == expected
@@ -235,7 +243,7 @@ def test_cache():
     module.p.e = PyroParam(torch.tensor(4.), constraint=constraints.positive)
     module.p.f = PyroSample(dist.Normal(0, 1))
 
-    assert module._pyro_cache is module.p._pyro_cache
+    assert module._pyro_context is module.p._pyro_context
 
     # Check that results are cached with an invocation of .__call__().
     result1 = module()
@@ -249,10 +257,10 @@ def test_cache():
         assert result1[0] is not result2[0], key
 
 
-def test_serialization():
-
+def test_torch_serialize():
     module = PyroModule()
     module.x = PyroParam(torch.tensor(1.234), constraints.positive)
+    module.y = nn.Parameter(torch.randn(3))
     assert isinstance(module.x, torch.Tensor)
 
     # Work around https://github.com/pytorch/pytorch/issues/27972
@@ -260,8 +268,46 @@ def test_serialization():
         warnings.filterwarnings("ignore", category=UserWarning)
         f = io.BytesIO()
         torch.save(module, f)
+        pyro.clear_param_store()
         f.seek(0)
         actual = torch.load(f)
+
+    assert_equal(actual.x, module.x)
+    actual_names = {name for name, _ in actual.named_parameters()}
+    expected_names = {name for name, _ in module.named_parameters()}
+    assert actual_names == expected_names
+
+
+def test_pyro_serialize():
+    class MyModule(PyroModule):
+        def __init__(self):
+            super().__init__()
+            self.x = PyroParam(torch.tensor(1.234), constraints.positive)
+            self.y = nn.Parameter(torch.randn(3))
+
+        def forward(self):
+            return self.x, self.y
+
+    module = MyModule()
+    assert len(pyro.get_param_store()) == 0
+
+    assert isinstance(module.x, torch.Tensor)
+    assert len(pyro.get_param_store()) == 0
+
+    actual = module()  # triggers saving in param store
+    assert_equal(actual[0], module.x)
+    assert_equal(actual[1], module.y)
+    assert len(pyro.get_param_store()) == 2
+
+    # Work around https://github.com/pytorch/pytorch/issues/27972
+    pyro.get_param_store().save("/tmp/pyro_module.pt")
+    pyro.clear_param_store()
+    assert len(pyro.get_param_store()) == 0
+    pyro.get_param_store().load("/tmp/pyro_module.pt")
+    assert len(pyro.get_param_store()) == 2
+    actual = MyModule()
+    actual()
+
     assert_equal(actual.x, module.x)
     actual_names = {name for name, _ in actual.named_parameters()}
     expected_names = {name for name, _ in module.named_parameters()}


### PR DESCRIPTION
Addresses #2120 

This aims to preserve our old serializability path, allowing `PyroModule`s and `AutoGuide`s to be saved and loaded via a side-effect of `pyro.get_param_store().load()`. This also fixes a bug whereby the param store was populated with partially qualified names during nested module construction, e.g. using @fehiepsi 's example:
```py
class Child(PyroModule):
    def __init__(self, x):
        super().__init__()
        self.a = nn.Parameter(torch.tensor(x))

class Family(PyroModule):
    def __init__(self):
        self.a = Child(1.0)  # Child.__setattr__('a', ...) used to trigger a premature pyro.param()
        self.v = Child(2.0)
```
To achieve these ends, I have
1. Renamed `._pyro_cache()` to `._pyro_context()` and restricted pyro primitives to be called only when the context is active (inside `__call__` or methods marked `@pyro_method`). Thus no pyro.param statements will be called during `__init__()`. Not foolproof, but less buggy.
2. Clearly defined precedence for when PyroModule takes precedence over ParamStore, and added comments to that effect.
3. In `PyroModule.__delattr__`, remove parameters from the param store.

## Tested
- added a new serialization test
- added some `len(pyro.get_param_store())` assertions to avoid duplicate param name errors.