### PR TITLE
add a comment to set_mode in gp tutorial

### DIFF
--- a/tutorial/source/gp.ipynb
+++ b/tutorial/source/gp.ipynb
@@ -490,6 +490,8 @@
     }
    ],
    "source": [
+    "# tell gpr that we want to get samples from guides\n",
+    "gpr.set_mode('guide')\n",
     "print('variance = {}'.format(gpr.kernel.variance))\n",
     "print('lengthscale = {}'.format(gpr.kernel.lengthscale))\n",
     "print('noise = {}'.format(gpr.noise))"


### PR DESCRIPTION
This PR adds a comment to avoid mistakes when users tried to access parameters with priors. In particular, a user has forgotten to call `set_mode` in [this topic](https://forum.pyro.ai/t/gp-evolution-of-length-scales-during-svi-training-different-in-pyro-1-0-0/1429) in the forum. There is no change for the results in the tutorial because we already set_mode when plotting (in addition, we only use Delta guides in the tutorial).