### PR TITLE
Switch to Apache 2.0 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,23 +1,202 @@
-Pyro PPL
 
-Copyright (c) 2017-2018
-Uber Technologies, Inc.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 An implementation of the model described in [1].
 

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 AIR applied to the multi-mnist data set [1].
 

--- a/examples/air/modules.py
+++ b/examples/air/modules.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/air/modules.py
+++ b/examples/air/modules.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/air/modules.py
+++ b/examples/air/modules.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 from torch.nn.functional import softplus

--- a/examples/air/viz.py
+++ b/examples/air/viz.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/examples/air/viz.py
+++ b/examples/air/viz.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/examples/air/viz.py
+++ b/examples/air/viz.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 from collections import namedtuple
 

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import logging
 import math

--- a/examples/capture_recapture/cjs.py
+++ b/examples/capture_recapture/cjs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/capture_recapture/cjs.py
+++ b/examples/capture_recapture/cjs.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/capture_recapture/cjs.py
+++ b/examples/capture_recapture/cjs.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 We show how to implement several variants of the Cormack-Jolly-Seber (CJS)
 [4, 5, 6] model used in ecology to analyze animal capture-recapture data.

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import torch

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import torch
 from torch.distributions import constraints

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import torch

--- a/examples/contrib/cevae/synthetic.py
+++ b/examples/contrib/cevae/synthetic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/contrib/cevae/synthetic.py
+++ b/examples/contrib/cevae/synthetic.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/contrib/cevae/synthetic.py
+++ b/examples/contrib/cevae/synthetic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This example demonstrates how to use the Causal Effect Variational Autoencoder
 [1] implemented in pyro.contrib.cevae.CEVAE, documented at

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 An example to use Pyro Gaussian Process module to classify MNIST and binary MNIST.
 

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from functools import partial
 import torch

--- a/examples/contrib/oed/gp_bayes_opt.py
+++ b/examples/contrib/oed/gp_bayes_opt.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/contrib/oed/gp_bayes_opt.py
+++ b/examples/contrib/oed/gp_bayes_opt.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.autograd as autograd
 import torch.optim as optim

--- a/examples/contrib/oed/gp_bayes_opt.py
+++ b/examples/contrib/oed/gp_bayes_opt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/contrib/timeseries/gp_models.py
+++ b/examples/contrib/timeseries/gp_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/examples/contrib/timeseries/gp_models.py
+++ b/examples/contrib/timeseries/gp_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/examples/contrib/timeseries/gp_models.py
+++ b/examples/contrib/timeseries/gp_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 An implementation of a Deep Markov Model in Pyro based on reference [1].
 This is essentially the DKS variant outlined in the paper. The primary difference

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/dmm/polyphonic_data_loader.py
+++ b/examples/dmm/polyphonic_data_loader.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Data loader logic with two main responsibilities:
 (i)  download raw data and process; this logic is initiated upon import

--- a/examples/dmm/util.py
+++ b/examples/dmm/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/examples/dmm/util.py
+++ b/examples/dmm/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/examples/dmm/util.py
+++ b/examples/dmm/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 

--- a/examples/eight_schools/data.py
+++ b/examples/eight_schools/data.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/eight_schools/data.py
+++ b/examples/eight_schools/data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/eight_schools/data.py
+++ b/examples/eight_schools/data.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import logging
 

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import logging
 

--- a/examples/einsum.py
+++ b/examples/einsum.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/einsum.py
+++ b/examples/einsum.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/einsum.py
+++ b/examples/einsum.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This example demonstrates how to use plated ``einsum`` with different backends
 to compute logprob, gradients, MAP estimates, posterior samples, and marginals.

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This example shows how to marginalize out discrete model variables in Pyro.
 

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 
 import argparse

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This example implements amortized Latent Dirichlet Allocation [1],
 demonstrating how to marginalize out discrete assignment variables in a Pyro

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import torch
 

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This example demonstrates the functionality of `pyro.contrib.minipyro`,
 which is a minimal implementation of the Pyro Probabilistic Programming

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import os
 import json

--- a/examples/mixed_hmm/model.py
+++ b/examples/mixed_hmm/model.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/mixed_hmm/model.py
+++ b/examples/mixed_hmm/model.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/examples/mixed_hmm/model.py
+++ b/examples/mixed_hmm/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from urllib.request import urlopen
 

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Interpreting generic statements with RSA models of pragmatics.
 

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Interpreting hyperbole with RSA models of pragmatics.
 

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Schelling coordination game:
 Two spies, Alice and Bob, want to meet.

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Schelling coordination game with false belief:
 Two spies, Alice and Bob, claim to want to meet.

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Inference algorithms and utilities used in the RSA example models.
 

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Combining models of RSA pragmatics and CCG-based compositional semantics.
 

--- a/examples/smcfilter.py
+++ b/examples/smcfilter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/smcfilter.py
+++ b/examples/smcfilter.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/smcfilter.py
+++ b/examples/smcfilter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import logging
 

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 # This is an implementation of the sparse gamma deep exponential family model described in

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This is an implementation of the sparse gamma deep exponential family model described in

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 # This is an implementation of the sparse gamma deep exponential family model described in
 # Ranganath, Rajesh, Tang, Linpeng, Charlin, Laurent, and Blei, David. Deep exponential families.
 #

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import numpy as np

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import torch

--- a/examples/vae/utils/custom_mlp.py
+++ b/examples/vae/utils/custom_mlp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from inspect import isclass

--- a/examples/vae/utils/custom_mlp.py
+++ b/examples/vae/utils/custom_mlp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from inspect import isclass

--- a/examples/vae/utils/custom_mlp.py
+++ b/examples/vae/utils/custom_mlp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from inspect import isclass
 
 import torch

--- a/examples/vae/utils/mnist_cached.py
+++ b/examples/vae/utils/mnist_cached.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import errno

--- a/examples/vae/utils/mnist_cached.py
+++ b/examples/vae/utils/mnist_cached.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import errno

--- a/examples/vae/utils/mnist_cached.py
+++ b/examples/vae/utils/mnist_cached.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import errno
 import os
 from functools import reduce

--- a/examples/vae/utils/vae_plots.py
+++ b/examples/vae/utils/vae_plots.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/vae/utils/vae_plots.py
+++ b/examples/vae/utils/vae_plots.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/examples/vae/utils/vae_plots.py
+++ b/examples/vae/utils/vae_plots.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import numpy as np

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import itertools
 import os

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import torch

--- a/profiler/hmm.py
+++ b/profiler/hmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/profiler/hmm.py
+++ b/profiler/hmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/profiler/hmm.py
+++ b/profiler/hmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import os
 import pickle

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import cProfile

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import cProfile

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import cProfile
 from io import StringIO
 import functools

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pyro.poutine as poutine
 from pyro.logger import log
 from pyro.poutine import condition, do, markov

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.poutine as poutine

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.poutine as poutine

--- a/pyro/contrib/__init__.py
+++ b/pyro/contrib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 r"""

--- a/pyro/contrib/__init__.py
+++ b/pyro/contrib/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 r"""
 Contributed Code
 ================

--- a/pyro/contrib/__init__.py
+++ b/pyro/contrib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 r"""

--- a/pyro/contrib/autoguide.py
+++ b/pyro/contrib/autoguide.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/contrib/autoguide.py
+++ b/pyro/contrib/autoguide.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/contrib/autoguide.py
+++ b/pyro/contrib/autoguide.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 from pyro.infer.autoguide import *  # noqa F403

--- a/pyro/contrib/autoname/__init__.py
+++ b/pyro/contrib/autoname/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/autoname/__init__.py
+++ b/pyro/contrib/autoname/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/autoname/__init__.py
+++ b/pyro/contrib/autoname/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The :mod:`pyro.contrib.autoname` module provides tools for automatically
 generating unique, semantically meaningful names for sample sites.

--- a/pyro/contrib/autoname/named.py
+++ b/pyro/contrib/autoname/named.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/autoname/named.py
+++ b/pyro/contrib/autoname/named.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/autoname/named.py
+++ b/pyro/contrib/autoname/named.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The ``pyro.contrib.named`` module is a thin syntactic layer on top of Pyro.  It
 allows Pyro models to be written to look like programs with operating on Python

--- a/pyro/contrib/autoname/scoping.py
+++ b/pyro/contrib/autoname/scoping.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/autoname/scoping.py
+++ b/pyro/contrib/autoname/scoping.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/autoname/scoping.py
+++ b/pyro/contrib/autoname/scoping.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 ``pyro.contrib.autoname.scoping`` contains the implementation of
 :func:`pyro.contrib.autoname.scope`, a tool for automatically appending

--- a/pyro/contrib/bnn/__init__.py
+++ b/pyro/contrib/bnn/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.bnn.hidden_layer import HiddenLayer
 
 __all__ = [

--- a/pyro/contrib/bnn/__init__.py
+++ b/pyro/contrib/bnn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.bnn.hidden_layer import HiddenLayer

--- a/pyro/contrib/bnn/__init__.py
+++ b/pyro/contrib/bnn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.bnn.hidden_layer import HiddenLayer

--- a/pyro/contrib/bnn/hidden_layer.py
+++ b/pyro/contrib/bnn/hidden_layer.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/bnn/hidden_layer.py
+++ b/pyro/contrib/bnn/hidden_layer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/bnn/hidden_layer.py
+++ b/pyro/contrib/bnn/hidden_layer.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 import torch
 from torch.distributions.utils import lazy_property

--- a/pyro/contrib/bnn/utils.py
+++ b/pyro/contrib/bnn/utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/bnn/utils.py
+++ b/pyro/contrib/bnn/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import math
 

--- a/pyro/contrib/bnn/utils.py
+++ b/pyro/contrib/bnn/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/cevae/__init__.py
+++ b/pyro/contrib/cevae/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/cevae/__init__.py
+++ b/pyro/contrib/cevae/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/cevae/__init__.py
+++ b/pyro/contrib/cevae/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This module implements the Causal Effect Variational Autoencoder [1], which
 demonstrates a number of innovations including:

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import defaultdict
 
 import torch

--- a/pyro/contrib/easyguide/__init__.py
+++ b/pyro/contrib/easyguide/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.easyguide.easyguide import EasyGuide, easy_guide

--- a/pyro/contrib/easyguide/__init__.py
+++ b/pyro/contrib/easyguide/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.easyguide.easyguide import EasyGuide, easy_guide

--- a/pyro/contrib/easyguide/__init__.py
+++ b/pyro/contrib/easyguide/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.easyguide.easyguide import EasyGuide, easy_guide
 
 

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 import weakref
 from abc import ABCMeta, abstractmethod

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/pyro/contrib/examples/bart.py
+++ b/pyro/contrib/examples/bart.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/pyro/contrib/examples/bart.py
+++ b/pyro/contrib/examples/bart.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/pyro/contrib/examples/bart.py
+++ b/pyro/contrib/examples/bart.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import csv
 import datetime

--- a/pyro/contrib/examples/multi_mnist.py
+++ b/pyro/contrib/examples/multi_mnist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/examples/multi_mnist.py
+++ b/pyro/contrib/examples/multi_mnist.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/examples/multi_mnist.py
+++ b/pyro/contrib/examples/multi_mnist.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This script generates a dataset similar to the Multi-MNIST dataset
 described in [1].

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp import kernels, likelihoods, models, parameterized, util

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp import kernels, likelihoods, models, parameterized, util

--- a/pyro/contrib/gp/__init__.py
+++ b/pyro/contrib/gp/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.gp import kernels, likelihoods, models, parameterized, util
 from pyro.contrib.gp.parameterized import Parameterized
 

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.kernels.brownian import Brownian

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.kernels.brownian import Brownian

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.gp.kernels.brownian import Brownian
 from pyro.contrib.gp.kernels.coregionalize import Coregionalize
 from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial

--- a/pyro/contrib/gp/kernels/brownian.py
+++ b/pyro/contrib/gp/kernels/brownian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/brownian.py
+++ b/pyro/contrib/gp/kernels/brownian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/gp/kernels/brownian.py
+++ b/pyro/contrib/gp/kernels/brownian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/coregionalize.py
+++ b/pyro/contrib/gp/kernels/coregionalize.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/kernels/dot_product.py
+++ b/pyro/contrib/gp/kernels/dot_product.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/dot_product.py
+++ b/pyro/contrib/gp/kernels/dot_product.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/gp/kernels/dot_product.py
+++ b/pyro/contrib/gp/kernels/dot_product.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/isotropic.py
+++ b/pyro/contrib/gp/kernels/isotropic.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/isotropic.py
+++ b/pyro/contrib/gp/kernels/isotropic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/gp/kernels/isotropic.py
+++ b/pyro/contrib/gp/kernels/isotropic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 
 from pyro.contrib.gp.parameterized import Parameterized

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/contrib/gp/kernels/periodic.py
+++ b/pyro/contrib/gp/kernels/periodic.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/contrib/gp/kernels/periodic.py
+++ b/pyro/contrib/gp/kernels/periodic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/contrib/gp/kernels/periodic.py
+++ b/pyro/contrib/gp/kernels/periodic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/contrib/gp/kernels/static.py
+++ b/pyro/contrib/gp/kernels/static.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/kernels/static.py
+++ b/pyro/contrib/gp/kernels/static.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/gp/kernels/static.py
+++ b/pyro/contrib/gp/kernels/static.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.likelihoods.binary import Binary

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.likelihoods.binary import Binary

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.gp.likelihoods.binary import Binary
 from pyro.contrib.gp.likelihoods.gaussian import Gaussian
 from pyro.contrib.gp.likelihoods.likelihood import Likelihood

--- a/pyro/contrib/gp/likelihoods/binary.py
+++ b/pyro/contrib/gp/likelihoods/binary.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/likelihoods/binary.py
+++ b/pyro/contrib/gp/likelihoods/binary.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro

--- a/pyro/contrib/gp/likelihoods/binary.py
+++ b/pyro/contrib/gp/likelihoods/binary.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/likelihoods/gaussian.py
+++ b/pyro/contrib/gp/likelihoods/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/likelihoods/gaussian.py
+++ b/pyro/contrib/gp/likelihoods/gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/gp/likelihoods/gaussian.py
+++ b/pyro/contrib/gp/likelihoods/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/likelihoods/likelihood.py
+++ b/pyro/contrib/gp/likelihoods/likelihood.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.parameterized import Parameterized

--- a/pyro/contrib/gp/likelihoods/likelihood.py
+++ b/pyro/contrib/gp/likelihoods/likelihood.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.parameterized import Parameterized

--- a/pyro/contrib/gp/likelihoods/likelihood.py
+++ b/pyro/contrib/gp/likelihoods/likelihood.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.gp.parameterized import Parameterized
 
 

--- a/pyro/contrib/gp/likelihoods/multi_class.py
+++ b/pyro/contrib/gp/likelihoods/multi_class.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn.functional as F

--- a/pyro/contrib/gp/likelihoods/multi_class.py
+++ b/pyro/contrib/gp/likelihoods/multi_class.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch.nn.functional as F
 
 import pyro

--- a/pyro/contrib/gp/likelihoods/multi_class.py
+++ b/pyro/contrib/gp/likelihoods/multi_class.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn.functional as F

--- a/pyro/contrib/gp/likelihoods/poisson.py
+++ b/pyro/contrib/gp/likelihoods/poisson.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/likelihoods/poisson.py
+++ b/pyro/contrib/gp/likelihoods/poisson.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro

--- a/pyro/contrib/gp/likelihoods/poisson.py
+++ b/pyro/contrib/gp/likelihoods/poisson.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/__init__.py
+++ b/pyro/contrib/gp/models/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.gp.models.gplvm import GPLVM
 from pyro.contrib.gp.models.gpr import GPRegression
 from pyro.contrib.gp.models.model import GPModel

--- a/pyro/contrib/gp/models/__init__.py
+++ b/pyro/contrib/gp/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.models.gplvm import GPLVM

--- a/pyro/contrib/gp/models/__init__.py
+++ b/pyro/contrib/gp/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.models.gplvm import GPLVM

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pyro.distributions as dist
 from pyro.contrib.gp.parameterized import Parameterized
 from pyro.nn.module import PyroSample, pyro_method

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions as dist

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions as dist

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.distributions as torchdist
 from torch.distributions import constraints

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.parameterized import Parameterized

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.gp.parameterized import Parameterized

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.gp.parameterized import Parameterized
 
 

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/pyro/contrib/gp/parameterized.py
+++ b/pyro/contrib/gp/parameterized.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/contrib/gp/parameterized.py
+++ b/pyro/contrib/gp/parameterized.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/contrib/gp/parameterized.py
+++ b/pyro/contrib/gp/parameterized.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 from collections import OrderedDict
 from functools import partial

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.infer import TraceMeanField_ELBO

--- a/pyro/contrib/gp/util.py
+++ b/pyro/contrib/gp/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Mini Pyro
 ---------

--- a/pyro/contrib/oed/__init__.py
+++ b/pyro/contrib/oed/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tasks such as choosing the next question to ask in a psychology study, designing an election polling

--- a/pyro/contrib/oed/__init__.py
+++ b/pyro/contrib/oed/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tasks such as choosing the next question to ask in a psychology study, designing an election polling
 strategy, and deciding which compounds to synthesize and test in biological sciences are all fundamentally asking the
 same question: how do we design an experiment to maximize the information gathered?  Pyro is designed to support

--- a/pyro/contrib/oed/__init__.py
+++ b/pyro/contrib/oed/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """Tasks such as choosing the next question to ask in a psychology study, designing an election polling

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import math
 import warnings

--- a/pyro/contrib/oed/glmm/__init__.py
+++ b/pyro/contrib/oed/glmm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/oed/glmm/__init__.py
+++ b/pyro/contrib/oed/glmm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/oed/glmm/__init__.py
+++ b/pyro/contrib/oed/glmm/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 .. warning :: This module will eventually be deprecated in favor of `brmp <https://github.com/pyro-ppl/brmp/>`_
 

--- a/pyro/contrib/oed/glmm/glmm.py
+++ b/pyro/contrib/oed/glmm/glmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/contrib/oed/glmm/glmm.py
+++ b/pyro/contrib/oed/glmm/glmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/contrib/oed/glmm/glmm.py
+++ b/pyro/contrib/oed/glmm/glmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 from collections import OrderedDict
 from functools import partial

--- a/pyro/contrib/oed/glmm/guides.py
+++ b/pyro/contrib/oed/glmm/guides.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch import nn
 

--- a/pyro/contrib/oed/glmm/guides.py
+++ b/pyro/contrib/oed/glmm/guides.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/oed/glmm/guides.py
+++ b/pyro/contrib/oed/glmm/guides.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/oed/search.py
+++ b/pyro/contrib/oed/search.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import queue

--- a/pyro/contrib/oed/search.py
+++ b/pyro/contrib/oed/search.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import queue

--- a/pyro/contrib/oed/search.py
+++ b/pyro/contrib/oed/search.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import queue
 from pyro.infer.abstract_infer import TracePosterior
 import pyro.poutine as poutine

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import torch
 

--- a/pyro/contrib/timeseries/__init__.py
+++ b/pyro/contrib/timeseries/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/timeseries/__init__.py
+++ b/pyro/contrib/timeseries/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/contrib/timeseries/__init__.py
+++ b/pyro/contrib/timeseries/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The :mod:`pyro.contrib.timeseries` module provides a collection of Bayesian time series
 models useful for forecasting applications.

--- a/pyro/contrib/timeseries/base.py
+++ b/pyro/contrib/timeseries/base.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.nn import PyroModule, pyro_method
 
 

--- a/pyro/contrib/timeseries/base.py
+++ b/pyro/contrib/timeseries/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.nn import PyroModule, pyro_method

--- a/pyro/contrib/timeseries/base.py
+++ b/pyro/contrib/timeseries/base.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.nn import PyroModule, pyro_method

--- a/pyro/contrib/timeseries/gp.py
+++ b/pyro/contrib/timeseries/gp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/contrib/timeseries/gp.py
+++ b/pyro/contrib/timeseries/gp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/contrib/timeseries/gp.py
+++ b/pyro/contrib/timeseries/gp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/contrib/timeseries/lgssm.py
+++ b/pyro/contrib/timeseries/lgssm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/timeseries/lgssm.py
+++ b/pyro/contrib/timeseries/lgssm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/timeseries/lgssm.py
+++ b/pyro/contrib/timeseries/lgssm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 from torch.distributions import MultivariateNormal, constraints

--- a/pyro/contrib/timeseries/lgssmgp.py
+++ b/pyro/contrib/timeseries/lgssmgp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/timeseries/lgssmgp.py
+++ b/pyro/contrib/timeseries/lgssmgp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/timeseries/lgssmgp.py
+++ b/pyro/contrib/timeseries/lgssmgp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 from torch.distributions import MultivariateNormal, constraints

--- a/pyro/contrib/tracking/__init__.py
+++ b/pyro/contrib/tracking/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.tracking import assignment

--- a/pyro/contrib/tracking/__init__.py
+++ b/pyro/contrib/tracking/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.contrib.tracking import assignment

--- a/pyro/contrib/tracking/__init__.py
+++ b/pyro/contrib/tracking/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.contrib.tracking import assignment
 
 __all__ = [

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import math
 import numbers

--- a/pyro/contrib/tracking/assignment.py
+++ b/pyro/contrib/tracking/assignment.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/tracking/dynamic_models.py
+++ b/pyro/contrib/tracking/dynamic_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/contrib/tracking/dynamic_models.py
+++ b/pyro/contrib/tracking/dynamic_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/contrib/tracking/dynamic_models.py
+++ b/pyro/contrib/tracking/dynamic_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABCMeta, abstractmethod
 
 import torch

--- a/pyro/contrib/tracking/extended_kalman_filter.py
+++ b/pyro/contrib/tracking/extended_kalman_filter.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/tracking/extended_kalman_filter.py
+++ b/pyro/contrib/tracking/extended_kalman_filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/contrib/tracking/extended_kalman_filter.py
+++ b/pyro/contrib/tracking/extended_kalman_filter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions.utils import lazy_property
 

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import heapq

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import heapq
 import itertools
 from collections import defaultdict

--- a/pyro/contrib/tracking/hashing.py
+++ b/pyro/contrib/tracking/hashing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import heapq

--- a/pyro/contrib/tracking/measurements.py
+++ b/pyro/contrib/tracking/measurements.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/contrib/tracking/measurements.py
+++ b/pyro/contrib/tracking/measurements.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/contrib/tracking/measurements.py
+++ b/pyro/contrib/tracking/measurements.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABCMeta, abstractmethod
 
 import torch

--- a/pyro/contrib/util.py
+++ b/pyro/contrib/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import OrderedDict
 import torch
 import pyro

--- a/pyro/contrib/util.py
+++ b/pyro/contrib/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict

--- a/pyro/contrib/util.py
+++ b/pyro/contrib/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions.torch_patch  # noqa F403

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pyro.distributions.torch_patch  # noqa F403
 from pyro.distributions.avf_mvn import AVFMultivariateNormal
 from pyro.distributions.conditional import (ConditionalDistribution, ConditionalTransform,

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions.torch_patch  # noqa F403

--- a/pyro/distributions/avf_mvn.py
+++ b/pyro/distributions/avf_mvn.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/avf_mvn.py
+++ b/pyro/distributions/avf_mvn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/avf_mvn.py
+++ b/pyro/distributions/avf_mvn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 
 import torch

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 
 import torch

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from torch.distributions.constraints import *  # noqa F403
 from torch.distributions.constraints import Constraint
 from torch.distributions.constraints import __all__ as torch_constraints

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions.constraints import *  # noqa F403

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions.constraints import *  # noqa F403

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 
 import torch

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 import math
 

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABCMeta, abstractmethod
 
 from pyro.distributions.score_parts import ScoreParts

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/empirical.py
+++ b/pyro/distributions/empirical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/folded.py
+++ b/pyro/distributions/folded.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import constraints

--- a/pyro/distributions/folded.py
+++ b/pyro/distributions/folded.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import constraints

--- a/pyro/distributions/folded.py
+++ b/pyro/distributions/folded.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from torch.distributions import constraints
 from torch.distributions.transforms import AbsTransform
 

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 import math
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property

--- a/pyro/distributions/inverse_gamma.py
+++ b/pyro/distributions/inverse_gamma.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import constraints

--- a/pyro/distributions/inverse_gamma.py
+++ b/pyro/distributions/inverse_gamma.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import constraints

--- a/pyro/distributions/inverse_gamma.py
+++ b/pyro/distributions/inverse_gamma.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from torch.distributions import constraints
 from torch.distributions.transforms import PowerTransform
 from pyro.distributions.torch import Gamma, TransformedDistribution

--- a/pyro/distributions/kl.py
+++ b/pyro/distributions/kl.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/kl.py
+++ b/pyro/distributions/kl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/kl.py
+++ b/pyro/distributions/kl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 from torch.distributions import TransformedDistribution, kl_divergence, register_kl

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import lazy_property

--- a/pyro/distributions/multivariate_studentt.py
+++ b/pyro/distributions/multivariate_studentt.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/multivariate_studentt.py
+++ b/pyro/distributions/multivariate_studentt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/multivariate_studentt.py
+++ b/pyro/distributions/multivariate_studentt.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable

--- a/pyro/distributions/rejector.py
+++ b/pyro/distributions/rejector.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/rejector.py
+++ b/pyro/distributions/rejector.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions.score_parts import ScoreParts

--- a/pyro/distributions/rejector.py
+++ b/pyro/distributions/rejector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/relaxed_straight_through.py
+++ b/pyro/distributions/relaxed_straight_through.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/relaxed_straight_through.py
+++ b/pyro/distributions/relaxed_straight_through.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/relaxed_straight_through.py
+++ b/pyro/distributions/relaxed_straight_through.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions.torch import RelaxedOneHotCategorical, RelaxedBernoulli

--- a/pyro/distributions/score_parts.py
+++ b/pyro/distributions/score_parts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/pyro/distributions/score_parts.py
+++ b/pyro/distributions/score_parts.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/pyro/distributions/score_parts.py
+++ b/pyro/distributions/score_parts.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import namedtuple
 
 from pyro.distributions.util import scale_and_mask

--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Contributors to the Pyro project.
+// Copyright Contributors to the Pyro project.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cmath>

--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2017-2020 Contributors to the Pyro project.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <cmath>
 #include <vector>
 #include <unordered_set>

--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -1,4 +1,4 @@
-// Copyright Contributors to the Pyro project.
+// Copyright Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cmath>

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import math
 

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/testing/__init__.py
+++ b/pyro/distributions/testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/distributions/testing/__init__.py
+++ b/pyro/distributions/testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/distributions/testing/__init__.py
+++ b/pyro/distributions/testing/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This module contains distributions that are useful for testing new Pyro
 inference algorithms.

--- a/pyro/distributions/testing/fakes.py
+++ b/pyro/distributions/testing/fakes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.distributions.torch import Beta, Dirichlet, Gamma, Normal

--- a/pyro/distributions/testing/fakes.py
+++ b/pyro/distributions/testing/fakes.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.distributions.torch import Beta, Dirichlet, Gamma, Normal

--- a/pyro/distributions/testing/fakes.py
+++ b/pyro/distributions/testing/fakes.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.distributions.torch import Beta, Dirichlet, Gamma, Normal
 
 

--- a/pyro/distributions/testing/naive_dirichlet.py
+++ b/pyro/distributions/testing/naive_dirichlet.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/testing/naive_dirichlet.py
+++ b/pyro/distributions/testing/naive_dirichlet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/testing/naive_dirichlet.py
+++ b/pyro/distributions/testing/naive_dirichlet.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions.torch import Beta, Dirichlet, Gamma

--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/testing/rejection_exponential.py
+++ b/pyro/distributions/testing/rejection_exponential.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions.utils import broadcast_all
 

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions.rejector import Rejector

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 from collections import OrderedDict
 

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 import weakref
 

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import biject_to, transform_to

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from torch.distributions import biject_to, transform_to
 from torch.distributions.transforms import *  # noqa F403
 from torch.distributions.transforms import __all__ as torch_transforms

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import biject_to, transform_to

--- a/pyro/distributions/transforms/affine_autoregressive.py
+++ b/pyro/distributions/transforms/affine_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/affine_autoregressive.py
+++ b/pyro/distributions/transforms/affine_autoregressive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/affine_autoregressive.py
+++ b/pyro/distributions/transforms/affine_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/affine_coupling.py
+++ b/pyro/distributions/transforms/affine_coupling.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/affine_coupling.py
+++ b/pyro/distributions/transforms/affine_coupling.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/transforms/affine_coupling.py
+++ b/pyro/distributions/transforms/affine_coupling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/batchnorm.py
+++ b/pyro/distributions/transforms/batchnorm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/batchnorm.py
+++ b/pyro/distributions/transforms/batchnorm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/batchnorm.py
+++ b/pyro/distributions/transforms/batchnorm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/block_autoregressive.py
+++ b/pyro/distributions/transforms/block_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This implementation is adapted in part from https://github.com/nicola-decao/BNAF under the MIT license.

--- a/pyro/distributions/transforms/block_autoregressive.py
+++ b/pyro/distributions/transforms/block_autoregressive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 # This implementation is adapted in part from https://github.com/nicola-decao/BNAF under the MIT license.
 import math
 

--- a/pyro/distributions/transforms/block_autoregressive.py
+++ b/pyro/distributions/transforms/block_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 # This implementation is adapted in part from https://github.com/nicola-decao/BNAF under the MIT license.

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import warnings
 

--- a/pyro/distributions/transforms/lower_cholesky_affine.py
+++ b/pyro/distributions/transforms/lower_cholesky_affine.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/lower_cholesky_affine.py
+++ b/pyro/distributions/transforms/lower_cholesky_affine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/lower_cholesky_affine.py
+++ b/pyro/distributions/transforms/lower_cholesky_affine.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.distributions.transforms import Transform

--- a/pyro/distributions/transforms/neural_autoregressive.py
+++ b/pyro/distributions/transforms/neural_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import absolute_import, division, print_function

--- a/pyro/distributions/transforms/neural_autoregressive.py
+++ b/pyro/distributions/transforms/neural_autoregressive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import absolute_import, division, print_function
 
 import math

--- a/pyro/distributions/transforms/neural_autoregressive.py
+++ b/pyro/distributions/transforms/neural_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import absolute_import, division, print_function

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions.utils import lazy_property
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 from torch.distributions import constraints

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/transforms/utils.py
+++ b/pyro/distributions/transforms/utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pyro/distributions/transforms/utils.py
+++ b/pyro/distributions/transforms/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pyro/distributions/transforms/utils.py
+++ b/pyro/distributions/transforms/utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2020 Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+
 def clamp_preserve_gradients(x, min, max):
     # This helper function clamps gradients but still passes through the gradient in clamped regions
     return x + (x.clamp(min, max) - x).detach()

--- a/pyro/distributions/transforms/utils.py
+++ b/pyro/distributions/transforms/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 def clamp_preserve_gradients(x, min, max):
     # This helper function clamps gradients but still passes through the gradient in clamped regions

--- a/pyro/distributions/unit.py
+++ b/pyro/distributions/unit.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/unit.py
+++ b/pyro/distributions/unit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/distributions/unit.py
+++ b/pyro/distributions/unit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 import numbers
 import weakref

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/von_mises.py
+++ b/pyro/distributions/von_mises.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/distributions/zero_inflated.py
+++ b/pyro/distributions/zero_inflated.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/distributions/zero_inflated.py
+++ b/pyro/distributions/zero_inflated.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all, lazy_property

--- a/pyro/distributions/zero_inflated.py
+++ b/pyro/distributions/zero_inflated.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/generic.py
+++ b/pyro/generic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/generic.py
+++ b/pyro/generic.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/generic.py
+++ b/pyro/generic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 from pyroapi import *  # noqa F401

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.abstract_infer import EmpiricalMarginal, TracePosterior, TracePredictive

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.infer.abstract_infer import EmpiricalMarginal, TracePosterior, TracePredictive
 from pyro.infer.csis import CSIS
 from pyro.infer.discrete import infer_discrete

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.abstract_infer import EmpiricalMarginal, TracePosterior, TracePredictive

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 import warnings
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta, AutoDiagonalNormal,

--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta, AutoDiagonalNormal,

--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta, AutoDiagonalNormal,
                                          AutoDiscreteParallel, AutoGuide, AutoGuideList, AutoIAFNormal,
                                          AutoLaplaceApproximation, AutoLowRankMultivariateNormal,

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 The :mod:`pyro.infer.autoguide` module provides algorithms to automatically
 generate guides from simple models, for use in :class:`~pyro.infer.svi.SVI`.

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 r"""
 The pyro.infer.autoguide.initialization module contains initialization functions for
 automatic guides.

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 r"""

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 r"""

--- a/pyro/infer/autoguide/utils.py
+++ b/pyro/infer/autoguide/utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro import poutine

--- a/pyro/infer/autoguide/utils.py
+++ b/pyro/infer/autoguide/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro import poutine
 
 

--- a/pyro/infer/autoguide/utils.py
+++ b/pyro/infer/autoguide/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro import poutine

--- a/pyro/infer/csis.py
+++ b/pyro/infer/csis.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/infer/csis.py
+++ b/pyro/infer/csis.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 
 import torch

--- a/pyro/infer/csis.py
+++ b/pyro/infer/csis.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 from collections import OrderedDict
 

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import warnings
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/pyro/infer/energy_distance.py
+++ b/pyro/infer/energy_distance.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import operator
 from collections import OrderedDict
 from functools import reduce

--- a/pyro/infer/energy_distance.py
+++ b/pyro/infer/energy_distance.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/pyro/infer/energy_distance.py
+++ b/pyro/infer/energy_distance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 from functools import partial
 from queue import LifoQueue

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import warnings
 

--- a/pyro/infer/mcmc/__init__.py
+++ b/pyro/infer/mcmc/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.nuts import NUTS

--- a/pyro/infer/mcmc/__init__.py
+++ b/pyro/infer/mcmc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.mcmc.hmc import HMC

--- a/pyro/infer/mcmc/__init__.py
+++ b/pyro/infer/mcmc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.mcmc.hmc import HMC

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import torch
 from collections import namedtuple

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This module offers a modified interface for MCMC inference with the following objectives:
   - making MCMC independent of Pyro specific trace data structure, to facilitate

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 from collections import OrderedDict
 

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import logging
 import os

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/mcmc/mcmc_kernel.py
+++ b/pyro/infer/mcmc/mcmc_kernel.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABCMeta, abstractmethod
 
 

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import namedtuple
 
 import torch

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 import warnings
 from collections import OrderedDict, defaultdict

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import reduce

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import reduce

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from functools import reduce
 import warnings
 

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/renyi_elbo.py
+++ b/pyro/infer/renyi_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import warnings
 

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .loc_scale import LocScaleReparam
 from .neutra import NeuTraReparam
 from .stable import StableHMMReparam, StableReparam, SymmetricStableReparam

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .loc_scale import LocScaleReparam

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .loc_scale import LocScaleReparam

--- a/pyro/infer/reparam/loc_scale.py
+++ b/pyro/infer/reparam/loc_scale.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/infer/reparam/loc_scale.py
+++ b/pyro/infer/reparam/loc_scale.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 

--- a/pyro/infer/reparam/loc_scale.py
+++ b/pyro/infer/reparam/loc_scale.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import biject_to

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from torch.distributions import biject_to

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from torch.distributions import biject_to
 
 import pyro

--- a/pyro/infer/reparam/reparam.py
+++ b/pyro/infer/reparam/reparam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/pyro/infer/reparam/reparam.py
+++ b/pyro/infer/reparam/reparam.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/pyro/infer/reparam/reparam.py
+++ b/pyro/infer/reparam/reparam.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 
 import pyro.distributions as dist

--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/infer/reparam/transform.py
+++ b/pyro/infer/reparam/transform.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro

--- a/pyro/infer/reparam/transform.py
+++ b/pyro/infer/reparam/transform.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pyro
 import pyro.distributions as dist
 

--- a/pyro/infer/reparam/transform.py
+++ b/pyro/infer/reparam/transform.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro

--- a/pyro/infer/rws.py
+++ b/pyro/infer/rws.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/rws.py
+++ b/pyro/infer/rws.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/rws.py
+++ b/pyro/infer/rws.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/infer/smcfilter.py
+++ b/pyro/infer/smcfilter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 
 import torch

--- a/pyro/infer/smcfilter.py
+++ b/pyro/infer/smcfilter.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/pyro/infer/smcfilter.py
+++ b/pyro/infer/smcfilter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/pyro/infer/svgd.py
+++ b/pyro/infer/svgd.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/svgd.py
+++ b/pyro/infer/svgd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod

--- a/pyro/infer/svgd.py
+++ b/pyro/infer/svgd.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABCMeta, abstractmethod
 import math
 

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/svi.py
+++ b/pyro/infer/svi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 import torch

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import weakref
 
 import pyro

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 import weakref
 

--- a/pyro/infer/trace_mmd.py
+++ b/pyro/infer/trace_mmd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict

--- a/pyro/infer/trace_mmd.py
+++ b/pyro/infer/trace_mmd.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import defaultdict

--- a/pyro/infer/trace_mmd.py
+++ b/pyro/infer/trace_mmd.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import defaultdict
 
 import torch

--- a/pyro/infer/trace_tail_adaptive_elbo.py
+++ b/pyro/infer/trace_tail_adaptive_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/trace_tail_adaptive_elbo.py
+++ b/pyro/infer/trace_tail_adaptive_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/trace_tail_adaptive_elbo.py
+++ b/pyro/infer/trace_tail_adaptive_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 import torch

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 import weakref
 from collections import OrderedDict

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import weakref
 from operator import itemgetter
 

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/infer/tracetmc_elbo.py
+++ b/pyro/infer/tracetmc_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import queue
 import warnings
 

--- a/pyro/infer/tracetmc_elbo.py
+++ b/pyro/infer/tracetmc_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import queue

--- a/pyro/infer/tracetmc_elbo.py
+++ b/pyro/infer/tracetmc_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import queue

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import numbers
 from collections import Counter, defaultdict

--- a/pyro/logger.py
+++ b/pyro/logger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/pyro/logger.py
+++ b/pyro/logger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/pyro/logger.py
+++ b/pyro/logger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import absolute_import, division, print_function

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import absolute_import, division, print_function
 
 from pyro.nn.auto_reg_nn import AutoRegressiveNN, ConditionalAutoRegressiveNN, MaskedLinear

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import absolute_import, division, print_function

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 import torch

--- a/pyro/nn/dense_nn.py
+++ b/pyro/nn/dense_nn.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/nn/dense_nn.py
+++ b/pyro/nn/dense_nn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/nn/dense_nn.py
+++ b/pyro/nn/dense_nn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn as nn
 

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Pyro includes an experimental class :class:`~pyro.nn.module.PyroModule`, a
 subclass of :class:`torch.nn.Module`, whose attributes can be modified by Pyro

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import warnings
 from collections import OrderedDict, defaultdict

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2020 Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+
 class DualAveraging(object):
     """
     Dual Averaging is a scheme to solve convex optimization problems. It belongs

--- a/pyro/ops/dual_averaging.py
+++ b/pyro/ops/dual_averaging.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 class DualAveraging(object):
     """

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import opt_einsum

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import opt_einsum
 
 from pyro.util import ignore_jit_warnings

--- a/pyro/ops/einsum/__init__.py
+++ b/pyro/ops/einsum/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import opt_einsum

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import weakref
 from abc import ABCMeta, abstractmethod
 

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/ops/einsum/adjoint.py
+++ b/pyro/ops/einsum/adjoint.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.ops.einsum.util import Tensordot

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import operator
 
 from functools import reduce

--- a/pyro/ops/einsum/torch_marginal.py
+++ b/pyro/ops/einsum/torch_marginal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.ops.einsum.torch_log

--- a/pyro/ops/einsum/torch_marginal.py
+++ b/pyro/ops/einsum/torch_marginal.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pyro.ops.einsum.torch_log
 from pyro.ops.einsum.adjoint import Backward, transpose
 from pyro.ops.einsum.util import Tensordot

--- a/pyro/ops/einsum/torch_marginal.py
+++ b/pyro/ops/einsum/torch_marginal.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.ops.einsum.torch_log

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import operator
 
 from functools import reduce

--- a/pyro/ops/einsum/util.py
+++ b/pyro/ops/einsum/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 EINSUM_SYMBOLS_BASE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 

--- a/pyro/ops/einsum/util.py
+++ b/pyro/ops/einsum/util.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 
 EINSUM_SYMBOLS_BASE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
@@ -12,6 +12,7 @@ class Tensordot(object):
         self.einsum = einsum
 
     # Copyright (c) 2014 Daniel Smith
+    # SPDX-License-Identifier: MIT
     # This function is copied and adapted from:
     # https://github.com/dgasmith/opt_einsum/blob/a6dd686/opt_einsum/backends/torch.py
     def __call__(self, x, y, axes=2):

--- a/pyro/ops/einsum/util.py
+++ b/pyro/ops/einsum/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 
 EINSUM_SYMBOLS_BASE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/pyro/ops/gamma_gaussian.py
+++ b/pyro/ops/gamma_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/gamma_gaussian.py
+++ b/pyro/ops/gamma_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/gamma_gaussian.py
+++ b/pyro/ops/gamma_gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/ops/hessian.py
+++ b/pyro/ops/hessian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/hessian.py
+++ b/pyro/ops/hessian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/hessian.py
+++ b/pyro/ops/hessian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/pyro/ops/indexing.py
+++ b/pyro/ops/indexing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/indexing.py
+++ b/pyro/ops/indexing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/indexing.py
+++ b/pyro/ops/indexing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.autograd import grad
 

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/pyro/ops/jit.py
+++ b/pyro/ops/jit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import warnings
 import weakref

--- a/pyro/ops/linalg.py
+++ b/pyro/ops/linalg.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/linalg.py
+++ b/pyro/ops/linalg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/linalg.py
+++ b/pyro/ops/linalg.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/ops/newton.py
+++ b/pyro/ops/newton.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/newton.py
+++ b/pyro/ops/newton.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/newton.py
+++ b/pyro/ops/newton.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.autograd import grad
 

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import weakref
 from abc import ABCMeta, abstractmethod
 

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/ops/rings.py
+++ b/pyro/ops/rings.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/pyro/ops/ssm_gp.py
+++ b/pyro/ops/ssm_gp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/ssm_gp.py
+++ b/pyro/ops/ssm_gp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/ssm_gp.py
+++ b/pyro/ops/ssm_gp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 
 import torch

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.optim.lr_scheduler import PyroLRScheduler
 from pyro.optim.optim import AdagradRMSProp, ClippedAdam, PyroOptim
 from pyro.optim.pytorch_optimizers import __all__ as pytorch_optims

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.optim.lr_scheduler import PyroLRScheduler

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.optim.lr_scheduler import PyroLRScheduler

--- a/pyro/optim/adagrad_rmsprop.py
+++ b/pyro/optim/adagrad_rmsprop.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/adagrad_rmsprop.py
+++ b/pyro/optim/adagrad_rmsprop.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/adagrad_rmsprop.py
+++ b/pyro/optim/adagrad_rmsprop.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.optim.optimizer import Optimizer
 

--- a/pyro/optim/clipped_adam.py
+++ b/pyro/optim/clipped_adam.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/optim/clipped_adam.py
+++ b/pyro/optim/clipped_adam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/pyro/optim/clipped_adam.py
+++ b/pyro/optim/clipped_adam.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.optim.optim import PyroOptim

--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.optim.optim import PyroOptim
 
 

--- a/pyro/optim/lr_scheduler.py
+++ b/pyro/optim/lr_scheduler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.optim.optim import PyroOptim

--- a/pyro/optim/multi.py
+++ b/pyro/optim/multi.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/multi.py
+++ b/pyro/optim/multi.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/multi.py
+++ b/pyro/optim/multi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.ops.newton import newton_step

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.nn.utils import clip_grad_norm_, clip_grad_value_
 

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.optim import PyroOptim

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
 
 __all__ = [

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 import warnings
 import weakref

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, reparam,

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, reparam,

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, reparam,
                        replay, scale, seed, trace, uncondition)
 from .runtime import NonlocalExit

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from functools import partial
 
 from pyro.poutine.messenger import Messenger

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.util import ignore_jit_warnings
 from .messenger import Messenger
 

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.util import ignore_jit_warnings

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.util import ignore_jit_warnings

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .messenger import Messenger
 from .trace_struct import Trace
 

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/condition_messenger.py
+++ b/pyro/poutine/condition_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 import warnings
 

--- a/pyro/poutine/enum_messenger.py
+++ b/pyro/poutine/enum_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions import Categorical

--- a/pyro/poutine/enum_messenger.py
+++ b/pyro/poutine/enum_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/enum_messenger.py
+++ b/pyro/poutine/enum_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/escape_messenger.py
+++ b/pyro/poutine/escape_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/escape_messenger.py
+++ b/pyro/poutine/escape_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/escape_messenger.py
+++ b/pyro/poutine/escape_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .messenger import Messenger
 from .runtime import NonlocalExit
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Poutine is a library of composable effect handlers for recording and modifying the
 behavior of Pyro programs. These lower-level ingredients simplify the implementation

--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numbers
 from collections import namedtuple
 

--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numbers

--- a/pyro/poutine/infer_config_messenger.py
+++ b/pyro/poutine/infer_config_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/infer_config_messenger.py
+++ b/pyro/poutine/infer_config_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .messenger import Messenger
 
 

--- a/pyro/poutine/infer_config_messenger.py
+++ b/pyro/poutine/infer_config_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/pyro/poutine/lift_messenger.py
+++ b/pyro/poutine/lift_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 from pyro import params

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import Counter

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import Counter

--- a/pyro/poutine/markov_messenger.py
+++ b/pyro/poutine/markov_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import Counter
 from contextlib import ExitStack  # python 3
 

--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.util import ignore_jit_warnings

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import partial

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from functools import partial
 
 from .runtime import _PYRO_STACK

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .broadcast_messenger import BroadcastMessenger

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .broadcast_messenger import BroadcastMessenger
 from .subsample_messenger import SubsampleMessenger
 

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .broadcast_messenger import BroadcastMessenger

--- a/pyro/poutine/reentrant_messenger.py
+++ b/pyro/poutine/reentrant_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 
 from .messenger import Messenger

--- a/pyro/poutine/reentrant_messenger.py
+++ b/pyro/poutine/reentrant_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/poutine/reentrant_messenger.py
+++ b/pyro/poutine/reentrant_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .messenger import Messenger
 
 

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .messenger import Messenger
 
 

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 
 from pyro.params.param_store import _MODULE_NAMESPACE_DIVIDER, ParamStoreDict  # noqa: F401

--- a/pyro/poutine/scale_messenger.py
+++ b/pyro/poutine/scale_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/scale_messenger.py
+++ b/pyro/poutine/scale_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/scale_messenger.py
+++ b/pyro/poutine/scale_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.poutine.util import is_validation_enabled

--- a/pyro/poutine/seed_messenger.py
+++ b/pyro/poutine/seed_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from pyro.util import get_rng_state, set_rng_seed, set_rng_state
 
 from .messenger import Messenger

--- a/pyro/poutine/seed_messenger.py
+++ b/pyro/poutine/seed_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.util import get_rng_state, set_rng_seed, set_rng_state

--- a/pyro/poutine/seed_messenger.py
+++ b/pyro/poutine/seed_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.util import get_rng_state, set_rng_seed, set_rng_state

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions.distribution import Distribution

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 
 from .messenger import Messenger

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import OrderedDict
 import sys
 

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict

--- a/pyro/poutine/uncondition_messenger.py
+++ b/pyro/poutine/uncondition_messenger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/uncondition_messenger.py
+++ b/pyro/poutine/uncondition_messenger.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from .messenger import Messenger
 
 

--- a/pyro/poutine/uncondition_messenger.py
+++ b/pyro/poutine/uncondition_messenger.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from .messenger import Messenger

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 _VALIDATION_ENABLED = False
 

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 _VALIDATION_ENABLED = False

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 _VALIDATION_ENABLED = False

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import copy

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import copy
 import warnings
 from collections import OrderedDict

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import copy

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 import numbers
 import random

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2020 Contributors to the Pyro project.
+import os
+import glob
+
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+blacklist = ["/build/", "/dist/"]
+file_types = [
+    ("*.py", "# {}"),
+    ("*.cpp", "// {}"),
+]
+
+for basename, comment in file_types:
+    copyright_line = comment.format("Copyright (c) 2017-2020 Contributors to the Pyro project.\n")
+    # See https://spdx.org/ids-how
+    spdx_line = comment.format("SPDX-License-Identifier: Apache-2.0\n")
+
+    filenames = glob.glob(os.path.join(root, "**", basename), recursive=True)
+    filenames.sort()
+    filenames = [
+        filename
+        for filename in filenames
+        if not any(word in filename for word in blacklist)
+    ]
+    for filename in filenames:
+        with open(filename) as f:
+            lines = f.readlines()
+
+        # Ignore empty files like __init__.py
+        if all(line.isspace() for line in lines):
+            continue
+
+        # Ensure first few line are copyright notices.
+        lineno = 0
+        if not lines[lineno].startswith(comment.format("Copyright")):
+            lines.insert(lineno, copyright_line)
+        lineno += 1
+        while lines[lineno].startswith(comment.format("Copyright")):
+            lineno += 1
+
+        # Ensure next line is an SPDX short identifier.
+        if not lines[lineno].startswith(comment.format("SPDX-License-Identifier")):
+            lines.insert(lineno, spdx_line)
+        lineno += 1
+
+        # Ensure next line is blank.
+        if not lines[lineno].isspace():
+            lines.insert(lineno, "\n")
+
+        with open(filename, "w") as f:
+            f.write("".join(lines))
+
+        print("updated {}".format(filename[len(root) + 1:]))

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -12,7 +12,7 @@ file_types = [
 ]
 
 for basename, comment in file_types:
-    copyright_line = comment.format("Copyright Contributors to the Pyro project.\n")
+    copyright_line = comment.format("Copyright (c) 2017-2019 Uber Technologies, Inc.\n")
     # See https://spdx.org/ids-how
     spdx_line = comment.format("SPDX-License-Identifier: Apache-2.0\n")
 

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -12,7 +12,7 @@ file_types = [
 ]
 
 for basename, comment in file_types:
-    copyright_line = comment.format("Copyright (c) 2017-2020 Contributors to the Pyro project.\n")
+    copyright_line = comment.format("Copyright Contributors to the Pyro project.\n")
     # See https://spdx.org/ids-how
     spdx_line = comment.format("SPDX-License-Identifier: Apache-2.0\n")
 

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import glob
 

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -12,7 +12,7 @@ file_types = [
 ]
 
 for basename, comment in file_types:
-    copyright_line = comment.format("Copyright (c) 2017-2019 Uber Technologies, Inc.\n")
+    copyright_line = comment.format("Copyright Contributors to the Pyro project.\n")
     # See https://spdx.org/ids-how
     spdx_line = comment.format("SPDX-License-Identifier: Apache-2.0\n")
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
     },
     python_requires='>=3.5',
     keywords='machine learning statistics probabilistic programming bayesian modeling pytorch',
-    license='MIT License',
+    license='Apache 2.0',
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Education',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import subprocess
 import sys

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import os

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import contextlib
 import numbers
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import warnings
 

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import numpy as np

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/autoguide/test_mean_field_entropy.py
+++ b/tests/contrib/autoguide/test_mean_field_entropy.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import scipy.special as sc
 import pytest

--- a/tests/contrib/autoguide/test_mean_field_entropy.py
+++ b/tests/contrib/autoguide/test_mean_field_entropy.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/autoguide/test_mean_field_entropy.py
+++ b/tests/contrib/autoguide/test_mean_field_entropy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/autoname/test_named.py
+++ b/tests/contrib/autoname/test_named.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/autoname/test_named.py
+++ b/tests/contrib/autoname/test_named.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro

--- a/tests/contrib/autoname/test_named.py
+++ b/tests/contrib/autoname/test_named.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/autoname/test_scoping.py
+++ b/tests/contrib/autoname/test_scoping.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/autoname/test_scoping.py
+++ b/tests/contrib/autoname/test_scoping.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/autoname/test_scoping.py
+++ b/tests/contrib/autoname/test_scoping.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import torch

--- a/tests/contrib/bnn/test_hidden_layer.py
+++ b/tests/contrib/bnn/test_hidden_layer.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/bnn/test_hidden_layer.py
+++ b/tests/contrib/bnn/test_hidden_layer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/bnn/test_hidden_layer.py
+++ b/tests/contrib/bnn/test_hidden_layer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import torch.nn.functional as F
 from torch.distributions import Normal

--- a/tests/contrib/cevae/test_cevae.py
+++ b/tests/contrib/cevae/test_cevae.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import io

--- a/tests/contrib/cevae/test_cevae.py
+++ b/tests/contrib/cevae/test_cevae.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import io
 import warnings
 

--- a/tests/contrib/cevae/test_cevae.py
+++ b/tests/contrib/cevae/test_cevae.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import io

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/easyguide/test_easyguide.py
+++ b/tests/contrib/easyguide/test_easyguide.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import io

--- a/tests/contrib/easyguide/test_easyguide.py
+++ b/tests/contrib/easyguide/test_easyguide.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import io
 import warnings
 

--- a/tests/contrib/easyguide/test_easyguide.py
+++ b/tests/contrib/easyguide/test_easyguide.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import io

--- a/tests/contrib/gp/test_conditional.py
+++ b/tests/contrib/gp/test_conditional.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/tests/contrib/gp/test_conditional.py
+++ b/tests/contrib/gp/test_conditional.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/tests/contrib/gp/test_conditional.py
+++ b/tests/contrib/gp/test_conditional.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import namedtuple
 
 import pytest

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import namedtuple
 
 import pytest

--- a/tests/contrib/gp/test_likelihoods.py
+++ b/tests/contrib/gp/test_likelihoods.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/tests/contrib/gp/test_likelihoods.py
+++ b/tests/contrib/gp/test_likelihoods.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import namedtuple

--- a/tests/contrib/gp/test_likelihoods.py
+++ b/tests/contrib/gp/test_likelihoods.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import namedtuple
 
 import pytest

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from collections import namedtuple
 

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/gp/test_parameterized.py
+++ b/tests/contrib/gp/test_parameterized.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/gp/test_parameterized.py
+++ b/tests/contrib/gp/test_parameterized.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/gp/test_parameterized.py
+++ b/tests/contrib/gp/test_parameterized.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from torch.distributions import constraints
 from torch.nn import Parameter

--- a/tests/contrib/oed/test_ewma.py
+++ b/tests/contrib/oed/test_ewma.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/contrib/oed/test_ewma.py
+++ b/tests/contrib/oed/test_ewma.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/contrib/oed/test_ewma.py
+++ b/tests/contrib/oed/test_ewma.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/tests/contrib/oed/test_finite_spaces_eig.py
+++ b/tests/contrib/oed/test_finite_spaces_eig.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import pytest
 

--- a/tests/contrib/oed/test_finite_spaces_eig.py
+++ b/tests/contrib/oed/test_finite_spaces_eig.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/oed/test_finite_spaces_eig.py
+++ b/tests/contrib/oed/test_finite_spaces_eig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/oed/test_glmm.py
+++ b/tests/contrib/oed/test_glmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/oed/test_glmm.py
+++ b/tests/contrib/oed/test_glmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/oed/test_glmm.py
+++ b/tests/contrib/oed/test_glmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.distributions.transforms import AffineTransform, SigmoidTransform

--- a/tests/contrib/oed/test_linear_models_eig.py
+++ b/tests/contrib/oed/test_linear_models_eig.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import pytest
 

--- a/tests/contrib/oed/test_linear_models_eig.py
+++ b/tests/contrib/oed/test_linear_models_eig.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/oed/test_linear_models_eig.py
+++ b/tests/contrib/oed/test_linear_models_eig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/oed/test_xexpx.py
+++ b/tests/contrib/oed/test_xexpx.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/oed/test_xexpx.py
+++ b/tests/contrib/oed/test_xexpx.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/oed/test_xexpx.py
+++ b/tests/contrib/oed/test_xexpx.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """

--- a/tests/contrib/oed/test_xexpx.py
+++ b/tests/contrib/oed/test_xexpx.py
@@ -1,13 +1,6 @@
 # Copyright (c) 2017-2020 Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Oct 30 10:52:27 2018
-
-@author: charlinelelan
-"""
 import pytest
 import torch
 

--- a/tests/contrib/test_hessian.py
+++ b/tests/contrib/test_hessian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/test_hessian.py
+++ b/tests/contrib/test_hessian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/test_hessian.py
+++ b/tests/contrib/test_hessian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro.distributions as dist

--- a/tests/contrib/test_minipyro.py
+++ b/tests/contrib/test_minipyro.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/contrib/test_minipyro.py
+++ b/tests/contrib/test_minipyro.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/contrib/test_minipyro.py
+++ b/tests/contrib/test_minipyro.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 import pytest

--- a/tests/contrib/test_util.py
+++ b/tests/contrib/test_util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict

--- a/tests/contrib/test_util.py
+++ b/tests/contrib/test_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict

--- a/tests/contrib/test_util.py
+++ b/tests/contrib/test_util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import OrderedDict
 import pytest
 import torch

--- a/tests/contrib/timeseries/test_gp.py
+++ b/tests/contrib/timeseries/test_gp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/contrib/timeseries/test_gp.py
+++ b/tests/contrib/timeseries/test_gp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/contrib/timeseries/test_gp.py
+++ b/tests/contrib/timeseries/test_gp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import torch
 

--- a/tests/contrib/timeseries/test_lgssm.py
+++ b/tests/contrib/timeseries/test_lgssm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/timeseries/test_lgssm.py
+++ b/tests/contrib/timeseries/test_lgssm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from tests.common import assert_equal

--- a/tests/contrib/timeseries/test_lgssm.py
+++ b/tests/contrib/timeseries/test_lgssm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/contrib/tracking/test_distributions.py
+++ b/tests/contrib/tracking/test_distributions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_distributions.py
+++ b/tests/contrib/tracking/test_distributions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_distributions.py
+++ b/tests/contrib/tracking/test_distributions.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.contrib.tracking.distributions import EKFDistribution

--- a/tests/contrib/tracking/test_dynamic_models.py
+++ b/tests/contrib/tracking/test_dynamic_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_dynamic_models.py
+++ b/tests/contrib/tracking/test_dynamic_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_dynamic_models.py
+++ b/tests/contrib/tracking/test_dynamic_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.contrib.tracking.dynamic_models import (NcpContinuous, NcvContinuous,

--- a/tests/contrib/tracking/test_ekf.py
+++ b/tests/contrib/tracking/test_ekf.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_ekf.py
+++ b/tests/contrib/tracking/test_ekf.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.contrib.tracking.extended_kalman_filter import EKFState

--- a/tests/contrib/tracking/test_ekf.py
+++ b/tests/contrib/tracking/test_ekf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import math
 

--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import pytest

--- a/tests/contrib/tracking/test_hashing.py
+++ b/tests/contrib/tracking/test_hashing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/contrib/tracking/test_measurements.py
+++ b/tests/contrib/tracking/test_measurements.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/contrib/tracking/test_measurements.py
+++ b/tests/contrib/tracking/test_measurements.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 import torch
 from pyro.contrib.tracking.measurements import PositionMeasurement

--- a/tests/contrib/tracking/test_measurements.py
+++ b/tests/contrib/tracking/test_measurements.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import numpy as np

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import numpy as np

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import numpy as np

--- a/tests/distributions/test_categorical.py
+++ b/tests/distributions/test_categorical.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_conjugate.py
+++ b/tests/distributions/test_conjugate.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_conjugate.py
+++ b/tests/distributions/test_conjugate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_conjugate.py
+++ b/tests/distributions/test_conjugate.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import numpy as np

--- a/tests/distributions/test_delta.py
+++ b/tests/distributions/test_delta.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import pytest
 import torch

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/distributions/test_gaussian_mixtures.py
+++ b/tests/distributions/test_gaussian_mixtures.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import math
 

--- a/tests/distributions/test_gaussian_mixtures.py
+++ b/tests/distributions/test_gaussian_mixtures.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/distributions/test_gaussian_mixtures.py
+++ b/tests/distributions/test_gaussian_mixtures.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import operator

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import operator
 from functools import reduce
 

--- a/tests/distributions/test_ig.py
+++ b/tests/distributions/test_ig.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_ig.py
+++ b/tests/distributions/test_ig.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_ig.py
+++ b/tests/distributions/test_ig.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_independent.py
+++ b/tests/distributions/test_independent.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.distributions.utils import _sum_rightmost

--- a/tests/distributions/test_kl.py
+++ b/tests/distributions/test_kl.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_kl.py
+++ b/tests/distributions/test_kl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_kl.py
+++ b/tests/distributions/test_kl.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.distributions import kl_divergence, transforms

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/tests/distributions/test_lowrank_mvn.py
+++ b/tests/distributions/test_lowrank_mvn.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/distributions/test_lowrank_mvn.py
+++ b/tests/distributions/test_lowrank_mvn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/distributions/test_lowrank_mvn.py
+++ b/tests/distributions/test_lowrank_mvn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from pyro.distributions import LowRankMultivariateNormal, MultivariateNormal

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch import tensor

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_mixture.py
+++ b/tests/distributions/test_mixture.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/distributions/test_mvt.py
+++ b/tests/distributions/test_mvt.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_mvt.py
+++ b/tests/distributions/test_mvt.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_mvt.py
+++ b/tests/distributions/test_mvt.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import numpy as np

--- a/tests/distributions/test_one_hot_categorical.py
+++ b/tests/distributions/test_one_hot_categorical.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import inspect

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import inspect
 
 import pytest

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/distributions/test_reshape.py
+++ b/tests/distributions/test_reshape.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_reshape.py
+++ b/tests/distributions/test_reshape.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_reshape.py
+++ b/tests/distributions/test_reshape.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/distributions/test_shapes.py
+++ b/tests/distributions/test_shapes.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/distributions/test_shapes.py
+++ b/tests/distributions/test_shapes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/distributions/test_shapes.py
+++ b/tests/distributions/test_shapes.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro.distributions as dist

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 from collections import Counter

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/distributions/test_stable.py
+++ b/tests/distributions/test_stable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/distributions/test_stable.py
+++ b/tests/distributions/test_stable.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/distributions/test_stable.py
+++ b/tests/distributions/test_stable.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 
 import numpy as np

--- a/tests/distributions/test_tensor_type.py
+++ b/tests/distributions/test_tensor_type.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_tensor_type.py
+++ b/tests/distributions/test_tensor_type.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_tensor_type.py
+++ b/tests/distributions/test_tensor_type.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import scipy.stats as sp
 import torch

--- a/tests/distributions/test_torch_patch.py
+++ b/tests/distributions/test_torch_patch.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_torch_patch.py
+++ b/tests/distributions/test_torch_patch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_torch_patch.py
+++ b/tests/distributions/test_torch_patch.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import pytest

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/distributions/test_unit.py
+++ b/tests/distributions/test_unit.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_unit.py
+++ b/tests/distributions/test_unit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_unit.py
+++ b/tests/distributions/test_unit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import weakref
 
 import numpy as np

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import weakref

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import os
 

--- a/tests/distributions/test_zero_inflated.py
+++ b/tests/distributions/test_zero_inflated.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_zero_inflated.py
+++ b/tests/distributions/test_zero_inflated.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/distributions/test_zero_inflated.py
+++ b/tests/distributions/test_zero_inflated.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/doctest_fixtures.py
+++ b/tests/doctest_fixtures.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy

--- a/tests/doctest_fixtures.py
+++ b/tests/doctest_fixtures.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy

--- a/tests/doctest_fixtures.py
+++ b/tests/doctest_fixtures.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy
 import pytest
 import torch

--- a/tests/infer/conftest.py
+++ b/tests/infer/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/infer/conftest.py
+++ b/tests/infer/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/conftest.py
+++ b/tests/infer/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/mcmc/test_adaptation.py
+++ b/tests/infer/mcmc/test_adaptation.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 from collections import namedtuple

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from functools import partial
 

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 from collections import namedtuple

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import pickle
 

--- a/tests/infer/reparam/test_loc_scale.py
+++ b/tests/infer/reparam/test_loc_scale.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/reparam/test_loc_scale.py
+++ b/tests/infer/reparam/test_loc_scale.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/reparam/test_loc_scale.py
+++ b/tests/infer/reparam/test_loc_scale.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/infer/reparam/test_neutra.py
+++ b/tests/infer/reparam/test_neutra.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/infer/reparam/test_neutra.py
+++ b/tests/infer/reparam/test_neutra.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro

--- a/tests/infer/reparam/test_neutra.py
+++ b/tests/infer/reparam/test_neutra.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.autograd import grad

--- a/tests/infer/reparam/test_transform.py
+++ b/tests/infer/reparam/test_transform.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/reparam/test_transform.py
+++ b/tests/infer/reparam/test_transform.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/reparam/test_transform.py
+++ b/tests/infer/reparam/test_transform.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 import io
 import warnings

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/tests/infer/test_conjugate_gradients.py
+++ b/tests/infer/test_conjugate_gradients.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 import pyro
 from pyro.infer.tracegraph_elbo import TraceGraph_ELBO

--- a/tests/infer/test_conjugate_gradients.py
+++ b/tests/infer/test_conjugate_gradients.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro

--- a/tests/infer/test_conjugate_gradients.py
+++ b/tests/infer/test_conjugate_gradients.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro

--- a/tests/infer/test_csis.py
+++ b/tests/infer/test_csis.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_csis.py
+++ b/tests/infer/test_csis.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_csis.py
+++ b/tests/infer/test_csis.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 import torch.nn as nn

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import math
 

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_discrete.py
+++ b/tests/infer/test_discrete.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import pytest

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import math
 import os

--- a/tests/infer/test_enum.py
+++ b/tests/infer/test_enum.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import numpy as np

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import math
 from unittest import TestCase

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import warnings
 

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import pytest

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/infer/test_smcfilter.py
+++ b/tests/infer/test_smcfilter.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_smcfilter.py
+++ b/tests/infer/test_smcfilter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_smcfilter.py
+++ b/tests/infer/test_smcfilter.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/test_svgd.py
+++ b/tests/infer/test_svgd.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_svgd.py
+++ b/tests/infer/test_svgd.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/infer/test_svgd.py
+++ b/tests/infer/test_svgd.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/infer/test_tmc.py
+++ b/tests/infer/test_tmc.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import math
 

--- a/tests/infer/test_tmc.py
+++ b/tests/infer/test_tmc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_tmc.py
+++ b/tests/infer/test_tmc.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import warnings
 from collections import defaultdict

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 import time

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from unittest import TestCase
 

--- a/tests/nn/conftest.py
+++ b/tests/nn/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/nn/conftest.py
+++ b/tests/nn/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/nn/conftest.py
+++ b/tests/nn/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/nn/test_autoregressive.py
+++ b/tests/nn/test_autoregressive.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import pytest

--- a/tests/nn/test_autoregressive.py
+++ b/tests/nn/test_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/nn/test_autoregressive.py
+++ b/tests/nn/test_autoregressive.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import io

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import io
 import warnings
 

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import io

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/conftest.py
+++ b/tests/ops/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/einsum/conftest.py
+++ b/tests/ops/einsum/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/ops/einsum/conftest.py
+++ b/tests/ops/einsum/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/einsum/conftest.py
+++ b/tests/ops/einsum/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/einsum/test_adjoint.py
+++ b/tests/ops/einsum/test_adjoint.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/einsum/test_adjoint.py
+++ b/tests/ops/einsum/test_adjoint.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 
 import pytest

--- a/tests/ops/einsum/test_adjoint.py
+++ b/tests/ops/einsum/test_adjoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 
 import pytest

--- a/tests/ops/einsum/test_torch_log.py
+++ b/tests/ops/einsum/test_torch_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/gamma_gaussian.py
+++ b/tests/ops/gamma_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/ops/gamma_gaussian.py
+++ b/tests/ops/gamma_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/ops/gamma_gaussian.py
+++ b/tests/ops/gamma_gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro.distributions as dist

--- a/tests/ops/gaussian.py
+++ b/tests/ops/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/ops/gaussian.py
+++ b/tests/ops/gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/ops/gaussian.py
+++ b/tests/ops/gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro.distributions as dist

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import numbers
 from collections import OrderedDict

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_gamma_gaussian.py
+++ b/tests/ops/test_gamma_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/ops/test_gamma_gaussian.py
+++ b/tests/ops/test_gamma_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/ops/test_gamma_gaussian.py
+++ b/tests/ops/test_gamma_gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import pytest

--- a/tests/ops/test_indexing.py
+++ b/tests/ops/test_indexing.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_indexing.py
+++ b/tests/ops/test_indexing.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 
 import pytest

--- a/tests/ops/test_indexing.py
+++ b/tests/ops/test_indexing.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from collections import namedtuple
 

--- a/tests/ops/test_integrator.py
+++ b/tests/ops/test_integrator.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/ops/test_jit.py
+++ b/tests/ops/test_jit.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/ops/test_jit.py
+++ b/tests/ops/test_jit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch

--- a/tests/ops/test_jit.py
+++ b/tests/ops/test_jit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 import pyro.ops.jit

--- a/tests/ops/test_linalg.py
+++ b/tests/ops/test_linalg.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/test_linalg.py
+++ b/tests/ops/test_linalg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/test_linalg.py
+++ b/tests/ops/test_linalg.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import logging
 

--- a/tests/ops/test_packed.py
+++ b/tests/ops/test_packed.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_packed.py
+++ b/tests/ops/test_packed.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/ops/test_packed.py
+++ b/tests/ops/test_packed.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 import random
 

--- a/tests/ops/test_ssm_gp.py
+++ b/tests/ops/test_ssm_gp.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/test_ssm_gp.py
+++ b/tests/ops/test_ssm_gp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/test_ssm_gp.py
+++ b/tests/ops/test_ssm_gp.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
 
 import warnings
 

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import numpy as np
 import torch

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import pytest
 import torch

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/ops/test_welford.py
+++ b/tests/ops/test_welford.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np

--- a/tests/optim/conftest.py
+++ b/tests/optim/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/optim/conftest.py
+++ b/tests/optim/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/optim/conftest.py
+++ b/tests/optim/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 from torch.distributions import constraints

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest import TestCase
 
 import pytest

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase

--- a/tests/params/conftest.py
+++ b/tests/params/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/params/conftest.py
+++ b/tests/params/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/params/conftest.py
+++ b/tests/params/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/params/test_module.py
+++ b/tests/params/test_module.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/params/test_module.py
+++ b/tests/params/test_module.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/params/test_module.py
+++ b/tests/params/test_module.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 import torch.nn as nn

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import copy

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import copy

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 from copy import copy
 from unittest import TestCase
 

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import cProfile
 import os

--- a/tests/poutine/conftest.py
+++ b/tests/poutine/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/poutine/conftest.py
+++ b/tests/poutine/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/poutine/conftest.py
+++ b/tests/poutine/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/poutine/test_counterfactual.py
+++ b/tests/poutine/test_counterfactual.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import pytest

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/poutine/test_nesting.py
+++ b/tests/poutine/test_nesting.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/poutine/test_nesting.py
+++ b/tests/poutine/test_nesting.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/poutine/test_nesting.py
+++ b/tests/poutine/test_nesting.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 import pyro

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import functools
 import logging
 import pickle

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import functools

--- a/tests/poutine/test_properties.py
+++ b/tests/poutine/test_properties.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/poutine/test_properties.py
+++ b/tests/poutine/test_properties.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/poutine/test_properties.py
+++ b/tests/poutine/test_properties.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
 

--- a/tests/poutine/test_trace_struct.py
+++ b/tests/poutine/test_trace_struct.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/poutine/test_trace_struct.py
+++ b/tests/poutine/test_trace_struct.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import itertools
 
 import pytest

--- a/tests/poutine/test_trace_struct.py
+++ b/tests/poutine/test_trace_struct.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import itertools

--- a/tests/pyroapi/conftest.py
+++ b/tests/pyroapi/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 

--- a/tests/pyroapi/conftest.py
+++ b/tests/pyroapi/conftest.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/pyroapi/conftest.py
+++ b/tests/pyroapi/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/pyroapi/test_pyroapi.py
+++ b/tests/pyroapi/test_pyroapi.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/pyroapi/test_pyroapi.py
+++ b/tests/pyroapi/test_pyroapi.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/pyroapi/test_pyroapi.py
+++ b/tests/pyroapi/test_pyroapi.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from pyroapi import pyro_backend

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import logging

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 import sys

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from pyro.generic import handlers, infer, pyro, pyro_backend, ops

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import warnings
 import pytest
 

--- a/tutorial/source/cleannb.py
+++ b/tutorial/source/cleannb.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/tutorial/source/cleannb.py
+++ b/tutorial/source/cleannb.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/tutorial/source/cleannb.py
+++ b/tutorial/source/cleannb.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import io  # for py2/py3 compatible
 

--- a/tutorial/source/conf.py
+++ b/tutorial/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 import sphinx_rtd_theme

--- a/tutorial/source/conf.py
+++ b/tutorial/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import sphinx_rtd_theme

--- a/tutorial/source/conf.py
+++ b/tutorial/source/conf.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import sphinx_rtd_theme
 from pyro import __version__
 

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -1,4 +1,4 @@
-# Copyright Contributors to the Pyro project.
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2017-2020 Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Inference algorithms and utilities used in the RSA example models.
 


### PR DESCRIPTION
Addresses #2249 #2067 

1. Switch from MIT to Apache-2.0 license
    - update LICENSE.md
    - update setup.py
2. Add a script to add copyright notices and SPDX identifiers to all .py and .cpp files.
3. Apply the script to all source files

I plan to update and modify the script as we e.g. update the copyright year next year or add new file types.

After this PR merges we can disable the Uber CLA 🎉 

@neerajprad we will also need to switch licenses in other repos:
- https://github.com/pyro-ppl/numpyro
- https://github.com/pyro-ppl/funsor
- https://github.com/pyro-ppl/pyro-api