### PR TITLE
Rewrite poutine.do to represent single-world counterfactuals

### DIFF
--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -31,8 +31,6 @@ class ConditionMessenger(Messenger):
         name = msg["name"]
 
         if name in self.data:
-            assert not msg["is_observed"], \
-                "should not change values of existing observes"
             if isinstance(self.data, Trace):
                 msg["value"] = self.data.nodes[name]["value"]
             else:

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -37,8 +37,5 @@ class ConditionMessenger(Messenger):
                 msg["value"] = self.data.nodes[name]["value"]
             else:
                 msg["value"] = self.data[name]
-            msg["is_observed"] = True
-        return None
-
-    def _pyro_param(self, msg):
+            msg["is_observed"] = msg["value"] is not None
         return None

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -82,12 +82,15 @@ class DoMessenger(Messenger):
                 msg['value'] = None
                 msg['is_observed'] = False
                 msg['fn'] = intervention
-            else:
+            elif isinstance(intervention, (numbers.Number, torch.Tensor)):
                 if isinstance(intervention, numbers.Number):
                     # Delta doesn't automatically convert its argument to tensor
                     intervention = torch.tensor(float(intervention))
                 msg['value'] = intervention
                 msg['fn'] = Delta(intervention, event_dim=len(msg['fn'].event_shape))
                 msg['is_observed'] = True  # keep inference algorithms from complaining about Deltas
+            else:
+                raise NotImplementedError(
+                    "Interventions of type {} not implemented".format(type(intervention)))
 
         return None

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -34,7 +34,8 @@ class DoMessenger(Messenger):
 
     def _pyro_sample(self, msg):
         if msg.get('_intervener_id', None) != self._intervener_id and \
-                msg['name'] in self.data:
+                msg['name'] in self.data and \
+                self.data[msg['name']] is not None:
             # split node, avoid reapplying self recursively to new node
             new_msg = msg.copy()
             new_msg['_intervener_id'] = self._intervener_id

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -18,7 +18,7 @@ class DoMessenger(Messenger):
     and introduce fresh sample sites with the same names
     whose values do not propagate.
 
-    Composes freely with :function:`~pyro.poutine.handlers.condition`
+    Composes freely with :func:`~pyro.poutine.handlers.condition`
     to represent counterfactual distributions over potential outcomes.
     See Single World Intervention Graphs [1] for additional details and theory.
 

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .messenger import Messenger
 from .runtime import apply_stack
 
@@ -36,6 +38,13 @@ class DoMessenger(Messenger):
         if msg.get('_intervener_id', None) != self._intervener_id and \
                 msg['name'] in self.data and \
                 self.data[msg['name']] is not None:
+
+            if msg.get('_intervener_id', None) is not None:
+                warnings.warn(
+                    "Attempting to intervene on variable {} multiple times,"
+                    "this is almost certainly incorrect behavior".format(msg['name']),
+                    RuntimeWarning)
+
             # split node, avoid reapplying self recursively to new node
             new_msg = msg.copy()
             new_msg['_intervener_id'] = self._intervener_id

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -32,7 +32,7 @@ class DoMessenger(Messenger):
         >>> intervened_model = pyro.poutine.do(model, data={"z": torch.tensor(1.)})
 
     This is equivalent to replacing `z = pyro.sample("z", ...)` with
-    `z = pyro.sample("z__CF", dist.Delta(v=torch.tensor(1.)))`
+    `z = torch.tensor(1.)`
     and introducing a fresh sample site pyro.sample("z", ...) whose value is not used elsewhere.
 
     References

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -31,7 +31,7 @@ class DoMessenger(Messenger):
 
     To intervene with a value for site `z`, we can write
 
-        >>> intervened_model = do(model, data={"z": torch.tensor(1.)})
+        >>> intervened_model = pyro.poutine.do(model, data={"z": torch.tensor(1.)})
 
     This is equivalent to replacing `z = pyro.sample("z", ...)` with
     `z = pyro.sample("z__CF", dist.Delta(v=torch.tensor(1.)))`

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -9,8 +9,13 @@ class DoMessenger(Messenger):
     Given a stochastic function with some sample statements
     and a dictionary of values at names,
     set the return values of those sites equal to the values
-    and hide them from the rest of the handler stack
-    as if they were hard-coded to those values.
+    as if they were hard-coded to those values
+    and introduce fresh sample sites with the same names
+    whose values do not propagate.
+
+    Composes freely with :function:`~pyro.poutine.handlers.condition`
+    to represent counterfactual distributions over potential outcomes.
+    See Single World Intervention Graphs [1] for additional details and theory.
 
     Consider the following Pyro program:
 
@@ -23,7 +28,13 @@ class DoMessenger(Messenger):
 
         >>> intervened_model = do(model, data={"z": torch.tensor(1.)})
 
-    This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`.
+    This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`
+    and introducing a fresh sample site pyro.sample("z", ...) whose value is not used elsewhere.
+
+    References
+
+    [1] `Single World Intervention Graphs: A Primer`,
+        Thomas Richardson, James Robins
 
     :param fn: a stochastic function (callable containing Pyro primitive calls)
     :param data: a ``dict`` mapping sample site names to interventions

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -1,0 +1,48 @@
+from .messenger import Messenger
+from .runtime import apply_stack
+
+
+class DoMessenger(Messenger):
+    """
+    Given a stochastic function with some sample statements
+    and a dictionary of values at names,
+    set the return values of those sites equal to the values
+    and hide them from the rest of the handler stack
+    as if they were hard-coded to those values.
+
+    Consider the following Pyro program:
+
+        >>> def model(x):
+        ...     s = pyro.param("s", torch.tensor(0.5))
+        ...     z = pyro.sample("z", dist.Normal(x, s))
+        ...     return z ** 2
+
+    To intervene with a value for site `z`, we can write
+
+        >>> intervened_model = do(model, data={"z": torch.tensor(1.)})
+
+    This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`.
+
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
+    :param data: a ``dict`` mapping sample site names to interventions
+    :returns: stochastic function decorated with a :class:`~pyro.poutine.do_messenger.DoMessenger`
+    """
+    def __init__(self, data):
+        super(DoMessenger, self).__init__()
+        self.data = data
+        self._intervener_id = str(id(self))
+
+    def _pyro_sample(self, msg):
+        if msg.get('_intervener_id', None) != self._intervener_id and \
+                msg['name'] in self.data:
+            # split node, avoid reapplying self recursively to new node
+            new_msg = msg.copy()
+            new_msg['_intervener_id'] = self._intervener_id
+            apply_stack(new_msg)
+            # apply intervention
+            msg['value'] = self.data[msg['name']]
+            msg['stop'] = True
+            msg['is_observed'] = True
+            msg['name'] = "INTERVENED__" + msg['name']  # mangle old name just in case
+
+        return None

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -47,8 +47,7 @@ class DoMessenger(Messenger):
 
     def _pyro_sample(self, msg):
         if msg.get('_intervener_id', None) != self._intervener_id and \
-                msg['name'] in self.data and \
-                self.data[msg['name']] is not None:
+                self.data.get(msg['name']) is not None:
 
             if msg.get('_intervener_id', None) is not None:
                 warnings.warn(

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -407,7 +407,8 @@ def do(fn=None, data=None):
 
         >>> intervened_model = do(model, data={"z": torch.tensor(1.)})
 
-    This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`
+    This is equivalent to replacing `z = pyro.sample("z", ...)` with
+    `z = pyro.sample("z__CF", dist.Delta(v=torch.tensor(1.)))`
     and introducing a fresh sample site pyro.sample("z", ...) whose value is not used elsewhere.
 
     References

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -383,17 +383,18 @@ def enum(fn=None, first_available_dim=None):
     return msngr(fn) if fn is not None else msngr
 
 
-#########################################
-# Begin composite operations
-#########################################
-
 def do(fn=None, data=None):
     """
     Given a stochastic function with some sample statements
     and a dictionary of values at names,
     set the return values of those sites equal to the values
-    and hide them from the rest of the handler stack
-    as if they were hard-coded to those values.
+    as if they were hard-coded to those values
+    and introduce fresh sample sites with the same names
+    whose values do not propagate.
+
+    Composes freely with :function:`~pyro.poutine.handlers.condition`
+    to represent counterfactual distributions over potential outcomes.
+    See Single World Intervention Graphs [1] for additional details and theory.
 
     Consider the following Pyro program:
 
@@ -406,7 +407,13 @@ def do(fn=None, data=None):
 
         >>> intervened_model = do(model, data={"z": torch.tensor(1.)})
 
-    This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`.
+    This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`
+    and introducing a fresh sample site pyro.sample("z", ...) whose value is not used elsewhere.
+
+    References
+
+    [1] `Single World Intervention Graphs: A Primer`,
+        Thomas Richardson, James Robins
 
     :param fn: a stochastic function (callable containing Pyro primitive calls)
     :param data: a ``dict`` mapping sample site names to interventions
@@ -415,6 +422,10 @@ def do(fn=None, data=None):
     msngr = DoMessenger(data=data)
     return msngr(fn) if fn is not None else msngr
 
+
+#########################################
+# Begin composite operations
+#########################################
 
 def queue(fn=None, queue=None, max_tries=None,
           extend_fn=None, escape_fn=None, num_samples=None):

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -55,6 +55,7 @@ from pyro.util import get_rng_state, set_rng_seed, set_rng_state
 from .block_messenger import BlockMessenger
 from .broadcast_messenger import BroadcastMessenger
 from .condition_messenger import ConditionMessenger
+from .do_messenger import DoMessenger
 from .enumerate_messenger import EnumerateMessenger
 from .escape_messenger import EscapeMessenger
 from .infer_config_messenger import InferConfigMessenger
@@ -391,9 +392,8 @@ def do(fn=None, data=None):
     Given a stochastic function with some sample statements
     and a dictionary of values at names,
     set the return values of those sites equal to the values
-    and hide them from the rest of the stack
-    as if they were hard-coded to those values
-    by using ``block``.
+    and hide them from the rest of the handler stack
+    as if they were hard-coded to those values.
 
     Consider the following Pyro program:
 
@@ -409,13 +409,11 @@ def do(fn=None, data=None):
     This is equivalent to replacing `z = pyro.sample("z", ...)` with `z = value`.
 
     :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param data: a ``dict`` or a :class:`~pyro.poutine.Trace`
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.block_messenger.BlockMessenger`
-      and :class:`pyro.poutine.condition_messenger.ConditionMessenger`
+    :param data: a ``dict`` mapping sample site names to interventions
+    :returns: stochastic function decorated with a :class:`~pyro.poutine.do_messenger.DoMessenger`
     """
-    def wrapper(wrapped):
-        return block(condition(wrapped, data=data), hide=list(data.keys()))
-    return wrapper(fn) if fn is not None else wrapper
+    msngr = DoMessenger(data=data)
+    return msngr(fn) if fn is not None else msngr
 
 
 def queue(fn=None, queue=None, max_tries=None,

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -408,7 +408,7 @@ def do(fn=None, data=None):
         >>> intervened_model = pyro.poutine.do(model, data={"z": torch.tensor(1.)})
 
     This is equivalent to replacing `z = pyro.sample("z", ...)` with
-    `z = pyro.sample("z__CF", dist.Delta(v=torch.tensor(1.)))`
+    `z = torch.tensor(1.)`
     and introducing a fresh sample site pyro.sample("z", ...) whose value is not used elsewhere.
 
     References

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -405,7 +405,7 @@ def do(fn=None, data=None):
 
     To intervene with a value for site `z`, we can write
 
-        >>> intervened_model = do(model, data={"z": torch.tensor(1.)})
+        >>> intervened_model = pyro.poutine.do(model, data={"z": torch.tensor(1.)})
 
     This is equivalent to replacing `z = pyro.sample("z", ...)` with
     `z = pyro.sample("z__CF", dist.Delta(v=torch.tensor(1.)))`

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -392,7 +392,7 @@ def do(fn=None, data=None):
     and introduce fresh sample sites with the same names
     whose values do not propagate.
 
-    Composes freely with :function:`~pyro.poutine.handlers.condition`
+    Composes freely with :func:`~pyro.poutine.handlers.condition`
     to represent counterfactual distributions over potential outcomes.
     See Single World Intervention Graphs [1] for additional details and theory.
 

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -10,9 +10,13 @@ from tests.common import assert_equal, assert_not_equal
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize('intervene', [True, False])
-@pytest.mark.parametrize('observe', [True, False])
-def test_counterfactual_query(intervene, observe):
+@pytest.mark.parametrize('intervene,observe,flip', [
+    (True, False, False),
+    (False, True, False),
+    (True, True, False),
+    (True, True, True),
+])
+def test_counterfactual_query(intervene, observe, flip):
     # x -> y -> z -> w
 
     sites = ["x", "y", "z", "w"]
@@ -26,14 +30,20 @@ def test_counterfactual_query(intervene, observe):
         w = pyro.sample("w", dist.Normal(z, 1))
         return dict(x=x, y=y, z=z, w=w)
 
-    if intervene:
-        model = poutine.do(model, data=interventions)
-    if observe:
-        model = poutine.condition(model, data=observations)
+    if not flip:
+        if intervene:
+            model = poutine.do(model, data=interventions)
+        if observe:
+            model = poutine.condition(model, data=observations)
+    elif flip and intervene and observe:
+        model = poutine.do(
+            poutine.condition(model, data=observations),
+            data=interventions)
 
     tr = poutine.trace(model).get_trace()
     actual_values = tr.nodes["_RETURN"]["value"]
     for name in sites:
+        # case 1: purely observational query like poutine.condition
         if not intervene and observe:
             if observations[name] is not None:
                 assert tr.nodes[name]['is_observed']
@@ -41,12 +51,14 @@ def test_counterfactual_query(intervene, observe):
                 assert_equal(observations[name], tr.nodes[name]['value'])
             if interventions[name] != observations[name]:
                 assert_not_equal(interventions[name], actual_values[name])
+        # case 2: purely interventional query like old poutine.do
         elif intervene and not observe:
             assert not tr.nodes[name]['is_observed']
             if interventions[name] is not None:
                 assert_equal(interventions[name], actual_values[name])
             assert_not_equal(observations[name], tr.nodes[name]['value'])
             assert_not_equal(interventions[name], tr.nodes[name]['value'])
+        # case 3: counterfactual query mixing intervention and observation
         elif intervene and observe:
             if observations[name] is not None:
                 assert tr.nodes[name]['is_observed']

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -1,0 +1,53 @@
+import logging
+
+import torch
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from tests.common import assert_equal, assert_close
+
+logger = logging.getLogger(__name__)
+
+
+def test_decorator_interface_do():
+
+    sites = ["x", "y", "z", "_INPUT", "_RETURN"]
+    data = {"x": torch.ones(1)}
+
+    @poutine.do(data=data)
+    def model():
+        p = torch.tensor([0.5])
+        loc = torch.zeros(1)
+        scale = torch.ones(1)
+
+        x = pyro.sample("x", dist.Normal(loc, scale))
+        y = pyro.sample("y", dist.Bernoulli(p))
+        z = pyro.sample("z", dist.Normal(loc, scale))
+        return dict(x=x, y=y, z=z)
+
+    tr = poutine.trace(model).get_trace()
+    for name in sites:
+        if name not in data:
+            assert name in tr
+        else:
+            assert name not in tr
+            assert_equal(tr.nodes["_RETURN"]["value"][name], data[name])
+
+
+def test_do_propagation():
+    pyro.clear_param_store()
+
+    def model():
+        z = pyro.sample("z", dist.Normal(10.0 * torch.ones(1), 0.0001 * torch.ones(1)))
+        latent_prob = torch.exp(z) / (torch.exp(z) + torch.ones(1))
+        flip = pyro.sample("flip", dist.Bernoulli(latent_prob))
+        return flip
+
+    sample_from_model = model()
+    z_data = {"z": -10.0 * torch.ones(1)}
+    # under model flip = 1 with high probability; so do indirect DO surgery to make flip = 0
+    sample_from_do_model = poutine.trace(poutine.do(model, data=z_data))()
+
+    assert_close(sample_from_model, torch.ones(1))
+    assert_close(sample_from_do_model, torch.zeros(1))

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -1,13 +1,9 @@
-import logging
-
 import pytest
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from tests.common import assert_equal, assert_not_equal
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize('intervene,observe,flip', [

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -57,14 +57,12 @@ def test_counterfactual_query(intervene, observe, flip):
         # case 2: purely interventional query like old poutine.do
         elif intervene and not observe:
             assert not tr.nodes[name]['is_observed']
-            assert name + "__CF" in tr
             if interventions[name] is not None:
                 assert_equal(interventions[name], actual_values[name])
             assert_not_equal(observations[name], tr.nodes[name]['value'])
             assert_not_equal(interventions[name], tr.nodes[name]['value'])
         # case 3: counterfactual query mixing intervention and observation
         elif intervene and observe:
-            assert name + "__CF" in tr
             if observations[name] is not None:
                 assert tr.nodes[name]['is_observed']
                 assert_equal(observations[name], tr.nodes[name]['value'])

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -525,13 +525,14 @@ class ConditionHandlerTests(NormalNormalNormalHandlerTestCase):
             tr2.nodes["latent2"]["is_observed"]
         assert tr2.nodes["latent2"]["value"] is tr1.nodes["latent2"]["value"]
 
-    def test_stack_overwrite_failure(self):
+    def test_stack_overwrite_behavior(self):
         data1 = {"latent2": torch.randn(2)}
         data2 = {"latent2": torch.randn(2)}
-        cm = poutine.condition(poutine.condition(self.model, data=data1),
-                               data=data2)
-        with pytest.raises(AssertionError):
+        with poutine.trace() as tr:
+            cm = poutine.condition(poutine.condition(self.model, data=data1),
+                                   data=data2)
             cm()
+        assert tr.trace.nodes['latent2']['value'] is data2['latent2']
 
     def test_stack_success(self):
         data1 = {"latent1": torch.randn(2)}

--- a/tests/poutine/test_properties.py
+++ b/tests/poutine/test_properties.py
@@ -104,7 +104,6 @@ def get_trace(fn, *args, **kwargs):
 @pytest.mark.parametrize('model', EXAMPLE_MODELS, ids=EXAMPLE_MODEL_IDS)
 @pytest.mark.parametrize('poutine_name', [
     'block',
-    'do',
     'replay',
     'trace',
 ])


### PR DESCRIPTION
Addresses #2153.

Before this PR, `poutine.do` and `poutine.condition` did not compose in an intuitive way to produce counterfactual queries.  After the changes in this PR, `poutine.do` modifies models to represent the joint distribution over a variable to be intervened on and a potential outcome after a particular intervention on that variable, as opposed to simply mutilating the model.

cc @robertness - what do you think of this change (proposed in #2153)?  Is it sensible?  Would it break a bunch of existing code?  I'm far from being an expert in causal inference but I'm hoping to find ways we can automate away more do-calculus drudgery in Pyro.