### PR TITLE
Return namedtuple from .call()

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -30,6 +30,7 @@ from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
 from pyro.infer.autoguide.initialization import InitMessenger, init_to_median
 from pyro.infer.autoguide.utils import _product
 from pyro.infer.enum import config_enumerate
+from pyro.infer.util import dict_to_namedtuple
 from pyro.nn import AutoRegressiveNN, PyroModule, PyroParam
 from pyro.ops.hessian import hessian
 from pyro.poutine.util import prune_subsample_sites
@@ -86,7 +87,7 @@ class AutoGuide(PyroModule):
     def call(self, *args, **kwargs):
         """
         Method that calls :meth:`forward` and returns parameter values of the
-        guide as a `tuple` instead of a `dict`, which is a requirement for
+        guide as a `namedtuple` instead of a `dict`, which is a requirement for
         JIT tracing. Unlike :meth:`forward`, this method can be traced by
         :func:`torch.jit.trace_module`.
 
@@ -96,7 +97,7 @@ class AutoGuide(PyroModule):
             `issue <https://github.com/pytorch/pytorch/issues/27743>_`.
         """
         result = self(*args, **kwargs)
-        return tuple(v for _, v in sorted(result.items()))
+        return dict_to_namedtuple(result)
 
     def sample_latent(*args, **kwargs):
         """

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -1,10 +1,11 @@
-from functools import reduce
 import warnings
+from functools import reduce
 
 import torch
 
 import pyro
 import pyro.poutine as poutine
+from pyro.infer.util import dict_to_namedtuple
 from pyro.poutine.util import prune_subsample_sites
 
 
@@ -176,7 +177,7 @@ class Predictive(torch.nn.Module):
             `issue <https://github.com/pytorch/pytorch/issues/27743>`_.
         """
         result = self.forward(*args, **kwargs)
-        return tuple(v for _, v in sorted(result.items()))
+        return dict_to_namedtuple(result)
 
     def forward(self, *args, **kwargs):
         """

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -1,6 +1,6 @@
 import math
 import numbers
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, namedtuple
 
 import torch
 from opt_einsum import shared_intermediates
@@ -30,6 +30,30 @@ def torch_item(x):
     Like ``x.item()`` for a :class:`~torch.Tensor`, but also works with numbers.
     """
     return x if isinstance(x, numbers.Number) else x.item()
+
+
+def dict_to_namedtuple(dct):
+    """
+    Converts a dictionary to a namedtuple.
+    """
+    assert isinstance(dct, dict)
+    cache = dict_to_namedtuple._cache
+    keys = tuple(sorted(dct.keys()))
+    if keys not in cache:
+        cache[keys] = namedtuple("DictAsNamedTuple", keys)
+    tp = cache[keys]
+    return tp(**dct)
+
+
+def namedtuple_to_dict(ntup):
+    """
+    Converts a namedtuple to a dictionary.
+    """
+    assert isinstance(ntup, tuple)
+    return dict(zip(ntup._fields, ntup))
+
+
+dict_to_namedtuple._cache = {}
 
 
 def torch_backward(x, retain_graph=None):

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -37,6 +37,9 @@ def dict_to_namedtuple(dct):
     Converts a dictionary to a namedtuple.
     """
     assert isinstance(dct, dict)
+    dct = {key if key.isidentifier() and not key.startswith("_") else
+           "key_{}".format(i): value
+           for i, (key, value) in enumerate(sorted(dct.items()))}
     cache = dict_to_namedtuple._cache
     keys = tuple(sorted(dct.keys()))
     if keys not in cache:

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -7,7 +7,7 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 import pytest
 from pyro.infer.importance import psis_diagnostic
-from pyro.infer.util import MultiFrameTensor
+from pyro.infer.util import MultiFrameTensor, dict_to_namedtuple, namedtuple_to_dict
 from tests.common import assert_equal
 
 
@@ -46,6 +46,20 @@ def test_multi_frame_tensor():
     for name, expected_sum in expected.items():
         actual_sum = actual.sum_to(stacks[name])
         assert_equal(actual_sum, expected_sum, msg=name)
+
+
+@pytest.mark.parametrize("bar", [None, 1.234, {"baz": 0}])
+def test_dict_to_namedtuple(bar):
+    x = {"foo": torch.tensor(0.1), "bar": bar}
+    y = dict_to_namedtuple(x)
+    assert isinstance(y, tuple)
+    assert y.foo is x["foo"]
+    assert y.bar is x["bar"]
+    z = namedtuple_to_dict(y)
+    assert isinstance(z, dict)
+    assert set(x.keys()) == set(z.keys())
+    for key in x.keys():
+        assert x[key] is z[key]
 
 
 @pytest.mark.parametrize('max_particles', [250 * 1000, 500 * 1000])


### PR DESCRIPTION
Replaces the `tuple` return from `AutoGuide.call()` and `Predictive.call()` with a dynamically-defined `namedtuple` object.

## Backwards compatibility

- the returned value is still a subclass of `tuple`
- the ordering is still sorted alphabetically by key

## Tested
- refactoring and serialization is exercised by autoguide tests
- added a unit test