### PR TITLE
Implement poutine.reparam with aux variable support

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -477,3 +477,27 @@ sylvester
 tanh
 ----
 .. autofunction:: pyro.distributions.transforms.tanh
+
+
+Reparameterizers
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: pyro.distributions.reparameterize.Reparameterizer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyro.distributions.reparameterize.TrivialReparameterizer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyro.distributions.reparameterize.LocScaleReparameterizer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pyro.distributions.stable.StableReparameterizer
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pyro.poutine.txt
+++ b/docs/source/pyro.poutine.txt
@@ -110,6 +110,14 @@ ___________________
     :undoc-members:
     :show-inheritance:
 
+ReparamMessenger
+________________
+
+.. automodule:: pyro.poutine.reparam_messenger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ReplayMessenger
 ________________
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -32,7 +32,7 @@ from pyro.distributions.von_mises_3d import VonMises3D
 from pyro.distributions.zero_inflated import (ZeroInflatedDistribution, ZeroInflatedPoisson,
                                               ZeroInflatedNegativeBinomial)
 
-from . import constraints, kl, transforms
+from . import constraints, kl, reparameterize, transforms
 
 __all__ = [
     "AVFMultivariateNormal",
@@ -75,6 +75,7 @@ __all__ = [
     "enable_validation",
     "is_validation_enabled",
     "kl",
+    "reparameterize",
     "transforms",
     "validation_enabled",
 ]

--- a/pyro/distributions/reparameterize.py
+++ b/pyro/distributions/reparameterize.py
@@ -66,7 +66,7 @@ class TrivialReparameterizer(Reparameterizer):
 class LocScaleReparameterizer(Reparameterizer):
     """
     Generic centering reparameterizer for distributions that are completely
-    spacified by parameters ``loc`` and ``scale``.
+    specified by parameters ``loc`` and ``scale``.
     """
     def get_dists(self, fn):
         loc = torch.zeros_like(fn.loc)

--- a/pyro/distributions/reparameterize.py
+++ b/pyro/distributions/reparameterize.py
@@ -71,7 +71,7 @@ class LocScaleReparameterizer(Reparameterizer):
     def get_dists(self, fn):
         loc = torch.zeros_like(fn.loc)
         scale = torch.ones_like(fn.scale)
-        new_fn = type(fn)(loc, scale)
+        new_fn = type(fn)(loc=loc, scale=scale)
         return OrderedDict([("centered", new_fn)])
 
     def transform_values(self, fn, values):

--- a/pyro/distributions/reparameterize.py
+++ b/pyro/distributions/reparameterize.py
@@ -28,21 +28,28 @@ class Reparameterizer(ABC):
     @abstractmethod
     def get_dists(self, fn):
         """
+        Constructs one or more auxiliary
+        :class:`~pyro.distribution.Distribution` s that will replace ``fn``.
+
         :param ~pyro.distributions.Distribution fn: A base distribution.
         :returns: An OrderedDict mapping name (suffix) to auxiliary distribution.
-        :rtype: OrderedDict
+        :rtype: ~collections.OrderedDict
         """
-        return OrderedDict([("trivial", fn)])
+        raise NotImplementedError
 
     @abstractmethod
     def transform_values(self, fn, values):
         """
+        Deterministically combines samples from the distributions returned by
+        :meth:`get_dists` into a single reparameterized sample from ``fn``.
+
         :param ~pyro.distributions.Distribution fn: A base distribution.
-        :param OrderedDict values:
+        :param ~collections.OrderedDict values: An OrderedDict mapping name (suffix) to
+            sample value drawn from corresponding auxiliary variable.
         :returns: A transformed value.
-        :rtype: Tensor
+        :rtype: ~torch.Tensor
         """
-        return values["trivial"]
+        raise NotImplementedError
 
 
 class TrivialReparameterizer(Reparameterizer):

--- a/pyro/distributions/reparameterize.py
+++ b/pyro/distributions/reparameterize.py
@@ -1,0 +1,71 @@
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+
+import torch
+
+
+class Reparameterizer(ABC):
+    """
+    Base class for reparameterization transforms, generalizing [1] to handle
+    multiple distributions and auxiliary variables.
+
+    The interface specifies two methods to be used by inference algorithms in
+    the following pattern::
+
+        # Transform a site like this...
+        pyro.sample("x", dist.Normal(loc, scale))
+
+        # ...to one or more sample sites plus a deterministic site:
+        d = dist.Normal(loc, scale)
+        values = OrderedDict((name, pyro.sample("x_"+name, fn))
+                             for name, fn in reparam.get_dists(d))
+        pyro.deterministic("x", reparam.transform_values(d, values))
+
+    [1] Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
+        "Automatic Reparameterisation of Probabilistic Programs"
+        https://arxiv.org/pdf/1906.03028.pdf
+    """
+    @abstractmethod
+    def get_dists(self, fn):
+        """
+        :param ~pyro.distributions.Distribution fn: A base distribution.
+        :returns: An OrderedDict mapping name (suffix) to auxiliary distribution.
+        :rtype: OrderedDict
+        """
+        return OrderedDict([("trivial", fn)])
+
+    @abstractmethod
+    def transform_values(self, fn, values):
+        """
+        :param ~pyro.distributions.Distribution fn: A base distribution.
+        :param OrderedDict values:
+        :returns: A transformed value.
+        :rtype: Tensor
+        """
+        return values["trivial"]
+
+
+class TrivialReparameterizer(Reparameterizer):
+    """
+    Trivial reparameterizer, mainly useful for testing.
+    """
+    def get_dists(self, fn):
+        return OrderedDict([("trivial", fn)])
+
+    def transform_values(self, fn, values):
+        return values["trivial"]
+
+
+class LocScaleReparameterizer(Reparameterizer):
+    """
+    Generic centering reparameterizer for distributions that are completely
+    spacified by parameters ``loc`` and ``scale``.
+    """
+    def get_dists(self, fn):
+        loc = torch.zeros_like(fn.loc)
+        scale = torch.ones_like(fn.scale)
+        new_fn = type(fn)(loc, scale)
+        return OrderedDict([("centered", new_fn)])
+
+    def transform_values(self, fn, values):
+        return fn.loc + fn.scale * values["centered"]

--- a/pyro/distributions/reparameterize.py
+++ b/pyro/distributions/reparameterize.py
@@ -21,6 +21,9 @@ class Reparameterizer(ABC):
                              for name, fn in reparam.get_dists(d))
         pyro.deterministic("x", reparam.transform_values(d, values))
 
+    To trigger use in Pyro models use the
+    :func:`~pyro.poutine.handlers.reparam` handler.
+
     [1] Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
         "Automatic Reparameterisation of Probabilistic Programs"
         https://arxiv.org/pdf/1906.03028.pdf

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -1,26 +1,28 @@
 import math
+from collections import OrderedDict
 
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all
 
+from pyro.distributions.reparameterize import Reparameterizer
+from pyro.distributions.torch import Exponential, Uniform
 from pyro.distributions.torch_distribution import TorchDistribution
 
 
-def _unsafe_standard_stable(shape, alpha, beta):
+def _unsafe_standard_stable(alpha, beta, V, W):
     # Implements a noisily reparametrized version of the sampler
     # Chambers-Mallows-Stuck method as corrected by Weron [1,3] and simplified
     # by Nolan [4]. This will fail if alpha is close to 1.
 
-    # Draw parameter-free noise.
-    with torch.no_grad():
-        half_pi = math.pi / 2
-        V = alpha.new_empty(shape).uniform_(-half_pi, half_pi)
-        W = alpha.new_empty(shape).exponential_()
+    # Assume auxiliary noise is parameter-free.
+    assert V.shape == W.shape
+    assert not V.requires_grad
+    assert not W.requires_grad
 
     # Differentiably transform noise via parameters.
     inv_alpha = alpha.reciprocal()
-    b = beta * (half_pi * alpha).tan()
+    b = beta * (math.pi / 2 * alpha).tan()
     v = b.atan() + alpha * V
     Z = v.sin() / ((1 + b * b).rsqrt() * V.cos()).pow(inv_alpha) \
         * ((v - V).cos() / W).pow(inv_alpha - 1)
@@ -35,16 +37,26 @@ def _unsafe_standard_stable(shape, alpha, beta):
 RADIUS = 0.01
 
 
-def _standard_stable(shape, alpha, beta):
+def _standard_stable(alpha, beta, aux_uniform, aux_exponential):
+    """
+    Differentiably transform two random variables::
+
+        aux_uniform ~ Uniform(-pi/2, pi/2)
+        aux_exponential ~ Exponential(1)
+
+    to a standard ``Stable(alpha, beta)`` random variable.
+    """
+    # Determine whether a hole workaround is needed.
     with torch.no_grad():
         hole = 1.
         near_hole = (alpha - hole).abs() <= RADIUS
     if not torch._C._get_tracing_state() and not near_hole.any():
-        return _unsafe_standard_stable(shape, alpha, beta)
+        return _unsafe_standard_stable(alpha, beta, aux_uniform, aux_exponential)
 
     # Avoid the hole at alpha=1 by interpolating between pairs
     # of points at hole-RADIUS and hole+RADIUS.
-    shape_ = shape + (1,)
+    aux_uniform_ = aux_uniform.unsqueeze(-1)
+    aux_exponential_ = aux_exponential.unsqueeze(-1)
     beta_ = beta.unsqueeze(-1)
     alpha_ = alpha.unsqueeze(-1).expand(alpha.shape + (2,)).contiguous()
     with torch.no_grad():
@@ -58,7 +70,7 @@ def _standard_stable(shape, alpha, beta):
         #              2 * RADIUS
         weights = (alpha_ - alpha.unsqueeze(-1)).abs_().mul_(-1 / (2 * RADIUS)).add_(1)
         weights[~near_hole] = 0.5
-    pairs = _unsafe_standard_stable(shape_, alpha_, beta_)
+    pairs = _unsafe_standard_stable(alpha_, beta_, aux_uniform_, aux_exponential_)
     return (pairs * weights).sum(-1)
 
 
@@ -120,6 +132,38 @@ class Stable(TorchDistribution):
         raise NotImplementedError("Stable.log_prob() is not implemented")
 
     def rsample(self, sample_shape=torch.Size()):
-        shape = self._extended_shape(sample_shape)
-        x = _standard_stable(shape, self.stability, self.skew)
+        # Draw parameter-free noise.
+        with torch.no_grad():
+            shape = self._extended_shape(sample_shape)
+            new_empty = self.stability.new_empty
+            aux_uniform = new_empty(shape).uniform_(-math.pi / 2, math.pi / 2)
+            aux_exponential = new_empty(shape).exponential_()
+
+        # Differentiably transform.
+        x = _standard_stable(self.stability, self.skew, aux_uniform, aux_exponential)
         return self.loc + self.scale * x
+
+
+class StableReparameterizer(Reparameterizer):
+    """
+    Auxiliary variable reparameterizer for :class:`Stable` distributions.
+
+    This introduces two parameter-free samples sites with well-defined
+    ``.log_prob()`` methods, thereby permitting use of reparameterized stable
+    distributions in likelihood-based inference algorithms.
+    """
+    def get_dists(self, fn):
+        # Draw parameter-free noise.
+        proto = fn.stability
+        half_pi = proto.new_full(proto.shape, math.pi / 2)
+        one = proto.new_ones(proto.shape)
+        return OrderedDict([
+            ("uniform", Uniform(-half_pi, half_pi)),
+            ("exponential", Exponential(one)),
+        ])
+
+    def reparam_transform_values(self, fn, values):
+        # Differentiably transform.
+        x = _standard_stable(fn.stability, fn.skew,
+                             values["uniform"], values["exponential"])
+        return fn.loc + fn.scale * x

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -162,7 +162,7 @@ class StableReparameterizer(Reparameterizer):
             ("exponential", Exponential(one)),
         ])
 
-    def reparam_transform_values(self, fn, values):
+    def transform_values(self, fn, values):
         # Differentiably transform.
         x = _standard_stable(fn.stability, fn.skew,
                              values["uniform"], values["exponential"])

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -81,9 +81,15 @@ class Stable(TorchDistribution):
     and :math:`\mu_0` = loc.
 
     This implements a reparametrized sampler :meth:`rsample` , but does not
-    implement :meth:`log_prob` . Use in inference is thus limited to
+    implement :meth:`log_prob` . Inference can be performed using either
     likelihood-free algorithms such as
-    :class:`~pyro.infer.energy_distance.EnergyDistance`.
+    :class:`~pyro.infer.energy_distance.EnergyDistance`, or reparameterization
+    via the :func:`~pyro.poutine.handlers.reparam` handler with
+    :class:`~pyro.distributions.stable.StableReparameterizer` e.g.::
+
+        with poutine.reparam():
+            pyro.sample("x", Stable(stability, skew, scale, loc),
+                        infer={"reparam": StableReparameterizer()})
 
     [1] S. Borak, W. Hardle, R. Weron (2005).
         Stable distributions.
@@ -142,9 +148,11 @@ class Stable(TorchDistribution):
 
 class StableReparameterizer(Reparameterizer):
     """
-    Auxiliary variable reparameterizer for :class:`Stable` distributions.
+    Auxiliary variable reparameterizer for
+    :class:`~pyro.distributions.Stable` distributions.
 
-    This introduces two parameter-free samples sites with well-defined
+    This creates a pair of parameter-free auxiliary distributions
+    (``Uniform(-pi/2,pi/2)`` and ``Exponential(1)``) with well-defined
     ``.log_prob()`` methods, thereby permitting use of reparameterized stable
     distributions in likelihood-based inference algorithms.
     """

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -15,12 +15,8 @@ def _unsafe_standard_stable(alpha, beta, V, W):
     # Chambers-Mallows-Stuck method as corrected by Weron [1,3] and simplified
     # by Nolan [4]. This will fail if alpha is close to 1.
 
-    # Assume auxiliary noise is parameter-free.
-    assert V.shape == W.shape
-    assert not V.requires_grad
-    assert not W.requires_grad
-
     # Differentiably transform noise via parameters.
+    assert V.shape == W.shape
     inv_alpha = alpha.reciprocal()
     b = beta * (math.pi / 2 * alpha).tan()
     v = b.atan() + alpha * V

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,5 +1,5 @@
-from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, replay,
-                       scale, seed, trace, uncondition)
+from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, reparam,
+                       replay, scale, seed, trace, uncondition)
 from .runtime import NonlocalExit
 from .trace_struct import Trace
 from .util import enable_validation, is_validation_enabled
@@ -19,6 +19,7 @@ __all__ = [
     "mask",
     "NonlocalExit",
     "replay",
+    "reparam",
     "queue",
     "scale",
     "seed",

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -62,6 +62,7 @@ from .lift_messenger import LiftMessenger
 from .markov_messenger import MarkovMessenger
 from .mask_messenger import MaskMessenger
 from .plate_messenger import PlateMessenger  # noqa F403
+from .reparam_messenger import ReparamMessenger
 from .replay_messenger import ReplayMessenger
 from .runtime import NonlocalExit
 from .scale_messenger import ScaleMessenger
@@ -84,6 +85,7 @@ _msngrs = [
     LiftMessenger,
     MarkovMessenger,
     MaskMessenger,
+    ReparamMessenger,
     ReplayMessenger,
     ScaleMessenger,
     SeedMessenger,

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -16,7 +16,7 @@ class ReparamMessenger(Messenger):
     To specify :class:`~pyro.distributions.reparameterize.Reparameterizer` s,
     either pass a ``config`` dict to the constructor, configure
     ``site["infer"]["reparam"] = my_reparameterizer`` for each desired sample
-    site, or use :func:`~pyro.poutine.config_enumerate` .
+    site, or use :func:`~pyro.poutine.infer_config` .
 
     See `available reparameterizers <distributions.html#reparameterizers>`_
 

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -1,0 +1,48 @@
+from collections import OrderedDict
+from pyro.distributions.delta import Delta
+
+from .messenger import Messenger
+from .runtime import apply_stack
+
+
+class ReparamMessenger(Messenger):
+    """
+    Reparametrizes each affected sample site into one or more auxiliary sample
+    sites followed by a deterministic transformation [1].
+
+    To specify :class:`~pyro.distributions.reparameterize.Reparameterizer` s
+    either configure ``site["infer"]["reparam"] = my_reparameterizer`` for each
+    desired sample site or use :func:`~pyro.poutine.config_enumerate` .
+    Only to sites marked ``site["infer"]["reparam"] = ...`` will be affected.
+
+    See `available reparameterizers <distributions.html#reparameterizers>`_
+
+    [1] Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
+        "Automatic Reparameterisation of Probabilistic Programs"
+        https://arxiv.org/pdf/1906.03028.pdf
+    """
+    def _pyro_sample(self, msg):
+        if msg["is_observed"]:
+            return None
+        reparam = msg["infer"].get("reparam")
+        if reparam is None:
+            return None
+        # Create auxiliary sites.
+        new_fns = reparam.get_dists(msg["fn"])
+        new_values = OrderedDict()
+        for name, fn in new_fns.items():
+            new_msg = msg.copy()
+            new_msg["infer"] = new_msg["infer"].copy()
+            new_msg["infer"]["reparam"] = False
+            new_msg["name"] = "{}_{}".format(msg["name"], name)
+            new_msg["fn"] = fn
+            apply_stack(new_msg)
+            new_values[name] = new_msg["value"]
+
+        # Combine auxiliary values via pyro.deterministic().
+        # TODO(https://github.com/pyro-ppl/pyro/issues/2214) refactor to
+        # use site type "deterministic" when it exists.
+        value = reparam.transform_values(msg["fn"], new_values)
+        msg["value"] = value
+        msg["fn"] = Delta(value, event_dim=msg["fn"].event_dim).mask(False)
+        msg["is_observed"] = True

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -17,6 +17,9 @@ class ReparamMessenger(Messenger):
 
     See `available reparameterizers <distributions.html#reparameterizers>`_
 
+    .. warning:: Reparameterizers are recursive; take care to avoid infinite
+        loops in your ``@infer_config`` filters.
+
     [1] Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
         "Automatic Reparameterisation of Probabilistic Programs"
         https://arxiv.org/pdf/1906.03028.pdf
@@ -32,10 +35,11 @@ class ReparamMessenger(Messenger):
         new_values = OrderedDict()
         for name, fn in new_fns.items():
             new_msg = msg.copy()
-            new_msg["infer"] = new_msg["infer"].copy()
-            new_msg["infer"]["reparam"] = False
             new_msg["name"] = "{}_{}".format(msg["name"], name)
             new_msg["fn"] = fn
+            new_msg["cond_indep_stack"] = ()
+            new_msg["infer"] = new_msg["infer"].copy()
+            new_msg["infer"]["reparam"] = None
             apply_stack(new_msg)
             new_values[name] = new_msg["value"]
 

--- a/tests/distributions/test_reparameterize.py
+++ b/tests/distributions/test_reparameterize.py
@@ -1,0 +1,94 @@
+import pytest
+import torch
+from torch.autograd import grad
+
+import pyro
+import pyro.distributions as dist
+from pyro import poutine
+from pyro.distributions.reparameterize import LocScaleReparameterizer, TrivialReparameterizer
+from pyro.distributions.stable import StableReparameterizer
+from tests.common import assert_close
+
+
+# Test helper to extract a few central moments from samples.
+def normal_probe(x):
+    m1 = x.mean(0)
+    x = x - m1
+    xx = x * x
+    xxx = x * xx
+    xxxx = xx * xx
+    m2 = xx.mean(0)
+    m3 = xxx.mean(0) / m2 ** 1.5
+    m4 = xxxx.mean(0) / m2 ** 2
+    return torch.stack([m1, m2, m3, m4])
+
+
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("Reparam", [
+    TrivialReparameterizer,
+    LocScaleReparameterizer,
+])
+def test_normal(shape, Reparam):
+    loc = torch.empty(shape).uniform_(-1., 1.).requires_grad_()
+    scale = torch.empty(shape).uniform_(0.5, 1.5).requires_grad_()
+
+    def model():
+        with pyro.plate_stack("plates", shape):
+            with pyro.plate("particles", 100000):
+                pyro.sample("x", dist.Normal(loc, scale))
+
+    value = poutine.trace(model).get_trace().nodes["x"]["value"]
+    expected_probe = normal_probe(value)
+
+    reparam_model = poutine.infer_config(model, lambda site: {"reparam": Reparam()})
+    value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
+    actual_probe = normal_probe(value)
+    assert_close(actual_probe, expected_probe, atol=0.05)
+
+    for actual_m, expected_m in zip(actual_probe, expected_probe):
+        expected_grads = grad(expected_m.sum(), [loc, scale], retain_graph=True)
+        actual_grads = grad(actual_m.sum(), [loc, scale], retain_graph=True)
+        assert_close(actual_grads[0], expected_grads[0], atol=0.02)
+        assert_close(actual_grads[1], expected_grads[1], atol=0.02)
+
+
+# Test helper to extract a few absolute moments from samples.
+# This is needed for Stable because variance is infinite.
+def stable_probe(x):
+    points = torch.tensor([-4., -2, -1., -0.5, 0., 0.5, 1., 2, 4.])
+    points = points.reshape((-1,) + (1,) * x.dim())
+    return (x - points).abs().mean(1)
+
+
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("Reparam", [
+    TrivialReparameterizer,
+    StableReparameterizer,
+])
+def test_stable(shape, Reparam):
+    stability = torch.empty(shape).uniform_(1.5, 2.).requires_grad_()
+    skew = torch.empty(shape).uniform_(-0.5, 0.5).requires_grad_()
+    scale = torch.empty(shape).uniform_(0.5, 1.0).requires_grad_()
+    loc = torch.empty(shape).uniform_(-1., 1.).requires_grad_()
+    params = [stability, skew, scale, loc]
+
+    def model():
+        with pyro.plate_stack("plates", shape):
+            with pyro.plate("particles", 100000):
+                pyro.sample("x", dist.Stable(stability, skew, scale, loc))
+
+    value = poutine.trace(model).get_trace().nodes["x"]["value"]
+    expected_probe = stable_probe(value)
+
+    reparam_model = poutine.infer_config(model, lambda site: {"reparam": Reparam()})
+    value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
+    actual_probe = stable_probe(value)
+    assert_close(actual_probe, expected_probe, atol=0.05)
+
+    for actual_m, expected_m in zip(actual_probe, expected_probe):
+        expected_grads = grad(expected_m.sum(), params, retain_graph=True)
+        actual_grads = grad(actual_m.sum(), params, retain_graph=True)
+        assert_close(actual_grads[0], expected_grads[0], atol=0.2)
+        assert_close(actual_grads[1], expected_grads[1], atol=0.1)
+        assert_close(actual_grads[2], expected_grads[2], atol=0.1)
+        assert_close(actual_grads[3], expected_grads[3], atol=0.1)

--- a/tests/distributions/test_reparameterize.py
+++ b/tests/distributions/test_reparameterize.py
@@ -40,12 +40,7 @@ def test_normal(shape, Reparam):
     value = poutine.trace(model).get_trace().nodes["x"]["value"]
     expected_probe = normal_probe(value)
 
-    def config_fn(site):
-        if site["name"] == "x" and isinstance(site["fn"], dist.Normal):
-            return {"reparam": Reparam()}
-        return {}
-
-    reparam_model = poutine.reparam(poutine.infer_config(model, config_fn))
+    reparam_model = poutine.reparam(model, {"x": Reparam()})
     value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
     actual_probe = normal_probe(value)
     assert_close(actual_probe, expected_probe, atol=0.05)
@@ -85,12 +80,7 @@ def test_stable(shape, Reparam):
     value = poutine.trace(model).get_trace().nodes["x"]["value"]
     expected_probe = stable_probe(value)
 
-    def config_fn(site):
-        if site["name"] == "x" and isinstance(site["fn"], dist.Stable):
-            return {"reparam": Reparam()}
-        return {}
-
-    reparam_model = poutine.reparam(poutine.infer_config(model, config_fn))
+    reparam_model = poutine.reparam(model, {"x": Reparam()})
     trace = poutine.trace(reparam_model).get_trace()
     if Reparam is StableReparameterizer:
         trace.compute_log_prob()  # smoke test only

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -7,12 +7,13 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
+from pyro.distributions.stable import StableReparameterizer
 from pyro.infer import config_enumerate
-from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc import HMC, NUTS
-from pyro.infer.mcmc.util import TraceTreeEvaluator, TraceEinsumEvaluator, initialize_model
+from pyro.infer.mcmc.api import MCMC
+from pyro.infer.mcmc.util import TraceEinsumEvaluator, TraceTreeEvaluator, initialize_model
 from pyro.poutine.subsample_messenger import _Subsample
-from tests.common import assert_equal, xfail_param, assert_close
+from tests.common import assert_close, assert_equal, xfail_param
 
 logger = logging.getLogger(__name__)
 
@@ -369,3 +370,20 @@ def test_potential_fn_pickling(jit):
                                              skip_jit_warnings=True)
     test_data = {'p_latent': torch.tensor([0.2, 0.6])}
     assert_close(pickle.loads(pickle.dumps(potential_fn))(test_data), potential_fn(test_data))
+
+
+@pytest.mark.parametrize("kernel, kwargs", [
+    (HMC, {"adapt_step_size": True, "num_steps": 3}),
+    (NUTS, {"adapt_step_size": True}),
+])
+def test_reparam_stable(kernel, kwargs):
+
+    @poutine.reparam(config={"z": StableReparameterizer()})
+    def model():
+        stability = pyro.sample("stability", dist.Uniform(0., 2.))
+        skew = pyro.sample("skew", dist.Uniform(-1., 1.))
+        y = pyro.sample("z", dist.Stable(stability, skew))
+        pyro.sample("x", dist.Poisson(y.abs()), obs=torch.tensor(1.))
+
+    mcmc_kernel = kernel(model, max_plate_nesting=0, **kwargs)
+    assert_ok(mcmc_kernel)

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -736,7 +736,7 @@ def test_reparam_stable():
         with pyro.plate("time2", len(data)):
             y = pyro.sample("y", dist.Stable(stability, obs_skew, scale, z),
                             infer={"reparam": StableReparameterizer()})
-            pyro.sample("z", dist.Poisson(y.abs()), obs=data)
+            pyro.sample("x", dist.Poisson(y.abs()), obs=data)
 
     guide = AutoDelta(model)
     svi = SVI(model, guide, optim.Adam({"lr": 0.01}), Trace_ELBO())


### PR DESCRIPTION
Addresses #2221 

This adds a `poutine.reparam` that transforms a sample site (based on `site["fn"]`) into one or more auxiliary sample sites followed by a deterministic transformation. This generalizes [(Gorinova et al. 2019)](https://arxiv.org/pdf/1906.03028.pdf) by allowing multiple "overparameterized" sample sites for auxiliary variable methods.

The main motivation for this PR is to support [Stable](http://docs.pyro.ai/en/stable/distributions.html#stable) distributions in variational inference. Although `Stable.log_prob()` is undefined, the distribution can be reparameterized to a pair of auxiliary variables with defined `.log_prob()`; thus `poutine.reparam` can make a stable model tractable.

I have designed to allow custom `Reparameterizer` instances to be set per-site, either manually or via `@infer_config`. This PR implements only `LocScaleReparameterizer` and `StableReparameterizer`. 

Note the `Reparameterizer` class restricts the dependency structure, disallowing one auxiliary variable to depend on another. In principle we could replace a `pyro.sample` site with an arbitrary probabilistic program (and the proposed `pyro.reparam()` interface could be adapted to this general case via an `isinstance(-,Reparameterizer)` check). One advantage of an opinionated `Reparameterizer` class is that if forces separation of concerns between `pyro.distributions` and `pyro.poutine`: no pyro primitives need be used in `Reparameterizer` implementations.

## Tested
- [x] test `TrivialReparameterizer`
- [x] test `LocScaleReparameterizer`
- [x] test `StableReparameterizer`
- [x] smoke test for `Stable` inference with autoguides
- [x] test SVI in tests/infer/test_valid_models.py
- [x] test MHC and NUTS in tests/infer/mcmc/test_valid_models.py
- [x] ensure `StableReparameterizer` is continuous

See generated [docs](http://fritzo.org/temp/pyro/html/distributions.html#reparameterizers)