### PR TITLE
Drop the unnecessary warning in renyi_elbo

### DIFF
--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -26,8 +26,6 @@ class RenyiELBO(ELBO):
         :class:`~pyro.infer.trace_elbo.Trace_ELBO` class because it helps reduce
         variances of gradient estimations.
 
-    .. warning:: Mini-batch training is not supported yet.
-
     :param float alpha: The order of :math:`\alpha`-divergence. Here
         :math:`\alpha \neq 1`. Default is 0.
     :param num_particles: The number of particles/samples used to form the objective


### PR DESCRIPTION
This is discussed in [forum](https://forum.pyro.ai/t/mini-batching-renyi-elbo-not-supported/1426). I can recall that I put the warning just because I only derived the formula for RenyiElbo without subsampling at that time. I have reread the references and found that RenyiElbo works just like the usual Elbo with subsampling (formula (9) of [this paper](https://arxiv.org/pdf/1602.02311.pdf)).