### PR TITLE
Implement Gaussian.rsample()

### DIFF
--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -104,6 +104,42 @@ def test_add(shape, dim):
     assert_close((x + y).log_density(value), x.log_density(value) + y.log_density(value))
 
 
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_rsample_shape(sample_shape, batch_shape, dim):
+    mvn = random_mvn(batch_shape, dim)
+    g = mvn_to_gaussian(mvn)
+    expected = mvn.rsample(sample_shape)
+    actual = g.rsample(sample_shape)
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("dim", [1, 2, 3])
+def test_rsample_distribution(batch_shape, dim):
+    num_samples = 20000
+    mvn = random_mvn(batch_shape, dim)
+    g = mvn_to_gaussian(mvn)
+    expected = mvn.rsample((num_samples,))
+    actual = g.rsample((num_samples,))
+
+    def get_moments(x):
+        mean = x.mean(0)
+        x = x - mean
+        cov = (x.unsqueeze(-1) * x.unsqueeze(-2)).mean(0)
+        std = cov.diagonal(dim1=-1, dim2=-2).sqrt()
+        corr = cov / (std.unsqueeze(-1) * std.unsqueeze(-2))
+        return mean, std, corr
+
+    expected_mean, expected_std, expected_corr = get_moments(expected)
+    actual_mean, actual_std, actual_corr = get_moments(actual)
+    assert_close(actual_mean, expected_mean, atol=0.1, rtol=0.02)
+    assert_close(actual_std, expected_std, atol=0.1, rtol=0.02)
+    assert_close(actual_corr, expected_corr, atol=0.05)
+
+
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("left", [1, 2, 3])
 @pytest.mark.parametrize("right", [1, 2, 3])


### PR DESCRIPTION
Addresses #2182

This implements the low level operation `Gaussian.rsample()` which will be used in a future parallel-scan algorithm for forward-filter-backward-sample.

## Tested
- shape tests
- distribution tests