### PR TITLE
Add in-place method Distribution.has_rsample_()

### DIFF
--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -83,6 +83,10 @@ class Distribution(object, metaclass=ABCMeta):
         distributions should override this method to compute correct
         `.score_function` and `.entropy_term` parts.
 
+        Setting ``.has_rsample`` on a distribution instance will determine
+        whether inference engines use reparameterized samplers or the score
+        function estimator.
+
         :param torch.Tensor x: A single value or batch of values.
         :return: A `ScoreParts` object containing parts of the ELBO estimator.
         :rtype: ScoreParts
@@ -112,3 +116,21 @@ class Distribution(object, metaclass=ABCMeta):
         :rtype: iterator
         """
         raise NotImplementedError("Support not implemented for {}".format(type(self)))
+
+    def has_rsample_(self, value):
+        """
+        Force reparameterized or detached sampling on a single distribution
+        instance. This sets the ``.has_rsample`` attribute in-place.
+
+        This is useful to instruct inference algorithms to avoid
+        reparameterized gradients for variables that discontinuously determine
+        downstream control flow.
+
+        :param bool value: Whether samples be pathwise differentiable.
+        :return: self
+        :rtype: Distribution
+        """
+        if not (value is True or value is False):
+            raise ValueError("Expected value in {False,True}, actual {}".format(value))
+        self.has_rsample = value
+        return self

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -84,8 +84,8 @@ class Distribution(object, metaclass=ABCMeta):
         `.score_function` and `.entropy_term` parts.
 
         Setting ``.has_rsample`` on a distribution instance will determine
-        whether inference engines use reparameterized samplers or the score
-        function estimator.
+        whether inference engines like :class:`~pyro.infer.svi.SVI` use
+        reparameterized samplers or the score function estimator.
 
         :param torch.Tensor x: A single value or batch of values.
         :return: A `ScoreParts` object containing parts of the ELBO estimator.
@@ -126,7 +126,7 @@ class Distribution(object, metaclass=ABCMeta):
         reparameterized gradients for variables that discontinuously determine
         downstream control flow.
 
-        :param bool value: Whether samples be pathwise differentiable.
+        :param bool value: Whether samples will be pathwise differentiable.
         :return: self
         :rtype: Distribution
         """

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -63,4 +63,6 @@ class BroadcastMessenger(Messenger):
             for i in range(-len(target_batch_shape) + 1, 1):
                 if target_batch_shape[i] is None:
                     target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) >= -i else 1
-            msg["fn"] = msg["fn"].expand(target_batch_shape)
+            msg["fn"] = dist.expand(target_batch_shape)
+            if "has_rsample" in dist.__dict__:
+                msg["fn"].has_rsample = dist.has_rsample

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -64,5 +64,5 @@ class BroadcastMessenger(Messenger):
                 if target_batch_shape[i] is None:
                     target_batch_shape[i] = actual_batch_shape[i] if len(actual_batch_shape) >= -i else 1
             msg["fn"] = dist.expand(target_batch_shape)
-            if "has_rsample" in dist.__dict__:
-                msg["fn"].has_rsample = dist.has_rsample
+            if msg["fn"].has_rsample != dist.has_rsample:
+                msg["fn"].has_rsample = dist.has_rsample  # copy custom attribute

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -25,7 +25,9 @@ def DiffTrace_ELBO(*args, **kwargs):
 
 
 @pytest.mark.parametrize("scale", [1., 2.], ids=["unscaled", "scaled"])
-@pytest.mark.parametrize("reparameterized", [True, False], ids=["reparam", "nonreparam"])
+@pytest.mark.parametrize("reparameterized,has_rsample",
+                         [(True, None), (True, False), (True, True), (False, None)],
+                         ids=["reparam", "reparam-False", "reparam-True", "nonreparam"])
 @pytest.mark.parametrize("subsample", [False, True], ids=["full", "subsample"])
 @pytest.mark.parametrize("Elbo,local_samples", [
     (Trace_ELBO, False),
@@ -35,7 +37,7 @@ def DiffTrace_ELBO(*args, **kwargs):
     (TraceEnum_ELBO, False),
     (TraceEnum_ELBO, True),
 ])
-def test_subsample_gradient(Elbo, reparameterized, subsample, local_samples, scale):
+def test_subsample_gradient(Elbo, reparameterized, has_rsample, subsample, local_samples, scale):
     pyro.clear_param_store()
     data = torch.tensor([-0.5, 2.0])
     subsample_size = 1 if subsample else len(data)
@@ -52,7 +54,10 @@ def test_subsample_gradient(Elbo, reparameterized, subsample, local_samples, sca
         scale = pyro.param("scale", lambda: torch.tensor([1.0]))
         with pyro.plate("data", len(data), subsample_size, subsample):
             loc = pyro.param("loc", lambda: torch.zeros(len(data)), event_dim=0)
-            pyro.sample("z", Normal(loc, scale))
+            z_dist = Normal(loc, scale)
+            if has_rsample is not None:
+                z_dist.has_rsample_(has_rsample)
+            pyro.sample("z", z_dist)
 
     if scale != 1.0:
         model = poutine.scale(model, scale=scale)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -201,6 +201,9 @@ def test_variable_clash_in_guide_error(Elbo):
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
 def test_set_has_rsample_ok(has_rsample, Elbo):
 
+    # This model has sparse gradients, so users may want to disable
+    # reparametrized sampling to reduce variance of gradient estimates.
+    # However both versions should be correct, i.e. with or without has_rsample.
     def model():
         z = pyro.sample("z", dist.Normal(0, 1))
         loc = (z * 100).clamp(min=0, max=1)  # sparse gradients

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -197,7 +197,7 @@ def test_variable_clash_in_guide_error(Elbo):
     assert_error(model, guide, Elbo(), match='Multiple sample sites named')
 
 
-@pytest.mark.parametrize("has_rsample", [False, True, 0, 1, 0.9])
+@pytest.mark.parametrize("has_rsample", [False, True])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
 def test_set_has_rsample_ok(has_rsample, Elbo):
 

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -197,6 +197,47 @@ def test_variable_clash_in_guide_error(Elbo):
     assert_error(model, guide, Elbo(), match='Multiple sample sites named')
 
 
+@pytest.mark.parametrize("has_rsample", [False, True, 0, 1, 0.9])
+@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+def test_set_has_rsample_ok(has_rsample, Elbo):
+
+    def model():
+        z = pyro.sample("z", dist.Normal(0, 1))
+        loc = (z * 100).clamp(min=0, max=1)  # sparse gradients
+        pyro.sample("x", dist.Normal(loc, 1), obs=torch.tensor(0.))
+
+    def guide():
+        loc = pyro.param("loc", torch.tensor(0.))
+        pyro.sample("z", dist.Normal(loc, 1).has_rsample_(has_rsample))
+
+    if Elbo is TraceEnum_ELBO:
+        guide = config_enumerate(guide)
+    elif Elbo is TraceTMC_ELBO:
+        guide = config_enumerate(guide, num_samples=2)
+
+    assert_ok(model, guide, Elbo(strict_enumeration_warning=False))
+
+
+@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+def test_not_has_rsample_ok(Elbo):
+
+    def model():
+        z = pyro.sample("z", dist.Normal(0, 1))
+        p = z.round().clamp(min=0.2, max=0.8)  # discontinuous
+        pyro.sample("x", dist.Bernoulli(p), obs=torch.tensor(0.))
+
+    def guide():
+        loc = pyro.param("loc", torch.tensor(0.))
+        pyro.sample("z", dist.Normal(loc, 1).has_rsample_(False))
+
+    if Elbo is TraceEnum_ELBO:
+        guide = config_enumerate(guide)
+    elif Elbo is TraceTMC_ELBO:
+        guide = config_enumerate(guide, num_samples=2)
+
+    assert_ok(model, guide, Elbo(strict_enumeration_warning=False))
+
+
 @pytest.mark.parametrize("subsample_size", [None, 2], ids=["full", "subsample"])
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
 def test_iplate_ok(subsample_size, Elbo):

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -713,6 +713,19 @@ def test_replay_enumerate_poutine(depth, first_available_dim):
         assert actual_shape == expected_shape, 'error on iteration {}'.format(i)
 
 
+@pytest.mark.parametrize("has_rsample", [False, True])
+@pytest.mark.parametrize("depth", [0, 1, 2])
+def test_plate_preserves_has_rsample(has_rsample, depth):
+    def guide():
+        loc = pyro.param("loc", torch.tensor(0.))
+        with pyro.plate_stack("plates", (2,) * depth):
+            return pyro.sample("x", dist.Normal(loc, 1).has_rsample_(has_rsample))
+
+    x = guide()
+    assert x.dim() == depth
+    assert x.requires_grad == has_rsample
+
+
 def test_plate_error_on_enter():
     def model():
         with pyro.plate('foo', 0):


### PR DESCRIPTION
Addresses #2277 

This adds a `.has_rsample_()` in-place method similar to torch's `.requires_grad_()`. This is intended use in guides where the reparametrization trick is invalid.

The minimal change I could find to support @hongseok-yang's request was to 
1. add an attribute override setter to `Distribution` class and
2. preserve any overridden `.has_rsample` attributes in `@broadcast`.

This should be orthogonal to all inference algorithms. Example usage:
```py
def model(data):
    z = pyro.sample("z", dist.Normal(0,1))
    p = z.round().clamp(min=0.2, max=0.8)  # discontinuous
    pyro.sample("x", dist.Bernoulli(p), obs=tensor(0.))

def guide(data):
    loc = pyro.param("loc", torch.tensor(0.))
    scale = pyro.param("scale", torch.tensor(1.), constraint=positive)
    pyro.sample("z", dist.Normal(loc, scale).has_rsample_(False))  # <------ HERE
```

## Tested
- smoke tests
- gradient tests