### PR TITLE
Add duration validation to HMMs

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -425,7 +425,9 @@ class GaussianHMM(HiddenMarkovModel):
         This should have event_shape ``(obs_dim,)``.
     :type observation_dist: ~torch.distributions.MultivariateNormal or
         ~torch.distributions.Independent of ~torch.distributions.Normal
-    :param int duration: Optional
+    :param int duration: Optional size of the time axis ``event_shape[0]``.
+        This is required when sampling from homogeneous HMMs whose parameters
+        are not expanded along the time axis.
     """
     has_rsample = True
     arg_constraints = {}
@@ -455,7 +457,7 @@ class GaussianHMM(HiddenMarkovModel):
                                 observation_matrix.shape[:-2],
                                 observation_dist.batch_shape)
         batch_shape, time_shape = shape[:-1], shape[-1:]
-        event_shape = time_shape + observation_dist.event_shape
+        event_shape = time_shape + (obs_dim,)
         super().__init__(duration, batch_shape, event_shape, validate_args=validate_args)
 
         self.hidden_dim = hidden_dim
@@ -652,6 +654,9 @@ class GammaGaussianHMM(HiddenMarkovModel):
         with unit scale mixing. This should have batch_shape broadcastable to
         ``self.batch_shape + (num_steps,)``.
         This should have event_shape ``(obs_dim,)``.
+    :param int duration: Optional size of the time axis ``event_shape[0]``.
+        This is required when sampling from homogeneous HMMs whose parameters
+        are not expanded along the time axis.
     """
     arg_constraints = {}
     support = constraints.real
@@ -818,6 +823,9 @@ class LinearHMM(HiddenMarkovModel):
     :param observation_dist: A observation noise distribution. This should have
         batch_shape broadcastable to ``self.batch_shape + (num_steps,)``.  This
         should have event_shape ``(obs_dim,)``.
+    :param int duration: Optional size of the time axis ``event_shape[0]``.
+        This is required when sampling from homogeneous HMMs whose parameters
+        are not expanded along the time axis.
     """
     arg_constraints = {}
     support = constraints.real

--- a/pyro/infer/reparam/hmm.py
+++ b/pyro/infer/reparam/hmm.py
@@ -75,12 +75,16 @@ class LinearHMMReparam(Reparam):
         # Reparameterize the transition distribution as conditionally Gaussian.
         trans_dist = fn.transition_dist
         if self.trans is not None:
+            if trans_dist.batch_shape[-1] != fn.duration:
+                trans_dist = trans_dist.expand(trans_dist.batch_shape[:-1] + (fn.duration,))
             trans_dist, _ = self.trans("{}_trans".format(name), trans_dist.to_event(1), None)
             trans_dist = trans_dist.to_event(-1)
 
         # Reparameterize the observation distribution as conditionally Gaussian.
         obs_dist = fn.observation_dist
         if self.obs is not None:
+            if obs_dist.batch_shape[-1] != fn.duration:
+                obs_dist = obs_dist.expand(obs_dist.batch_shape[:-1] + (fn.duration,))
             obs_dist, obs = self.obs("{}_obs".format(name), obs_dist.to_event(1), obs)
             obs_dist = obs_dist.to_event(-1)
 

--- a/pyro/infer/reparam/hmm.py
+++ b/pyro/infer/reparam/hmm.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions as dist
+from pyro.distributions.hmm import LinearHMM
 
 from .reparam import Reparam
 
@@ -62,7 +63,7 @@ class LinearHMMReparam(Reparam):
 
     def __call__(self, name, fn, obs):
         assert isinstance(fn, LinearHMM)
-        if fn.duration is not None:
+        if fn.duration is None:
             raise ValueError("LinearHMMReparam requires duration to be specified "
                              "on targeted LinearHMM distributions")
 

--- a/pyro/infer/reparam/hmm.py
+++ b/pyro/infer/reparam/hmm.py
@@ -61,6 +61,11 @@ class LinearHMMReparam(Reparam):
         self.obs = obs
 
     def __call__(self, name, fn, obs):
+        assert isinstance(fn, LinearHMM)
+        if fn.duration is not None:
+            raise ValueError("LinearHMMReparam requires duration to be specified "
+                             "on targeted LinearHMM distributions")
+
         # Reparameterize the initial distribution as conditionally Gaussian.
         init_dist = fn.initial_dist
         if self.init is not None:
@@ -80,7 +85,7 @@ class LinearHMMReparam(Reparam):
 
         # Reparameterize the entire HMM as conditionally Gaussian.
         hmm = dist.GaussianHMM(init_dist, fn.transition_matrix, trans_dist,
-                               fn.observation_matrix, obs_dist)
+                               fn.observation_matrix, obs_dist, duration=fn.duration)
 
         # Apply any observation transforms.
         if fn.transforms:

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -106,11 +106,10 @@ def test_sequential_gamma_gaussian_tensordot(batch_shape, state_dim, num_steps):
 @pytest.mark.parametrize('state_dim', [2, 3])
 @pytest.mark.parametrize('event_shape', [(), (5,), (2, 3)], ids=str)
 @pytest.mark.parametrize('ok,init_shape,trans_shape,obs_shape', [
-    (True, (), (1,), ()),
     (True, (), (), (1,)),
-    (True, (), (7,), ()),
+    (True, (), (1,), (1,)),
     (True, (), (), (7,)),
-    (True, (), (7,), (1,)),
+    (True, (), (7,), (7,)),
     (True, (), (1,), (7,)),
     (True, (), (7,), (11, 7)),
     (True, (), (11, 7), (7,)),
@@ -120,6 +119,9 @@ def test_sequential_gamma_gaussian_tensordot(batch_shape, state_dim, num_steps):
     (True, (11,), (11, 7), (7,)),
     (True, (11,), (11, 7), (11, 7)),
     (True, (4, 1, 1), (3, 1, 7), (2, 7)),
+    (False, (), (1,), ()),
+    (False, (), (7,), ()),
+    (False, (), (7,), (1,)),
     (False, (), (7,), (6,)),
     (False, (3,), (4, 7), (7,)),
     (False, (3,), (7,), (4, 7)),
@@ -134,7 +136,8 @@ def test_discrete_hmm_shape(ok, init_shape, trans_shape, obs_shape, event_shape,
 
     if not ok:
         with pytest.raises(ValueError):
-            dist.DiscreteHMM(init_logits, trans_logits, obs_dist)
+            d = dist.DiscreteHMM(init_logits, trans_logits, obs_dist)
+            d.log_prob(data)
         return
 
     d = dist.DiscreteHMM(init_logits, trans_logits, obs_dist)

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -338,7 +338,7 @@ def test_gaussian_hmm_distribution(diag, sample_shape, batch_shape, num_steps, h
     if diag:
         scale = obs_dist.scale_tril.diagonal(dim1=-2, dim2=-1)
         obs_dist = dist.Normal(obs_dist.loc, scale).to_event(1)
-    d = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    d = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=num_steps)
     if diag:
         obs_mvn = dist.MultivariateNormal(obs_dist.base_dist.loc,
                                           scale_tril=obs_dist.base_dist.scale.diag_embed())

--- a/tests/infer/reparam/test_conjugate.py
+++ b/tests/infer/reparam/test_conjugate.py
@@ -162,7 +162,7 @@ def test_stable_hmm_smoke(batch_shape, num_steps, hidden_dim, obs_dim):
     assert data.shape == batch_shape + (num_steps, obs_dim)
 
     def model(data):
-        hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+        hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=num_steps)
         with pyro.plate_stack("plates", batch_shape):
             z = pyro.sample("z", hmm)
             pyro.sample("x", dist.Normal(z, 1).to_event(2), obs=data)

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -8,7 +8,6 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.infer.reparam import LinearHMMReparam, StableReparam, StudentTReparam, SymmetricStableReparam
-from tests.common import assert_close
 from tests.ops.gaussian import random_mvn
 
 
@@ -38,7 +37,7 @@ def test_transformed_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
     obs_mat = torch.randn(batch_shape + (duration, hidden_dim, obs_dim))
     obs_dist = dist.LogNormal(torch.randn(batch_shape + (duration, obs_dim)),
                               torch.rand(batch_shape + (duration, obs_dim)).exp()).to_event(1)
-    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=duration)
 
     def model(data=None):
         with pyro.plate_stack("plates", batch_shape):
@@ -64,7 +63,7 @@ def test_studentt_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
     trans_dist = random_studentt(batch_shape + (duration, hidden_dim)).to_event(1)
     obs_mat = torch.randn(batch_shape + (duration, hidden_dim, obs_dim))
     obs_dist = random_studentt(batch_shape + (duration, obs_dim)).to_event(1)
-    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=duration)
 
     def model(data=None):
         with pyro.plate_stack("plates", batch_shape):
@@ -94,7 +93,7 @@ def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
     obs_mat = torch.randn(batch_shape + (duration, hidden_dim, obs_dim))
     obs_dist = random_stable(batch_shape + (duration, obs_dim),
                              stability.unsqueeze(-1).unsqueeze(-1), skew=skew).to_event(1)
-    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=duration)
     assert hmm.batch_shape == batch_shape
     assert hmm.event_shape == (duration, obs_dim)
 
@@ -135,56 +134,6 @@ def test_stable_hmm_shape_error(batch_shape, duration, hidden_dim, obs_dim):
 
     data = torch.randn(duration, obs_dim)
     rep = StableReparam()
-    with poutine.trace() as tr:
-        with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
-            model(data)
-    assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
-    assert not tr.trace.nodes["x"]["fn"]._broadcast_time
-    assert tr.trace.nodes["x"]["fn"]._validate_args
-
-    # smoke test only
-    if duration == 1:
-        tr.trace.compute_log_prob()
-    else:
+    with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
         with pytest.raises(ValueError):
-            tr.trace.compute_log_prob()
-
-
-# Test helper to extract a few fractional moments from joint samples.
-# This uses fractional moments because Stable variance is infinite.
-def get_hmm_moments(samples):
-    loc = samples.median(0).values
-    delta = samples - loc
-    cov = (delta.unsqueeze(-1) * delta.unsqueeze(-2)).sqrt().mean(0)
-    scale = cov.diagonal(dim1=-2, dim2=-1)
-    sigma = scale.sqrt()
-    corr = cov / (sigma.unsqueeze(-1) * sigma.unsqueeze(-2))
-    return loc, scale, corr
-
-
-@pytest.mark.parametrize("duration", [1, 2, 3])
-@pytest.mark.parametrize("obs_dim", [1, 2])
-@pytest.mark.parametrize("hidden_dim", [1, 2])
-@pytest.mark.parametrize("stability", [1.9, 1.6])
-@pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
-def test_stable_hmm_distribution(stability, skew, duration, hidden_dim, obs_dim):
-    init_dist = random_stable((hidden_dim,), stability, skew=skew).to_event(1)
-    trans_mat = torch.randn(duration, hidden_dim, hidden_dim)
-    trans_dist = random_stable((duration, hidden_dim), stability, skew=skew).to_event(1)
-    obs_mat = torch.randn(duration, hidden_dim, obs_dim)
-    obs_dist = random_stable((duration, obs_dim), stability, skew=skew).to_event(1)
-    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
-
-    num_samples = 200000
-    expected_samples = hmm.sample([num_samples]).reshape(num_samples, duration * obs_dim)
-    expected_loc, expected_scale, expected_corr = get_hmm_moments(expected_samples)
-
-    rep = SymmetricStableReparam() if skew == 0 else StableReparam()
-    with pyro.plate("samples", num_samples):
-        with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
-            actual_samples = pyro.sample("x", hmm).reshape(num_samples, duration * obs_dim)
-    actual_loc, actual_scale, actual_corr = get_hmm_moments(actual_samples)
-
-    assert_close(actual_loc, expected_loc, atol=0.05, rtol=0.05)
-    assert_close(actual_scale, expected_scale, atol=0.05, rtol=0.05)
-    assert_close(actual_corr, expected_corr, atol=0.01)
+            model(data)

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -8,6 +8,7 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.infer.reparam import LinearHMMReparam, StableReparam, StudentTReparam, SymmetricStableReparam
+from tests.common import assert_close
 from tests.ops.gaussian import random_mvn
 
 
@@ -108,6 +109,46 @@ def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
             model(data)
     assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
     tr.trace.compute_log_prob()  # smoke test only
+
+
+# Test helper to extract a few fractional moments from joint samples.
+# This uses fractional moments because Stable variance is infinite.
+def get_hmm_moments(samples):
+    loc = samples.median(0).values
+    delta = samples - loc
+    cov = (delta.unsqueeze(-1) * delta.unsqueeze(-2)).sqrt().mean(0)
+    scale = cov.diagonal(dim1=-2, dim2=-1)
+    sigma = scale.sqrt()
+    corr = cov / (sigma.unsqueeze(-1) * sigma.unsqueeze(-2))
+    return loc, scale, corr
+
+
+@pytest.mark.parametrize("duration", [1, 2, 3])
+@pytest.mark.parametrize("obs_dim", [1, 2])
+@pytest.mark.parametrize("hidden_dim", [1, 2])
+@pytest.mark.parametrize("stability", [1.9, 1.6])
+@pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
+def test_stable_hmm_distribution(stability, skew, duration, hidden_dim, obs_dim):
+    init_dist = random_stable((hidden_dim,), stability, skew=skew).to_event(1)
+    trans_mat = torch.randn(duration, hidden_dim, hidden_dim)
+    trans_dist = random_stable((duration, hidden_dim), stability, skew=skew).to_event(1)
+    obs_mat = torch.randn(duration, hidden_dim, obs_dim)
+    obs_dist = random_stable((duration, obs_dim), stability, skew=skew).to_event(1)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=duration)
+
+    num_samples = 200000
+    expected_samples = hmm.sample([num_samples]).reshape(num_samples, duration * obs_dim)
+    expected_loc, expected_scale, expected_corr = get_hmm_moments(expected_samples)
+
+    rep = SymmetricStableReparam() if skew == 0 else StableReparam()
+    with pyro.plate("samples", num_samples):
+        with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
+            actual_samples = pyro.sample("x", hmm).reshape(num_samples, duration * obs_dim)
+    actual_loc, actual_scale, actual_corr = get_hmm_moments(actual_samples)
+
+    assert_close(actual_loc, expected_loc, atol=0.05, rtol=0.05)
+    assert_close(actual_scale, expected_scale, atol=0.05, rtol=0.05)
+    assert_close(actual_corr, expected_corr, atol=0.01)
 
 
 @pytest.mark.parametrize("duration", [1, 2, 3, 4, 5, 6])

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -86,7 +86,6 @@ def test_studentt_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
 @pytest.mark.parametrize("skew", [0, None], ids=["symmetric", "skewed"])
 def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
     stability = dist.Uniform(0.5, 2).sample(batch_shape)
-
     init_dist = random_stable(batch_shape + (hidden_dim,),
                               stability.unsqueeze(-1), skew=skew).to_event(1)
     trans_mat = torch.randn(batch_shape + (duration, hidden_dim, hidden_dim))
@@ -96,18 +95,59 @@ def test_stable_hmm_shape(skew, batch_shape, duration, hidden_dim, obs_dim):
     obs_dist = random_stable(batch_shape + (duration, obs_dim),
                              stability.unsqueeze(-1).unsqueeze(-1), skew=skew).to_event(1)
     hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    assert hmm.batch_shape == batch_shape
+    assert hmm.event_shape == (duration, obs_dim)
 
     def model(data=None):
         with pyro.plate_stack("plates", batch_shape):
             return pyro.sample("x", hmm, obs=data)
 
-    data = model()
+    data = torch.randn(duration, obs_dim)
     rep = SymmetricStableReparam() if skew == 0 else StableReparam()
     with poutine.trace() as tr:
         with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
             model(data)
     assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
     tr.trace.compute_log_prob()  # smoke test only
+
+
+@pytest.mark.parametrize("duration", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("obs_dim", [1, 2])
+@pytest.mark.parametrize("hidden_dim", [1, 3])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (2, 3)], ids=str)
+def test_stable_hmm_shape_error(batch_shape, duration, hidden_dim, obs_dim):
+    stability = dist.Uniform(0.5, 2).sample(batch_shape)
+    init_dist = random_stable(batch_shape + (hidden_dim,),
+                              stability.unsqueeze(-1)).to_event(1)
+    trans_mat = torch.randn(batch_shape + (1, hidden_dim, hidden_dim))
+    trans_dist = random_stable(batch_shape + (1, hidden_dim),
+                               stability.unsqueeze(-1).unsqueeze(-1)).to_event(1)
+    obs_mat = torch.randn(batch_shape + (1, hidden_dim, obs_dim))
+    obs_dist = random_stable(batch_shape + (1, obs_dim),
+                             stability.unsqueeze(-1).unsqueeze(-1)).to_event(1)
+    hmm = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    assert hmm.batch_shape == batch_shape
+    assert hmm.event_shape == (1, obs_dim)
+
+    def model(data=None):
+        with pyro.plate_stack("plates", batch_shape):
+            return pyro.sample("x", hmm, obs=data)
+
+    data = torch.randn(duration, obs_dim)
+    rep = StableReparam()
+    with poutine.trace() as tr:
+        with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
+            model(data)
+    assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
+    assert not tr.trace.nodes["x"]["fn"]._broadcast_time
+    assert tr.trace.nodes["x"]["fn"]._validate_args
+
+    # smoke test only
+    if duration == 1:
+        tr.trace.compute_log_prob()
+    else:
+        with pytest.raises(ValueError):
+            tr.trace.compute_log_prob()
 
 
 # Test helper to extract a few fractional moments from joint samples.

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -75,7 +75,11 @@ def test_studentt_hmm_shape(batch_shape, duration, hidden_dim, obs_dim):
     with poutine.trace() as tr:
         with poutine.reparam(config={"x": LinearHMMReparam(rep, rep, rep)}):
             model(data)
+
     assert isinstance(tr.trace.nodes["x"]["fn"], dist.GaussianHMM)
+    assert tr.trace.nodes["x_init_gamma"]["fn"].event_shape == (hidden_dim,)
+    assert tr.trace.nodes["x_trans_gamma"]["fn"].event_shape == (duration, hidden_dim)
+    assert tr.trace.nodes["x_obs_gamma"]["fn"].event_shape == (duration, obs_dim)
     tr.trace.compute_log_prob()  # smoke test only
 
 


### PR DESCRIPTION
Addresses #2299 
Replaces #2300 

This adds a `duration` kwarg to Pyro's HMM classes and enables `._validate_sample()` on relevant methods. The crux is that HMMs can broadcast along the time axis, allowing cheap specification of homogeneous HMMs with time-unbroadcasted parameters.

This also fixes a duration broadcasting bug in `LinearHMMReparam` whereby unbroadcasted component distributions incorrectly led to unbroadcasted auxiliary variables.

@neerajprad this currently introduces minor backwards incompatibility, but I think this fixes more errors than it introduces. WDYT?
- `GaussianHMM.rsample()` and `LinearHMM.rsample()` will error when `event_shape[0] == 1` and `duration` is unspecified (which I think we want; this caused a bug in #2299 that took me a day to diagnose)

## Tested
- new validation logic is exercised by existing tests
- added a death test for `LinearHMMReparam`
- added a regression test for the `LinearHMMReparam` shape bug