### PR TITLE
bugfix #2270

### DIFF
--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -102,6 +102,7 @@ class MaskedMixture(TorchDistribution):
 
     def sample(self, sample_shape=torch.Size()):
         mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
+        mask = mask.reshape(mask.shape + (1,) * len(self.event_shape))
         result = torch.where(mask,
                              self.component1.sample(sample_shape),
                              self.component0.sample(sample_shape))

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -101,16 +101,16 @@ class MaskedMixture(TorchDistribution):
             return type(self)(mask, component0, component1)
 
     def sample(self, sample_shape=torch.Size()):
-        mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
-        mask = mask.reshape(mask.shape + (1,) * len(self.event_shape))
+        mask = self.mask.reshape(self.mask.shape + (1,) * self.event_dim)
+        mask = mask.expand(sample_shape + self.shape())
         result = torch.where(mask,
                              self.component1.sample(sample_shape),
                              self.component0.sample(sample_shape))
         return result
 
     def rsample(self, sample_shape=torch.Size()):
-        mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
-        mask = mask.reshape(mask.shape + (1,) * len(self.event_shape))
+        mask = self.mask.reshape(self.mask.shape + (1,) * self.event_dim)
+        mask = mask.expand(sample_shape + self.shape())
         result = torch.where(mask,
                              self.component1.rsample(sample_shape),
                              self.component0.rsample(sample_shape))

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -102,14 +102,16 @@ class MaskedMixture(TorchDistribution):
 
     def sample(self, sample_shape=torch.Size()):
         mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
-        result = self.component0.sample(sample_shape)
-        result[mask] = self.component1.sample(sample_shape)[mask]
+        result = torch.where(mask,
+                             self.component1.sample(sample_shape),
+                             self.component0.sample(sample_shape))
         return result
 
     def rsample(self, sample_shape=torch.Size()):
         mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
-        result = self.component0.rsample(sample_shape)
-        result[mask] = self.component1.rsample(sample_shape)[mask]
+        result = torch.where(mask,
+                             self.component1.rsample(sample_shape),
+                             self.component0.rsample(sample_shape))
         return result
 
     def log_prob(self, value):
@@ -122,8 +124,9 @@ class MaskedMixture(TorchDistribution):
         mask = self.mask
         if mask.shape != mask_shape:
             mask = mask.expand(mask_shape)
-        result = self.component0.log_prob(value)
-        result[mask] = self.component1.log_prob(value)[mask]
+        result = torch.where(mask,
+                             self.component1.log_prob(value),
+                             self.component0.log_prob(value))
         return result
 
     @lazy_property

--- a/pyro/distributions/mixture.py
+++ b/pyro/distributions/mixture.py
@@ -110,6 +110,7 @@ class MaskedMixture(TorchDistribution):
 
     def rsample(self, sample_shape=torch.Size()):
         mask = self.mask.expand(sample_shape + self.batch_shape) if sample_shape else self.mask
+        mask = mask.reshape(mask.shape + (1,) * len(self.event_shape))
         result = torch.where(mask,
                              self.component1.rsample(sample_shape),
                              self.component0.rsample(sample_shape))


### PR DESCRIPTION
Resolves #2270 
Using torch.where seems to resolve the issues related to using the Delta distribution as a component in the MaskedMixture.