### PR TITLE
Update reference to JMLR

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,22 @@ Refer to the instructions [here](docker/README.md).
 ## Citation
 If you use Pyro, please consider citing:
 ```
-@article{bingham2018pyro,
-  author = {Bingham, Eli and Chen, Jonathan P. and Jankowiak, Martin and Obermeyer, Fritz and
-            Pradhan, Neeraj and Karaletsos, Theofanis and Singh, Rohit and Szerlip, Paul and
-            Horsfall, Paul and Goodman, Noah D.},
-  title = {{Pyro: Deep Universal Probabilistic Programming}},
-  journal = {arXiv preprint arXiv:1810.09538},
-  year = {2018}
+@article{bingham2019pyro,
+  author    = {Eli Bingham and
+               Jonathan P. Chen and
+               Martin Jankowiak and
+               Fritz Obermeyer and
+               Neeraj Pradhan and
+               Theofanis Karaletsos and
+               Rohit Singh and
+               Paul A. Szerlip and
+               Paul Horsfall and
+               Noah D. Goodman},
+  title     = {Pyro: Deep Universal Probabilistic Programming},
+  journal   = {J. Mach. Learn. Res.},
+  volume    = {20},
+  pages     = {28:1--28:6},
+  year      = {2019},
+  url       = {http://jmlr.org/papers/v20/18-403.html}
 }
 ```


### PR DESCRIPTION
Hi Pyro Devs,

Since you have published the preprint in JMLR, I suggest updating the suggested citation in README to the published version.
It's based on https://dblp.org/rec/bibtex/journals/jmlr/BinghamCJOPKSSH19 (which is CC0).