### PR TITLE
Refactor StableHMM to LinearHMM

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -154,6 +154,13 @@ InverseGamma
     :undoc-members:
     :show-inheritance:
 
+LinearHMM
+---------
+.. autoclass:: pyro.distributions.LinearHMM
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 LKJCorrCholesky
 ---------------
 .. autoclass:: pyro.distributions.LKJCorrCholesky
@@ -227,13 +234,6 @@ SpanningTree
 Stable
 ------
 .. autoclass:: pyro.distributions.Stable
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-StableHMM
----------
-.. autoclass:: pyro.distributions.StableHMM
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -13,7 +13,7 @@ from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.folded import FoldedDistribution
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
-from pyro.distributions.hmm import DiscreteHMM, GammaGaussianHMM, GaussianHMM, GaussianMRF, StableHMM
+from pyro.distributions.hmm import DiscreteHMM, GammaGaussianHMM, GaussianHMM, GaussianMRF, LinearHMM
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.lkj import LKJCorrCholesky
 from pyro.distributions.mixture import MaskedMixture
@@ -32,8 +32,7 @@ from pyro.distributions.unit import Unit
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
 from pyro.distributions.von_mises import VonMises
 from pyro.distributions.von_mises_3d import VonMises3D
-from pyro.distributions.zero_inflated import (ZeroInflatedDistribution, ZeroInflatedPoisson,
-                                              ZeroInflatedNegativeBinomial)
+from pyro.distributions.zero_inflated import ZeroInflatedDistribution, ZeroInflatedNegativeBinomial, ZeroInflatedPoisson
 
 from . import constraints, kl, transforms
 
@@ -56,6 +55,7 @@ __all__ = [
     "GaussianMRF",
     "GaussianScaleMixture",
     "InverseGamma",
+    "LinearHMM",
     "LKJCorrCholesky",
     "MaskedMixture",
     "MixtureOfDiagNormals",
@@ -67,7 +67,6 @@ __all__ = [
     "RelaxedOneHotCategoricalStraightThrough",
     "SpanningTree",
     "Stable",
-    "StableHMM",
     "TorchDistribution",
     "TransformModule",
     "Unit",

--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -112,20 +112,20 @@ class SymmetricStableReparam(Reparam):
 class StableHMMReparam(Reparam):
     """
     Auxiliary variable reparameterizer for symmetric
-    :class:`~pyro.distributions.StableHMM` random variables whose
+    :class:`~pyro.distributions.LinearHMM` random variables whose
     ``initial_dist``, ``transition_dist``, and ``observation_dist`` are
     symmetric.
 
     This is useful for training the parameters of a
-    :class:`~pyro.distributions.StableHMM` distribution, whose
-    :meth:`~pyro.distributions.StableHMM.log_prob` method is undefined.
+    :class:`~pyro.distributions.LinearHMM` distribution, whose
+    :meth:`~pyro.distributions.LinearHMM.log_prob` method is undefined.
 
     This introduces auxiliary random variables conditioned on which the process
     becomes a :class:`~pyro.distributions.GaussianHMM` . The component
     distributions are reparameterized by :class:`SymmetricStableReparam` .
     """
     def __call__(self, name, fn, obs):
-        assert isinstance(fn, dist.StableHMM)
+        assert isinstance(fn, dist.LinearHMM)
 
         # Reparameterize the initial distribution as conditionally Gaussian.
         init_dist, _ = SymmetricStableReparam()("{}_init".format(name), fn.initial_dist, None)

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -109,7 +109,7 @@ def test_stable_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
     obs_mat = torch.randn(batch_shape + (duration, hidden_dim, obs_dim))
     obs_dist = random_stable(batch_shape + (duration, obs_dim),
                              stability.unsqueeze(-1).unsqueeze(-1), skew=0).to_event(1)
-    hmm = dist.StableHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
 
     def model(data=None):
         with pyro.plate_stack("plates", batch_shape):
@@ -145,7 +145,7 @@ def test_stable_hmm_distribution(stability, duration, hidden_dim, obs_dim):
     trans_dist = random_stable((duration, hidden_dim), stability, skew=0).to_event(1)
     obs_mat = torch.randn(duration, hidden_dim, obs_dim)
     obs_dist = random_stable((duration, obs_dim), stability, skew=0).to_event(1)
-    hmm = dist.StableHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
 
     num_samples = 200000
     expected_samples = hmm.sample([num_samples]).reshape(num_samples, duration * obs_dim)


### PR DESCRIPTION
Addresses #2254 

This relaxes the assertions on `StableHMM` and renames it to `LinearHMM` so it can serve also as a reparameterizable `HMM` for `StudentT` (after #2254) and for arbitrary combinations of `Stable`, `Normal`, `StudentT`, and even `LogNormal` `observation_dist` (as suggested by @martinjankowiak).

Note this class is very general, provides no `.log_prob()` method, and relies on `LinearHMMReparam` #2259 to convert to a `GaussianHMM` for inference.

## Tested
- refactoring is exercised by existing tests
- added a new shape test for `StudentT`