### PR TITLE
Add NeuTra reparam example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ examples/*/results
 examples/*/raw
 examples/dmm/*.pkl
 examples/*.csv
+examples/*.pdf
 examples/mixed_hmm/*csv
 pyro/contrib/examples/processed
 pyro/contrib/examples/results

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -208,4 +208,3 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     main(args)
-

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -164,7 +164,7 @@ def main(args):
             title='Posterior \n(BNAF autoguide)')
     sns.kdeplot(guide_samples[:, 0], guide_samples[:, 1], ax=ax6)
 
-    # 3(b). Draw samples using NeuTra HMC
+    # 4(b). Draw samples using NeuTra HMC
     logging.info('\nDrawing samples using BNAF autoguide + NeuTra HMC ...')
     neutra = NeuTraReparam(guide.requires_grad_(False))
     neutra_model = poutine.reparam(model, config=lambda _: neutra)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -1,0 +1,211 @@
+"""
+This example illustrates the use of `NeuTraReparam` to run neural transport HMC [1]
+on a toy model that draws from a banana-shaped bivariate distribution [2]. We first
+train an autoguide by using `AutoNormalizingFlow` that learns a transformation from
+a simple latent space (isotropic gaussian) to the more complex geometry of the
+posterior. Subsequently, we use `NeuTraReparam` to run HMC and draw samples from this
+simplified "warped" posterior. Finally, we use our learnt transformation to transform
+these samples back to the original space. For comparison, we also draw samples from
+a NeuTra-reparametrized model that uses a much simpler `AutoDiagonalNormal` guide.
+
+References:
+----------
+[1] Hoffman, M., Sountsov, P., Dillon, J. V., Langmore, I., Tran, D., and Vasudevan,
+ S. Neutra-lizing bad geometry in hamiltonian monte carlo using neural transport.
+ arXiv preprint arXiv:1903.03704, 2019.
+[2] Wang Z., Broccardo M., and Song J. Hamiltonian Monte Carlo Methods for Subset
+ Simulation in Reliability Analysis. arXiv preprint arXiv:1706.01435, 2018.
+"""
+
+import argparse
+import logging
+from functools import partial
+
+import torch
+import matplotlib.pyplot as plt
+import seaborn as sns
+from matplotlib.gridspec import GridSpec
+
+import pyro
+from pyro import optim, poutine
+import pyro.distributions as dist
+from pyro.distributions import constraints
+from pyro.distributions.transforms import iterated, block_autoregressive
+from pyro.infer import MCMC, NUTS, SVI, Trace_ELBO
+from pyro.infer.autoguide import AutoDiagonalNormal, AutoNormalizingFlow
+from pyro.infer.reparam import NeuTraReparam
+
+
+logging.basicConfig(format='%(message)s', level=logging.INFO)
+
+
+class BananaShaped(dist.TorchDistribution):
+    support = constraints.real_vector
+
+    def __init__(self, a, b, rho=0.9):
+        self.a = a
+        self.b = b
+        self.rho = rho
+        self.mvn = dist.MultivariateNormal(torch.tensor([0., 0.]),
+                                           covariance_matrix=torch.tensor([[1., self.rho], [self.rho, 1.]]))
+        super().__init__(event_shape=(2,))
+
+    def sample(self, sample_shape=()):
+        u = self.mvn.sample(sample_shape)
+        u0, u1 = u[..., 0], u[..., 1]
+        a, b = self.a, self.b
+        x = a * u0
+        y = (u1 / a) + b * (u0 ** 2 + a ** 2)
+        return torch.stack([x, y], -1)
+
+    def log_prob(self, x):
+        x, y = x[..., 0], x[..., 1]
+        a, b = self.a, self.b
+        u0 = x / a
+        u1 = (y - b * (u0 ** 2 + a ** 2)) * a
+        return self.mvn.log_prob(torch.stack([u0, u1], dim=-1))
+
+
+def model(a, b, rho=0.9):
+    pyro.sample('x', BananaShaped(a, b, rho))
+
+
+def fit_guide(guide, args):
+    pyro.clear_param_store()
+    adam = optim.Adam({'lr': args.learning_rate})
+    svi = SVI(model, guide, adam, Trace_ELBO())
+    for i in range(args.num_steps):
+        loss = svi.step(args.param_a, args.param_b)
+        if i % 500 == 0:
+            logging.info("[{}]Elbo loss = {:.2f}".format(i, loss))
+
+
+def run_hmc(args, model):
+    nuts_kernel = NUTS(model)
+    mcmc = MCMC(nuts_kernel, warmup_steps=args.num_warmup, num_samples=args.num_samples)
+    mcmc.run(args.param_a, args.param_b)
+    mcmc.summary()
+    return mcmc
+
+
+def main(args):
+    pyro.set_rng_seed(args.rng_seed)
+    fig = plt.figure(figsize=(8, 16), constrained_layout=True)
+    gs = GridSpec(4, 2, figure=fig)
+    ax1 = fig.add_subplot(gs[0, 0])
+    ax2 = fig.add_subplot(gs[0, 1])
+    ax3 = fig.add_subplot(gs[1, 0])
+    ax4 = fig.add_subplot(gs[1, 1])
+    ax5 = fig.add_subplot(gs[2, 0])
+    ax6 = fig.add_subplot(gs[2, 1])
+    ax7 = fig.add_subplot(gs[3, 0])
+    ax8 = fig.add_subplot(gs[3, 1])
+    xlim = tuple(int(x) for x in args.x_lim.strip().split(','))
+    ylim = tuple(int(x) for x in args.y_lim.strip().split(','))
+    assert len(xlim) == 2
+    assert len(ylim) == 2
+
+    # 1. Plot samples drawn from BananaShaped distribution
+    x1, x2 = torch.meshgrid([torch.linspace(*xlim, 100), torch.linspace(*ylim, 100)])
+    d = BananaShaped(args.param_a, args.param_b)
+    p = torch.exp(d.log_prob(torch.stack([x1, x2], dim=-1)))
+    ax1.contourf(x1, x2, p, cmap='OrRd',)
+    ax1.set(xlabel='x0', ylabel='x1', xlim=xlim, ylim=ylim,
+            title='BananaShaped distribution: \nlog density')
+
+    # 2. Run vanilla HMC
+    logging.info('\nDrawing samples using vanilla HMC ...')
+    mcmc = run_hmc(args, model)
+    vanilla_samples = mcmc.get_samples()['x'].cpu().numpy()
+    ax2.contourf(x1, x2, p, cmap='OrRd')
+    ax2.set(xlabel='x0', ylabel='x1', xlim=xlim, ylim=ylim,
+            title='Posterior \n(vanilla HMC)')
+    sns.kdeplot(vanilla_samples[:, 0], vanilla_samples[:, 1], ax=ax2)
+
+    # 3(a). Fit a diagonal normal autoguide
+    logging.info('\nFitting a DiagNormal autoguide ...')
+    guide = AutoDiagonalNormal(model, init_scale=0.05)
+    fit_guide(guide, args)
+    with pyro.plate('N', args.num_samples):
+        guide_samples = guide()['x'].detach().cpu().numpy()
+
+    ax3.contourf(x1, x2, p, cmap='OrRd')
+    ax3.set(xlabel='x0', ylabel='x1', xlim=xlim, ylim=ylim,
+            title='Posterior \n(DiagNormal autoguide)')
+    sns.kdeplot(guide_samples[:, 0], guide_samples[:, 1], ax=ax3)
+
+    # 3(b). Draw samples using NeuTra HMC
+    logging.info('\nDrawing samples using DiagNormal autoguide + NeuTra HMC ...')
+    neutra = NeuTraReparam(guide.requires_grad_(False))
+    neutra_model = poutine.reparam(model, config=lambda _: neutra)
+    mcmc = run_hmc(args, neutra_model)
+    zs = mcmc.get_samples()['x_shared_latent']
+    sns.scatterplot(zs[:, 0], zs[:, 1], alpha=0.2, ax=ax4)
+    ax4.set(xlabel='x0', ylabel='x1',
+            title='Posterior (warped) samples \n(DiagNormal + NeuTra HMC)')
+
+    samples = neutra.transform_sample(zs)
+    samples = samples['x'].cpu().numpy()
+    ax5.contourf(x1, x2, p, cmap='OrRd')
+    ax5.set(xlabel='x0', ylabel='x1', xlim=xlim, ylim=ylim,
+            title='Posterior (transformed) \n(DiagNormal + NeuTra HMC)')
+    sns.kdeplot(samples[:, 0], samples[:, 1], ax=ax5)
+
+    # 4(a). Fit a BNAF autoguide
+    logging.info('\nFitting a BNAF autoguide ...')
+    guide = AutoNormalizingFlow(model, partial(iterated, args.num_flows, block_autoregressive))
+    fit_guide(guide, args)
+    with pyro.plate('N', args.num_samples):
+        guide_samples = guide()['x'].detach().cpu().numpy()
+
+    ax6.contourf(x1, x2, p, cmap='OrRd')
+    ax6.set(xlabel='x0', ylabel='x1', xlim=xlim, ylim=ylim,
+            title='Posterior \n(BNAF autoguide)')
+    sns.kdeplot(guide_samples[:, 0], guide_samples[:, 1], ax=ax6)
+
+    # 3(b). Draw samples using NeuTra HMC
+    logging.info('\nDrawing samples using BNAF autoguide + NeuTra HMC ...')
+    neutra = NeuTraReparam(guide.requires_grad_(False))
+    neutra_model = poutine.reparam(model, config=lambda _: neutra)
+    mcmc = run_hmc(args, neutra_model)
+    zs = mcmc.get_samples()['x_shared_latent']
+    sns.scatterplot(zs[:, 0], zs[:, 1], alpha=0.2, ax=ax7)
+    ax7.set(xlabel='x0', ylabel='x1', title='Posterior (warped) samples \n(BNAF + NeuTra HMC)')
+
+    samples = neutra.transform_sample(zs)
+    samples = samples['x'].cpu().numpy()
+    ax8.contourf(x1, x2, p, cmap='OrRd')
+    ax8.set(xlabel='x0', ylabel='x1', xlim=xlim, ylim=ylim,
+            title='Posterior (transformed) \n(BNAF + NeuTra HMC)')
+    sns.kdeplot(samples[:, 0], samples[:, 1], ax=ax8)
+
+    plt.savefig('neutra.pdf')
+
+
+if __name__ == '__main__':
+    assert pyro.__version__.startswith('1.2.1')
+    parser = argparse.ArgumentParser(description='Example illustrating NeuTra Reparametrizer')
+    parser.add_argument('-n', '--num-steps', default=10000, type=int,
+                        help='number of SVI steps')
+    parser.add_argument('-lr', '--learning-rate', default=1e-2, type=float,
+                        help='learning rate for the Adam optimizer')
+    parser.add_argument('--rng-seed', default=1, type=int,
+                        help='RNG seed')
+    parser.add_argument('--num-warmup', default=500, type=int,
+                        help='number of warmup steps for NUTS')
+    parser.add_argument('--num-samples', default=1000, type=int,
+                        help='number of samples to be drawn from NUTS')
+    parser.add_argument('--param-a', default=1.15, type=float,
+                        help='parameter `a` of BananaShaped distribution')
+    parser.add_argument('--param-b', default=1., type=float,
+                        help='parameter `b` of BananaShaped distribution')
+    parser.add_argument('--num-flows', default=1, type=int,
+                        help='number of flows in the BNAF autoguide')
+    parser.add_argument('--x-lim', default='-3,3', type=str,
+                        help='x limits for the plots')
+    parser.add_argument('--y-lim', default='0,8', type=str,
+                        help='y limits for the plots')
+
+    args = parser.parse_args()
+    main(args)
+

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -19,6 +19,7 @@ References:
 
 import argparse
 import logging
+import os
 from functools import partial
 
 import torch
@@ -179,7 +180,7 @@ def main(args):
             title='Posterior (transformed) \n(BNAF + NeuTra HMC)')
     sns.kdeplot(samples[:, 0], samples[:, 1], ax=ax8)
 
-    plt.savefig('neutra.pdf')
+    plt.savefig(os.path.join(os.path.dirname(__file__), 'neutra.pdf'))
 
 
 if __name__ == '__main__':

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -545,7 +545,9 @@ class AutoMultivariateNormal(AutoContinuous):
         """
         Returns a MultivariateNormal posterior distribution.
         """
-        return dist.MultivariateNormal(self.loc, scale_tril=self.scale_tril)
+        transform = dist.transforms.LowerCholeskyAffine(self.loc, scale_tril=self.scale_tril)
+        return dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]).to_event(1),
+                                            transform)
 
     def _loc_scale(self, *args, **kwargs):
         return self.loc, self.scale_tril.diag()
@@ -589,7 +591,9 @@ class AutoDiagonalNormal(AutoContinuous):
         """
         Returns a diagonal Normal posterior distribution.
         """
-        return dist.Normal(self.loc, self.scale).to_event(1)
+        transform = dist.transforms.AffineTransform(self.loc, self.scale)
+        return dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]).to_event(1),
+                                            transform)
 
     def _loc_scale(self, *args, **kwargs):
         return self.loc, self.scale

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -721,10 +721,10 @@ class AutoNormalizingFlow(AutoContinuous):
     """
 
     def __init__(self, model, init_transform_fn):
+        super().__init__(model, init_loc_fn=init_to_feasible)
         self._init_transform_fn = init_transform_fn
         self.transform = None
         self._prototype_tensor = torch.tensor(0.)
-        super().__init__(model, init_loc_fn=init_to_feasible)
 
     def get_base_dist(self):
         loc = self._prototype_tensor.new_zeros(1)

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -401,11 +401,41 @@ class AutoContinuous(AutoGuide):
         assert latent.size() == (self.latent_dim,)
         return latent
 
+    def get_base_dist(self):
+        """
+        Returns the base distribution of the posterior when reparameterized
+        as a :class:`~pyro.distributions.TransformedDistribution`. This
+        should not depend on the model's `*args, **kwargs`.
+
+        .. code-block:: python
+
+          posterior = TransformedDistribution(self.get_base_dist(), self.get_transform(*args, **kwargs))
+
+        :return: :class:`~pyro.distributions.TorchDistribution` instance representing the base distribution.
+        """
+        raise NotImplementedError
+
+    def get_transform(self, *args, **kwargs):
+        """
+        Returns the transform applied to the base distribution when the posterior
+        is reparameterized as a :class:`~pyro.distributions.TransformedDistribution`.
+        This may depend on the model's `*args, **kwargs`.
+
+        .. code-block:: python
+
+          posterior = TransformedDistribution(self.get_base_dist(), self.get_transform(*args, **kwargs))
+
+        :return: a :class:`~torch.distributions.Transform` instance.
+        """
+        raise NotImplementedError
+
     def get_posterior(self, *args, **kwargs):
         """
         Returns the posterior distribution.
         """
-        raise NotImplementedError
+        base_dist = self.get_base_dist()
+        transform = self.get_transform(*args, **kwargs)
+        return dist.TransformedDistribution(base_dist, transform)
 
     def sample_latent(self, *args, **kwargs):
         """
@@ -541,13 +571,17 @@ class AutoMultivariateNormal(AutoContinuous):
         self.scale_tril = PyroParam(eye_like(self.loc, self.latent_dim) * self._init_scale,
                                     constraints.lower_cholesky)
 
+    def get_base_dist(self):
+        return dist.Normal(torch.zeros_like(self.loc), torch.zeros_like(self.loc)).to_event(1)
+
+    def get_transform(self, *args, **kwargs):
+        return dist.transforms.LowerCholeskyAffine(self.loc, scale_tril=self.scale_tril)
+
     def get_posterior(self, *args, **kwargs):
         """
         Returns a MultivariateNormal posterior distribution.
         """
-        transform = dist.transforms.LowerCholeskyAffine(self.loc, scale_tril=self.scale_tril)
-        return dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]).to_event(1),
-                                            transform)
+        return dist.MultivariateNormal(self.loc, scale_tril=self.scale_tril)
 
     def _loc_scale(self, *args, **kwargs):
         return self.loc, self.scale_tril.diag()
@@ -587,13 +621,17 @@ class AutoDiagonalNormal(AutoContinuous):
         self.scale = PyroParam(self.loc.new_full((self.latent_dim,), self._init_scale),
                                constraints.positive)
 
+    def get_base_dist(self):
+        return dist.Normal(torch.zeros_like(self.loc), torch.zeros_like(self.loc)).to_event(1)
+
+    def get_transform(self, *args, **kwargs):
+        return dist.transforms.AffineTransform(self.loc, self.scale)
+
     def get_posterior(self, *args, **kwargs):
         """
         Returns a diagonal Normal posterior distribution.
         """
-        transform = dist.transforms.AffineTransform(self.loc, self.scale)
-        return dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]).to_event(1),
-                                            transform)
+        return dist.Normal(self.loc, self.scale).to_event(1)
 
     def _loc_scale(self, *args, **kwargs):
         return self.loc, self.scale
@@ -685,17 +723,26 @@ class AutoNormalizingFlow(AutoContinuous):
     def __init__(self, model, init_transform_fn):
         self._init_transform_fn = init_transform_fn
         self.transform = None
+        self._prototype_tensor = torch.tensor(0.)
         super().__init__(model, init_loc_fn=init_to_feasible)
 
+    def get_base_dist(self):
+        loc = self._prototype_tensor.new_zeros(1)
+        scale = self._prototype_tensor.new_ones(1)
+        return dist.Normal(loc, scale).expand([self.latent_dim]).to_event(1)
+
+    def get_transform(self, *args, **kwargs):
+        return self.transform
+
     def get_posterior(self, *args, **kwargs):
-        """
-        Returns a diagonal Normal posterior distribution transformed by
-        a bijective transform.
-        """
         if self.transform is None:
             self.transform = self._init_transform_fn(self.latent_dim)
-        flow_dist = dist.TransformedDistribution(dist.Normal(0., 1.).expand([self.latent_dim]), self.transform)
-        return flow_dist
+            # Update prototype tensor in case transform parameters
+            # device/dtype is not the same as default tensor type.
+            for _, p in self.named_pyro_params():
+                self._prototype_tensor = p
+                break
+        return super().get_posterior(*args, **kwargs)
 
 
 class AutoIAFNormal(AutoNormalizingFlow):

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -62,15 +62,15 @@ class NeuTraReparam(Reparam):
         log_density = 0.
         if not self.x_unconstrained:  # On first sample site.
             # Sample a shared latent.
-            # TODO(fehiepsi) Consider adding a method to extract transform from an Auto*Normal(posterior).
-            posterior = self.guide.get_posterior()
-            if not isinstance(posterior, dist.TransformedDistribution):
-                raise ValueError("NeuTraReparam only supports guides whose posteriors are "
-                                 "TransformedDistributions but got a posterior of type {}"
-                                 .format(type(posterior)))
-            self.transform = dist.transforms.ComposeTransform(posterior.transforms)
+            try:
+                self.transform = self.guide.get_transform()
+            except (NotImplementedError, TypeError):
+                raise ValueError("NeuTraReparam only supports guides that implement "
+                                 "`get_transform` method that does not depend on the "
+                                 "model's `*args, **kwargs`")
+
             z_unconstrained = pyro.sample("{}_shared_latent".format(name),
-                                          posterior.base_dist.mask(False))
+                                          self.guide.get_base_dist().mask(False))
 
             # Differentiably transform.
             x_unconstrained = self.transform(z_unconstrained)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -67,7 +67,7 @@ CPU_EXAMPLES = [
     'minipyro.py --backend=pyro',
     'minipyro.py',
     'mixed_hmm/experiment.py --timesteps=1',
-    'neutra.py -n 10 --num-warmup 10 --num-samples 10'
+    'neutra.py -n 10 --num-warmup 10 --num-samples 10',
     'rsa/generics.py --num-samples=10',
     'rsa/hyperbole.py --price=10000',
     'rsa/schelling.py --num-samples=10',

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -67,6 +67,7 @@ CPU_EXAMPLES = [
     'minipyro.py --backend=pyro',
     'minipyro.py',
     'mixed_hmm/experiment.py --timesteps=1',
+    'neutra.py -n 10 --num-warmup 10 --num-samples 10'
     'rsa/generics.py --num-samples=10',
     'rsa/hyperbole.py --price=10000',
     'rsa/schelling.py --num-samples=10',


### PR DESCRIPTION
This adds a NeuTra reparametrizer example on a banana shaped distribution. See [neutra.pdf](https://github.com/pyro-ppl/pyro/files/4150898/neutra.pdf), following discussion in #2294. 

Regarding the API, here are a few things that might need further discussion (separately from this PR):
 - I have changed the `AutoDiagonalNormal` and `AutoMultivariateNormal` guides to use a `TransformedDistribution` so that we can use it with `NeuTraReparam`. 
   - Should we expose `transform` and `base_dist` be available as properties for these classes directly?
   - I think these two are good enough, but I'm not sure if `LowRankMultivariateNormal` should also be written as a `TransformedDistribution`. 
 - Currently, we require users to set `guide.requires_grad_(False)` before passing this to `NeuTraReparam`, since we don't want guide parameters to be updated while running HMC. We can probably do this inside `NeuTraRepam` itself by default (if the guide is a `PyroModule` instance), but I'm not sure if changing the `requires_grad` flag for parameters in the param store is something that might be a surprising side effect for users. Alternative suggestions are welcome. cc. @martinjankowiak 