### PR TITLE
add comment in Poutine tutorial that the first version of LogJointMessenger can only handle observed samples

### DIFF
--- a/tutorial/source/effect_handlers.ipynb
+++ b/tutorial/source/effect_handlers.ipynb
@@ -213,6 +213,8 @@
     "    # It takes a dictionary msg containing the name, distribution,\n",
     "    # observation or sample value, and other metadata from the sample site.\n",
     "    def _pyro_sample(self, msg):\n",
+    "        # Any unobserved random variables will trigger this assertion.\n",
+    "        # In the next section, we'll learn how to also handle sampled values.\n",
     "        assert msg[\"name\"] in self.data\n",
     "        msg[\"value\"] = self.data[msg[\"name\"]]\n",
     "        # Since we've observed a value for this site, we set the \"is_observed\" flag to True\n",


### PR DESCRIPTION
It looks to me like when `LogJointMessenger` is introduced in the tutorial, the messenger can only handle observed values (because `_pyro_post_sample` is not yet introduced).

I guess it's relatively clear, but it took me a couple readings to see that that's what was going on -- so I thought a comment might help.

Apologies if I've misunderstood anything!