### PR TITLE
Add vectorized interface stubs to pyro.markov

### DIFF
--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -493,7 +493,7 @@ def markov(fn=None, history=1, keep=False, dim=None, name=None):
     :param int dim: An optional dimension to use for this independence index.
         Interface stub, behavior not yet implemented.
     :param str name: An optional unique name to help inference algorithms match
-        :fn:`pyro.markov` sites between models and guides.
+        :func:`pyro.markov` sites between models and guides.
         Interface stub, behavior not yet implemented.
     """
     if fn is None:

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -474,7 +474,7 @@ def queue(fn=None, queue=None, max_tries=None,
     return wrapper(fn) if fn is not None else wrapper
 
 
-def markov(fn=None, history=1, keep=False):
+def markov(fn=None, history=1, keep=False, dim=None, name=None):
     """
     Markov dependency declaration.
 
@@ -490,15 +490,20 @@ def markov(fn=None, history=1, keep=False):
         when branching: if ``keep=True``, neighboring branches at the same
         level can depend on each other; if ``keep=False``, neighboring branches
         are independent (conditioned on their share"
+    :param int dim: An optional dimension to use for this independence index.
+        Interface stub, behavior not yet implemented.
+    :param str name: An optional unique name to help inference algorithms match
+        :fn:`pyro.markov` sites between models and guides.
+        Interface stub, behavior not yet implemented.
     """
     if fn is None:
         # Used as a decorator with bound args
-        return MarkovMessenger(history=history, keep=keep)
+        return MarkovMessenger(history=history, keep=keep, dim=dim, name=name)
     if not callable(fn):
         # Used as a generator
-        return MarkovMessenger(history=history, keep=keep).generator(iterable=fn)
+        return MarkovMessenger(history=history, keep=keep, dim=dim, name=name).generator(iterable=fn)
     # Used as a decorator with bound args
-    return MarkovMessenger(history=history, keep=keep)(fn)
+    return MarkovMessenger(history=history, keep=keep, dim=dim, name=name)(fn)
 
 
 class _SeedMessenger(Messenger):

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -17,11 +17,24 @@ class MarkovMessenger(ReentrantMessenger):
         when branching: if ``keep=True``, neighboring branches at the same
         level can depend on each other; if ``keep=False``, neighboring branches
         are independent (conditioned on their shared ancestors).
+    :param int dim: An optional dimension to use for this independence index.
+        Interface stub, behavior not yet implemented.
+    :param str name: An optional unique name to help inference algorithms match
+        :fn:`pyro.markov` sites between models and guides.
+        Interface stub, behavior not yet implemented.
     """
-    def __init__(self, history=1, keep=False):
+    def __init__(self, history=1, keep=False, dim=None, name=None):
         assert history >= 0
         self.history = history
         self.keep = keep
+        self.dim = dim
+        self.name = name
+        if dim is not None:
+            raise NotImplementedError(
+                "vectorized markov not yet implemented, try setting dim to None")
+        if name is not None:
+            raise NotImplementedError(
+                "vectorized markov not yet implemented, try setting name to None")
         self._iterable = None
         self._pos = -1
         self._stack = []

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -20,7 +20,7 @@ class MarkovMessenger(ReentrantMessenger):
     :param int dim: An optional dimension to use for this independence index.
         Interface stub, behavior not yet implemented.
     :param str name: An optional unique name to help inference algorithms match
-        :fn:`pyro.markov` sites between models and guides.
+        :func:`pyro.markov` sites between models and guides.
         Interface stub, behavior not yet implemented.
     """
     def __init__(self, history=1, keep=False, dim=None, name=None):


### PR DESCRIPTION
In the interest of primitive API stability, this PR adds a couple non-functioning arguments to `pyro.markov` that I intend to implement soon.