### PR TITLE
Switch from pillow to pillow-simd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'graphviz>=0.8',
     'matplotlib>=1.3',
-    'pillow',
+    'pillow-simd',
     'torchvision>=0.4.0',
     'visdom>=0.1.4',
     'pandas',


### PR DESCRIPTION
This attempts to fix some `pillow`-`torchvision` breakage blocking #2239 by switching to the alternative torchvision-recommended library `pillow-simd`.