### PR TITLE
Avoid PyroMeta inheriting from ABCMeta

### DIFF
--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -16,7 +16,11 @@ from pyro.nn.module import PyroModule, PyroParam
 from pyro.poutine.util import prune_subsample_sites
 
 
-class EasyGuide(PyroModule, metaclass=ABCMeta):
+class _EasyGuideMeta(type(PyroModule), ABCMeta):
+    pass
+
+
+class EasyGuide(PyroModule, metaclass=_EasyGuideMeta):
     """
     Base class for "easy guides", which are more flexible than
     :class:`~pyro.infer.AutoGuide` s, but are easier to write than raw Pyro guides.


### PR DESCRIPTION
Addresses #2161 

This reverts an inheritance change from #2164 so that `PyroModule`s (and hence `AutoGuide` and many other derived classes) do not inherit from `ABCMeta`. Previously I thought it would be preferable to make `PyroModule[m]` work for classes `m` with metaclass deriving from `ABCMeta` (e.g. `EasyGuide`). Now I believe that will cause more issues than simply working around the one `EasyGuide` case and later adding auto-metaclass logic (with which this PR is forward compatible).

I've also tried to make the `PyroModule[-]` logic easier to understand by creating a local class.

## Tested
- refactoring is exercised by existing tests