### PR TITLE
Tune defaults of Auto*Normal guides

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -606,7 +606,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         svi = SVI(model, guide, ...)
 
     By default the ``cov_diag`` is initialized to a small constant and the
-    ``cov_factor`` is intialized randomly such that on average
+    ``cov_factor`` is initialized randomly such that on average
     ``cov_factor.matmul(cov_factor.t())`` has the same scale as ``cov_diag``.
 
     :param callable model: A generative model.

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -517,7 +517,7 @@ class AutoMultivariateNormal(AutoContinuous):
         svi = SVI(model, guide, ...)
 
     By default the mean vector is initialized by ``init_loc_fn()`` and the
-    Cholesky factor is initialized to the identity.
+    Cholesky factor is initialized to the identity times a small factor.
 
     :param callable model: A generative model.
     :param callable init_loc_fn: A per-site initialization function.

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -526,8 +526,7 @@ class AutoMultivariateNormal(AutoContinuous):
         (unconstrained transformed) latent variable.
     """
 
-    def __init__(self, model, init_loc_fn=init_to_median,
-                 init_scale=1.0):
+    def __init__(self, model, init_loc_fn=init_to_median, init_scale=0.1):
         if not isinstance(init_scale, float) or not (init_scale > 0):
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
         self._init_scale = init_scale
@@ -562,7 +561,7 @@ class AutoDiagonalNormal(AutoContinuous):
         svi = SVI(model, guide, ...)
 
     By default the mean vector is initialized to zero and the scale is
-    initialized to the identity.
+    initialized to the identity times a small factor.
 
     :param callable model: A generative model.
     :param callable init_loc_fn: A per-site initialization function.
@@ -571,8 +570,7 @@ class AutoDiagonalNormal(AutoContinuous):
         (unconstrained transformed) latent variable.
     """
 
-    def __init__(self, model, init_loc_fn=init_to_median,
-                 init_scale=1.0):
+    def __init__(self, model, init_loc_fn=init_to_median, init_scale=0.1):
         if not isinstance(init_scale, float) or not (init_scale > 0):
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
         self._init_scale = init_scale
@@ -607,22 +605,24 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         guide = AutoLowRankMultivariateNormal(model, rank=10)
         svi = SVI(model, guide, ...)
 
-    By default the ``cov_diag`` is initialized to 1/2 and the ``cov_factor`` is
-    intialized randomly such that ``cov_factor.matmul(cov_factor.t())`` is half the
-    identity matrix.
+    By default the ``cov_diag`` is initialized to a small constant and the
+    ``cov_factor`` is intialized randomly such that on average
+    ``cov_factor.matmul(cov_factor.t())`` has the same scale as ``cov_diag``.
 
     :param callable model: A generative model.
-    :param int rank: The rank of the low-rank part of the covariance matrix.
+    :param rank: The rank of the low-rank part of the covariance matrix.
+        Defaults to approximately ``sqrt(latent dim)``.
+    :type rank: int or None
     :param callable init_loc_fn: A per-site initialization function.
         See :ref:`autoguide-initialization` section for available functions.
     :param float init_scale: Approximate initial scale for the standard
         deviation of each (unconstrained transformed) latent variable.
     """
 
-    def __init__(self, model, init_loc_fn=init_to_median, init_scale=1.0, rank=1):
+    def __init__(self, model, init_loc_fn=init_to_median, init_scale=0.1, rank=None):
         if not isinstance(init_scale, float) or not (init_scale > 0):
             raise ValueError("Expected init_scale > 0. but got {}".format(init_scale))
-        if not isinstance(rank, int) or not rank > 0:
+        if not (rank is None or isinstance(rank, int) and rank > 0):
             raise ValueError("Expected rank > 0 but got {}".format(rank))
         self._init_scale = init_scale
         self.rank = rank
@@ -632,6 +632,8 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         super()._setup_prototype(*args, **kwargs)
         # Initialize guide params
         self.loc = nn.Parameter(self._init_loc())
+        if self.rank is None:
+            self.rank = int(round(self.latent_dim ** 0.5))
         self.scale = PyroParam(
             self.loc.new_full((self.latent_dim,), 0.5 ** 0.5 * self._init_scale),
             constraint=constraints.positive)

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -216,8 +216,11 @@ def test_median(auto_class, Elbo):
         pyro.sample("z", dist.Beta(2.0, 2.0))
 
     guide = auto_class(model)
-    infer = SVI(model, guide, Adam({'lr': 0.005}), Elbo(strict_enumeration_warning=False))
-    for _ in range(800):
+    optim = Adam({'lr': 0.05, 'betas': (0.8, 0.99)})
+    elbo = Elbo(strict_enumeration_warning=False,
+                num_particles=100, vectorize_particles=True)
+    infer = SVI(model, guide, optim, elbo)
+    for _ in range(100):
         infer.step()
 
     if auto_class is AutoLaplaceApproximation:
@@ -303,7 +306,10 @@ def test_quantiles(auto_class, Elbo):
         pyro.sample("z", dist.Beta(2.0, 2.0))
 
     guide = auto_class(model)
-    infer = SVI(model, guide, Adam({'lr': 0.01}), Elbo(strict_enumeration_warning=False))
+    optim = Adam({'lr': 0.05, 'betas': (0.8, 0.99)})
+    elbo = Elbo(strict_enumeration_warning=False,
+                num_particles=100, vectorize_particles=True)
+    infer = SVI(model, guide, optim, elbo)
     for _ in range(100):
         infer.step()
 


### PR DESCRIPTION
Resolves #2120 

1. Reduce `init_scale` from 1.0 to 0.1. I typically use 0.1 for small models and 0.01 for large models. I choose 0.1 as a nice value for beginner users. Not so large that the model goes wild early in training (which I often see with 1.0), but not so small that it takes a long time for variance to increase.
2. Use a default heuristic of `rank ~ sqrt(latent_dim)` in `AutoLowRankMultivariateNormal`. This is a good computational tradeoff in practice. The old default of `rank=1` was silly.
3. Tune optimizers to reduce test time. `pytest -n auto tests/infer/test_autoguide.py` reduces from 42sec to 12sec on my laptop.

## Tested
- updated `test_mean` and `test_quantiles`
- used these defaults in small and large practical models