### PR TITLE
Discrete Cosine reparameterizer

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,5 @@ numpy>=1.7
 observations>=0.1.4
 opt_einsum>=2.3.2
 pyro-api>=0.1.1
+torch-dct==0.1.5
 tqdm>=4.36

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -332,6 +332,13 @@ TanhTransform
     :undoc-members:
     :show-inheritance:
 
+DiscreteCosineTransform
+-----------------------
+.. autoclass:: pyro.distributions.transforms.DiscreteCosineTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 TransformModules
 ~~~~~~~~~~~~~~~~
 

--- a/docs/source/infer.reparam.rst
+++ b/docs/source/infer.reparam.rst
@@ -32,6 +32,15 @@ Transformed Distributions
     :special-members: __call__
     :show-inheritance:
 
+Discrete Cosine Transform
+-------------------------
+.. automodule:: pyro.infer.reparam.discrete_cosine
+    :members:
+    :undoc-members:
+    :member-order: bysource
+    :special-members: __call__
+    :show-inheritance:
+
 Stable Distributions
 --------------------
 .. automodule:: pyro.infer.reparam.stable

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -9,6 +9,7 @@ from pyro.distributions.transforms.affine_autoregressive import AffineAutoregres
 from pyro.distributions.transforms.affine_coupling import AffineCoupling, affine_coupling
 from pyro.distributions.transforms.batchnorm import BatchNorm, batchnorm
 from pyro.distributions.transforms.block_autoregressive import BlockAutoregressive, block_autoregressive
+from pyro.distributions.transforms.discrete_cosine import DiscreteCosineTransform
 from pyro.distributions.transforms.householder import Householder, householder
 from pyro.distributions.transforms.lower_cholesky_affine import LowerCholeskyAffine
 from pyro.distributions.transforms.neural_autoregressive import (ELUTransform, LeakyReLUTransform,
@@ -43,6 +44,7 @@ __all__ = [
     'BlockAutoregressive',
     'ConditionalPlanar',
     'CorrLCholeskyTransform',
+    'DiscreteCosineTransform',
     'ELUTransform',
     'Householder',
     'LeakyReLUTransform',

--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -47,5 +47,5 @@ class DiscreteCosineTransform(Transform):
             x = x.transpose(dim, -1)
         return x
 
-    def _log_abs_det_jacobian(self, x, y):
+    def log_abs_det_jacobian(self, x, y):
         return x.new_zeros((1,) * self.event_dim)

--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -4,8 +4,6 @@
 from torch.distributions import constraints
 from torch.distributions.transforms import Transform
 
-from pyro.ops.tensor_utils import dct_ii, idct_ii
-
 
 class DiscreteCosineTransform(Transform):
     """
@@ -30,19 +28,21 @@ class DiscreteCosineTransform(Transform):
         return type(self) == type(other) and self.event_dim == other.event_dim
 
     def _call(self, x):
+        import torch_dct
         dim = -self.event_dim
         if dim != -1:
             x = x.transpose(dim, -1)
-        y = dct_ii(x)
+        y = torch_dct.dct(x, norm="ortho")
         if dim != -1:
             y = y.transpose(dim, -1)
         return y
 
     def _inverse(self, y):
+        import torch_dct
         dim = -self.event_dim
         if dim != -1:
             y = y.transpose(dim, -1)
-        x = idct_ii(y)
+        x = torch_dct.idct(y, norm="ortho")
         if dim != -1:
             x = x.transpose(dim, -1)
         return x

--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -1,0 +1,51 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from torch.distributions import constraints
+from torch.distributions.transforms import Transform
+
+from pyro.ops.tensor_utils import dct_ii, idct_ii
+
+
+class DiscreteCosineTransform(Transform):
+    """
+    Discrete Cosine Transform of type-II.
+
+    This uses :func:`~pyro.ops.tensor_utils.dct_ii` and
+    :func:`~pyro.ops.tensor_utils.idct_ii` internally.
+
+    :param int dim: Dimension along which to transform. Must be negative.
+    """
+    domain = constraints.real
+    codomain = constraints.real
+    bijective = True
+    sign = +1  # TODO verify this
+
+    def __init__(self, dim=-1, cache_size=0):
+        assert isinstance(dim, int) and dim < 0
+        self.event_dim = -dim
+        super().__init__(cache_size=cache_size)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.event_dim == other.event_dim
+
+    def _call(self, x):
+        dim = -self.event_dim
+        if dim != -1:
+            x = x.transpose(dim, -1)
+        y = dct_ii(x)
+        if dim != -1:
+            y = y.transpose(dim, -1)
+        return y
+
+    def _inverse(self, y):
+        dim = -self.event_dim
+        if dim != -1:
+            y = y.transpose(dim, -1)
+        x = idct_ii(y)
+        if dim != -1:
+            x = x.transpose(dim, -1)
+        return x
+
+    def _log_abs_det_jacobian(self, x, y):
+        return x.new_zeros((1,) * self.event_dim)

--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -9,15 +9,14 @@ class DiscreteCosineTransform(Transform):
     """
     Discrete Cosine Transform of type-II.
 
-    This uses :func:`~pyro.ops.tensor_utils.dct_ii` and
-    :func:`~pyro.ops.tensor_utils.idct_ii` internally.
+    This uses the https://github.com/zh217/torch-dct library to compute
+    orthonormal dct and inverse dct transforms. The jacobian is 1.
 
     :param int dim: Dimension along which to transform. Must be negative.
     """
     domain = constraints.real
     codomain = constraints.real
     bijective = True
-    sign = +1  # TODO verify this
 
     def __init__(self, dim=-1, cache_size=0):
         assert isinstance(dim, int) and dim < 0

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from .discrete_cosine import DiscreteCosineReparam
 from .loc_scale import LocScaleReparam
 from .neutra import NeuTraReparam
 from .stable import StableHMMReparam, StableReparam, SymmetricStableReparam
 from .transform import TransformReparam
 
 __all__ = [
+    "DiscreteCosineReparam",
     "LocScaleReparam",
     "NeuTraReparam",
     "StableHMMReparam",

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -31,11 +31,13 @@ class DiscreteCosineReparam(Reparam):
 
     def __call__(self, name, fn, obs):
         assert obs is None, "TransformReparam does not support observe statements"
+        assert fn.event_dim >= -self.dim, ("Cannot transform along batch dimension; "
+                                           "try converting a batch dimension to an event dimension")
 
         # Draw noise from the base distribution.
         transform = DiscreteCosineTransform(dim=self.dim, cache_size=1)
         x_dct = pyro.sample("{}_dct".format(name),
-                            dist.TransformedDistribution(fn.base_dist, transform))
+                            dist.TransformedDistribution(fn, transform))
 
         # Differentiably transform.
         x = transform.inv(x_dct)  # should be free due to transform cache

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -1,0 +1,36 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pyro
+import pyro.distributions as dist
+from pyro.distributions.transforms.discrete_cosine import DiscreteCosineTransform
+
+from .reparam import Reparam
+
+
+class DiscreteCosineReparam(Reparam):
+    """
+    Discrete Cosine reparamterizer, using a
+    :class:`~pyro.distributions.transforms.DiscreteCosineTransform` .
+
+    :param int dim: Dimension along which to transform. Must be negative.
+        This is an absolute dim counting from the right.
+    """
+    def __init__(self, dim=-1):
+        assert isinstance(dim, int) and dim < 0
+        self.dim = dim
+
+    def __call__(self, name, fn, obs):
+        assert obs is None, "TransformReparam does not support observe statements"
+
+        # Draw noise from the base distribution.
+        transform = DiscreteCosineTransform(dim=self.dim, cache_size=1)
+        x_dct = pyro.sample("{}_dct".format(name),
+                            dist.TransformedDistribution(fn.base_dist, transform))
+
+        # Differentiably transform.
+        x = transform.inv(x_dct)
+
+        # Simulate a pyro.deterministic() site.
+        new_fn = dist.Delta(x, event_dim=fn.event_dim)
+        return new_fn, x

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -13,6 +13,15 @@ class DiscreteCosineReparam(Reparam):
     Discrete Cosine reparamterizer, using a
     :class:`~pyro.distributions.transforms.DiscreteCosineTransform` .
 
+    This is useful for sequential models where coupling along a time-like axis
+    (e.g. a banded precision matrix) introduces long-range correlation. This
+    reparameterizes to a frequency-domain represetation where posterior
+    covariance should be closer to diagonal, thereby improving the accuracy of
+    diagonal guides in SVI and improving the effectiveness of a diagonal mass
+    matrix in HMC.
+
+    This reparameterization works only for latent variables, not likelihoods.
+
     :param int dim: Dimension along which to transform. Must be negative.
         This is an absolute dim counting from the right.
     """
@@ -29,7 +38,7 @@ class DiscreteCosineReparam(Reparam):
                             dist.TransformedDistribution(fn.base_dist, transform))
 
         # Differentiably transform.
-        x = transform.inv(x_dct)
+        x = transform.inv(x_dct)  # should be free due to transform cache
 
         # Simulate a pyro.deterministic() site.
         new_fn = dist.Delta(x, event_dim=fn.event_dim)

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -92,6 +92,7 @@ def dct_ii(x):
 
     :param Tensor x:
     """
+    return x  # FIXME
     raise NotImplementedError("TODO")
 
 
@@ -102,6 +103,7 @@ def idct_ii(y):
 
     :param Tensor y:
     """
+    return y  # FIXME
     raise NotImplementedError("TODO")
 
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -110,3 +110,48 @@ def repeated_matmul(M, n):
         result = torch.stack([result, doubled]).reshape(-1, *result.shape[1:])
 
     return result[0:n]
+
+
+def _real_of_complex_mul(a, b):
+    ar, ai = a.unbind(-1)
+    br, bi = b.unbind(-1)
+    return ar * br - ai * bi
+
+
+def dct(x):
+    # Ref: http://fourier.eng.hmc.edu/e161/lectures/dct/node2.html
+    N = x.size(-1)
+    # Step 1
+    y = torch.cat([x[..., ::2], x[..., 1::2].flip(-1)], dim=-1)
+    # Step 2
+    Y = torch.rfft(y, 1, onesided=False)
+    # Step 3
+    coef_real = torch.cos(torch.linspace(0, 0.5 * math.pi, N + 1))
+    coef = torch.stack([coef_real[:-1], -coef_real[1:].flip(-1)], dim=-1)
+    X = _real_of_complex_mul(coef, Y)
+    # orthogonalize
+    scale = torch.cat([x.new_tensor([math.sqrt(N)]), x.new_full((N - 1,), math.sqrt(0.5 * N))])
+    return X / scale
+
+
+def idct(x):
+    N = x.size(-1)
+    scale = torch.cat([x.new_tensor([math.sqrt(N)]), x.new_full((N - 1,), math.sqrt(0.5 * N))])
+    x = x * scale
+    # Step 1, solve X = cos(k) * Yr - sin(k) * Yi
+    # We know that Y[1:] is conjugate to Y[:0:-1], hence
+    # X[:0:-1] = sin(k) * Yr[1:] + cos(k) * Yi[1:]
+    # So Yr[1:] = cos(k) * X[1:] + sin(k) * X[:0:-1]
+    # and Yi[1:] = -sin(k) * X[1:] + cos(k) * X[:0:-1]
+    # In addition, Yi[0] = 0, Yr[0] = X[0]
+    # In other words, Y = complex_mul(e^-ik, X + i[0, X[:0:-1]])
+    xi = torch.nn.functional.pad(x[..., 1:], (0, 1)).flip(-1)
+    X = torch.stack([x, xi], dim=-1)
+    coef_real = torch.cos(torch.linspace(0, 0.5 * math.pi, N + 1))
+    coef = torch.stack([coef_real[:-1], -coef_real[1:].flip(-1)], dim=-1)
+    Y = _complex_mul(coef, X)
+    # Step 2
+    y = torch.irfft(Y, 1, onesided=False)
+    # Step 3
+    # FIXME: something is wrong here
+    return torch.stack([y, y.flip(-1)], axis=-1).reshape(x.shape[:-1] + (-1,))[..., :N]

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -85,6 +85,26 @@ def convolve(signal, kernel, mode='full'):
     return result[..., start_idx: start_idx + truncate]
 
 
+def dct_ii(x):
+    """
+    Discrete cosine transform of type II.
+    This is the inverse of :func:`idct_ii` .
+
+    :param Tensor x:
+    """
+    raise NotImplementedError("TODO")
+
+
+def idct_ii(y):
+    """
+    Inverse discrete cosine transform of type II.
+    This is the inverse of :func:`dct_ii` .
+
+    :param Tensor y:
+    """
+    raise NotImplementedError("TODO")
+
+
 def repeated_matmul(M, n):
     """
     Takes a batch of matrices `M` as input and returns the stacked result of doing the

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -148,7 +148,7 @@ def idct(x):
     Inverse discrete cosine transform of type II, scaled to be orthonormal.
 
     This is the inverse of :func:`dct_ii` , and is equivalent to
-    :func:`scipy.fftpack.dct` with ``norm="ortho"``.
+    :func:`scipy.fftpack.idct` with ``norm="ortho"``.
 
     :param Tensor x: The input signal
     :rtype: Tensor

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -85,28 +85,6 @@ def convolve(signal, kernel, mode='full'):
     return result[..., start_idx: start_idx + truncate]
 
 
-def dct_ii(x):
-    """
-    Discrete cosine transform of type II.
-    This is the inverse of :func:`idct_ii` .
-
-    :param Tensor x:
-    """
-    return x  # FIXME
-    raise NotImplementedError("TODO")
-
-
-def idct_ii(y):
-    """
-    Inverse discrete cosine transform of type II.
-    This is the inverse of :func:`dct_ii` .
-
-    :param Tensor y:
-    """
-    return y  # FIXME
-    raise NotImplementedError("TODO")
-
-
 def repeated_matmul(M, n):
     """
     Takes a batch of matrices `M` as input and returns the stacked result of doing the

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -126,7 +126,7 @@ def dct(x):
     # Step 2
     Y = torch.rfft(y, 1, onesided=False)
     # Step 3
-    coef_real = torch.cos(torch.linspace(0, 0.5 * math.pi, N + 1))
+    coef_real = torch.cos(torch.linspace(0, 0.5 * math.pi, N + 1, dtype=x.dtype, device=x.device))
     coef = torch.stack([coef_real[:-1], -coef_real[1:].flip(-1)], dim=-1)
     X = _real_of_complex_mul(coef, Y)
     # orthogonalize
@@ -149,9 +149,9 @@ def idct(x):
     X = torch.stack([x, xi], dim=-1)
     coef_real = torch.cos(torch.linspace(0, 0.5 * math.pi, N + 1))
     coef = torch.stack([coef_real[:-1], coef_real[1:].flip(-1)], dim=-1)
-    Y = _complex_mul(coef, X)
+    half_size = N // 2 + 1
+    Y = _complex_mul(coef[..., :half_size, :], X[..., :half_size, :])
     # Step 2
-    y = torch.irfft(Y, 1, onesided=False)
+    y = torch.irfft(Y, 1, onesided=True, signal_sizes=(N,))
     # Step 3
-    # FIXME: something is wrong here
     return torch.stack([y, y.flip(-1)], axis=-1).reshape(x.shape[:-1] + (-1,))[..., :N]

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
         'torch>=1.3.0',
+        'torch-dct==0.1.5',
         'tqdm>=4.36',
     ],
     extras_require={

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -110,6 +110,10 @@ class TransformTests(TestCase):
         for input_dim in [2, 5, 10]:
             self._test_jacobian(input_dim, T.tanh())
 
+    def test_dct_jacobians(self):
+        for input_dim in [2, 5, 10]:
+            self._test_jacobian(input_dim, T.DiscreteCosineTransform())
+
     def test_neural_autoregressive_jacobians(self):
         for activation in ['ELU', 'LeakyReLU', 'sigmoid', 'tanh']:
             for input_dim in [2, 5, 10]:
@@ -188,6 +192,10 @@ class TransformTests(TestCase):
     def test_tanh_inverses(self):
         for input_dim in [2, 5, 10]:
             self._test_inverse(input_dim, T.tanh())
+
+    def test_dct_inverses(self):
+        for input_dim in [2, 5, 10]:
+            self._test_inverse(input_dim, T.DiscreteCosineTransform())
 
     def test_householder_shapes(self):
         for shape in [(3,), (3, 4), (3, 4, 2)]:
@@ -274,3 +282,7 @@ class TransformTests(TestCase):
     def test_tanh_shapes(self):
         for shape in [(3,), (3, 4), (3, 4, 2)]:
             self._test_shape(shape, T.tanh())
+
+    def test_dct_shapes(self):
+        for shape in [(3,), (3, 4), (3, 4, 2)]:
+            self._test_shape(shape, T.DiscreteCosineTransform())

--- a/tests/infer/reparam/test_discrete_cosine.py
+++ b/tests/infer/reparam/test_discrete_cosine.py
@@ -1,0 +1,54 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from torch.autograd import grad
+
+import pyro
+import pyro.distributions as dist
+from pyro import poutine
+from pyro.infer.reparam import DiscreteCosineReparam
+from tests.common import assert_close
+
+
+# Test helper to extract central moments from samples.
+def get_moments(x):
+    n = x.size(0)
+    x = x.reshape(n, -1)
+    mean = x.mean(0)
+    x = x - mean
+    std = (x * x).mean(0).sqrt()
+    x = x / std
+    corr = (x.unsqueeze(-1) * x.unsqueeze(-2)).mean(0).reshape(-1)
+    return torch.cat([mean, std, corr])
+
+
+@pytest.mark.parametrize("shape,dim", [
+    ((6,), -1),
+    ((2, 5,), -1),
+    ((4, 2), -2),
+    ((2, 3, 1), -2),
+], ids=str)
+def test_normal(shape, dim):
+    loc = torch.empty(shape).uniform_(-1., 1.).requires_grad_()
+    scale = torch.empty(shape).uniform_(0.5, 1.5).requires_grad_()
+
+    def model():
+        with pyro.plate_stack("plates", shape[:dim]):
+            with pyro.plate("particles", 10000):
+                pyro.sample("x", dist.Normal(loc, scale).expand(shape).to_event(-dim))
+
+    value = poutine.trace(model).get_trace().nodes["x"]["value"]
+    expected_probe = get_moments(value)
+
+    reparam_model = poutine.reparam(model, {"x": DiscreteCosineReparam(dim=dim)})
+    value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
+    actual_probe = get_moments(value)
+    assert_close(actual_probe, expected_probe, atol=0.1)
+
+    for actual_m, expected_m in zip(actual_probe[:10], expected_probe[:10]):
+        expected_grads = grad(expected_m.sum(), [loc, scale], retain_graph=True)
+        actual_grads = grad(actual_m.sum(), [loc, scale], retain_graph=True)
+        assert_close(actual_grads[0], expected_grads[0], atol=0.05)
+        assert_close(actual_grads[1], expected_grads[1], atol=0.05)

--- a/tests/infer/reparam/test_discrete_cosine.py
+++ b/tests/infer/reparam/test_discrete_cosine.py
@@ -43,7 +43,10 @@ def test_normal(shape, dim):
     expected_probe = get_moments(value)
 
     reparam_model = poutine.reparam(model, {"x": DiscreteCosineReparam(dim=dim)})
-    value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
+    trace = poutine.trace(reparam_model).get_trace()
+    assert isinstance(trace.nodes["x_dct"]["fn"], dist.TransformedDistribution)
+    assert isinstance(trace.nodes["x"]["fn"], dist.Delta)
+    value = trace.nodes["x"]["value"]
     actual_probe = get_moments(value)
     assert_close(actual_probe, expected_probe, atol=0.1)
 

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -78,7 +78,7 @@ def test_repeated_matmul(size, n):
         serial_result = torch.matmul(serial_result, M)
 
 
-@pytest.mark.parametrize('shape', [(3, 4), (5,)])
+@pytest.mark.parametrize('shape', [(3, 4), (5,), (2, 1, 6)])
 def test_dct(shape):
     x = torch.randn(shape)
     actual = dct(x)
@@ -86,7 +86,7 @@ def test_dct(shape):
     assert_close(actual, expected)
 
 
-@pytest.mark.parametrize('shape', [(3, 4), (5,)])
+@pytest.mark.parametrize('shape', [(3, 4), (5,), (2, 1, 6)])
 def test_idct(shape):
     x = torch.randn(shape)
     actual = idct(x)

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -3,9 +3,10 @@
 
 import pytest
 import numpy as np
+import scipy.fftpack as fftpack
 import torch
 
-from pyro.ops.tensor_utils import block_diag_embed, convolve, repeated_matmul, block_diagonal
+from pyro.ops.tensor_utils import block_diag_embed, convolve, repeated_matmul, block_diagonal, dct, idct
 from tests.common import assert_equal, assert_close
 
 
@@ -75,3 +76,19 @@ def test_repeated_matmul(size, n):
     for i in range(n):
         assert_equal(result[i, ...], serial_result)
         serial_result = torch.matmul(serial_result, M)
+
+
+@pytest.mark.parametrize('shape', [(3, 4), (5,)])
+def test_dct(shape):
+    x = torch.randn(shape)
+    actual = dct(x)
+    expected = torch.from_numpy(fftpack.dct(x.numpy(), norm='ortho'))
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize('shape', [(3, 4), (5,)])
+def test_idct(shape):
+    x = torch.randn(shape)
+    actual = idct(x)
+    expected = torch.from_numpy(fftpack.idct(x.numpy(), norm='ortho'))
+    assert_close(actual, expected)


### PR DESCRIPTION
Resolves #2221 
Blocking #2253 
Joint work with @fehiepsi 

This implements a Discrete Cosine Transform reparameterizer, intended for use in time series models. The motivating model class is time series models where it is natural to specify a model in terms of increments (e.g. a Gaussian or StudentT or Stable process), but where that parameterization is extremely poorly conditioned, leading to heavily non-diagonal posterior covariances. By reparameterizing in the frequency domain we can nearly (sometimes exactly) diagonalize the posterior covariance.

Empirically this seems to work well for the stochastic volatility model in #2253, where log-volatility is a latent gaussian process. Using an `AutoDiagonalNormal` guide I get cleaner posterior median and lower loss.

## Tasks
- [x] implement low-level ops `dct` and `idct`
    @fritzo initially added torch-dct as a dependency.
    @fehiepsi then replaced this with a custom implementation.
- [x] test on a time series model, e.g. stochastic volatility #2253