### PR TITLE
Make it clear when fullname is defined in PyroModule

### DIFF
--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -1,7 +1,7 @@
 import warnings
 
 from pyro import params
-from pyro.distributions import Distribution
+from pyro.distributions.distribution import Distribution
 from pyro.poutine.util import is_validation_enabled
 
 from .messenger import Messenger


### PR DESCRIPTION
Addresses #2161 

1. This makes adds a `._pyro_get_fullname()` method, to replace the use of `_make_name` in #2135 . This method also adds new checks to ensure that `fullname` is actually well-defined; these checks required some fixes to `__delattr__`. Hopefully these new checks will surface misuses earlier an aid debugging.
2. Removes dependency of `pyro.nn.module` on `pyro.distributions`, which was causing problems in #1932 . (relatedly, removes a dependency in lift_messenger.py)

## Tested
- refactoring is exercised by existing tests