### PR TITLE
Expose pyro.ops.tensor_utils in docs

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -34,6 +34,15 @@ Newton Optimizers
     :show-inheritance:
     :member-order: bysource
 
+Tensor Utilities
+----------------
+
+.. automodule:: pyro.ops.tensor_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 Tensor Indexing
 ---------------
 


### PR DESCRIPTION
@martinjankowiak is it ok if we make these public (and freeze the interfaces)? I find myself using `pyro.ops.tensor_utils.convolve` quite often for smoothing and visualization.