### PR TITLE
Fix autoguide latent unpacking with batched latent samples

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -26,7 +26,7 @@ import pyro
 import pyro.distributions as dist
 import pyro.distributions.transforms as transforms
 import pyro.poutine as poutine
-from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
+from pyro.distributions.util import eye_like, sum_rightmost
 from pyro.infer.autoguide.initialization import InitMessenger, init_to_median
 from pyro.infer.autoguide.utils import _product
 from pyro.infer.enum import config_enumerate

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -421,13 +421,9 @@ class AutoContinuous(AutoGuide):
         batch_shape = latent.shape[:-1]  # for plates outside of _setup_prototype, e.g. parallel particles
         pos = 0
         for name, site in self.prototype_trace.iter_stochastic_nodes():
-            constrained_shape = site["value"].shape
             unconstrained_shape = self._unconstrained_shapes[name]
             size = _product(unconstrained_shape)
-            event_dim = site["fn"].event_dim + len(unconstrained_shape) - len(constrained_shape)
-            unconstrained_shape = broadcast_shape(unconstrained_shape,
-                                                  batch_shape + (1,) * event_dim)
-            unconstrained_value = latent[..., pos:pos + size].view(unconstrained_shape)
+            unconstrained_value = latent[..., pos:pos + size].view(batch_shape + unconstrained_shape)
             yield site, unconstrained_value
             pos += size
         if not torch._C._get_tracing_state():


### PR DESCRIPTION
This fixes an issue with autoguide `_unpack_latent` method where unpacking might not work with batching. Needed for Neutra reparametrizer in #2235.