### PR TITLE
Add shape validation to LinearHMMReparam, GaussianHMM

### DIFF
--- a/pyro/infer/reparam/hmm.py
+++ b/pyro/infer/reparam/hmm.py
@@ -80,7 +80,7 @@ class LinearHMMReparam(Reparam):
 
         # Reparameterize the entire HMM as conditionally Gaussian.
         hmm = dist.GaussianHMM(init_dist, fn.transition_matrix, trans_dist,
-                               fn.observation_matrix, obs_dist)
+                               fn.observation_matrix, obs_dist, broadcast_time=False)
 
         # Apply any observation transforms.
         if fn.transforms:

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -86,7 +86,6 @@ def test_studentt_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
 @pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
 def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
     stability = dist.Uniform(0.5, 2).sample(batch_shape)
-
     init_dist = random_stable(batch_shape + (hidden_dim,),
                               stability.unsqueeze(-1), skew=skew).to_event(1)
     trans_mat = torch.randn(batch_shape + (duration, hidden_dim, hidden_dim))
@@ -96,18 +95,59 @@ def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
     obs_dist = random_stable(batch_shape + (duration, obs_dim),
                              stability.unsqueeze(-1).unsqueeze(-1), skew=skew).to_event(1)
     hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    assert hmm.batch_shape == batch_shape
+    assert hmm.event_shape == (duration, obs_dim)
 
     def model(data=None):
         with pyro.plate_stack("plates", batch_shape):
             return pyro.sample("x", hmm, obs=data)
 
-    data = model()
+    data = torch.randn(duration, obs_dim)
     rep = SymmetricStableReparam() if skew == 0 else StableReparam()
     with poutine.trace() as tr:
         with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
             model(data)
     assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
     tr.trace.compute_log_prob()  # smoke test only
+
+
+@pytest.mark.parametrize("duration", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("obs_dim", [1, 2])
+@pytest.mark.parametrize("hidden_dim", [1, 3])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
+def test_stable_hmm_shape_error(batch_shape, duration, hidden_dim, obs_dim):
+    stability = dist.Uniform(0.5, 2).sample(batch_shape)
+    init_dist = random_stable(batch_shape + (hidden_dim,),
+                              stability.unsqueeze(-1)).to_event(1)
+    trans_mat = torch.randn(batch_shape + (1, hidden_dim, hidden_dim))
+    trans_dist = random_stable(batch_shape + (1, hidden_dim),
+                               stability.unsqueeze(-1).unsqueeze(-1)).to_event(1)
+    obs_mat = torch.randn(batch_shape + (1, hidden_dim, obs_dim))
+    obs_dist = random_stable(batch_shape + (1, obs_dim),
+                             stability.unsqueeze(-1).unsqueeze(-1)).to_event(1)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    assert hmm.batch_shape == batch_shape
+    assert hmm.event_shape == (1, obs_dim)
+
+    def model(data=None):
+        with pyro.plate_stack("plates", batch_shape):
+            return pyro.sample("x", hmm, obs=data)
+
+    data = torch.randn(duration, obs_dim)
+    rep = StableReparam()
+    with poutine.trace() as tr:
+        with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
+            model(data)
+    assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
+    assert not tr.trace.nodes["x"]["fn"]._broadcast_time
+    assert tr.trace.nodes["x"]["fn"]._validate_args
+
+    # smoke test only
+    if duration == 1:
+        tr.trace.compute_log_prob()
+    else:
+        with pytest.raises(ValueError):
+            tr.trace.compute_log_prob()
 
 
 # Test helper to extract a few fractional moments from joint samples.


### PR DESCRIPTION
Addresses #2299 

This enables partial validation of the `GaussianHMM` sample and of the `LinearHMMReparam`.

The motivation was a silent bug due when using `LinearHMMReparam` on a homogeneous `LinearHMM`, i.e. one whose duration is 1. By special convention our HMM distributions allow broadcasting of event_shape since time is part of the event shape and HMMs are often constructed as time-homogeneous systems.

This PR adds an attribute `._broadcast_time` so that `LinearHMMReparam` can disallow subsequent broadcasting of time; since that broadcasting would also need to apply to any time-local auxiliary variables created by `LinearHMMReparam`.

Note this is reminiscent of `Multinomial` whose `total_count` is ignored in `.log_prob()`.

## Tested
- added a death test