### PR TITLE
Block non-stochastic sites from AutoGuide prototype_trace

### DIFF
--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -15,8 +15,8 @@ import pyro.poutine as poutine
 import pyro.poutine.runtime as runtime
 from pyro.distributions.util import broadcast_shape, sum_rightmost
 from pyro.infer.autoguide.initialization import InitMessenger
+from pyro.infer.autoguide.guides import prototype_hide_fn
 from pyro.nn.module import PyroModule, PyroParam
-from pyro.poutine.util import prune_subsample_sites
 
 
 class _EasyGuideMeta(type(PyroModule), ABCMeta):
@@ -57,9 +57,8 @@ class EasyGuide(PyroModule, metaclass=_EasyGuideMeta):
 
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
-        model = InitMessenger(self.init)(self.model)
+        model = poutine.block(InitMessenger(self.init)(self.model), prototype_hide_fn)
         self.prototype_trace = poutine.block(poutine.trace(model).get_trace)(*args, **kwargs)
-        self.prototype_trace = prune_subsample_sites(self.prototype_trace)
 
         for name, site in self.prototype_trace.iter_stochastic_nodes():
             for frame in site["cond_indep_stack"]:

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -58,7 +58,7 @@ def _deep_setattr(obj, key, val):
     setattr(obj, rpart, val)
 
 
-def _prototype_hide_fn(msg):
+def prototype_hide_fn(msg):
     # Record only stochastic sites in the prototype_trace.
     return msg["type"] != "sample" or msg["is_observed"] or site_is_subsample(msg)
 
@@ -129,7 +129,7 @@ class AutoGuide(PyroModule):
 
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
-        model = poutine.block(self.model, _prototype_hide_fn)
+        model = poutine.block(self.model, prototype_hide_fn)
         self.prototype_trace = poutine.block(poutine.trace(model).get_trace)(*args, **kwargs)
         if self.master is not None:
             self.master()._check_prototype(self.prototype_trace)
@@ -764,7 +764,7 @@ class AutoDiscreteParallel(AutoGuide):
     """
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
-        model = poutine.block(config_enumerate(self.model), _prototype_hide_fn)
+        model = poutine.block(config_enumerate(self.model), prototype_hide_fn)
         self.prototype_trace = poutine.block(poutine.trace(model).get_trace)(*args, **kwargs)
         if self.master is not None:
             self.master()._check_prototype(self.prototype_trace)

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -35,7 +35,7 @@ from pyro.infer.autoguide.utils import _product
 from pyro.infer.enum import config_enumerate
 from pyro.nn import AutoRegressiveNN, PyroModule, PyroParam
 from pyro.ops.hessian import hessian
-from pyro.poutine.util import prune_subsample_sites
+from pyro.poutine.util import site_is_subsample
 
 
 def _deep_setattr(obj, key, val):
@@ -56,6 +56,11 @@ def _deep_setattr(obj, key, val):
     if lpart:
         obj = functools.reduce(_getattr, [obj] + lpart.split('.'))
     setattr(obj, rpart, val)
+
+
+def _prototype_hide_fn(msg):
+    # Record only stochastic sites in the prototype_trace.
+    return msg["type"] != "sample" or msg["is_observed"] or site_is_subsample(msg)
 
 
 class AutoGuide(PyroModule):
@@ -124,8 +129,8 @@ class AutoGuide(PyroModule):
 
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
-        self.prototype_trace = poutine.block(poutine.trace(self.model).get_trace)(*args, **kwargs)
-        self.prototype_trace = prune_subsample_sites(self.prototype_trace)
+        model = poutine.block(self.model, _prototype_hide_fn)
+        self.prototype_trace = poutine.block(poutine.trace(model).get_trace)(*args, **kwargs)
         if self.master is not None:
             self.master()._check_prototype(self.prototype_trace)
 
@@ -759,9 +764,8 @@ class AutoDiscreteParallel(AutoGuide):
     """
     def _setup_prototype(self, *args, **kwargs):
         # run the model so we can inspect its structure
-        model = config_enumerate(self.model)
+        model = poutine.block(config_enumerate(self.model), _prototype_hide_fn)
         self.prototype_trace = poutine.block(poutine.trace(model).get_trace)(*args, **kwargs)
-        self.prototype_trace = prune_subsample_sites(self.prototype_trace)
         if self.master is not None:
             self.master()._check_prototype(self.prototype_trace)
 

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -49,7 +49,7 @@ class NeuTraReparam(Reparam):
         self.x_unconstrained = []
 
     def _reparam_config(self, site):
-        if site["name"] in self.guide.prototype_trace and not site['is_observed']:
+        if site["name"] in self.guide.prototype_trace:
             return self
 
     def reparam(self, fn=None):


### PR DESCRIPTION
As @neerajprad observed in #2291, `AutoGuide.prototype_trace` currently records all sites, which I find unexpected. This PR changes to record only stochastic sites, saving memory and slightly simplifying logic in neutra.