### PR TITLE
Store args, kwargs in mcmc

### DIFF
--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -301,6 +301,8 @@ class MCMC(object):
         self.transforms = transforms
         self.disable_validation = disable_validation
         self._samples = None
+        self._args = None
+        self._kwargs = None
         if isinstance(self.kernel, (HMC, NUTS)) and self.kernel.potential_fn is not None:
             if initial_params is None:
                 raise ValueError("Must provide valid initial parameters to begin sampling"

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -345,6 +345,7 @@ class MCMC(object):
 
     @poutine.block
     def run(self, *args, **kwargs):
+        self._args, self._kwargs = args, kwargs
         num_samples = [0] * self.num_chains
         z_flat_acc = [[] for _ in range(self.num_chains)]
         with pyro.validation_enabled(not self.disable_validation):


### PR DESCRIPTION
As in numpyro, it is useful for third-party library arviz to access `args, kwargs` of `.run` method (to compute likelihood, information criterion,... and for some plots such as [ppc](https://arviz-devs.github.io/arviz/examples/plot_ppc.html) which needs to access observation data).