### PR TITLE
Add cheap test for log joint computation in neutra reparametrizer

### DIFF
--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -49,7 +49,7 @@ class NeuTraReparam(Reparam):
         self.x_unconstrained = []
 
     def _reparam_config(self, site):
-        if site["name"] in self.guide.prototype_trace:
+        if site["name"] in self.guide.prototype_trace and not site['is_observed']:
             return self
 
     def reparam(self, fn=None):

--- a/tests/infer/reparam/test_neutra.py
+++ b/tests/infer/reparam/test_neutra.py
@@ -40,7 +40,7 @@ def test_neals_funnel_smoke():
     model = neutra.reparam(neals_funnel)
     nuts = NUTS(model)
     mcmc = MCMC(nuts, num_samples=50, warmup_steps=50)
-    mcmc.run()
+    mcmc.run(dim)
     samples = mcmc.get_samples()
     # XXX: `MCMC.get_samples` adds a leftmost batch dim to all sites, not uniformly at -max_plate_nesting-1;
     # hence the unsqueeze

--- a/tests/infer/reparam/test_neutra.py
+++ b/tests/infer/reparam/test_neutra.py
@@ -1,31 +1,42 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
+import pytest
 import torch
 
 import pyro
 import pyro.distributions as dist
+from pyro.distributions.transforms import ComposeTransform
 from pyro.infer import SVI, Trace_ELBO, NUTS, MCMC
 from pyro.infer.autoguide import AutoIAFNormal
 from pyro import optim
+from pyro.infer.mcmc.util import initialize_model
 from pyro.infer.reparam import NeuTraReparam
+from tests.common import assert_close
+
+
+def neals_funnel(dim):
+    y = pyro.sample('y', dist.Normal(0, 3))
+    with pyro.plate('D', dim):
+        pyro.sample('x', dist.Normal(0, torch.exp(y / 2)))
+
+
+def dirichlet_categorical(data):
+    concentration = torch.tensor([1.0, 1.0, 1.0])
+    p_latent = pyro.sample('p', dist.Dirichlet(concentration))
+    pyro.sample('obs', dist.Categorical(p_latent), obs=data)
+    return p_latent
 
 
 def test_neals_funnel_smoke():
     dim = 10
 
-    def model():
-        y = pyro.sample('y', dist.Normal(0, 3))
-        with pyro.plate("D", dim):
-            pyro.sample('x', dist.Normal(0, torch.exp(y/2)))
-
-    guide = AutoIAFNormal(model)
-    svi = SVI(model, guide,  optim.Adam({"lr": 1e-10}), Trace_ELBO())
+    guide = AutoIAFNormal(neals_funnel)
+    svi = SVI(neals_funnel, guide,  optim.Adam({"lr": 1e-10}), Trace_ELBO())
     for _ in range(1000):
-        svi.step()
+        svi.step(dim)
 
     neutra = NeuTraReparam(guide)
-    model = neutra.reparam(model)
+    model = neutra.reparam(neals_funnel)
     nuts = NUTS(model)
     mcmc = MCMC(nuts, num_samples=50, warmup_steps=50)
     mcmc.run()
@@ -35,3 +46,24 @@ def test_neals_funnel_smoke():
     transformed_samples = neutra.transform_sample(samples['y_shared_latent'].unsqueeze(-2))
     assert 'x' in transformed_samples
     assert 'y' in transformed_samples
+
+
+@pytest.mark.parametrize('model, kwargs', [
+    (neals_funnel, {'dim': 10}),
+    (dirichlet_categorical, {'data': torch.ones(3, 10)})
+])
+def test_reparam_log_joint(model, kwargs):
+    guide = AutoIAFNormal(model)
+    guide(**kwargs)
+    neutra = NeuTraReparam(guide)
+    reparam_model = neutra.reparam(model)
+    _, pe_fn, transforms, _ = initialize_model(model, model_kwargs=kwargs)
+    init_params, pe_fn_neutra, _, _ = initialize_model(reparam_model, model_kwargs=kwargs)
+    latent_x = list(init_params.values())[0]
+    transformed_params = neutra.transform_sample(latent_x)
+    pe_transformed = pe_fn_neutra(init_params)
+    neutra_transform = ComposeTransform(guide.get_posterior(**kwargs).transforms)
+    latent_y = neutra_transform(latent_x)
+    log_det_jacobian = neutra_transform.log_abs_det_jacobian(latent_x, latent_y)
+    pe = pe_fn({k: transforms[k](v) for k, v in transformed_params.items()})
+    assert_close(pe_transformed, pe - log_det_jacobian)

--- a/tests/infer/reparam/test_neutra.py
+++ b/tests/infer/reparam/test_neutra.py
@@ -23,7 +23,8 @@ def neals_funnel(dim):
 def dirichlet_categorical(data):
     concentration = torch.tensor([1.0, 1.0, 1.0])
     p_latent = pyro.sample('p', dist.Dirichlet(concentration))
-    pyro.sample('obs', dist.Categorical(p_latent), obs=data)
+    with pyro.plate('N', data.shape[0]):
+        pyro.sample('obs', dist.Categorical(p_latent), obs=data)
     return p_latent
 
 
@@ -50,7 +51,7 @@ def test_neals_funnel_smoke():
 
 @pytest.mark.parametrize('model, kwargs', [
     (neals_funnel, {'dim': 10}),
-    (dirichlet_categorical, {'data': torch.ones(3, 10)})
+    (dirichlet_categorical, {'data': torch.ones(10,)})
 ])
 def test_reparam_log_joint(model, kwargs):
     guide = AutoIAFNormal(model)


### PR DESCRIPTION
I have been trying to understand why the results from neutraHMC are sub par on a few examples that I have tried out, and this test is to just validate the log joint computation (which looks fine). I am still debugging other issues with the example. 