### PR TITLE
Bump dependency versions to torch=1.4 and torchvision=0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     - pip install -U pip
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-    - pip install torch==1.3.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - pip install .[test]
     - pip install coveralls
     - pip freeze

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,5 +210,5 @@ def setup(app):
 # @jpchen's hack to get rtd builder to install latest pytorch
 # See similar line in the install section of .travis.yml
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.3.0+cpu torchvision==0.4.0+cpu '
+    os.system('pip install torch==1.4.0+cpu torchvision==0.5.0+cpu '
               '-f https://download.pytorch.org/whl/torch_stable.html')

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ EXTRAS_REQUIRE = [
     'graphviz>=0.8',
     'matplotlib>=1.3',
     'pillow-simd',
-    'torchvision>=0.4.0',
+    'torchvision>=0.5.0',
     'visdom>=0.1.4',
     'pandas',
     'seaborn',
@@ -86,7 +86,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
-        'torch>=1.3.0',
+        'torch>=1.4.0',
         'tqdm>=4.36',
     ],
     extras_require={


### PR DESCRIPTION
This attempts to work around increasingly problematic `PILLOW_VERSION` errors, e.g. https://api.travis-ci.com/v3/job/276356644/log.txt