### PR TITLE
Test coveralls for coverage info

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [report]
+omit =
+    pyro/docutil.py
+    pyro/logger.py
 exclude_lines =
     pragma: no cover
     def backward

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
     - pip install torch==1.3.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - pip install .[test]
+    - pip install coveralls
     - pip freeze
 
 branches:
@@ -81,4 +82,4 @@ jobs:
           script: pytest -vs --cov=pyro --cov-config .coveragerc --stage integration_batch_2 --durations 10
 
 after_success:
-          - bash <(curl -s https://codecov.io/bash)
+          - coveralls

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pyro is a flexible, scalable deep probabilistic programming library built on PyT
 - **Minimal**: Pyro is agile and maintainable. It is implemented with a small core of powerful, composable abstractions.
 - **Flexible**: Pyro aims for automation when you want it, control when you need it. This is accomplished through high-level abstractions to express generative and inference models, while allowing experts easy-access to customize inference.
 
-Pyro is in a beta release.  It is developed and maintained by [Uber AI Labs](http://uber.ai) and community contributors.
+Pyro is developed and maintained by [Uber AI Labs](http://uber.ai) and community contributors.
 For more information, check out our [blog post](http://eng.uber.com/pyro).
 
 ## Installing

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -26,6 +26,7 @@ Welcome to Pyro Examples and Tutorials!
    jit
    minipyro
    effect_handlers
+   elections
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
codecov.io seems to be increasingly flaky lately, and has been reporting incorrect coverage. Many other OS projects at Uber use https://coveralls.io/, and it looks like a more stable product. 

There is an additional minor edit to the readme and including the elections tutorial on the website.

Once this PR merges and the coverage information looks right, I'll remove `codecov` related config and change the badge in a separate PR.