### PR TITLE
Fix for mcmc api transforms None for potential_fn

### DIFF
--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -385,13 +385,13 @@ class MCMC(object):
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.
         if self.transforms is None:
-            if hasattr(self.kernel, 'transforms'):
-                if self.kernel.transforms is not None:
-                    self.transforms = self.kernel.transforms
-            elif self.kernel.model:
-                _, _, self.transforms, _ = initialize_model(self.kernel.model,
-                                                            model_args=args,
-                                                            model_kwargs=kwargs)
+            if hasattr(self.kernel, 'transforms'): # If the kernel has transforms
+                if self.kernel.transforms is not None: # and they are not None
+                    self.transforms = self.kernel.transforms # then use the kernels transforms
+                else:
+                    self.transforms = {}
+            elif self.kernel.model: # else if the kernel doesn't define transforms, try using the model
+                _, _, self.transforms, _ = initialize_model(self.kernel.model, model_args=args, model_kwargs=kwargs)
             else:
                 self.transforms = {}
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -385,12 +385,12 @@ class MCMC(object):
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.
         if self.transforms is None:
-            if hasattr(self.kernel, 'transforms'): # If the kernel has transforms
-                if self.kernel.transforms is not None: # and they are not None
+            if hasattr(self.kernel, 'transforms'):  # If the kernel has transforms
+                if self.kernel.transforms is not None:  # and they are not None
                     self.transforms = self.kernel.transforms # then use the kernels transforms
                 else:
                     self.transforms = {}
-            elif self.kernel.model: # else if the kernel doesn't define transforms, try using the model
+            elif self.kernel.model:  # else if the kernel doesn't define transforms, try using the model
                 _, _, self.transforms, _ = initialize_model(self.kernel.model, model_args=args, model_kwargs=kwargs)
             else:
                 self.transforms = {}

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -385,15 +385,15 @@ class MCMC(object):
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.
         if self.transforms is None:
-            if hasattr(self.kernel, 'transforms'):
-                # Use kernel transforms if not `None`
-                if self.kernel.transforms is not None:  
-                    self.transforms = self.kernel.transforms 
-                # Set default value
-                else:
-                    self.transforms = {}
-            elif self.kernel.model:  # else if the kernel doesn't define transforms, try using the model
-                _, _, self.transforms, _ = initialize_model(self.kernel.model, model_args=args, model_kwargs=kwargs)
+            # Use `kernel.transforms` when available
+            if hasattr(self.kernel, 'transforms') and self.kernel.transforms is not None:
+                self.transforms = self.kernel.transforms
+            # Else, get transforms from model (e.g. in multiprocessing).
+            elif self.kernel.model:
+                _, _, self.transforms, _ = initialize_model(self.kernel.model,
+                                                            model_args=args,
+                                                            model_kwargs=kwargs)
+            # Assign default value
             else:
                 self.transforms = {}
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -385,9 +385,11 @@ class MCMC(object):
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.
         if self.transforms is None:
-            if hasattr(self.kernel, 'transforms'):  # If the kernel has transforms
-                if self.kernel.transforms is not None:  # and they are not None
-                    self.transforms = self.kernel.transforms # then use the kernels transforms
+            if hasattr(self.kernel, 'transforms'):
+                # Use kernel transforms if not `None`
+                if self.kernel.transforms is not None:  
+                    self.transforms = self.kernel.transforms 
+                # Set default value
                 else:
                     self.transforms = {}
             elif self.kernel.model:  # else if the kernel doesn't define transforms, try using the model


### PR DESCRIPTION
Fixes #2272. 

This PR fixes a logic gap for assign `self.transforms` in the `MCMC` api.
It can be the case that both `MCMC.transforms is None` and `MCMC.kernel.transforms is None`
in which case MCMC.transforms should be set to an empty dict.
This bug appears when using HMC/NUTS with a potential_fn.

Note sure on the style guide for inline comments so will leave them as is.