### PR TITLE
Implement .conjugate_update() and ConjugateReparam

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,6 +189,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'torch': ('https://pytorch.org/docs/master/', None),
+    'funsor': ('http://funsor.pyro.ai/en/stable/', None),
     'opt_einsum': ('https://optimized-einsum.readthedocs.io/en/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -28,6 +28,7 @@ Abstract Distribution
     :undoc-members:
     :special-members: __call__
     :show-inheritance:
+    :member-order: bysource
 
 TorchDistributionMixin
 ----------------------

--- a/docs/source/infer.reparam.rst
+++ b/docs/source/infer.reparam.rst
@@ -14,6 +14,15 @@ shaped. These can be used with a variety of inference algorithms, e.g.
     :member-order: bysource
     :special-members: __call__
 
+Conjugate Update
+----------------
+.. automodule:: pyro.infer.reparam.conjugate
+    :members:
+    :undoc-members:
+    :member-order: bysource
+    :special-members: __call__
+    :show-inheritance:
+
 Loc-Scale Decentering
 ---------------------
 .. automodule:: pyro.infer.reparam.loc_scale

--- a/docs/source/infer.reparam.rst
+++ b/docs/source/infer.reparam.rst
@@ -14,8 +14,8 @@ shaped. These can be used with a variety of inference algorithms, e.g.
     :member-order: bysource
     :special-members: __call__
 
-Conjugate Update
-----------------
+Conjugate Updating
+------------------
 .. automodule:: pyro.infer.reparam.conjugate
     :members:
     :undoc-members:

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -112,3 +112,22 @@ class Distribution(object, metaclass=ABCMeta):
         :rtype: iterator
         """
         raise NotImplementedError("Support not implemented for {}".format(type(self)))
+
+    def conjugate_update(self, other):
+        """
+        Creates an updated distribution fusing information from another
+        compatible distribution. This is supported by only a few conjugate
+        distributions.
+
+        This should satisfy::
+
+            fg, log_normalizer = f.conjugate_update(g)
+            assert f.log_prob(x) + g.log_prob(x) == fg.log_prob(x) + log_normalizer
+
+        :param other: A distribution representing ``p(data|self.probs)`` but
+            normalized over ``self.probs`` rather than ``data``.
+        :return: a pair ``(updated,log_normalizer)`` where ``updated`` is an
+            updated distribution of type ``type(self)``, and ``log_normalizer``
+            is a :class:`~torch.Tensor` representing the normalization factor.
+        """
+        raise NotImplementedError("{} does not support .conjugate_update()".format(type(self)))

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -111,7 +111,7 @@ class Distribution(object, metaclass=ABCMeta):
         :return: An iterator over the distribution's discrete support.
         :rtype: iterator
         """
-        raise NotImplementedError("Support not implemented for {}".format(type(self)))
+        raise NotImplementedError("Support not implemented for {}".format(type(self).__name__))
 
     def conjugate_update(self, other):
         """
@@ -130,4 +130,5 @@ class Distribution(object, metaclass=ABCMeta):
             updated distribution of type ``type(self)``, and ``log_normalizer``
             is a :class:`~torch.Tensor` representing the normalization factor.
         """
-        raise NotImplementedError("{} does not support .conjugate_update()".format(type(self)))
+        raise NotImplementedError("{} does not support .conjugate_update()"
+                                  .format(type(self).__name__))

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -132,7 +132,7 @@ class Distribution(object, metaclass=ABCMeta):
         :func:`~funsor.pyro.convert.tensor_to_funsor` ::
 
             dist_to_funsor(f) + dist_to_funsor(g)
-              == dist_to_funsor(gf) + tensor_to_funsor(log_normalizer)
+              == dist_to_funsor(fg) + tensor_to_funsor(log_normalizer)
 
         :param other: A distribution representing ``p(data|latent)`` but
             normalized over ``latent`` rather than ``data``. Here ``latent``

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -119,13 +119,25 @@ class Distribution(object, metaclass=ABCMeta):
         compatible distribution. This is supported by only a few conjugate
         distributions.
 
-        This should satisfy::
+        This should satisfy the equation::
 
             fg, log_normalizer = f.conjugate_update(g)
             assert f.log_prob(x) + g.log_prob(x) == fg.log_prob(x) + log_normalizer
 
-        :param other: A distribution representing ``p(data|self.probs)`` but
-            normalized over ``self.probs`` rather than ``data``.
+        Note this is equivalent to :obj:`funsor.ops.add` on
+        :class:`~funsor.terms.Funsor` distributions, but we return a lazy sum
+        ``(updated, log_normalizer)`` because PyTorch distributions must be
+        normalized.  Thus :meth:`conjugate_update` should commute with
+        :func:`~funsor.pyro.convert.dist_to_funsor` and
+        :func:`~funsor.pyro.convert.tensor_to_funsor` ::
+
+            dist_to_funsor(f) + dist_to_funsor(g)
+              == dist_to_funsor(gf) + tensor_to_funsor(log_normalizer)
+
+        :param other: A distribution representing ``p(data|latent)`` but
+            normalized over ``latent`` rather than ``data``. Here ``latent``
+            is a candidate sample from ``self`` and ``data`` is a ground
+            observation of unrelated type.
         :return: a pair ``(updated,log_normalizer)`` where ``updated`` is an
             updated distribution of type ``type(self)``, and ``log_normalizer``
             is a :class:`~torch.Tensor` representing the normalization factor.

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -362,7 +362,9 @@ class GaussianHMM(TorchDistribution):
     :type observation_dist: ~torch.distributions.MultivariateNormal or
         ~torch.distributions.Independent of ~torch.distributions.Normal
     """
+    has_rsample = True
     arg_constraints = {}
+    support = constraints.real
 
     def __init__(self, initial_dist, transition_matrix, transition_dist,
                  observation_matrix, observation_dist, validate_args=None):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -7,6 +7,7 @@ from torch.distributions.utils import lazy_property
 
 from pyro.distributions.constraints import IndependentConstraint
 from pyro.distributions.torch_distribution import TorchDistributionMixin
+from pyro.distributions.util import sum_rightmost
 
 
 class Beta(torch.distributions.Beta, TorchDistributionMixin):
@@ -106,6 +107,13 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
     @_validate_args.setter
     def _validate_args(self, value):
         self.base_dist._validate_args = value
+
+    def conjugate_update(self, other):
+        n = self.reintepreted_batch_ndims
+        updated, log_normalizer = self.base_dist.conjugate_update(other.to_event(-n))
+        updated = updated.to_event(n)
+        log_normalizer = sum_rightmost(log_normalizer, n)
+        return updated, log_normalizer
 
 
 # Programmatically load all distributions from PyTorch.

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -170,26 +170,6 @@ class TorchDistributionMixin(Distribution):
         """
         return MaskedDistribution(self, mask)
 
-    def conjugate_update(self, other):
-        """
-        Creates an updated distribution fusing information from another
-        compatible distribution. This is supported by only a few conjugate
-        distributions.
-
-        This should satisfy::
-
-            fg, log_normalizer = f.conjugate_update(g)
-            assert f.log_prob(x) + g.log_prob(x) == fg.log_prob(x) + log_normalizer
-
-        :param other: A distribution representing ``p(data|self.probs)`` but
-            normalized over ``self.probs`` rather than ``data``.
-        :return: a pair ``(updated,log_normalizer)`` where ``updated`` is an
-            updated distribution of type ``type(self)``, and ``log_normalizer``
-            is a :class:`~torch.Tensor` representing the normalization factor.
-        """
-        assert other.event_shape == self.event_shape
-        raise NotImplementedError("{} does not support .conjugate_update()".format(type(self)))
-
 
 class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin):
     """

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -170,6 +170,26 @@ class TorchDistributionMixin(Distribution):
         """
         return MaskedDistribution(self, mask)
 
+    def conjugate_update(self, other):
+        """
+        Creates an updated distribution fusing information from another
+        compatible distribution. This is supported by only a few conjugate
+        distributions.
+
+        This should satisfy::
+
+            fg, log_normalizer = f.conjugate_update(g)
+            assert f.log_prob(x) + g.log_prob(x) == fg.log_prob(x) + log_normalizer
+
+        :param other: A distribution representing ``p(data|self.probs)`` but
+            normalized over ``self.probs`` rather than ``data``.
+        :return: a pair ``(updated,log_normalizer)`` where ``updated`` is an
+            updated distribution of type ``type(self)``, and ``log_normalizer``
+            is a :class:`~torch.Tensor` representing the normalization factor.
+        """
+        assert other.event_shape == self.event_shape
+        raise NotImplementedError("{} does not support .conjugate_update()".format(type(self)))
+
 
 class TorchDistribution(torch.distributions.Distribution, TorchDistributionMixin):
     """
@@ -317,6 +337,12 @@ class MaskedDistribution(TorchDistribution):
     @property
     def variance(self):
         return self.base_dist.variance
+
+    def conjugate_update(self, other):
+        updated, log_normalizer = self.base_dist.conjugate_update(other)
+        updated = updated.mask(self._mask)
+        log_normalizer = torch.where(self._mask, log_normalizer, torch.zeros_like(log_normalizer))
+        return updated, log_normalizer
 
 
 class ExpandedDistribution(TorchDistribution):

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -428,6 +428,12 @@ class ExpandedDistribution(TorchDistribution):
     def variance(self):
         return self.base_dist.variance.expand(self.batch_shape + self.event_shape)
 
+    def conjugate_update(self, other):
+        updated, log_normalizer = self.base_dist.conjugate_update(other)
+        updated = updated.expand(self.batch_shape)
+        log_normalizer = log_normalizer.expand(self.batch_shape)
+        return updated, log_normalizer
+
 
 @register_kl(MaskedDistribution, MaskedDistribution)
 def _kl_masked_masked(p, q):

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -5,11 +5,13 @@ from .discrete_cosine import DiscreteCosineReparam
 from .hmm import LinearHMMReparam
 from .loc_scale import LocScaleReparam
 from .neutra import NeuTraReparam
+from .conjugate import ConjugateReparam
 from .stable import LatentStableReparam, StableReparam, SymmetricStableReparam
 from .studentt import StudentTReparam
 from .transform import TransformReparam
 
 __all__ = [
+    "ConjugateReparam",
     "DiscreteCosineReparam",
     "LatentStableReparam",
     "LinearHMMReparam",

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -1,0 +1,41 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pyro
+import pyro.distributions as dist
+
+from .reparam import Reparam
+
+
+class ConjugateReparam(Reparam):
+    """
+    Reparameterize to propose from the conjugate posterior given a likelihood
+    function.  The likelihood function may be approximate or learned.
+
+    :param guide: A likelihood distribution or a callable returning a
+        likelihood distribution.
+    :type guide: ~pyro.distributions.Distribution or callable
+    """
+    def __init__(self, guide):
+        self.guide = guide
+
+    def __call__(self, name, fn, obs):
+        assert obs is None, "PosteriorReparam does not support observe statements"
+
+        # Create a likelihood guide.
+        guide_dist = self.guide
+        if not isinstance(guide_dist, dist.Distribution):
+            args, kwargs = self.args_kwargs
+            guide_dist = guide_dist(*args, **kwargs)
+        assert isinstance(guide_dist, dist.Distribution)
+
+        # Draw a sample from the approximate posterior.
+        posterior, log_normalizer = fn.posterior(guide_dist)
+        assert isinstance(guide_dist, dist.Distribution)
+        value = pyro.sample("{}_posterior", posterior, infer={"from_prior": True})
+
+        # Return an importance-weighted point estimate.
+        # This is equal to fn.log_prob(value) - posterior.log_prob(value).
+        log_density = log_normalizer - guide_dist.log_prob(value)
+        new_fn = dist.Delta(value, log_density=log_density, event_dim=fn.event_dim)
+        return new_fn, value

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -78,7 +78,7 @@ class ConjugateReparam(Reparam):
         #   p(z) / u(z) = normalizer / q(z|x)                          (Eqn 1)
         # Note that q(z|x) is often approximate; in the exact case
         #   q(z|x) = p(x|z) / integral p(x|z) dz
-        # this site and the downstream likelihood site will have combined density
+        # so this site and the downstream likelihood site will have combined density
         #   (p(z) / u(z)) p(x|z) = (normalizer / q(z|x)) p(x|z)
         #                        = normalizer integral p(x|z) dz
         # Hence in the exact case, downstream probability does not depend on the sampled z,

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -63,10 +63,11 @@ class ConjugateReparam(Reparam):
         fn, log_normalizer = fn.conjugate_update(guide_dist)
         assert isinstance(guide_dist, dist.Distribution)
         if not fn.has_rsample:
+            # Note supporting non-reparameterized sites would require more delicate
+            # handling of traced sites than the crude _do_not_trace flag below.
             raise NotImplementedError("ConjugateReparam inference supports only reparameterized "
                                       "distributions, but got {}".format(type(fn)))
-        value = pyro.sample("{}_posterior".format(name), fn,
-                            infer={"_do_not_trace": True})
+        value = pyro.sample("{}_updated".format(name), fn, infer={"_do_not_trace": True})
 
         # Compute importance weight. Let p(z) be the original fn, q(z|x) be
         # the guide, and u(z) be the conjugate_updated distribution. Then

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -9,10 +9,41 @@ from .reparam import Reparam
 
 class ConjugateReparam(Reparam):
     """
-    Reparameterize to propose from a conjugate updated The likelihood function may be approximate or learned.
+    Reparameterize to a conjugate updated distribution.
+
+    This updates a prior distribution ``fn`` using the
+    :meth:`~pyro.distributions.Distribution.conjugate_update`
+    method.  The guide may be either a distribution object or a callable
+    inputting model ``*args,**kwargs`` and returning a distribution object. The
+    guide may be approximate or learned.
+
+    For example consider the model and naive variational guide::
+
+        total = torch.tensor(10.)
+        count = torch.tensor(2.)
+
+        def model():
+            prob = pyro.sample("prob", dist.Beta(0.5, 1.5))
+            pyro.sample("count", dist.Binomial(total, prob), obs=count)
+
+        guide = AutoDiagonalNormal(model)  # learns the posterior over prob
+
+    Instead of using this learned guide, we can hand-compute the conjugate
+    posterior distribution over "prob", and then use a simpler guide during
+    inference, in this case an empty guide::
+
+        reparam_model = poutine.reparam(model, {
+            "prob": ConjugateReparam(dist.Beta(1 + count, 1 + total - count))
+        })
+
+        def reparam_guide():
+            pass  # nothing remains to be modeled!
 
     :param guide: A likelihood distribution or a callable returning a
-        likelihood distribution.
+        guide distribution. Only a few distributions are supported, depending
+        on the prior distribution's
+        :meth:`~pyro.distributions.Distribution.conjugate_update`
+        implementation.
     :type guide: ~pyro.distributions.Distribution or callable
     """
     def __init__(self, guide):
@@ -21,7 +52,7 @@ class ConjugateReparam(Reparam):
     def __call__(self, name, fn, obs):
         assert obs is None, "PosteriorReparam does not support observe statements"
 
-        # Create a likelihood guide.
+        # Compute a guide distribution, either static or dependent.
         guide_dist = self.guide
         if not isinstance(guide_dist, dist.Distribution):
             args, kwargs = self.args_kwargs
@@ -37,7 +68,20 @@ class ConjugateReparam(Reparam):
         value = pyro.sample("{}_posterior".format(name), fn,
                             infer={"_do_not_trace": True})
 
+        # Compute importance weight. Let p(z) be the original fn, q(z|x) be
+        # the guide, and u(z) be the conjugate_updated distribution. Then
+        #   normalizer = p(z) q(z|x) / u(z).
+        # Since we've sampled from u(z) instead of p(z), we
+        # need an importance weight
+        #   p(z) / u(z) = normalizer / q(z|x)                       (Eqn 1)
+        # Note that q(z|x) is often approximate; in the exact case
+        #   q(z|x) = p(x|z) / integral p(x|z) dz
+        # and since this site and the downstream likelihood site will have combined density
+        #   normalizer q(z|x) p(x|z) = normalizer / integral p(x|z) dz
+        # Hence in the exact case, downstream probability does not depend on the sampled z,
+        # permitting this reparameterizer to be used in HMC.
+        log_density = log_normalizer - guide_dist.log_prob(value)  # By Eqn 1.
+
         # Return an importance-weighted point estimate.
-        log_density = log_normalizer - guide_dist.log_prob(value)
         new_fn = dist.Delta(value, log_density=log_density, event_dim=fn.event_dim)
         return new_fn, value

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -32,7 +32,7 @@ class ConjugateReparam(Reparam):
         # Draw a sample from the approximate posterior.
         posterior, log_normalizer = fn.posterior(guide_dist)
         assert isinstance(guide_dist, dist.Distribution)
-        value = pyro.sample("{}_posterior", posterior, infer={"from_prior": True})
+        value = pyro.sample("{}_posterior", posterior, infer={"require_guide": False})
 
         # Return an importance-weighted point estimate.
         # This is equal to fn.log_prob(value) - posterior.log_prob(value).

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -9,8 +9,7 @@ from .reparam import Reparam
 
 class ConjugateReparam(Reparam):
     """
-    Reparameterize to propose from the conjugate posterior given a likelihood
-    function.  The likelihood function may be approximate or learned.
+    Reparameterize to propose from a conjugate updated The likelihood function may be approximate or learned.
 
     :param guide: A likelihood distribution or a callable returning a
         likelihood distribution.
@@ -29,13 +28,16 @@ class ConjugateReparam(Reparam):
             guide_dist = guide_dist(*args, **kwargs)
         assert isinstance(guide_dist, dist.Distribution)
 
-        # Draw a sample from the approximate posterior.
-        posterior, log_normalizer = fn.posterior(guide_dist)
+        # Draw a sample from the updated distribution.
+        fn, log_normalizer = fn.conjugate_update(guide_dist)
         assert isinstance(guide_dist, dist.Distribution)
-        value = pyro.sample("{}_posterior", posterior, infer={"require_guide": False})
+        if not fn.has_rsample:
+            raise NotImplementedError("ConjugateReparam inference supports only reparameterized "
+                                      "distributions, but got {}".format(type(fn)))
+        value = pyro.sample("{}_posterior".format(name), fn,
+                            infer={"_do_not_trace": True})
 
         # Return an importance-weighted point estimate.
-        # This is equal to fn.log_prob(value) - posterior.log_prob(value).
         log_density = log_normalizer - guide_dist.log_prob(value)
         new_fn = dist.Delta(value, log_density=log_density, event_dim=fn.event_dim)
         return new_fn, value

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -75,11 +75,12 @@ class ConjugateReparam(Reparam):
         #   normalizer = p(z) q(z|x) / u(z).
         # Since we've sampled from u(z) instead of p(z), we
         # need an importance weight
-        #   p(z) / u(z) = normalizer / q(z|x)                       (Eqn 1)
+        #   p(z) / u(z) = normalizer / q(z|x)                          (Eqn 1)
         # Note that q(z|x) is often approximate; in the exact case
         #   q(z|x) = p(x|z) / integral p(x|z) dz
-        # and since this site and the downstream likelihood site will have combined density
-        #   normalizer q(z|x) p(x|z) = normalizer / integral p(x|z) dz
+        # this site and the downstream likelihood site will have combined density
+        #   (p(z) / u(z)) p(x|z) = (normalizer / q(z|x)) p(x|z)
+        #                        = normalizer integral p(x|z) dz
         # Hence in the exact case, downstream probability does not depend on the sampled z,
         # permitting this reparameterizer to be used in HMC.
         log_density = log_normalizer - guide_dist.log_prob(value)  # By Eqn 1.

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -67,7 +67,8 @@ class ConjugateReparam(Reparam):
             # handling of traced sites than the crude _do_not_trace flag below.
             raise NotImplementedError("ConjugateReparam inference supports only reparameterized "
                                       "distributions, but got {}".format(type(fn)))
-        value = pyro.sample("{}_updated".format(name), fn, infer={"_do_not_trace": True})
+        value = pyro.sample("{}_updated".format(name), fn,
+                            infer={"is_auxiliary": True, "_do_not_trace": True})
 
         # Compute importance weight. Let p(z) be the original fn, q(z|x) be
         # the guide, and u(z) be the conjugate_updated distribution. Then

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -31,11 +31,10 @@ class ReparamMessenger(Messenger):
         super().__init__()
         assert isinstance(config, dict) or callable(config)
         self.config = config
-        self._context = {}
         self._args_kwargs = None
 
     def __call__(self, fn):
-        return ParamHandler(self, fn)
+        return ReparamHandler(self, fn)
 
     def _pyro_sample(self, msg):
         if isinstance(self.config, dict):
@@ -61,7 +60,7 @@ class ReparamMessenger(Messenger):
         msg["fn"] = new_fn
 
 
-class ParamHandler(object):
+class ReparamHandler(object):
     """
     Reparameterization poutine.
     """

--- a/pyro/poutine/reparam_messenger.py
+++ b/pyro/poutine/reparam_messenger.py
@@ -13,6 +13,10 @@ class ReparamMessenger(Messenger):
     constructor.  See the :mod:`pyro.infer.reparam` module for available
     reparameterizers.
 
+    Note some reparameterizers can examine the ``*args,**kwargs`` inputs of
+    functions they affect; these reparameterizers require using
+    ``poutine.reparam`` as a decorator rather than as a context manager.
+
     [1] Maria I. Gorinova, Dave Moore, Matthew D. Hoffman (2019)
         "Automatic Reparameterisation of Probabilistic Programs"
         https://arxiv.org/pdf/1906.03028.pdf
@@ -27,6 +31,11 @@ class ReparamMessenger(Messenger):
         super().__init__()
         assert isinstance(config, dict) or callable(config)
         self.config = config
+        self._context = {}
+        self._args_kwargs = None
+
+    def __call__(self, fn):
+        return ParamHandler(self, fn)
 
     def _pyro_sample(self, msg):
         if isinstance(self.config, dict):
@@ -36,7 +45,12 @@ class ReparamMessenger(Messenger):
         if reparam is None:
             return
 
-        new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
+        reparam.args_kwargs = self._args_kwargs
+        try:
+            new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
+        finally:
+            reparam.args_kwargs = None
+
         if value is not None:
             if msg["value"] is None:
                 msg["is_observed"] = True
@@ -45,3 +59,21 @@ class ReparamMessenger(Messenger):
                 # Validate while the original msg["fn"] is known.
                 msg["fn"]._validate_sample(value)
         msg["fn"] = new_fn
+
+
+class ParamHandler(object):
+    """
+    Reparameterization poutine.
+    """
+    def __init__(self, msngr, fn):
+        self.msngr = msngr
+        self.fn = fn
+
+    def __call__(self, *args, **kwargs):
+        # This saves args,kwargs for optional use by reparameterizers.
+        self.msngr._args_kwargs = args, kwargs
+        try:
+            with self.msngr:
+                return self.fn(*args, **kwargs)
+        finally:
+            self.msngr._args_kwargs = None

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -118,7 +118,7 @@ class TraceMessenger(Messenger):
         super()._reset()
 
     def _pyro_post_sample(self, msg):
-        if not self.param_only:
+        if not self.param_only and not msg["infer"].get("_do_not_trace"):
             self.trace.add_node(msg["name"], **msg.copy())
 
     def _pyro_post_param(self, msg):

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -118,8 +118,13 @@ class TraceMessenger(Messenger):
         super()._reset()
 
     def _pyro_post_sample(self, msg):
-        if not self.param_only and not msg["infer"].get("_do_not_trace"):
-            self.trace.add_node(msg["name"], **msg.copy())
+        if self.param_only:
+            return
+        if msg["infer"].get("_do_not_trace"):
+            assert msg["infer"].get("is_auxiliary")
+            assert not msg["is_observed"]
+            return
+        self.trace.add_node(msg["name"], **msg.copy())
 
     def _pyro_post_param(self, msg):
         self.trace.add_node(msg["name"], **msg.copy())

--- a/tests/distributions/test_conjugate_update.py
+++ b/tests/distributions/test_conjugate_update.py
@@ -1,0 +1,24 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import pyro.distributions as dist
+from tests.common import assert_close
+
+
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+def test_beta_binomial(sample_shape, batch_shape):
+    concentration1 = torch.randn(batch_shape).exp()
+    concentration0 = torch.randn(batch_shape).exp()
+    total = 10
+    obs = dist.Binomial(total, 0.2).sample(sample_shape + batch_shape)
+
+    f = dist.Beta(concentration1, concentration0)
+    g = dist.Beta(1 + obs, 1 + total - obs)
+    fg, log_normalizer = f.conjugate_update(g)
+
+    x = fg.sample(sample_shape)
+    assert_close(f.log_prob(x) + g.log_prob(x), fg.log_prob(x) + log_normalizer)

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -50,7 +50,7 @@ def test_beta_binomial_elbo():
         pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
 
     def guide():
-        pyro.sample("probs", posterior)
+        pyro.sample("prob", posterior)
 
     reparam_model = poutine.reparam(model, {"prob": ConjugateReparam(likelihood)})
 
@@ -60,7 +60,7 @@ def test_beta_binomial_elbo():
     elbo = Trace_ELBO(num_particles=100000, vectorize_particles=True, max_plate_nesting=0)
     expected_loss = elbo.differentiable_loss(model, guide)
     actual_loss = elbo.differentiable_loss(reparam_model, reparam_guide)
-    assert_close(actual_loss, expected_loss, 0, atol=0.01)
+    assert_close(actual_loss, expected_loss, atol=0.01)
 
     params = [concentration1, concentration0]
     expected_grads = torch.autograd.grad(expected_loss, params, retain_graph=True)

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -6,29 +6,64 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
+from pyro.infer import Trace_ELBO
 from pyro.infer.reparam import ConjugateReparam
 from tests.common import assert_close
 
 
-def test_beta_binomial():
+def test_beta_binomial_sample():
     total = 10
     counts = dist.Binomial(total, 0.3).sample()
     concentration1 = torch.tensor(0.5)
     concentration0 = torch.tensor(1.5)
+
     prior = dist.Beta(concentration1, concentration0)
+    likelihood = dist.Beta(1 + counts, 1 + total - counts)
+    posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
 
     def model(counts):
         prob = pyro.sample("prob", prior)
         pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
 
-    reparam_model = poutine.reparam(model, {
-        "prob": ConjugateReparam(dist.Beta(1 + counts, 1 + total - counts))
-    })
+    reparam_model = poutine.reparam(model, {"prob": ConjugateReparam(likelihood)})
 
     with poutine.trace() as tr, pyro.plate("particles", 100000):
         reparam_model(counts)
     samples = tr.trace.nodes["prob"]["value"]
 
-    posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
     assert_close(samples.mean(), posterior.mean, atol=0.01)
     assert_close(samples.std(), posterior.variance.sqrt(), atol=0.01)
+
+
+def test_beta_binomial_elbo():
+    total = 10
+    counts = dist.Binomial(total, 0.3).sample()
+    concentration1 = torch.tensor(0.5, requires_grad=True)
+    concentration0 = torch.tensor(1.5, requires_grad=True)
+
+    prior = dist.Beta(concentration1, concentration0)
+    likelihood = dist.Beta(1 + counts, 1 + total - counts)
+    posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
+
+    def model():
+        prob = pyro.sample("prob", prior)
+        pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
+
+    def guide():
+        pyro.sample("probs", posterior)
+
+    reparam_model = poutine.reparam(model, {"prob": ConjugateReparam(likelihood)})
+
+    def reparam_guide():
+        pass
+
+    elbo = Trace_ELBO(num_particles=100000, vectorize_particles=True, max_plate_nesting=0)
+    expected_loss = elbo.differentiable_loss(model, guide)
+    actual_loss = elbo.differentiable_loss(reparam_model, reparam_guide)
+    assert_close(actual_loss, expected_loss, 0, atol=0.01)
+
+    params = [concentration1, concentration0]
+    expected_grads = torch.autograd.grad(expected_loss, params, retain_graph=True)
+    actual_grads = torch.autograd.grad(actual_loss, params, retain_graph=True)
+    for a, e in zip(actual_grads, expected_grads):
+        assert_close(a, e, rtol=0.01)

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -1,0 +1,34 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import pyro
+import pyro.distributions as dist
+import pyro.poutine as poutine
+from pyro.infer.reparam import ConjugateReparam
+from tests.common import assert_close
+
+
+def test_beta_binomial():
+    total = 10
+    counts = dist.Binomial(total, 0.3).sample()
+    concentration1 = torch.tensor(0.5)
+    concentration0 = torch.tensor(1.5)
+    prior = dist.Beta(concentration1, concentration0)
+
+    def model(counts):
+        prob = pyro.sample("prob", prior)
+        pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
+
+    reparam_model = poutine.reparam(model, {
+        "prob": ConjugateReparam(dist.Beta(1 + counts, 1 + total - counts))
+    })
+
+    with poutine.trace() as tr, pyro.plate("particles", 100000):
+        reparam_model(counts)
+    samples = tr.trace.nodes["prob"]["value"]
+
+    posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
+    assert_close(samples.mean(), posterior.mean, atol=0.01)
+    assert_close(samples.std(), posterior.variance.sqrt(), atol=0.01)

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -6,12 +6,14 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.infer import Trace_ELBO
+from pyro.infer import Predictive, Trace_ELBO
+from pyro.infer.mcmc.api import MCMC
+from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.reparam import ConjugateReparam
 from tests.common import assert_close
 
 
-def test_beta_binomial_sample():
+def test_beta_binomial_static_sample():
     total = 10
     counts = dist.Binomial(total, 0.3).sample()
     concentration1 = torch.tensor(0.5)
@@ -21,13 +23,38 @@ def test_beta_binomial_sample():
     likelihood = dist.Beta(1 + counts, 1 + total - counts)
     posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
 
-    def model(counts):
+    def model():
         prob = pyro.sample("prob", prior)
         pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
 
     reparam_model = poutine.reparam(model, {"prob": ConjugateReparam(likelihood)})
 
-    with poutine.trace() as tr, pyro.plate("particles", 100000):
+    with poutine.trace() as tr, pyro.plate("particles", 10000):
+        reparam_model()
+    samples = tr.trace.nodes["prob"]["value"]
+
+    assert_close(samples.mean(), posterior.mean, atol=0.01)
+    assert_close(samples.std(), posterior.variance.sqrt(), atol=0.01)
+
+
+def test_beta_binomial_dependent_sample():
+    total = 10
+    counts = dist.Binomial(total, 0.3).sample()
+    concentration1 = torch.tensor(0.5)
+    concentration0 = torch.tensor(1.5)
+
+    prior = dist.Beta(concentration1, concentration0)
+    posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
+
+    def model(counts):
+        prob = pyro.sample("prob", prior)
+        pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
+
+    reparam_model = poutine.reparam(model, {
+        "prob": ConjugateReparam(lambda counts: dist.Beta(1 + counts, 1 + total - counts)),
+    })
+
+    with poutine.trace() as tr, pyro.plate("particles", 10000):
         reparam_model(counts)
     samples = tr.trace.nodes["prob"]["value"]
 
@@ -57,7 +84,7 @@ def test_beta_binomial_elbo():
     def reparam_guide():
         pass
 
-    elbo = Trace_ELBO(num_particles=100000, vectorize_particles=True, max_plate_nesting=0)
+    elbo = Trace_ELBO(num_particles=10000, vectorize_particles=True, max_plate_nesting=0)
     expected_loss = elbo.differentiable_loss(model, guide)
     actual_loss = elbo.differentiable_loss(reparam_model, reparam_guide)
     assert_close(actual_loss, expected_loss, atol=0.01)
@@ -67,3 +94,30 @@ def test_beta_binomial_elbo():
     actual_grads = torch.autograd.grad(actual_loss, params, retain_graph=True)
     for a, e in zip(actual_grads, expected_grads):
         assert_close(a, e, rtol=0.01)
+
+
+def test_beta_binomial_hmc():
+    num_samples = 1000
+    total = 10
+    counts = dist.Binomial(total, 0.3).sample()
+    concentration1 = torch.tensor(0.5)
+    concentration0 = torch.tensor(1.5)
+
+    prior = dist.Beta(concentration1, concentration0)
+    likelihood = dist.Beta(1 + counts, 1 + total - counts)
+    posterior = dist.Beta(concentration1 + counts, concentration0 + total - counts)
+
+    def model():
+        prob = pyro.sample("prob", prior)
+        pyro.sample("counts", dist.Binomial(total, prob), obs=counts)
+
+    reparam_model = poutine.reparam(model, {"prob": ConjugateReparam(likelihood)})
+
+    kernel = HMC(reparam_model)
+    samples = MCMC(kernel, num_samples, warmup_steps=0).run()
+    pred = Predictive(reparam_model, samples, num_samples=num_samples)
+    trace = pred.get_vectorized_trace()
+    samples = trace.nodes["prob"]["value"]
+
+    assert_close(samples.mean(), posterior.mean, atol=0.01)
+    assert_close(samples.std(), posterior.variance.sqrt(), atol=0.01)

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -1,16 +1,19 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer import Predictive, Trace_ELBO
+from pyro.infer.autoguide import AutoDiagonalNormal
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.hmc import HMC
-from pyro.infer.reparam import ConjugateReparam
+from pyro.infer.reparam import ConjugateReparam, LinearHMMReparam, StableReparam
 from tests.common import assert_close
+from tests.ops.gaussian import random_mvn
 
 
 def test_beta_binomial_static_sample():
@@ -94,6 +97,90 @@ def test_beta_binomial_elbo():
     actual_grads = torch.autograd.grad(actual_loss, params, retain_graph=True)
     for a, e in zip(actual_grads, expected_grads):
         assert_close(a, e, rtol=0.01)
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("hidden_dim,obs_dim", [(1, 1), (3, 2)], ids=str)
+@pytest.mark.parametrize("num_steps", range(1, 6))
+def test_gaussian_hmm_elbo(batch_shape, num_steps, hidden_dim, obs_dim):
+    init_dist = random_mvn(batch_shape, hidden_dim)
+    trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim), requires_grad=True)
+    trans_dist = random_mvn(batch_shape + (num_steps,), hidden_dim)
+    obs_mat = torch.randn(batch_shape + (num_steps, hidden_dim, obs_dim), requires_grad=True)
+    obs_dist = random_mvn(batch_shape + (num_steps,), obs_dim)
+
+    data = obs_dist.sample()
+    assert data.shape == batch_shape + (num_steps, obs_dim)
+    prior = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    likelihood = dist.Normal(data, 1).to_event(2)
+    posterior, log_normalizer = prior.conjugate_update(likelihood)
+
+    def model(data):
+        with pyro.plate_stack("plates", batch_shape):
+            z = pyro.sample("z", prior)
+            pyro.sample("x", dist.Normal(z, 1).to_event(2), obs=data)
+
+    def guide(data):
+        with pyro.plate_stack("plates", batch_shape):
+            pyro.sample("z", posterior)
+
+    reparam_model = poutine.reparam(model, {"z": ConjugateReparam(likelihood)})
+
+    def reparam_guide(data):
+        pass
+
+    elbo = Trace_ELBO(num_particles=1000, vectorize_particles=True)
+    expected_loss = elbo.differentiable_loss(model, guide, data)
+    actual_loss = elbo.differentiable_loss(reparam_model, reparam_guide, data)
+    assert_close(actual_loss, expected_loss, atol=0.01)
+
+    params = [trans_mat, obs_mat]
+    expected_grads = torch.autograd.grad(expected_loss, params, retain_graph=True)
+    actual_grads = torch.autograd.grad(actual_loss, params, retain_graph=True)
+    for a, e in zip(actual_grads, expected_grads):
+        assert_close(a, e, rtol=0.01)
+
+
+def random_stable(shape):
+    stability = dist.Uniform(1.4, 1.9).sample(shape)
+    skew = dist.Uniform(-1, 1).sample(shape)
+    scale = torch.rand(shape).exp()
+    loc = torch.randn(shape)
+    return dist.Stable(stability, skew, scale, loc)
+
+
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("hidden_dim,obs_dim", [(1, 1), (2, 3)], ids=str)
+@pytest.mark.parametrize("num_steps", range(1, 6))
+def test_stable_hmm_smoke(batch_shape, num_steps, hidden_dim, obs_dim):
+    init_dist = random_stable(batch_shape + (hidden_dim,)).to_event(1)
+    trans_mat = torch.randn(batch_shape + (num_steps, hidden_dim, hidden_dim), requires_grad=True)
+    trans_dist = random_stable(batch_shape + (num_steps, hidden_dim)).to_event(1)
+    obs_mat = torch.randn(batch_shape + (num_steps, hidden_dim, obs_dim), requires_grad=True)
+    obs_dist = random_stable(batch_shape + (num_steps, obs_dim)).to_event(1)
+    data = obs_dist.sample()
+    assert data.shape == batch_shape + (num_steps, obs_dim)
+
+    def model(data):
+        hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+        with pyro.plate_stack("plates", batch_shape):
+            z = pyro.sample("z", hmm)
+            pyro.sample("x", dist.Normal(z, 1).to_event(2), obs=data)
+
+    # Test that we can combine these two reparameterizers.
+    reparam_model = poutine.reparam(model, {
+        "z": LinearHMMReparam(StableReparam(), StableReparam(), StableReparam()),
+    })
+    reparam_model = poutine.reparam(reparam_model, {
+        "z": ConjugateReparam(dist.Normal(data, 1).to_event(2)),
+    })
+    reparam_guide = AutoDiagonalNormal(reparam_model)  # Models auxiliary variables.
+
+    # Smoke test only.
+    elbo = Trace_ELBO(num_particles=5, vectorize_particles=True)
+    loss = elbo.differentiable_loss(reparam_model, reparam_guide, data)
+    params = [trans_mat, obs_mat]
+    torch.autograd.grad(loss, params, retain_graph=True)
 
 
 def test_beta_binomial_hmc():

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -116,6 +116,27 @@ def test_nonempty_model_empty_guide_ok(Elbo, strict_enumeration_warning):
         assert_ok(model, guide, elbo)
 
 
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    EnergyDistance_prior,
+    EnergyDistance_noprior,
+])
+@pytest.mark.parametrize("strict_enumeration_warning", [True, False])
+def test_nonempty_model_empty_guide_error(Elbo, strict_enumeration_warning):
+
+    def model():
+        pyro.sample("x", dist.Normal(0, 1))
+
+    def guide():
+        pass
+
+    elbo = Elbo(strict_enumeration_warning=strict_enumeration_warning)
+    assert_error(model, guide, elbo)
+
+
 @pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
 @pytest.mark.parametrize("strict_enumeration_warning", [True, False])
 def test_empty_model_empty_guide_ok(Elbo, strict_enumeration_warning):


### PR DESCRIPTION
Addresses #1723, #2182 
Similar to https://github.com/pytorch/pytorch/pull/32177

This adds `ConjugateReparam` as a new facility to handle conjugate distributions.

The motivation is to handle the new conjugate pair (`GaussianHMM`, `Independent(MultivariateNormal)`) as in #2285. Additionally this may be able to replace `pyro.contrib.conjugate`.

## Changes

- [x] Adds a `ConjugateReparam` class for reparameterization.
- [x] Adds a new method interface `Distribution.conugate_update()`, as needed in #2285.
    - [x] `Beta` for `Bernoulli` and `Binomial`
    - [x] `Dirichlet` for `Categorical` and `Multinomial`
    - [x] `Gamma` for `Poisson`
- [x] Adds logic to allow `poutine.trace` to ignore sites sampled from the prior. This is needed because conjugate-reparameterized sites are sampled from the posterior (or a learned approximate posterior), and thus should not be handled by SVI or MCMC.
- [x] Adds functionality to `Reparam` to have access to the `*args,**kwargs` provided to a function that it decorates (typically model inputs, but possibly inputs to a sub-model as subroutine). This is needed for data-dependent conjugate updates.

## Triaged
- This does not implement conjugation operations : `p(x|z)` -> `q(z|x)`, so the onus is on the user to provide exact or approximate `q(z|x)`. For example in a Gamma-Poisson model, the user must hand-conjugate to manually construct a `Gamma` equivalent to the funsor expression
    ```py
    p_x_given_z = Poisson(Variable("z"), value=data)
    q_z_given_x = p_x_given_z - p_x_given_z.reduce(ops.logaddexp)  # a Gamma funsor
    ```
    I'd like to see what patterns we develop before adding helpers.

## Tested
- [x] `log_normalizer` computation in posterior methods
- [x] `ConjugateReparam` on a Beta-Binomial model
- [x] `ConjugateReparam` on a `GaussianHMM`
- [x] combine `ConjugateReparam`+`LinearHMMReparam`+`StableReparam`
- [x] inference in SVI
- [x] inference for HMC
- [x] data-dependent likelihood
- [x] test that spurious model sites raise an error #2288 