### PR TITLE
Add a to_pyro_module_() helper

### DIFF
--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -18,7 +18,6 @@ from torch.distributions import constraints, transform_to
 import pyro
 from pyro.poutine.runtime import _PYRO_PARAM_STORE
 
-
 PyroParam = namedtuple("PyroParam", ("init_value", "constraint", "event_dim"))
 PyroParam.__new__.__defaults__ = (constraints.real, None)
 PyroParam.__doc__ = """

--- a/tests/common.py
+++ b/tests/common.py
@@ -196,6 +196,8 @@ def assert_close(actual, expected, atol=1e-7, rtol=0, msg=''):
         for key, x_val in actual.items():
             assert_close(x_val, expected[key], atol=atol, rtol=rtol,
                          msg='At key{}: {} vs {}'.format(key, x_val, expected[key]))
+    elif isinstance(actual, str):
+        assert actual == expected, msg
     elif is_iterable(actual) and is_iterable(expected):
         assert len(actual) == len(expected), msg
         for xi, yi in zip(actual, expected):

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -419,7 +419,7 @@ def test_to_pyro_module_():
                 assert_identical(a[key], e[key])
         elif isinstance(a, nn.Module):
             assert_identical(a.__dict__, e.__dict__)
-        elif isinstance(a, torch.Tensor):
+        elif isinstance(a, (str, int, float, torch.Tensor)):
             assert_equal(a, e)
 
     assert_identical(actual, expected)

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -424,11 +424,23 @@ def test_to_pyro_module_():
 
     assert_identical(actual, expected)
 
+    # check output
     data = torch.randn(28 * 28)
     actual_out = actual(data)
     pyro.clear_param_store()
     expected_out = expected(data)
     assert_equal(actual_out, expected_out)
+
+    # check randomization
+    def randomize(model):
+        for m in model.modules():
+            for name, value in list(m.named_parameters(recurse=False)):
+                setattr(m, name, PyroSample(prior=dist.Normal(0, 1)
+                                                      .expand(value.shape)
+                                                      .to_event(value.dim())))
+    randomize(actual)
+    randomize(expected)
+    assert_identical(actual, expected)
 
 
 def test_torch_serialize():

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -371,6 +371,8 @@ def test_mixin_factory():
     assert isinstance(module[0], PyroModule)
     assert type(module[0]).__name__ == "PyroLinear"
     assert type(module[2]) is type(module[0])  # noqa: E721
+    assert module[0]._pyro_name == "0"
+    assert module[1]._pyro_name == "1"
 
     # Ensure new types are serializable.
     data = torch.randn(28 * 28)

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -399,6 +399,7 @@ def test_to_pyro_module_():
         nn.Linear(200, 10),
     )
     to_pyro_module_(actual)
+    pyro.clear_param_store()
 
     pyro.set_rng_seed(123)
     expected = PyroModule[nn.Sequential](
@@ -408,6 +409,7 @@ def test_to_pyro_module_():
         PyroModule[nn.Sigmoid](),
         PyroModule[nn.Linear](200, 10),
     )
+    pyro.clear_param_store()
 
     def assert_identical(a, e):
         assert type(a) is type(e)
@@ -423,7 +425,10 @@ def test_to_pyro_module_():
     assert_identical(actual, expected)
 
     data = torch.randn(28 * 28)
-    assert_equal(actual(data), expected(data))
+    actual_out = actual(data)
+    pyro.clear_param_store()
+    expected_out = expected(data)
+    assert_equal(actual_out, expected_out)
 
 
 def test_torch_serialize():


### PR DESCRIPTION
Addresses #2161 

This aims to make it easier to convert 3rd party `nn.Module` instances to `PyroModule`s, as described in @simeneide's [forum post](https://forum.pyro.ai/t/the-usage-of-pyromodule/1443).

The safest way to do this appears to be to update the `.__class__` attribute in-place:
```py
module.__class__ = PyroModule[module.__class__]
module._pyro_... = ...  # initialize PyroModule attributes
```
While this appears intrusive, it is equivalent to replacing `nn.Linear -> PyroModule[nn.Linear]` and so forth in the 3rd-party code that created the instance. It should therefore also be compatible with serialization.

## 🐛 Bugfixes

This PR also fixes two bugs surfaced by new tests:

- A bug whereby `._pyro_set_supermodule()` was being bypassed due to `nn.Module` subclasses calling `.add_module()` rather than `.__setitem__()` directly.
- A recursion bug in `tests.common.assert_close("foo", "foo")`

## Tested
- added a test that `to_pyro_module_(m)` is equivalent to recursively inserting `PyroModule[-]`
- strengthen existing tests