### PR TITLE
Pyro enum bugfix [WIP]

### DIFF
--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -98,7 +98,7 @@ def _compute_model_factors(model_trace, guide_trace):
         if site["type"] == "sample":
             if name in guide_trace.nodes:
                 cost_sites.setdefault(ordering[name], []).append(site)
-                non_enum_dims.update(site["packed"]["log_prob"]._pyro_dims)
+                non_enum_dims.update(guide_trace.nodes[name]["packed"]["log_prob"]._pyro_dims)
             elif site["infer"].get("_enumerate_dim") is None:
                 cost_sites.setdefault(ordering[name], []).append(site)
             else:

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -143,11 +143,11 @@ class Fixture(object):
 def tensor_wrap(*args, **kwargs):
     tensor_list, tensor_map = [], {}
     for arg in args:
-        wrapped_arg = torch.tensor(arg) if (isinstance(arg, list) or isinstance(arg, float)) else arg
+        wrapped_arg = torch.tensor(arg) if isinstance(arg, list) else arg
         tensor_list.append(wrapped_arg)
     for k in kwargs:
         kwarg = kwargs[k]
-        wrapped_kwarg = torch.tensor(kwarg) if (isinstance(kwarg, list) or isinstance(kwarg, float)) else kwarg
+        wrapped_kwarg = torch.tensor(kwarg) if isinstance(kwarg, list) else kwarg
         tensor_map[k] = wrapped_kwarg
     if args and not kwargs:
         return tensor_list

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -143,11 +143,11 @@ class Fixture(object):
 def tensor_wrap(*args, **kwargs):
     tensor_list, tensor_map = [], {}
     for arg in args:
-        wrapped_arg = torch.tensor(arg) if isinstance(arg, list) else arg
+        wrapped_arg = torch.tensor(arg) if (isinstance(arg, list) or isinstance(arg, float)) else arg
         tensor_list.append(wrapped_arg)
     for k in kwargs:
         kwarg = kwargs[k]
-        wrapped_kwarg = torch.tensor(kwarg) if isinstance(kwarg, list) else kwarg
+        wrapped_kwarg = torch.tensor(kwarg) if (isinstance(kwarg, list) or isinstance(kwarg, float)) else kwarg
         tensor_map[k] = wrapped_kwarg
     if args and not kwargs:
         return tensor_list

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -3260,9 +3260,9 @@ def test_multi_dependence_enumeration():
     """
     K = 5
     d = 2
-    N_obs = 100
+    N_obs = 3
 
-    @infer.config_enumerate
+    @config_enumerate
     def model(N=1):
         with pyro.plate('data_plate', N, dim=-2):
             mixing_weights = pyro.param('pi', torch.ones(K) / K, constraint=constraints.simplex)

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -3253,8 +3253,8 @@ def test_vectorized_importance(num_samples):
 
 def test_multi_dependence_enumeration():
     """
-    This test verifes whether enumeration works correctly in the case where multiple downstream
-    variables are coupled to the same random discrite variable.
+    This test checks whether enumeration works correctly in the case where multiple downstream
+    variables are coupled to the same random discrete variable.
     This is based on [issue 2223](https://github.com/pyro-ppl/pyro/issues/2223), and should
     pass when it has been resolved
     """


### PR DESCRIPTION
As suggested [here](https://github.com/pyro-ppl/pyro/issues/2223#issuecomment-565234047), this pull request adds a failing test which reproduces #2223. It currently makes no attempt to fix the issue, but should hopefully be useful when debugging.

If anything needs cleaning up please let me know. Help is appreciated - I'm not very familiar with the low level mechanics of the enumeration code atm.

I also found that the test for the multivariate student T was failing on cuda because it parameterises df as a float rather than a tensor, and then the samples inherit the device of df. The first commit here fixes this test by changing tensor_wrap to also wrap floats, sending these to cuda if wrapped in a tensors_default_to context. I squashed this here because it came up first when I was trying to hit my failing test.