### PR TITLE
most contributors can't add tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,5 +114,5 @@ In your PR, please include:
 - Tests
 - Dependencies
 
-Please add the `awaiting review` tag and add any of the core Pyro contributors as reviewers.
-For speculative changes meant for early-stage review, add the `WIP` tag.
+For speculative changes meant for early-stage review, include `[WIP]` in the PR's title. 
+(One of the maintainers will add the `WIP` tag.)


### PR DESCRIPTION
When I tried following the instructions in CONTRIBUTING.md for my first PR, I didn't see a way to add tags or reviewers.

Since I can add tags/reviews on PRs for repositories I'm a member of, I'm guessing this is just something non-member contributors can't do.