### PR TITLE
Make sure hierarchy PyroSample is executed once

### DIFF
--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -166,7 +166,7 @@ def test_submodule_contains_torch_module():
 
 
 def test_hierarchy_prior_cached():
-    def hierarchy_prior(self):
+    def hierarchy_prior(module):
         latent = pyro.sample("a", dist.Normal(0, 1))
         return dist.Normal(latent, 1)
 


### PR DESCRIPTION
Part of #2161.

Currently, if we define a PyroSample variable using the pattern `lambda self: ...`. The content of `lambda self: ...` will be executed each time we access the variable. This PR fixes that issue.

In addition, I also fix the issue where sub PyroModule contains a PyTorch nn.Module.

I believe those are the remaining blockers of #2135.