### PR TITLE
Automatically generate handlers from Messengers

### DIFF
--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -9,7 +9,7 @@ from pyro.infer.traceenum_elbo import TraceEnum_ELBO
 from pyro.ops.contract import contract_tensor_tree
 from pyro.ops.einsum.adjoint import require_backward
 from pyro.ops.rings import MapRing, SampleRing
-from pyro.poutine.enumerate_messenger import EnumerateMessenger
+from pyro.poutine.enum_messenger import EnumMessenger
 from pyro.poutine.replay_messenger import ReplayMessenger
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import jit_iter
@@ -38,7 +38,7 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
     # For internal use by infer_discrete.
 
     # Create an enumerated trace.
-    with poutine.block(), EnumerateMessenger(first_available_dim):
+    with poutine.block(), EnumMessenger(first_available_dim):
         enum_trace = poutine.trace(model).get_trace(*args, **kwargs)
     enum_trace = prune_subsample_sites(enum_trace)
     enum_trace.compute_log_prob()

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -5,7 +5,7 @@ from queue import LifoQueue
 from pyro import poutine
 from pyro.infer.util import is_validation_enabled
 from pyro.poutine import Trace
-from pyro.poutine.enumerate_messenger import enumerate_site
+from pyro.poutine.enum_messenger import enumerate_site
 from pyro.poutine.util import prune_subsample_sites
 from pyro.util import check_model_guide_match, check_site_shape, ignore_jit_warnings
 

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -17,7 +17,7 @@ from pyro.infer.util import Dice, is_validation_enabled
 from pyro.ops import packed
 from pyro.ops.contract import contract_tensor_tree, contract_to_tensor
 from pyro.ops.rings import SampleRing
-from pyro.poutine.enumerate_messenger import EnumerateMessenger
+from pyro.poutine.enum_messenger import EnumMessenger
 from pyro.util import check_traceenum_requirements, ignore_jit_warnings, warn_if_nan
 
 
@@ -327,8 +327,8 @@ class TraceEnum_ELBO(ELBO):
         # Enable parallel enumeration over the vectorized guide and model.
         # The model allocates enumeration dimensions after (to the left of) the guide,
         # accomplished by preserving the _ENUM_ALLOCATOR state after the guide call.
-        guide_enum = EnumerateMessenger(first_available_dim=-1 - self.max_plate_nesting)
-        model_enum = EnumerateMessenger()  # preserve _ENUM_ALLOCATOR state
+        guide_enum = EnumMessenger(first_available_dim=-1 - self.max_plate_nesting)
+        model_enum = EnumMessenger()  # preserve _ENUM_ALLOCATOR state
         guide = guide_enum(guide)
         model = model_enum(model)
 

--- a/pyro/infer/tracetmc_elbo.py
+++ b/pyro/infer/tracetmc_elbo.py
@@ -11,7 +11,7 @@ from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_dis
 from pyro.infer.util import compute_site_dice_factor, is_validation_enabled, torch_item
 from pyro.ops import packed
 from pyro.ops.contract import einsum
-from pyro.poutine.enumerate_messenger import EnumerateMessenger
+from pyro.poutine.enum_messenger import EnumMessenger
 from pyro.util import check_traceenum_requirements, warn_if_nan
 
 
@@ -151,8 +151,8 @@ class TraceTMC_ELBO(ELBO):
         # Enable parallel enumeration over the vectorized guide and model.
         # The model allocates enumeration dimensions after (to the left of) the guide,
         # accomplished by preserving the _ENUM_ALLOCATOR state after the guide call.
-        guide_enum = EnumerateMessenger(first_available_dim=-1 - self.max_plate_nesting)
-        model_enum = EnumerateMessenger()  # preserve _ENUM_ALLOCATOR state
+        guide_enum = EnumMessenger(first_available_dim=-1 - self.max_plate_nesting)
+        model_enum = EnumMessenger()  # preserve _ENUM_ALLOCATOR state
         guide = guide_enum(guide)
         model = model_enum(model)
 

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -81,8 +81,8 @@ class BlockMessenger(Messenger):
         >>> def fn():
         ...     a = pyro.sample("a", dist.Normal(0., 1.))
         ...     return pyro.sample("b", dist.Normal(a, 1.))
-        >>> fn_inner = trace(fn)
-        >>> fn_outer = trace(block(fn_inner, hide=["a"]))
+        >>> fn_inner = pyro.poutine.trace(fn)
+        >>> fn_outer = pyro.poutine.trace(pyro.poutine.block(fn_inner, hide=["a"]))
         >>> trace_inner = fn_inner.get_trace()
         >>> trace_outer  = fn_outer.get_trace()
         >>> "a" in trace_inner

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -63,11 +63,8 @@ def _make_default_hide_fn(hide_all, expose_all, hide, expose, hide_types, expose
 
 class BlockMessenger(Messenger):
     """
-    This Messenger selectively hides Pyro primitive sites from the outside world.
+    This handler selectively hides Pyro primitive sites from the outside world.
     Default behavior: block everything.
-    BlockMessenger has a flexible interface that allows users
-    to specify in several different ways
-    which sites should be hidden or exposed.
 
     A site is hidden if at least one of the following holds:
 
@@ -77,47 +74,38 @@ class BlockMessenger(Messenger):
         3. ``msg["name"] not in expose and msg["type"] not in expose_types``
         4. ``hide``, ``hide_types``, and ``expose_types`` are all ``None``
 
-
     For example, suppose the stochastic function fn has two sample sites "a" and "b".
-    Then any poutine outside of BlockMessenger(fn, hide=["a"])
+    Then any effect outside of ``BlockMessenger(fn, hide=["a"])``
     will not be applied to site "a" and will only see site "b":
 
-    .. doctest::
-       :hide:
+        >>> def fn():
+        ...     a = pyro.sample("a", dist.Normal(0., 1.))
+        ...     return pyro.sample("b", dist.Normal(a, 1.))
+        >>> fn_inner = trace(fn)
+        >>> fn_outer = trace(block(fn_inner, hide=["a"]))
+        >>> trace_inner = fn_inner.get_trace()
+        >>> trace_outer  = fn_outer.get_trace()
+        >>> "a" in trace_inner
+        True
+        >>> "a" in trace_outer
+        False
+        >>> "b" in trace_inner
+        True
+        >>> "b" in trace_outer
+        True
 
-       >>> from pyro.poutine.trace_messenger import TraceMessenger
-
-    >>> def fn():
-    ...     a = pyro.sample("a", dist.Normal(0., 1.))
-    ...     return pyro.sample("b", dist.Normal(a, 1.))
-
-    >>> fn_inner = TraceMessenger()(fn)
-    >>> fn_outer = TraceMessenger()(BlockMessenger(hide=["a"])(TraceMessenger()(fn)))
-    >>> trace_inner = fn_inner.get_trace()
-    >>> trace_outer  = fn_outer.get_trace()
-    >>> "a" in trace_inner
-    True
-    >>> "a" in trace_outer
-    False
-    >>> "b" in trace_inner
-    True
-    >>> "b" in trace_outer
-    True
-
-    See the constructor for details.
-
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
     :param hide_fn: function that takes a site and returns True to hide the site
         or False/None to expose it.  If specified, all other parameters are ignored.
         Only specify one of hide_fn or expose_fn, not both.
     :param expose_fn: function that takes a site and returns True to expose the site
         or False/None to hide it.  If specified, all other parameters are ignored.
         Only specify one of hide_fn or expose_fn, not both.
-    :param bool hide_all: hide all sites
-    :param bool expose_all: expose all sites normally
-    :param list hide: list of site names to hide, rest will be exposed normally
-    :param list expose: list of site names to expose, rest will be hidden
-    :param list hide_types: list of site types to hide, rest will be exposed normally
-    :param list expose_types: list of site types to expose normally, rest will be hidden
+    :param hide: list of site names to hide
+    :param expose: list of site names to be exposed while all others hidden
+    :param hide_types: list of site types to be hidden
+    :param expose_types: list of site types to be exposed while all others hidden
+    :returns: stochastic function decorated with a :class:`~pyro.poutine.block_messenger.BlockMessenger`
     """
 
     def __init__(self, hide_fn=None, expose_fn=None,

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -4,12 +4,34 @@ from .messenger import Messenger
 
 class BroadcastMessenger(Messenger):
     """
-    `BroadcastMessenger` automatically broadcasts the batch shape of
-    the stochastic function at a sample site when inside a single
-    or nested plate context. The existing `batch_shape` must be
-    broadcastable with the size of the :class:`~pyro.plate`
-    contexts installed in the `cond_indep_stack`.
+    Automatically broadcasts the batch shape of the stochastic function
+    at a sample site when inside a single or nested plate context.
+    The existing `batch_shape` must be broadcastable with the size
+    of the :class:`~pyro.plate` contexts installed in the
+    `cond_indep_stack`.
+
+    Notice how `model_automatic_broadcast` below automates expanding of
+    distribution batch shapes. This makes it easy to modularize a
+    Pyro model as the sub-components are agnostic of the wrapping
+    :class:`~pyro.plate` contexts.
+
+    >>> def model_broadcast_by_hand():
+    ...     with IndepMessenger("batch", 100, dim=-2):
+    ...         with IndepMessenger("components", 3, dim=-1):
+    ...             sample = pyro.sample("sample", dist.Bernoulli(torch.ones(3) * 0.5)
+    ...                                                .expand_by(100))
+    ...             assert sample.shape == torch.Size((100, 3))
+    ...     return sample
+
+    >>> @poutine.broadcast
+    ... def model_automatic_broadcast():
+    ...     with IndepMessenger("batch", 100, dim=-2):
+    ...         with IndepMessenger("components", 3, dim=-1):
+    ...             sample = pyro.sample("sample", dist.Bernoulli(torch.tensor(0.5)))
+    ...             assert sample.shape == torch.Size((100, 3))
+    ...     return sample
     """
+
     @staticmethod
     @ignore_jit_warnings(["Converting a tensor to a Python boolean"])
     def _pyro_sample(msg):

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -18,7 +18,7 @@ class ConditionMessenger(Messenger):
 
     To observe a value for site `z`, we can write
 
-        >>> conditioned_model = condition(model, data={"z": torch.tensor(1.)})
+        >>> conditioned_model = pyro.poutine.condition(model, data={"z": torch.tensor(1.)})
 
     This is equivalent to adding `obs=value` as a keyword argument
     to `pyro.sample("z", ...)` in `model`.

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -4,7 +4,28 @@ from .trace_struct import Trace
 
 class ConditionMessenger(Messenger):
     """
-    Adds values at observe sites to condition on data and override sampling
+    Given a stochastic function with some sample statements
+    and a dictionary of observations at names,
+    change the sample statements at those names into observes
+    with those values.
+
+    Consider the following Pyro program:
+
+        >>> def model(x):
+        ...     s = pyro.param("s", torch.tensor(0.5))
+        ...     z = pyro.sample("z", dist.Normal(x, s))
+        ...     return z ** 2
+
+    To observe a value for site `z`, we can write
+
+        >>> conditioned_model = condition(model, data={"z": torch.tensor(1.)})
+
+    This is equivalent to adding `obs=value` as a keyword argument
+    to `pyro.sample("z", ...)` in `model`.
+
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
+    :param data: a dict or a :class:`~pyro.poutine.Trace`
+    :returns: stochastic function decorated with a :class:`~pyro.poutine.condition_messenger.ConditionMessenger`
     """
     def __init__(self, data):
         """

--- a/pyro/poutine/enum_messenger.py
+++ b/pyro/poutine/enum_messenger.py
@@ -73,7 +73,7 @@ def enumerate_site(msg):
     return value
 
 
-class EnumerateMessenger(Messenger):
+class EnumMessenger(Messenger):
     """
     Enumerates in parallel over discrete sample sites marked
     ``infer={"enumerate": "parallel"}``.
@@ -86,7 +86,7 @@ class EnumerateMessenger(Messenger):
     def __init__(self, first_available_dim=None):
         assert first_available_dim is None or first_available_dim < 0, first_available_dim
         self.first_available_dim = first_available_dim
-        super(EnumerateMessenger, self).__init__()
+        super(EnumMessenger, self).__init__()
 
     def __enter__(self):
         if self.first_available_dim is not None:
@@ -94,7 +94,7 @@ class EnumerateMessenger(Messenger):
         self._markov_depths = {}  # site name -> depth (nonnegative integer)
         self._param_dims = {}  # site name -> (enum dim -> unique id)
         self._value_dims = {}  # site name -> (enum dim -> unique id)
-        return super(EnumerateMessenger, self).__enter__()
+        return super(EnumMessenger, self).__enter__()
 
     @ignore_jit_warnings()
     def _pyro_sample(self, msg):

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -47,6 +47,7 @@ in just a few lines of code::
 """
 
 import functools
+import re
 
 from pyro.poutine import util
 from pyro.poutine.messenger import Messenger
@@ -56,7 +57,7 @@ from .block_messenger import BlockMessenger
 from .broadcast_messenger import BroadcastMessenger
 from .condition_messenger import ConditionMessenger
 from .do_messenger import DoMessenger
-from .enumerate_messenger import EnumerateMessenger
+from .enum_messenger import EnumMessenger
 from .escape_messenger import EscapeMessenger
 from .infer_config_messenger import InferConfigMessenger
 from .lift_messenger import LiftMessenger
@@ -69,359 +70,76 @@ from .scale_messenger import ScaleMessenger
 from .trace_messenger import TraceMessenger
 from .uncondition_messenger import UnconditionMessenger
 
+
+class SeedMessenger(Messenger):
+    """
+    Handler to set the random number generator to a pre-defined state by setting its
+    seed. This is the same as calling :func:`pyro.set_rng_seed` before the
+    call to `fn`. This handler has no additional effect on primitive statements on the
+    standard Pyro backend, but it might intercept ``pyro.sample`` calls in other
+    backends. e.g. the NumPy backend.
+
+    :param fn: a stochastic function (callable containing Pyro primitive calls).
+    :param int rng_seed: rng seed.
+    """
+    def __init__(self, rng_seed):
+        assert isinstance(rng_seed, int)
+        self.rng_seed = rng_seed
+        super(SeedMessenger, self).__init__()
+
+    def __enter__(self):
+        self.old_state = get_rng_state()
+        set_rng_seed(self.rng_seed)
+
+    def __exit__(self, type, value, traceback):
+        set_rng_state(self.old_state)
+
+
 ############################################
 # Begin primitive operations
 ############################################
 
 
-def trace(fn=None, graph_type=None, param_only=None):
-    """
-    Return a handler that records the inputs and outputs of primitive calls
-    and their dependencies.
-
-    Consider the following Pyro program:
-
-        >>> def model(x):
-        ...     s = pyro.param("s", torch.tensor(0.5))
-        ...     z = pyro.sample("z", dist.Normal(x, s))
-        ...     return z ** 2
-
-    We can record its execution using ``trace``
-    and use the resulting data structure to compute the log-joint probability
-    of all of the sample sites in the execution or extract all parameters.
-
-        >>> trace = trace(model).get_trace(0.0)
-        >>> logp = trace.log_prob_sum()
-        >>> params = [trace.nodes[name]["value"].unconstrained() for name in trace.param_nodes]
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param graph_type: string that specifies the kind of graph to construct
-    :param param_only: if true, only records params and not samples
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.trace_messenger.TraceMessenger`
-    """
-    msngr = TraceMessenger(graph_type=graph_type, param_only=param_only)
-    return msngr(fn) if fn is not None else msngr
-
-
-def replay(fn=None, trace=None, params=None):
-    """
-    Given a callable that contains Pyro primitive calls,
-    return a callable that runs the original, reusing the values at sites in trace
-    at those sites in the new trace
-
-    Consider the following Pyro program:
-
-        >>> def model(x):
-        ...     s = pyro.param("s", torch.tensor(0.5))
-        ...     z = pyro.sample("z", dist.Normal(x, s))
-        ...     return z ** 2
-
-    ``replay`` makes ``sample`` statements behave as if they had sampled the values
-    at the corresponding sites in the trace:
-
-        >>> old_trace = trace(model).get_trace(1.0)
-        >>> replayed_model = replay(model, trace=old_trace)
-        >>> bool(replayed_model(0.0) == old_trace.nodes["_RETURN"]["value"])
-        True
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param trace: a :class:`~pyro.poutine.Trace` data structure to replay against
-    :param params: dict of names of param sites and constrained values
-        in fn to replay against
-    :returns: a stochastic function decorated with a :class:`~pyro.poutine.replay_messenger.ReplayMessenger`
-    """
-    msngr = ReplayMessenger(trace=trace, params=params)
-    return msngr(fn) if fn is not None else msngr
-
-
-def lift(fn=None, prior=None):
-    """
-    Given a stochastic function with param calls and a prior distribution,
-    create a stochastic function where all param calls are replaced by sampling from prior.
-    Prior should be a callable or a dict of names to callables.
-
-    Consider the following Pyro program:
-
-        >>> def model(x):
-        ...     s = pyro.param("s", torch.tensor(0.5))
-        ...     z = pyro.sample("z", dist.Normal(x, s))
-        ...     return z ** 2
-        >>> lifted_model = lift(model, prior={"s": dist.Exponential(0.3)})
-
-    ``lift`` makes ``param`` statements behave like ``sample`` statements
-    using the distributions in ``prior``.  In this example, site `s` will now behave
-    as if it was replaced with ``s = pyro.sample("s", dist.Exponential(0.3))``:
-
-        >>> tr = trace(lifted_model).get_trace(0.0)
-        >>> tr.nodes["s"]["type"] == "sample"
-        True
-        >>> tr2 = trace(lifted_model).get_trace(0.0)
-        >>> bool((tr2.nodes["s"]["value"] == tr.nodes["s"]["value"]).all())
-        False
-
-    :param fn: function whose parameters will be lifted to random values
-    :param prior: prior function in the form of a Distribution or a dict of stochastic fns
-    :returns: ``fn`` decorated with a :class:`~pyro.poutine.lift_messenger.LiftMessenger`
-    """
-    msngr = LiftMessenger(prior=prior)
-    return msngr(fn) if fn is not None else msngr
-
-
-def block(fn=None, hide_fn=None, expose_fn=None, hide=None, expose=None, hide_types=None, expose_types=None):
-    """
-    This handler selectively hides Pyro primitive sites from the outside world.
-    Default behavior: block everything.
-
-    A site is hidden if at least one of the following holds:
-
-        0. ``hide_fn(msg) is True`` or ``(not expose_fn(msg)) is True``
-        1. ``msg["name"] in hide``
-        2. ``msg["type"] in hide_types``
-        3. ``msg["name"] not in expose and msg["type"] not in expose_types``
-        4. ``hide``, ``hide_types``, and ``expose_types`` are all ``None``
-
-    For example, suppose the stochastic function fn has two sample sites "a" and "b".
-    Then any effect outside of ``BlockMessenger(fn, hide=["a"])``
-    will not be applied to site "a" and will only see site "b":
-
-        >>> def fn():
-        ...     a = pyro.sample("a", dist.Normal(0., 1.))
-        ...     return pyro.sample("b", dist.Normal(a, 1.))
-        >>> fn_inner = trace(fn)
-        >>> fn_outer = trace(block(fn_inner, hide=["a"]))
-        >>> trace_inner = fn_inner.get_trace()
-        >>> trace_outer  = fn_outer.get_trace()
-        >>> "a" in trace_inner
-        True
-        >>> "a" in trace_outer
-        False
-        >>> "b" in trace_inner
-        True
-        >>> "b" in trace_outer
-        True
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param hide_fn: function that takes a site and returns True to hide the site
-        or False/None to expose it.  If specified, all other parameters are ignored.
-        Only specify one of hide_fn or expose_fn, not both.
-    :param expose_fn: function that takes a site and returns True to expose the site
-        or False/None to hide it.  If specified, all other parameters are ignored.
-        Only specify one of hide_fn or expose_fn, not both.
-    :param hide: list of site names to hide
-    :param expose: list of site names to be exposed while all others hidden
-    :param hide_types: list of site types to be hidden
-    :param expose_types: list of site types to be exposed while all others hidden
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.block_messenger.BlockMessenger`
-    """
-    msngr = BlockMessenger(hide_fn=hide_fn, expose_fn=expose_fn,
-                           hide=hide, expose=expose,
-                           hide_types=hide_types, expose_types=expose_types)
-    return msngr(fn) if fn is not None else msngr
-
-
-def broadcast(fn=None):
-    """
-    Automatically broadcasts the batch shape of the stochastic function
-    at a sample site when inside a single or nested plate context.
-    The existing `batch_shape` must be broadcastable with the size
-    of the :class:`~pyro.plate` contexts installed in the
-    `cond_indep_stack`.
-
-    Notice how `model_automatic_broadcast` below automates expanding of
-    distribution batch shapes. This makes it easy to modularize a
-    Pyro model as the sub-components are agnostic of the wrapping
-    :class:`~pyro.plate` contexts.
-
-    >>> def model_broadcast_by_hand():
-    ...     with IndepMessenger("batch", 100, dim=-2):
-    ...         with IndepMessenger("components", 3, dim=-1):
-    ...             sample = pyro.sample("sample", dist.Bernoulli(torch.ones(3) * 0.5)
-    ...                                                .expand_by(100))
-    ...             assert sample.shape == torch.Size((100, 3))
-    ...     return sample
-
-    >>> @poutine.broadcast
-    ... def model_automatic_broadcast():
-    ...     with IndepMessenger("batch", 100, dim=-2):
-    ...         with IndepMessenger("components", 3, dim=-1):
-    ...             sample = pyro.sample("sample", dist.Bernoulli(torch.tensor(0.5)))
-    ...             assert sample.shape == torch.Size((100, 3))
-    ...     return sample
-    """
-    msngr = BroadcastMessenger()
-    return msngr(fn) if fn is not None else msngr
-
-
-def escape(fn=None, escape_fn=None):
-    """
-    Given a callable that contains Pyro primitive calls,
-    evaluate escape_fn on each site, and if the result is True,
-    raise a :class:`~pyro.poutine.runtime.NonlocalExit` exception that stops execution
-    and returns the offending site.
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param escape_fn: function that takes a partial trace and a site,
-        and returns a boolean value to decide whether to exit at that site
-    :returns: stochastic function decorated with :class:`~pyro.poutine.escape_messenger.EscapeMessenger`
-    """
-    msngr = EscapeMessenger(escape_fn)
-    return msngr(fn) if fn is not None else msngr
-
-
-def condition(fn=None, data=None):
-    """
-    Given a stochastic function with some sample statements
-    and a dictionary of observations at names,
-    change the sample statements at those names into observes
-    with those values.
-
-    Consider the following Pyro program:
-
-        >>> def model(x):
-        ...     s = pyro.param("s", torch.tensor(0.5))
-        ...     z = pyro.sample("z", dist.Normal(x, s))
-        ...     return z ** 2
-
-    To observe a value for site `z`, we can write
-
-        >>> conditioned_model = condition(model, data={"z": torch.tensor(1.)})
-
-    This is equivalent to adding `obs=value` as a keyword argument
-    to `pyro.sample("z", ...)` in `model`.
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param data: a dict or a :class:`~pyro.poutine.Trace`
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.condition_messenger.ConditionMessenger`
-    """
-    msngr = ConditionMessenger(data=data)
-    return msngr(fn) if fn is not None else msngr
-
-
-def uncondition(fn=None):
-    """
-    Given a stochastic funtion with sample statements, conditioned on observed
-    values at some sample statements, removes the conditioning so that all
-    nodes are sampled from.
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :returns: a stochastic function decorated with a :class: `~pyro.poutine.uncondition_messenger.UnconditionMessenger`
-    """
-    msngr = UnconditionMessenger()
-    return msngr(fn) if fn is not None else msngr
-
-
-def infer_config(fn=None, config_fn=None):
-    """
-    Given a callable that contains Pyro primitive calls
-    and a callable taking a trace site and returning a dictionary,
-    updates the value of the infer kwarg at a sample site to config_fn(site).
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param config_fn: a callable taking a site and returning an infer dict
-    :returns: stochastic function decorated with :class:`~pyro.poutine.infer_config_messenger.InferConfigMessenger`
-    """
-    msngr = InferConfigMessenger(config_fn)
-    return msngr(fn) if fn is not None else msngr
-
-
-def scale(fn=None, scale=None):
-    """
-    Given a stochastic function with some sample statements and a positive
-    scale factor, scale the score of all sample and observe sites in the
-    function.
-
-    Consider the following Pyro program:
-
-        >>> def model(x):
-        ...     s = pyro.param("s", torch.tensor(0.5))
-        ...     z = pyro.sample("z", dist.Normal(x, s), obs=1.0)
-        ...     return z ** 2
-
-    ``scale`` multiplicatively scales the log-probabilities of sample sites:
-
-        >>> scaled_model = scale(model, scale=0.5)
-        >>> scaled_tr = trace(scaled_model).get_trace(0.0)
-        >>> unscaled_tr = trace(model).get_trace(0.0)
-        >>> bool((scaled_tr.log_prob_sum() == 0.5 * unscaled_tr.log_prob_sum()).all())
-        True
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param scale: a positive scaling factor
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.scale_messenger.ScaleMessenger`
-    """
-    msngr = ScaleMessenger(scale=scale)
-    # XXX temporary compatibility fix
-    return msngr(fn) if callable(fn) else msngr
-
-
-def mask(fn=None, mask=None):
-    """
-    Given a stochastic function with some batched sample statements and
-    masking tensor, mask out some of the sample statements elementwise.
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param torch.BoolTensor mask: a ``{0,1}``-valued masking tensor
-        (1 includes a site, 0 excludes a site)
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.scale_messenger.MaskMessenger`
-    """
-    msngr = MaskMessenger(mask=mask)
-    return msngr(fn) if fn is not None else msngr
-
-
-def enum(fn=None, first_available_dim=None):
-    """
-    Enumerates in parallel over discrete sample sites marked
-    ``infer={"enumerate": "parallel"}``.
-
-    :param int first_available_dim: The first tensor dimension (counting
-        from the right) that is available for parallel enumeration. This
-        dimension and all dimensions left may be used internally by Pyro.
-        This should be a negative integer.
-    """
-    assert first_available_dim < 0, first_available_dim
-    msngr = EnumerateMessenger(first_available_dim=first_available_dim)
-    return msngr(fn) if fn is not None else msngr
-
-
-def do(fn=None, data=None):
-    """
-    Given a stochastic function with some sample statements
-    and a dictionary of values at names,
-    set the return values of those sites equal to the values
-    as if they were hard-coded to those values
-    and introduce fresh sample sites with the same names
-    whose values do not propagate.
-
-    Composes freely with :func:`~pyro.poutine.handlers.condition`
-    to represent counterfactual distributions over potential outcomes.
-    See Single World Intervention Graphs [1] for additional details and theory.
-
-    Consider the following Pyro program:
-
-        >>> def model(x):
-        ...     s = pyro.param("s", torch.tensor(0.5))
-        ...     z = pyro.sample("z", dist.Normal(x, s))
-        ...     return z ** 2
-
-    To intervene with a value for site `z`, we can write
-
-        >>> intervened_model = pyro.poutine.do(model, data={"z": torch.tensor(1.)})
-
-    This is equivalent to replacing `z = pyro.sample("z", ...)` with
-    `z = torch.tensor(1.)`
-    and introducing a fresh sample site pyro.sample("z", ...) whose value is not used elsewhere.
-
-    References
-
-    [1] `Single World Intervention Graphs: A Primer`,
-        Thomas Richardson, James Robins
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls)
-    :param data: a ``dict`` mapping sample site names to interventions
-    :returns: stochastic function decorated with a :class:`~pyro.poutine.do_messenger.DoMessenger`
-    """
-    msngr = DoMessenger(data=data)
-    return msngr(fn) if fn is not None else msngr
+_msngrs = [
+    BlockMessenger,
+    BroadcastMessenger,
+    ConditionMessenger,
+    DoMessenger,
+    EnumMessenger,
+    EscapeMessenger,
+    InferConfigMessenger,
+    LiftMessenger,
+    MarkovMessenger,
+    MaskMessenger,
+    ReplayMessenger,
+    ScaleMessenger,
+    SeedMessenger,
+    TraceMessenger,
+    UnconditionMessenger,
+]
+
+
+def _make_handler(msngr_cls):
+
+    def handler(fn=None, *args, **kwargs):
+        if fn is not None and not callable(fn):
+            raise ValueError(
+                "{} is not callable, did you mean to pass it as a keyword arg?".format(fn))
+        msngr = msngr_cls(*args, **kwargs)
+        return msngr(fn) if fn is not None else msngr
+
+    return handler
+
+
+_re1 = re.compile('(.)([A-Z][a-z]+)')
+_re2 = re.compile('([a-z0-9])([A-Z])')
+for _msngr_cls in _msngrs:
+    _handler_name = _re2.sub(
+        r'\1_\2', _re1.sub(r'\1_\2', _msngr_cls.__name__.split("Messenger")[0])).lower()
+    _handler = _make_handler(_msngr_cls)
+    _handler.__module__ = __name__
+    _handler.__doc__ = _msngr_cls.__doc__
+    locals()[_handler_name] = _handler
 
 
 #########################################
@@ -468,7 +186,7 @@ def queue(fn=None, queue=None, max_tries=None,
 
                 next_trace = queue.get()
                 try:
-                    ftr = trace(escape(replay(wrapped, trace=next_trace),
+                    ftr = trace(escape(replay(wrapped, trace=next_trace),  # noqa: F821
                                        escape_fn=functools.partial(escape_fn,
                                                                    next_trace)))
                     return ftr(*args, **kwargs)
@@ -514,32 +232,3 @@ def markov(fn=None, history=1, keep=False, dim=None, name=None):
         return MarkovMessenger(history=history, keep=keep, dim=dim, name=name).generator(iterable=fn)
     # Used as a decorator with bound args
     return MarkovMessenger(history=history, keep=keep, dim=dim, name=name)(fn)
-
-
-class _SeedMessenger(Messenger):
-    def __init__(self, rng_seed):
-        assert isinstance(rng_seed, int)
-        self.rng_seed = rng_seed
-        super(_SeedMessenger, self).__init__()
-
-    def __enter__(self):
-        self.old_state = get_rng_state()
-        set_rng_seed(self.rng_seed)
-
-    def __exit__(self, type, value, traceback):
-        set_rng_state(self.old_state)
-
-
-def seed(fn=None, rng_seed=None):
-    """
-    Handler to set the random number generator to a pre-defined state by setting its
-    seed. This is the same as calling :func:`pyro.set_rng_seed` before the
-    call to `fn`. This handler has no additional effect on primitive statements on the
-    standard Pyro backend, but it might intercept ``pyro.sample`` calls in other
-    backends. e.g. the NumPy backend.
-
-    :param fn: a stochastic function (callable containing Pyro primitive calls).
-    :param int rng_seed: rng seed.
-    """
-    msngr = _SeedMessenger(rng_seed)
-    return msngr(fn) if fn is not None else msngr

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -139,6 +139,7 @@ for _msngr_cls in _msngrs:
     _handler = _make_handler(_msngr_cls)
     _handler.__module__ = __name__
     _handler.__doc__ = _msngr_cls.__doc__
+    _handler.__name__ = _handler_name
     locals()[_handler_name] = _handler
 
 

--- a/pyro/poutine/infer_config_messenger.py
+++ b/pyro/poutine/infer_config_messenger.py
@@ -3,8 +3,8 @@ from .messenger import Messenger
 
 class InferConfigMessenger(Messenger):
     """
-    Given a callable that contains Pyro primitive calls
-    and a callable taking a trace site and returning a dictionary,
+    Given a callable `fn` that contains Pyro primitive calls
+    and a callable `config_fn` taking a trace site and returning a dictionary,
     updates the value of the infer kwarg at a sample site to config_fn(site).
 
     :param fn: a stochastic function (callable containing Pyro primitive calls)

--- a/pyro/poutine/infer_config_messenger.py
+++ b/pyro/poutine/infer_config_messenger.py
@@ -3,7 +3,13 @@ from .messenger import Messenger
 
 class InferConfigMessenger(Messenger):
     """
-    Modifies contents of the infer kwarg at sample sites
+    Given a callable that contains Pyro primitive calls
+    and a callable taking a trace site and returning a dictionary,
+    updates the value of the infer kwarg at a sample site to config_fn(site).
+
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
+    :param config_fn: a callable taking a site and returning an infer dict
+    :returns: stochastic function decorated with :class:`~pyro.poutine.infer_config_messenger.InferConfigMessenger`
     """
     def __init__(self, config_fn):
         """

--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -9,12 +9,32 @@ from .messenger import Messenger
 
 class LiftMessenger(Messenger):
     """
-    Messenger which "lifts" parameters to random samples.
-    Given a stochastic function with param calls and a prior,
-    creates a stochastic function where all param calls are
-    replaced by sampling from prior.
-
+    Given a stochastic function with param calls and a prior distribution,
+    create a stochastic function where all param calls are replaced by sampling from prior.
     Prior should be a callable or a dict of names to callables.
+
+    Consider the following Pyro program:
+
+        >>> def model(x):
+        ...     s = pyro.param("s", torch.tensor(0.5))
+        ...     z = pyro.sample("z", dist.Normal(x, s))
+        ...     return z ** 2
+        >>> lifted_model = lift(model, prior={"s": dist.Exponential(0.3)})
+
+    ``lift`` makes ``param`` statements behave like ``sample`` statements
+    using the distributions in ``prior``.  In this example, site `s` will now behave
+    as if it was replaced with ``s = pyro.sample("s", dist.Exponential(0.3))``:
+
+        >>> tr = trace(lifted_model).get_trace(0.0)
+        >>> tr.nodes["s"]["type"] == "sample"
+        True
+        >>> tr2 = trace(lifted_model).get_trace(0.0)
+        >>> bool((tr2.nodes["s"]["value"] == tr.nodes["s"]["value"]).all())
+        False
+
+    :param fn: function whose parameters will be lifted to random values
+    :param prior: prior function in the form of a Distribution or a dict of stochastic fns
+    :returns: ``fn`` decorated with a :class:`~pyro.poutine.lift_messenger.LiftMessenger`
     """
 
     def __init__(self, prior):

--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -19,16 +19,16 @@ class LiftMessenger(Messenger):
         ...     s = pyro.param("s", torch.tensor(0.5))
         ...     z = pyro.sample("z", dist.Normal(x, s))
         ...     return z ** 2
-        >>> lifted_model = lift(model, prior={"s": dist.Exponential(0.3)})
+        >>> lifted_model = pyro.poutine.lift(model, prior={"s": dist.Exponential(0.3)})
 
     ``lift`` makes ``param`` statements behave like ``sample`` statements
     using the distributions in ``prior``.  In this example, site `s` will now behave
     as if it was replaced with ``s = pyro.sample("s", dist.Exponential(0.3))``:
 
-        >>> tr = trace(lifted_model).get_trace(0.0)
+        >>> tr = pyro.poutine.trace(lifted_model).get_trace(0.0)
         >>> tr.nodes["s"]["type"] == "sample"
         True
-        >>> tr2 = trace(lifted_model).get_trace(0.0)
+        >>> tr2 = pyro.poutine.trace(lifted_model).get_trace(0.0)
         >>> bool((tr2.nodes["s"]["value"] == tr.nodes["s"]["value"]).all())
         False
 

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -69,7 +69,7 @@ class MarkovMessenger(ReentrantMessenger):
         # We use a Counter rather than a set here so that sites can correctly
         # go out of scope when any one of their markov contexts exits.
         # This accounting can be done by users of these fields,
-        # e.g. EnumerateMessenger.
+        # e.g. EnumMessenger.
         infer = msg["infer"]
         scope = infer.setdefault("_markov_scope", Counter())  # site name -> markov depth
         for pos in range(max(0, self._pos - self.history), self._pos + 1):

--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -7,12 +7,13 @@ from .messenger import Messenger
 
 class MaskMessenger(Messenger):
     """
-    This messenger masks sample sites.
+    Given a stochastic function with some batched sample statements and
+    masking tensor, mask out some of the sample statements elementwise.
 
-    This is typically used for masking out parts of tensors.
-
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
     :param torch.BoolTensor mask: a ``{0,1}``-valued masking tensor
         (1 includes a site, 0 excludes a site)
+    :returns: stochastic function decorated with a :class:`~pyro.poutine.scale_messenger.MaskMessenger`
     """
     def __init__(self, mask):
         if isinstance(mask, torch.Tensor):

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -3,7 +3,30 @@ from .messenger import Messenger
 
 class ReplayMessenger(Messenger):
     """
-    Messenger for replaying from an existing execution trace.
+    Given a callable that contains Pyro primitive calls,
+    return a callable that runs the original, reusing the values at sites in trace
+    at those sites in the new trace
+
+    Consider the following Pyro program:
+
+        >>> def model(x):
+        ...     s = pyro.param("s", torch.tensor(0.5))
+        ...     z = pyro.sample("z", dist.Normal(x, s))
+        ...     return z ** 2
+
+    ``replay`` makes ``sample`` statements behave as if they had sampled the values
+    at the corresponding sites in the trace:
+
+        >>> old_trace = trace(model).get_trace(1.0)
+        >>> replayed_model = replay(model, trace=old_trace)
+        >>> bool(replayed_model(0.0) == old_trace.nodes["_RETURN"]["value"])
+        True
+
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
+    :param trace: a :class:`~pyro.poutine.Trace` data structure to replay against
+    :param params: dict of names of param sites and constrained values
+        in fn to replay against
+    :returns: a stochastic function decorated with a :class:`~pyro.poutine.replay_messenger.ReplayMessenger`
     """
 
     def __init__(self, trace=None, params=None):

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -17,8 +17,8 @@ class ReplayMessenger(Messenger):
     ``replay`` makes ``sample`` statements behave as if they had sampled the values
     at the corresponding sites in the trace:
 
-        >>> old_trace = trace(model).get_trace(1.0)
-        >>> replayed_model = replay(model, trace=old_trace)
+        >>> old_trace = pyro.poutine.trace(model).get_trace(1.0)
+        >>> replayed_model = pyro.poutine.replay(model, trace=old_trace)
         >>> bool(replayed_model(0.0) == old_trace.nodes["_RETURN"]["value"])
         True
 

--- a/pyro/poutine/scale_messenger.py
+++ b/pyro/poutine/scale_messenger.py
@@ -7,13 +7,28 @@ from .messenger import Messenger
 
 class ScaleMessenger(Messenger):
     """
-    This messenger rescales the log probability score.
+    Given a stochastic function with some sample statements and a positive
+    scale factor, scale the score of all sample and observe sites in the
+    function.
 
-    This is typically used for data subsampling or for stratified sampling of data
-    (e.g. in fraud detection where negatives vastly outnumber positives).
+    Consider the following Pyro program:
 
+        >>> def model(x):
+        ...     s = pyro.param("s", torch.tensor(0.5))
+        ...     z = pyro.sample("z", dist.Normal(x, s), obs=1.0)
+        ...     return z ** 2
+
+    ``scale`` multiplicatively scales the log-probabilities of sample sites:
+
+        >>> scaled_model = scale(model, scale=0.5)
+        >>> scaled_tr = trace(scaled_model).get_trace(0.0)
+        >>> unscaled_tr = trace(model).get_trace(0.0)
+        >>> bool((scaled_tr.log_prob_sum() == 0.5 * unscaled_tr.log_prob_sum()).all())
+        True
+
+    :param fn: a stochastic function (callable containing Pyro primitive calls)
     :param scale: a positive scaling factor
-    :type scale: float or torch.Tensor
+    :returns: stochastic function decorated with a :class:`~pyro.poutine.scale_messenger.ScaleMessenger`
     """
     def __init__(self, scale):
         if isinstance(scale, torch.Tensor):

--- a/pyro/poutine/scale_messenger.py
+++ b/pyro/poutine/scale_messenger.py
@@ -20,9 +20,9 @@ class ScaleMessenger(Messenger):
 
     ``scale`` multiplicatively scales the log-probabilities of sample sites:
 
-        >>> scaled_model = scale(model, scale=0.5)
-        >>> scaled_tr = trace(scaled_model).get_trace(0.0)
-        >>> unscaled_tr = trace(model).get_trace(0.0)
+        >>> scaled_model = pyro.poutine.scale(model, scale=0.5)
+        >>> scaled_tr = pyro.poutine.trace(scaled_model).get_trace(0.0)
+        >>> unscaled_tr = pyro.poutine.trace(model).get_trace(0.0)
         >>> bool((scaled_tr.log_prob_sum() == 0.5 * unscaled_tr.log_prob_sum()).all())
         True
 

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -45,7 +45,7 @@ class TraceMessenger(Messenger):
     and use the resulting data structure to compute the log-joint probability
     of all of the sample sites in the execution or extract all parameters.
 
-        >>> trace = trace(model).get_trace(0.0)
+        >>> trace = pyro.poutine.trace(model).get_trace(0.0)
         >>> logp = trace.log_prob_sum()
         >>> params = [trace.nodes[name]["value"].unconstrained() for name in trace.param_nodes]
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -846,3 +846,19 @@ def test_pickling(wrapper):
     assert tuple(actual_trace) == tuple(expected_trace.nodes)
     assert_close([actual_trace.nodes[site]['value'] for site in actual_trace.stochastic_nodes],
                  [expected_trace.nodes[site]['value'] for site in expected_trace.stochastic_nodes])
+
+
+def test_arg_kwarg_error():
+
+    def model():
+        pyro.param("p", torch.zeros(1, requires_grad=True))
+        pyro.sample("a", Bernoulli(torch.tensor([0.5])),
+                    infer={"enumerate": "parallel"})
+        pyro.sample("b", Bernoulli(torch.tensor([0.5])))
+
+    with pytest.raises(ValueError, match="not callable"):
+        with poutine.mask(False):
+            model()
+
+    with poutine.mask(mask=False):
+        model()


### PR DESCRIPTION
Resolves #2188.

This almost-pure refactoring PR:
1. Removes all the hand-defined boilerplate convenience functions like `poutine.trace` defined in `pyro/poutine/handlers.py` and moves or merges their docstrings into the corresponding `Messenger` classes.
2. Programatically generates new versions of these functions that behave identically (necessary to address #2188)
3. Adds a one-line check in the automatically generated versions that addresses #2188 
4. Adds a regression test that would have caught #2188 to `test/poutine/test_poutine.py`
5. Changes the name of `EnumerateMessenger` to `EnumMessenger` to avoid a name collision with the `enumerate` builtin during programmatic handler generation and be consistent with its preexisting alias `poutine.enum`

Almost all of the changes in this PR are copy-pasted docstrings and deleted boilerplate.

Tested:
- Pure refactoring exercised by existing tests
- Regression test in `test_poutine.py`
- Docs render correctly on my machine