### PR TITLE
Recursively set attributes for dynamic autoguides

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -48,11 +48,11 @@ def _deep_setattr(obj, key, val):
         setattr(obj, attr, PyroModule())
         return getattr(obj, attr)
 
-    path, _, attr = key.rpartition(".")
+    lpart, _, rpart = key.rpartition(".")
     # Recursive getattr while setting any prefix attributes to PyroModule
-    if path:
-        obj = functools.reduce(_getattr, [obj] + key.split('.'))
-    setattr(obj, attr, val)
+    if lpart:
+        obj = functools.reduce(_getattr, [obj] + lpart.split('.'))
+    setattr(obj, rpart, val)
 
 
 class AutoGuide(PyroModule):


### PR DESCRIPTION
This resolves one of the issues in #2146, where `PyroSample` statements in submodules throw errors in dynamic autoguides like `AutoDelta` because we try to set attributes with names like `module.x` which throws an error in `nn.Module`. This instead does a recursive `setattr` - initializing `PyroModule`s recursively if the prefix attributes do not exist. We can merge this separately or as part of #2146. 