### PR TITLE
Rename stable reparam to make way for skewed reparam

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -572,8 +572,7 @@ class StableHMM(TorchDistribution):
     r"""
     Hidden Markov Model with linear dynamics and observations and
     :class:`~pyro.distributions.Stable` noise for initial, transition, and
-    observation distributions. The stability parameter :math:`\alpha` must be
-    shared among all distributions (but can differ among elements of a batch).
+    observation distributions.
 
     This corresponds to the generative model::
 
@@ -588,6 +587,9 @@ class StableHMM(TorchDistribution):
     either reparameterization with
     :class:`~pyro.infer.reparam.stable.StableHMMReparam` or likelihood-free
     algorithms such as :class:`~pyro.infer.energy_distance.EnergyDistance` .
+    Note that while stable processes generally require a common shared
+    stability parameter :math:`\alpha` , this distribution and the above
+    inference algorithms allow heterogeneous stability parameters.
 
     The event_shape of this distribution includes time on the left::
 
@@ -651,16 +653,6 @@ class StableHMM(TorchDistribution):
         batch_shape, time_shape = shape[:-1], shape[-1:]
         event_shape = time_shape + (obs_dim,)
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
-
-        if self._validate_args:
-            initial_stability = initial_dist.base_dist.stability[..., :1]
-            assert (initial_stability == initial_dist.base_dist.stability).all()
-            transition_stability = transition_dist.base_dist.stability[..., :1]
-            assert (transition_stability == transition_dist.base_dist.stability).all()
-            assert (transition_stability == initial_stability.unsqueeze(-2)).all()
-            observation_stability = observation_dist.base_dist.stability[..., :1]
-            assert (observation_stability == observation_dist.base_dist.stability).all()
-            assert (observation_stability == initial_stability.unsqueeze(-2)).all()
 
         if initial_dist.batch_shape != batch_shape:
             initial_dist = initial_dist.expand(batch_shape)

--- a/pyro/distributions/stable.py
+++ b/pyro/distributions/stable.py
@@ -31,7 +31,7 @@ def _unsafe_standard_stable(alpha, beta, V, W):
 
     # Return both the standard Zolotarev parameterization Z and the shift b to
     # convert to Nolan's parametrization S^0 where samples depend continuously
-    # on (alpha,beta), allowing interpolate around the hole at alpha=1.
+    # on (alpha,beta), allowing interpolation around the hole at alpha=1.
     return Z, b  # Nolan's parameterization is Z - b
 
 

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -4,7 +4,7 @@
 from .discrete_cosine import DiscreteCosineReparam
 from .loc_scale import LocScaleReparam
 from .neutra import NeuTraReparam
-from .stable import StableHMMReparam, StableReparam, SymmetricStableReparam
+from .stable import StableHMMReparam, LatentStableReparam, SymmetricStableReparam
 from .transform import TransformReparam
 
 __all__ = [
@@ -12,7 +12,7 @@ __all__ = [
     "LocScaleReparam",
     "NeuTraReparam",
     "StableHMMReparam",
-    "StableReparam",
+    "LatentStableReparam",
     "SymmetricStableReparam",
     "TransformReparam",
 ]

--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -13,7 +13,7 @@ from pyro.infer.util import is_validation_enabled
 from .reparam import Reparam
 
 
-class StableReparam(Reparam):
+class LatentStableReparam(Reparam):
     """
     Auxiliary variable reparameterizer for
     :class:`~pyro.distributions.Stable` latent variables.
@@ -39,7 +39,7 @@ class StableReparam(Reparam):
     def __call__(self, name, fn, obs):
         fn, event_dim = self._unwrap(fn)
         assert isinstance(fn, dist.Stable)
-        assert obs is None, "StableReparam does not support observe statements"
+        assert obs is None, "LatentStableReparam does not support observe statements"
 
         # Draw parameter-free noise.
         proto = fn.stability
@@ -99,7 +99,7 @@ class SymmetricStableReparam(Reparam):
                         self._wrap(dist.Exponential(one), event_dim))
 
         # Differentiably transform to scale drawn from a totally-skewed stable variable.
-        _, z = _unsafe_standard_stable(fn.stability / 2, 1, u, e)
+        z, _ = _unsafe_standard_stable(fn.stability / 2, 1, u, e)
         assert (z >= 0).all()
         scale = fn.scale * (2 ** 0.5) * (math.pi / 4 * fn.stability).cos().pow(1 / fn.stability) * z.sqrt()
         scale = scale.clamp(min=torch.finfo(scale.dtype).tiny)

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -14,7 +14,7 @@ from pyro.infer import config_enumerate
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.util import TraceEinsumEvaluator, TraceTreeEvaluator, initialize_model
-from pyro.infer.reparam import StableReparam
+from pyro.infer.reparam import LatentStableReparam
 from pyro.poutine.subsample_messenger import _Subsample
 from tests.common import assert_close, assert_equal, xfail_param
 
@@ -381,7 +381,7 @@ def test_potential_fn_pickling(jit):
 ])
 def test_reparam_stable(kernel, kwargs):
 
-    @poutine.reparam(config={"z": StableReparam()})
+    @poutine.reparam(config={"z": LatentStableReparam()})
     def model():
         stability = pyro.sample("stability", dist.Uniform(0., 2.))
         skew = pyro.sample("skew", dist.Uniform(-1., 1.))

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -9,7 +9,7 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.distributions.torch_distribution import MaskedDistribution
-from pyro.infer.reparam import StableHMMReparam, StableReparam, SymmetricStableReparam
+from pyro.infer.reparam import StableHMMReparam, LatentStableReparam, SymmetricStableReparam
 from tests.common import assert_close
 
 
@@ -37,7 +37,7 @@ def test_stable(shape):
     value = model()
     expected_moments = get_moments(value)
 
-    reparam_model = poutine.reparam(model, {"x": StableReparam()})
+    reparam_model = poutine.reparam(model, {"x": LatentStableReparam()})
     trace = poutine.trace(reparam_model).get_trace()
     assert isinstance(trace.nodes["x"]["fn"], MaskedDistribution)
     assert isinstance(trace.nodes["x"]["fn"].base_dist, dist.Delta)

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -20,7 +20,7 @@ from pyro.infer import (SVI, EnergyDistance, JitTrace_ELBO, JitTraceEnum_ELBO, J
                         ReweightedWakeSleep, Trace_ELBO, Trace_MMD, TraceEnum_ELBO, TraceGraph_ELBO,
                         TraceMeanField_ELBO, TraceTailAdaptive_ELBO)
 from pyro.infer.autoguide import AutoDelta
-from pyro.infer.reparam import StableReparam
+from pyro.infer.reparam import LatentStableReparam
 from pyro.infer.util import torch_item
 from tests.common import assert_close, assert_equal, xfail_if_not_implemented, xfail_param
 
@@ -724,7 +724,7 @@ def test_energy_distance_multivariate(prior_scale):
 def test_reparam_stable():
     data = dist.Poisson(torch.randn(8).exp()).sample()
 
-    @poutine.reparam(config={"dz": StableReparam(), "y": StableReparam()})
+    @poutine.reparam(config={"dz": LatentStableReparam(), "y": LatentStableReparam()})
     def model():
         stability = pyro.sample("stability", dist.Uniform(1., 2.))
         trans_skew = pyro.sample("trans_skew", dist.Uniform(-1., 1.))

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -15,7 +15,7 @@ import pyro.poutine as poutine
 from pyro.distributions.testing import fakes
 from pyro.infer import (SVI, EnergyDistance, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO,
                         TraceTailAdaptive_ELBO, config_enumerate)
-from pyro.infer.reparam import StableReparam
+from pyro.infer.reparam import LatentStableReparam
 from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.util import torch_item
 from pyro.ops.indexing import Vindex
@@ -2066,7 +2066,7 @@ def test_no_log_prob_ok(Elbo):
 
 def test_reparam_stable():
 
-    @poutine.reparam(config={"z": StableReparam()})
+    @poutine.reparam(config={"z": LatentStableReparam()})
     def model():
         stability = pyro.sample("stability", dist.Uniform(0., 2.))
         skew = pyro.sample("skew", dist.Uniform(-1., 1.))


### PR DESCRIPTION
1. Renames `StableReparam` -> `LatentStableReparam` to make way for a possible future `StableRepram` that works also for likelihoods and nonzero skew. (This new reparamterizer appears out of scope for the 1.2 release.)
2. Drops requirement for homogeneous `stability` parameter of `StableHMM`, after @martinjankowiak observed that this is not required by any of our inference algorithms.
3. Refactors interface of low-level `_unsafe_standard_stable()` to avoid an unnecessary tensor op when used in reparameterizers.

## Tested
- refactoring is exercised by existing tests