### PR TITLE
Fix equation rendering in OED election tutorial

### DIFF
--- a/tutorial/source/elections.ipynb
+++ b/tutorial/source/elections.ipynb
@@ -16,12 +16,12 @@
     "$$ \\alpha_i = \\text{logit }\\mathbb{P}(\\text{a random voter in state } i \\text{ votes Democrat in the 2016 election}) $$\n",
     "\n",
     "and we assume all other voters vote Republican. Right before the election, the value of $\\alpha$ is unknown and we wish to estimate it by conducting a poll with $n_i$ people in state $i$ for $i=1, ..., 51$ . The winner $w$ of the election is decided by the Electoral College system. The number of electoral college votes gained by the Democrats in state $i$ is\n",
-    "$$\n",
+    "$$",
     "e_i =  \\begin{cases}\n",
     "k_i \\text{ if } \\alpha_i > \\frac{1}{2} \\\\\n",
     "0 \\text{ otherwise}\n",
     "\\end{cases}\n",
-    "$$\n",
+    "$$",
     "(this is a rough approximation of the true system). All other electoral college votes go to the Republicans. Here $k_i$ is the number of electoral college votes alloted to state $i$, which are listed in the following data frame."
    ]
   },

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -26,7 +26,6 @@ Welcome to Pyro Examples and Tutorials!
    jit
    minipyro
    effect_handlers
-   elections
 
 .. toctree::
    :maxdepth: 2
@@ -54,6 +53,7 @@ Welcome to Pyro Examples and Tutorials!
    RSA-hyperbole
    ekf
    working_memory
+   elections
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR fixes a Markdown error in one of the equations in the [OED election tutorial](http://pyro.ai/examples/elections.html#Choosing-a-prior) and moves it next to the other OED tutorial in the contents.

Tested: renders correctly on my machine now.