### PR TITLE
transforms in mcmc/api.py

### DIFF
--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -384,9 +384,10 @@ class MCMC(object):
 
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.
-        if self.transforms is None and isinstance(self.kernel, (HMC, NUTS)):
-            if self.kernel.transforms is not None:
-                self.transforms = self.kernel.transforms
+        if self.transforms is None:
+            if hasattr(self.kernel, 'transforms'):
+                if self.kernel.transforms is not None:
+                    self.transforms = self.kernel.transforms
             elif self.kernel.model:
                 _, _, self.transforms, _ = initialize_model(self.kernel.model,
                                                             model_args=args,


### PR DESCRIPTION
When trying to use a custom MCMC kernel, inherited from MCMCKernel, the MCMC api raises an error at line 398 since `self.transforms is None`.
This is because the `if` block starting at line 387 always fails for any `self.kernel` which is not HMC or NUTS.

I propose removing the check that `self.kernel` is an instance of `HMC` or `NUTS` to allow for custom kernels.

This raises a problem: `self.kernel.transforms` may not exist for the check on line 388.
I propose changing that to first check that ``hasattr(self.kernel, 'transforms')``