### PR TITLE
Small typo in unused function in tutorial

### DIFF
--- a/tutorial/source/intro_part_ii.ipynb
+++ b/tutorial/source/intro_part_ii.ipynb
@@ -106,7 +106,7 @@
     "def scale_obs(guess):  # equivalent to conditioned_scale above\n",
     "    weight = pyro.sample(\"weight\", dist.Normal(guess, 1.))\n",
     "     # here we condition on measurement == 9.5\n",
-    "    return pyro.sample(\"measurement\", dist.Normal(weight, 1.), obs=9.5)"
+    "    return pyro.sample(\"measurement\", dist.Normal(weight, 0.75), obs=9.5)"
    ]
   },
   {


### PR DESCRIPTION
The second part of the basic tutorial [An Introduction to Inference in Pyro](http://pyro.ai/examples/intro_part_ii.html) shows how to condition on an observation in different ways. The first example `conditioned_scale` is used for the remainder of the tutorial, and a function `scale_obs(guess)` is defined to show an equivalent way of doing the conditioning. In order for this function to be equivalent, the standard deviation for one `dist.Normal()` call needs to be updated to match the value used in `scale(guess)`.

The function `scale_obs(guess)` changed by this is not used afterwards in the tutorial, so this changes no functionality.