### PR TITLE
Expand MaskedDistribution batch shape to the broadcast of mask and base_dist batch shapes

### DIFF
--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -252,7 +252,6 @@ class MaskedDistribution(TorchDistribution):
     arg_constraints = {}
 
     def __init__(self, base_dist, mask):
-        self.base_dist = base_dist
         if isinstance(mask, bool):
             self._mask = mask
         else:
@@ -262,6 +261,7 @@ class MaskedDistribution(TorchDistribution):
             if base_dist.batch_shape != batch_shape:
                 base_dist = base_dist.expand(batch_shape)
             self._mask = mask.bool()
+        self.base_dist = base_dist
         super(MaskedDistribution, self).__init__(base_dist.batch_shape, base_dist.event_shape)
 
 

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -256,11 +256,14 @@ class MaskedDistribution(TorchDistribution):
         if isinstance(mask, bool):
             self._mask = mask
         else:
-            if broadcast_shape(mask.shape, base_dist.batch_shape) != base_dist.batch_shape:
-                raise ValueError("Expected mask.shape to be broadcastable to base_dist.batch_shape, "
-                                 "actual {} vs {}".format(mask.shape, base_dist.batch_shape))
+            batch_shape = broadcast_shape(mask.shape, base_dist.batch_shape)
+            if mask.shape != batch_shape:
+                mask = mask.expand(batch_shape)
+            if base_dist.batch_shape != batch_shape:
+                base_dist = base_dist.expand(batch_shape)
             self._mask = mask.bool()
         super(MaskedDistribution, self).__init__(base_dist.batch_shape, base_dist.event_shape)
+
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(MaskedDistribution, _instance)

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -264,7 +264,6 @@ class MaskedDistribution(TorchDistribution):
         self.base_dist = base_dist
         super(MaskedDistribution, self).__init__(base_dist.batch_shape, base_dist.event_shape)
 
-
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(MaskedDistribution, _instance)
         batch_shape = torch.Size(batch_shape)


### PR DESCRIPTION
### Issue Description
Add feature to expand the `batch_shape` of the `MaskedDistribution` to the `broadcast_shape(mask.shape, base_dist.batch_shape)` which seems to me like an intuitive behavior. These changes fail `tests/distributions/test_mask.py::test_mask_invalid_shape` test most likely because of the differences in the intended behavior.