### PR TITLE
Add named_pyro_params method to PyroModule

### DIFF
--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -140,6 +140,9 @@ def test_module_cache():
             super().__init__()
             self.a = PyroParam(torch.tensor(x))
 
+        def forward(self):
+            return self.a
+
     class Family(PyroModule):
         def __init__(self):
             super().__init__()
@@ -149,14 +152,10 @@ def test_module_cache():
             return self.c.a
 
     f = Family()
+    assert_equal(f().detach(), torch.tensor(1.))
     f.c = Child(3.)
     assert_equal(f().detach(), torch.tensor(3.))
-
-    g = Family()
-    g.c = Child(4.)
-    assert_equal(g().detach(), torch.tensor(4.))
-    # FIXME: failing test
-    assert_equal(f().detach(), torch.tensor(3.))
+    assert_equal(f.c().detach(), torch.tensor(3.))
 
 
 SHAPE_CONSTRAINT = [

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -103,6 +103,11 @@ def test_names():
               if site["type"] == "param"}
     assert actual == expected
 
+    # Check pyro_parameters method
+    expected = {"x", "y", "m.u", "p.v", "p.w"}
+    actual = set(k for k, v in model.named_pyro_params())
+    assert actual == expected
+
 
 def test_delete():
     m = PyroModule()
@@ -127,6 +132,25 @@ def test_nested():
     f = Family()
     assert_equal(f.child1.a.detach(), torch.tensor(1.))
     assert_equal(f.child2.a.detach(), torch.tensor(2.))
+
+
+def test_module_delete():
+    class Child(PyroModule):
+        def __init__(self, x):
+            super().__init__()
+            self.a = PyroParam(torch.tensor(x))
+
+    class Family(PyroModule):
+        def __init__(self):
+            super().__init__()
+            self.c = Child(1.0)
+
+        def forward(self):
+            return self.c.a
+
+    f = Family()
+    f.c = Child(3.)
+    assert_equal(f().detach(), torch.tensor(3.))
 
 
 SHAPE_CONSTRAINT = [

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -134,7 +134,7 @@ def test_nested():
     assert_equal(f.child2.a.detach(), torch.tensor(2.))
 
 
-def test_module_delete():
+def test_module_cache():
     class Child(PyroModule):
         def __init__(self, x):
             super().__init__()
@@ -150,6 +150,12 @@ def test_module_delete():
 
     f = Family()
     f.c = Child(3.)
+    assert_equal(f().detach(), torch.tensor(3.))
+
+    g = Family()
+    g.c = Child(4.)
+    assert_equal(g().detach(), torch.tensor(4.))
+    # FIXME: failing test
     assert_equal(f().detach(), torch.tensor(3.))
 
 


### PR DESCRIPTION
This PR adds an analogous method to `named_parameters()` of nn.Module, which yields all Pyro params.

The issue https://github.com/pyro-ppl/pyro/issues/2120#issuecomment-553247132 is also fixed in this PR.