### PR TITLE
Do not use varargs in internal functions / methods in pyro.infer

### DIFF
--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -208,9 +208,9 @@ class TraceEnumSample_ELBO(TraceEnum_ELBO):
                            first_available_dim=-2)(*args, **kwargs)
 
     """
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         model_trace, guide_trace = super(TraceEnumSample_ELBO, self)._get_trace(
-            model, guide, *args, **kwargs)
+            model, guide, args, kwargs)
 
         # Mark all sample sites with require_backward to gather enumerated
         # sites and adjust cond_indep_stack of all sample sites.

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -79,7 +79,7 @@ class ELBO(object, metaclass=ABCMeta):
         self.jit_options = jit_options
         self.tail_adaptive_beta = tail_adaptive_beta
 
-    def _guess_max_plate_nesting(self, model, guide, *args, **kwargs):
+    def _guess_max_plate_nesting(self, model, guide, args, kwargs):
         """
         Guesses max_plate_nesting by running the (model,guide) pair once
         without enumeration. This optimistically assumes static model
@@ -135,7 +135,7 @@ class ELBO(object, metaclass=ABCMeta):
 
         return wrapped_fn
 
-    def _get_vectorized_trace(self, model, guide, *args, **kwargs):
+    def _get_vectorized_trace(self, model, guide, args, kwargs):
         """
         Wraps the model and guide to vectorize ELBO computation over
         ``num_particles``, and returns a single trace from the wrapped model
@@ -143,25 +143,25 @@ class ELBO(object, metaclass=ABCMeta):
         """
         return self._get_trace(self._vectorized_num_particles(model),
                                self._vectorized_num_particles(guide),
-                               *args, **kwargs)
+                               args, kwargs)
 
     @abstractmethod
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         """
         Returns a single trace from the guide, and the model that is run
         against it.
         """
         raise NotImplementedError
 
-    def _get_traces(self, model, guide, *args, **kwargs):
+    def _get_traces(self, model, guide, args, kwargs):
         """
         Runs the guide and runs the model against the guide with
         the result packaged as a trace generator.
         """
         if self.vectorize_particles:
             if self.max_plate_nesting == float('inf'):
-                self._guess_max_plate_nesting(model, guide, *args, **kwargs)
-            yield self._get_vectorized_trace(model, guide, *args, **kwargs)
+                self._guess_max_plate_nesting(model, guide, args, kwargs)
+            yield self._get_vectorized_trace(model, guide, args, kwargs)
         else:
             for i in range(self.num_particles):
-                yield self._get_trace(model, guide, *args, **kwargs)
+                yield self._get_trace(model, guide, args, kwargs)

--- a/pyro/infer/energy_distance.py
+++ b/pyro/infer/energy_distance.py
@@ -94,11 +94,11 @@ class EnergyDistance:
             return x.sqrt()  # cheaper than .pow()
         return x.pow(self.beta / 2)
 
-    def _get_traces(self, model, guide, *args, **kwargs):
+    def _get_traces(self, model, guide, args, kwargs):
         if self.max_plate_nesting == float("inf"):
             with validation_enabled(False):  # Avoid calling .log_prob() when undefined.
                 # TODO factor this out as a stand-alone helper.
-                ELBO._guess_max_plate_nesting(self, model, guide, *args, **kwargs)
+                ELBO._guess_max_plate_nesting(self, model, guide, args, kwargs)
         vectorize = pyro.plate("num_particles_vectorized", self.num_particles,
                                dim=-self.max_plate_nesting)
 
@@ -148,7 +148,7 @@ class EnergyDistance:
         Computes the surrogate loss that can be differentiated with autograd
         to produce gradient estimates for the model and guide parameters.
         """
-        guide_trace, model_trace = self._get_traces(model, guide, *args, **kwargs)
+        guide_trace, model_trace = self._get_traces(model, guide, args, kwargs)
 
         # Extract observations and posterior predictive samples.
         data = OrderedDict()

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -33,7 +33,7 @@ def iter_discrete_extend(trace, site, **ignored):
         yield extended_trace
 
 
-def get_importance_trace(graph_type, max_plate_nesting, model, guide, *args, **kwargs):
+def get_importance_trace(graph_type, max_plate_nesting, model, guide, args, kwargs):
     """
     Returns a single trace from the guide, and the model that is run
     against it.

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -118,7 +118,7 @@ def vectorized_importance_weights(model, guide, *args, **kwargs):
         return _fn
 
     model_trace, guide_trace = get_importance_trace(
-        "flat", max_plate_nesting, vectorize(model), vectorize(guide), *args, **kwargs)
+        "flat", max_plate_nesting, vectorize(model), vectorize(guide), args, kwargs)
 
     guide_trace.pack_tensors()
     model_trace.pack_tensors(guide_trace.plate_to_symbol)

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -67,13 +67,13 @@ class RenyiELBO(ELBO):
                                         vectorize_particles=vectorize_particles,
                                         strict_enumeration_warning=strict_enumeration_warning)
 
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         """
         Returns a single trace from the guide, and the model that is run
         against it.
         """
         model_trace, guide_trace = get_importance_trace(
-            "flat", self.max_plate_nesting, model, guide, *args, **kwargs)
+            "flat", self.max_plate_nesting, model, guide, args, kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)
         return model_trace, guide_trace
@@ -89,7 +89,7 @@ class RenyiELBO(ELBO):
         is_vectorized = self.vectorize_particles and self.num_particles > 1
 
         # grab a vectorized trace from the generator
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             elbo_particle = 0.
 
             # compute elbo
@@ -141,7 +141,7 @@ class RenyiELBO(ELBO):
         tensor_holder = None
 
         # grab a vectorized trace from the generator
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             elbo_particle = 0
             surrogate_elbo_particle = 0
 

--- a/pyro/infer/rws.py
+++ b/pyro/infer/rws.py
@@ -94,13 +94,12 @@ class ReweightedWakeSleep(ELBO):
         assert(insomnia >= 0 and insomnia <= 1), \
             "insomnia should be in [0, 1]"
 
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         """
         Returns a single trace from the guide, and the model that is run against it.
         """
         model_trace, guide_trace = get_importance_trace("flat", self.max_plate_nesting,
-                                                        model, guide, detach=True,
-                                                        *args, **kwargs)
+                                                        model, guide, args, kwargs, detach=True)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)
         return model_trace, guide_trace
@@ -121,7 +120,7 @@ class ReweightedWakeSleep(ELBO):
             log_joints = []
             log_qs = []
 
-            for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+            for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
                 log_joint = 0.
                 log_q = 0.
 

--- a/pyro/infer/rws.py
+++ b/pyro/infer/rws.py
@@ -104,7 +104,7 @@ class ReweightedWakeSleep(ELBO):
             check_if_enumerated(guide_trace)
         return model_trace, guide_trace
 
-    def _loss(self, model, guide, *args, **kwargs):
+    def _loss(self, model, guide, args, kwargs):
         """
         :returns: returns model loss and guide loss
         :rtype: float, float
@@ -166,14 +166,14 @@ class ReweightedWakeSleep(ELBO):
 
             if self.vectorize_particles:
                 if self.max_plate_nesting == float('inf'):
-                    self._guess_max_plate_nesting(_model, _guide, *args, **kwargs)
+                    self._guess_max_plate_nesting(_model, _guide, args, kwargs)
                 _model = self._vectorized_num_sleep_particles(_model)
                 _guide = self._vectorized_num_sleep_particles(guide)
 
             for _ in range(1 if self.vectorize_particles else self.num_sleep_particles):
                 _model_trace = poutine.trace(_model).get_trace(*args, **kwargs)
                 _model_trace.detach_()
-                _guide_trace = self._get_matched_trace(_model_trace, _guide, *args, **kwargs)
+                _guide_trace = self._get_matched_trace(_model_trace, _guide, args, kwargs)
                 _log_q += _guide_trace.log_prob_sum()
 
             sleep_phi_loss = -_log_q / self.num_sleep_particles
@@ -195,7 +195,7 @@ class ReweightedWakeSleep(ELBO):
           guide (insomnia * wake-phi + (1 - insomnia) * sleep-phi).
         """
         with torch.no_grad():
-            wake_theta_loss, phi_loss = self._loss(model, guide, *args, **kwargs)
+            wake_theta_loss, phi_loss = self._loss(model, guide, args, kwargs)
 
         return wake_theta_loss, phi_loss
 
@@ -207,7 +207,7 @@ class ReweightedWakeSleep(ELBO):
         Computes the RWS estimators for the model (wake-theta) and the guide (wake-phi).
         Performs backward as appropriate on both, using num_particle many samples/particles.
         """
-        wake_theta_loss, phi_loss = self._loss(model, guide, *args, **kwargs)
+        wake_theta_loss, phi_loss = self._loss(model, guide, args, kwargs)
         # convenience addition to ensure easier gradients without requiring `retain_graph=True`
         (wake_theta_loss + phi_loss).backward()
 
@@ -226,7 +226,7 @@ class ReweightedWakeSleep(ELBO):
         return wrapped_fn
 
     @staticmethod
-    def _get_matched_trace(model_trace, guide, *args, **kwargs):
+    def _get_matched_trace(model_trace, guide, args, kwargs):
         kwargs["observations"] = {}
         for node in model_trace.stochastic_nodes + model_trace.observation_nodes:
             if "was_observed" in model_trace.nodes[node]["infer"]:

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -41,13 +41,13 @@ class Trace_ELBO(ELBO):
         Rajesh Ranganath, Sean Gerrish, David M. Blei
     """
 
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         """
         Returns a single trace from the guide, and the model that is run
         against it.
         """
         model_trace, guide_trace = get_importance_trace(
-            "flat", self.max_plate_nesting, model, guide, *args, **kwargs)
+            "flat", self.max_plate_nesting, model, guide, args, kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)
         return model_trace, guide_trace
@@ -60,7 +60,7 @@ class Trace_ELBO(ELBO):
         Evaluates the ELBO with an estimator that uses num_particles many samples/particles.
         """
         elbo = 0.0
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             elbo_particle = torch_item(model_trace.log_prob_sum()) - torch_item(guide_trace.log_prob_sum())
             elbo += elbo_particle / self.num_particles
 
@@ -103,7 +103,7 @@ class Trace_ELBO(ELBO):
         """
         loss = 0.
         surrogate_loss = 0.
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             loss_particle, surrogate_loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
             surrogate_loss += surrogate_loss_particle / self.num_particles
             loss += loss_particle / self.num_particles
@@ -120,7 +120,7 @@ class Trace_ELBO(ELBO):
         """
         loss = 0.0
         # grab a trace from the generator
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             loss_particle, surrogate_loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
             loss += loss_particle / self.num_particles
 
@@ -165,7 +165,7 @@ class JitTrace_ELBO(Trace_ELBO):
                 self = weakself()
                 loss = 0.0
                 surrogate_loss = 0.0
-                for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+                for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
                     elbo_particle = 0
                     surrogate_elbo_particle = 0
                     log_r = None

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -60,9 +60,9 @@ class TraceMeanField_ELBO(Trace_ELBO):
     condition is always satisfied if the model and guide have identical
     dependency structures.
     """
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         model_trace, guide_trace = super(TraceMeanField_ELBO, self)._get_trace(
-            model, guide, *args, **kwargs)
+            model, guide, args, kwargs)
         if is_validation_enabled():
             _check_mean_field_requirement(model_trace, guide_trace)
         return model_trace, guide_trace
@@ -75,7 +75,7 @@ class TraceMeanField_ELBO(Trace_ELBO):
         Evaluates the ELBO with an estimator that uses num_particles many samples/particles.
         """
         loss = 0.0
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             loss_particle, _ = self._differentiable_loss_particle(model_trace, guide_trace)
             loss = loss + loss_particle / self.num_particles
 
@@ -150,7 +150,7 @@ class JitTraceMeanField_ELBO(TraceMeanField_ELBO):
                 kwargs.pop('_pyro_guide_id')
                 self = weakself()
                 loss = 0.0
-                for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+                for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
                     _, loss_particle = self._differentiable_loss_particle(model_trace, guide_trace)
                     loss = loss + loss_particle / self.num_particles
                 return loss

--- a/pyro/infer/trace_mmd.py
+++ b/pyro/infer/trace_mmd.py
@@ -109,24 +109,24 @@ class Trace_MMD(ELBO):
         else:
             raise TypeError("`mmd_scale` should be either float, or a dict of floats")
 
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         """
         Returns a single trace from the guide, and the model that is run
         against it.
         """
         model_trace, guide_trace = get_importance_trace(
-            "flat", self.max_plate_nesting, model, guide, *args, **kwargs)
+            "flat", self.max_plate_nesting, model, guide, args, kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)
         return model_trace, guide_trace
 
-    def _differentiable_loss_parts(self, model, guide, *args, **kwargs):
+    def _differentiable_loss_parts(self, model, guide, args, kwargs):
         all_model_samples = defaultdict(list)
         all_guide_samples = defaultdict(list)
 
         loglikelihood = 0.0
         penalty = 0.0
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             if self.vectorize_particles:
                 model_trace_independent = poutine.trace(
                     self._vectorized_num_particles(model)
@@ -189,7 +189,7 @@ class Trace_MMD(ELBO):
             Shengjia Zhao
             https://ermongroup.github.io/blog/a-tutorial-on-mmd-variational-autoencoders/
         """
-        loglikelihood, penalty = self._differentiable_loss_parts(model, guide, *args, **kwargs)
+        loglikelihood, penalty = self._differentiable_loss_parts(model, guide, args, kwargs)
         loss = -loglikelihood + penalty
         warn_if_nan(loss, "loss")
         return loss

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -213,13 +213,13 @@ class TraceGraph_ELBO(ELBO):
         Andriy Mnih, Karol Gregor
     """
 
-    def _get_trace(self, model, guide, *args, **kwargs):
+    def _get_trace(self, model, guide, args, kwargs):
         """
         Returns a single trace from the guide, and the model that is run
         against it.
         """
         model_trace, guide_trace = get_importance_trace(
-            "dense", self.max_plate_nesting, model, guide, *args, **kwargs)
+            "dense", self.max_plate_nesting, model, guide, args, kwargs)
         if is_validation_enabled():
             check_if_enumerated(guide_trace)
         return model_trace, guide_trace
@@ -232,7 +232,7 @@ class TraceGraph_ELBO(ELBO):
         Evaluates the ELBO with an estimator that uses num_particles many samples/particles.
         """
         elbo = 0.0
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
             elbo_particle = torch_item(model_trace.log_prob_sum()) - torch_item(guide_trace.log_prob_sum())
             elbo += elbo_particle / float(self.num_particles)
 
@@ -249,7 +249,7 @@ class TraceGraph_ELBO(ELBO):
         Performs backward on the latter. Num_particle many samples are used to form the estimators.
         If baselines are present, a baseline loss is also constructed and differentiated.
         """
-        elbo, surrogate_loss = self._loss_and_surrogate_loss(model, guide, *args, **kwargs)
+        elbo, surrogate_loss = self._loss_and_surrogate_loss(model, guide, args, kwargs)
 
         torch_backward(surrogate_loss, retain_graph=self.retain_graph)
 
@@ -258,14 +258,14 @@ class TraceGraph_ELBO(ELBO):
         warn_if_nan(loss, "loss")
         return loss
 
-    def _loss_and_surrogate_loss(self, model, guide, *args, **kwargs):
+    def _loss_and_surrogate_loss(self, model, guide, args, kwargs):
 
         loss = 0.0
         surrogate_loss = 0.0
 
-        for model_trace, guide_trace in self._get_traces(model, guide, *args, **kwargs):
+        for model_trace, guide_trace in self._get_traces(model, guide, args, kwargs):
 
-            lp, slp = self._loss_and_surrogate_loss_particle(model_trace, guide_trace, *args, **kwargs)
+            lp, slp = self._loss_and_surrogate_loss_particle(model_trace, guide_trace)
             loss += lp
             surrogate_loss += slp
 
@@ -274,7 +274,7 @@ class TraceGraph_ELBO(ELBO):
 
         return loss, surrogate_loss
 
-    def _loss_and_surrogate_loss_particle(self, model_trace, guide_trace, *args, **kwargs):
+    def _loss_and_surrogate_loss_particle(self, model_trace, guide_trace):
 
         # compute elbo for reparameterized nodes
         elbo, surrogate_elbo = _compute_elbo_reparam(model_trace, guide_trace)
@@ -322,7 +322,7 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
                 kwargs.pop('_pyro_model_id')
                 kwargs.pop('_pyro_guide_id')
                 self = weakself()
-                return self._loss_and_surrogate_loss(model, guide, *args, **kwargs)
+                return self._loss_and_surrogate_loss(model, guide, args, kwargs)
 
             self._jit_loss_and_surrogate_loss = jit_loss_and_surrogate_loss
 

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -343,10 +343,10 @@ class PoissonGammaTests(TestCase):
                 beta_error = param_mse("beta_q", self.beta0)
                 with torch.no_grad():
                     if k == 0:
-                        avg_loglikelihood, avg_penalty = loss._differentiable_loss_parts(model, guide)
+                        avg_loglikelihood, avg_penalty = loss._differentiable_loss_parts(model, guide, (), {})
                         avg_loglikelihood = torch_item(avg_loglikelihood)
                         avg_penalty = torch_item(avg_penalty)
-                    loglikelihood, penalty = loss._differentiable_loss_parts(model, guide)
+                    loglikelihood, penalty = loss._differentiable_loss_parts(model, guide, (), {})
                     avg_loglikelihood = alpha * avg_loglikelihood + (1-alpha) * torch_item(loglikelihood)
                     avg_penalty = alpha * avg_penalty + (1-alpha) * torch_item(penalty)
                 if k % 100 == 0:


### PR DESCRIPTION
Based on comment in https://github.com/pyro-ppl/pyro/pull/2191#discussion_r352404596, this uses `args, kwargs` directly in internal methods / functions in `pyro.infer`.

I have tried to restrict this PR to the following  methods / functions:
 - `get_importance_trace`.
 - methods internal to `ELBO` - `_get_trace`, `_get_traces`, `_get_vectorized_trace`, `_guess_max_plate_nesting`.
 - `TraceMMD._differentiable_loss_parts`, `TraceGraph_ELBO. _loss_and_surrogate_loss `

This is an internal refactoring, and shouldn't affect existing tests. I think it is usually best to reserve the varargs pattern for user-facing interface. All internal functions / methods that get these from a user-facing API should just pass these along as is without doing additional packing and unpacking. I'm happy to revert this, or open it up for further discussion if reviewers think otherwise. 