### PR TITLE
Remove torch.einsum patch

### DIFF
--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -52,13 +52,4 @@ def _Multinomial_support(self):
     return torch.distributions.constraints.integer_interval(0, total_count)
 
 
-@patch_dependency('torch.einsum')
-def _einsum(equation, *operands):
-    if len(operands) == 1 and isinstance(operands[0], (list, tuple)):
-        # the old interface of passing the operands as one list argument
-        operands = operands[0]
-
-    return _einsum._pyro_unpatched(equation, *operands)
-
-
 __all__ = []


### PR DESCRIPTION
The patch has dwindled to a no-op, and can now be removed. Simon Wang also complained this was hacky.