### PR TITLE
Patch Transform to unset cache on call to backward

### DIFF
--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -44,10 +44,14 @@ def _Transform__call__(self, x):
         return y_old
     y = self._call(x)
 
-    if self._cache_size > 0:
-        # unset cached value after call to backward
+    if self._cache_size > 0 and x.requires_grad:
+        weakself = weakref.ref(self)
+
+        # hook to unset cached value after call to backward
         def _hook(_):
-            self._cached_x_y = None, None
+            self = weakself()
+            if self is not None:
+                self._cached_x_y = None, None
 
         y.register_hook(_hook)
     self._cached_x_y = x, y
@@ -66,10 +70,14 @@ def _Transform_inv_call(self, y):
         return x_old
     x = self._inverse(y)
 
-    if self._cache_size > 0:
-        # unset cached value after call to backward
+    if self._cache_size > 0 and y.requires_grad:
+        weakself = weakref.ref(self)
+
+        # hook to unset cached value after call to backward
         def _hook(_):
-            self._cached_x_y = None, None
+            self = weakself()
+            if self is not None:
+                self._cached_x_y = None, None
 
         x.register_hook(_hook)
     self._cached_x_y = x, y


### PR DESCRIPTION
This problem was seen in #2282 when we use caching with one of the transforms, and can be seen in the following failure pattern (see test below too):

```python
x = torch.tensor(2., requires_grad=True)
t = ExpTransform(cache_size=1)
torch.autograd.grad(t(x), x)
# Error on second call
torch.autograd.grad(t(x), x)
```
, where the second call throws `RuntimeError: Trying to backward through the graph a second time`. 

To get around this, we can add a backward hook to the transformed values in `__call__` and `_inv_call` to unset `cached_x_y` after the first `grad` call. This ensures that we rebuild the autograd graph instead of reusing the previous transformed value on the second `grad` call even if the original argument remains the same. 