### PR TITLE
Tutorial: update to differentiate torch.optim.Adam and pyro.optim.Adam

### DIFF
--- a/tutorial/source/bayesian_regression.ipynb
+++ b/tutorial/source/bayesian_regression.ipynb
@@ -396,11 +396,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyro import optim\n",
     "from pyro.infer import SVI, Trace_ELBO\n",
     "\n",
     "\n",
-    "adam = optim.Adam({\"lr\": 0.03})\n",
+    "adam = pyro.optim.Adam({\"lr\": 0.03})\n",
     "svi = SVI(model, guide, adam, loss=Trace_ELBO())"
    ]
   },


### PR DESCRIPTION
It might be confusing and cause error if we run the code in tutorial together in a separate python file. Thus it might help better differentiate `torch.optim.Adam` and `pyro.optim.Adam` this way. 