### PR TITLE
Add GaussianHMM.posterior_rsample, fix .rsample bugs

### DIFF
--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -119,9 +119,9 @@ class Distribution(object, metaclass=ABCMeta):
 
     def conjugate_update(self, other):
         """
-        Creates an updated distribution fusing information from another
-        compatible distribution. This is supported by only a few conjugate
-        distributions.
+        EXPERIMENTAL Creates an updated distribution fusing information from
+        another compatible distribution. This is supported by only a few
+        conjugate distributions.
 
         This should satisfy the equation::
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -930,7 +930,8 @@ class LinearHMM(HiddenMarkovModel):
         init = self.initial_dist.rsample(sample_shape)
         trans = self.transition_dist.expand(self.batch_shape + (self.duration,)).rsample(sample_shape)
         obs = self.observation_dist.expand(self.batch_shape + (self.duration,)).rsample(sample_shape)
-        z = _linear_integrate(init, self.transition_matrix, trans)
+        trans_matrix = self.transition_matrix.expand(self.batch_shape + (self.duration, -1, -1))
+        z = _linear_integrate(init, trans_matrix, trans)
         x = (z.unsqueeze(-2) @ self.observation_matrix).squeeze(-2) + obs
         for t in self.transforms:
             x = t(x)

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -550,8 +550,8 @@ class GaussianHMM(HiddenMarkovModel):
 
     def conjugate_update(self, other):
         """
-        Creates an updated :class:`GaussianHMM` fusing information from another
-        compatible distribution.
+        EXPERIMENTAL Creates an updated :class:`GaussianHMM` fusing information
+        from another compatible distribution.
 
         This should satisfy::
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -514,6 +514,9 @@ class GaussianHMM(HiddenMarkovModel):
         return x
 
     def rsample_posterior(self, value, sample_shape=torch.Size()):
+        """
+        EXPERIMENTAL Sample from the latent state conditioned on observation.
+        """
         trans = self._trans + self._obs.condition(value).event_pad(left=self.hidden_dim)
         trans = trans.expand(trans.batch_shape)
         z = _sequential_gaussian_filter_sample(self._init, trans, sample_shape)

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -12,6 +12,9 @@ from pyro.distributions.util import sum_rightmost
 
 class Beta(torch.distributions.Beta, TorchDistributionMixin):
     def conjugate_update(self, other):
+        """
+        EXPERIMENTAL.
+        """
         assert isinstance(other, Beta)
         concentration1 = self.concentration1 + other.concentration1 - 1
         concentration0 = self.concentration0 + other.concentration0 - 1
@@ -57,6 +60,9 @@ class Categorical(torch.distributions.Categorical, TorchDistributionMixin):
 
 class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
     def conjugate_update(self, other):
+        """
+        EXPERIMENTAL.
+        """
         assert isinstance(other, Dirichlet)
         concentration = self.concentration + other.concentration - 1
         updated = Dirichlet(concentration)
@@ -71,6 +77,9 @@ class Dirichlet(torch.distributions.Dirichlet, TorchDistributionMixin):
 
 class Gamma(torch.distributions.Gamma, TorchDistributionMixin):
     def conjugate_update(self, other):
+        """
+        EXPERIMENTAL.
+        """
         assert isinstance(other, Gamma)
         concentration = self.concentration + other.concentration - 1
         rate = self.rate + other.rate
@@ -109,6 +118,9 @@ class Independent(torch.distributions.Independent, TorchDistributionMixin):
         self.base_dist._validate_args = value
 
     def conjugate_update(self, other):
+        """
+        EXPERIMENTAL.
+        """
         n = self.reintepreted_batch_ndims
         updated, log_normalizer = self.base_dist.conjugate_update(other.to_event(-n))
         updated = updated.to_event(n)

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -319,6 +319,9 @@ class MaskedDistribution(TorchDistribution):
         return self.base_dist.variance
 
     def conjugate_update(self, other):
+        """
+        EXPERIMENTAL.
+        """
         updated, log_normalizer = self.base_dist.conjugate_update(other)
         updated = updated.mask(self._mask)
         log_normalizer = torch.where(self._mask, log_normalizer, torch.zeros_like(log_normalizer))
@@ -429,6 +432,9 @@ class ExpandedDistribution(TorchDistribution):
         return self.base_dist.variance.expand(self.batch_shape + self.event_shape)
 
     def conjugate_update(self, other):
+        """
+        EXPERIMENTAL.
+        """
         updated, log_normalizer = self.base_dist.conjugate_update(other)
         updated = updated.expand(self.batch_shape)
         log_normalizer = log_normalizer.expand(self.batch_shape)

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -9,7 +9,7 @@ from .reparam import Reparam
 
 class ConjugateReparam(Reparam):
     """
-    Reparameterize to a conjugate updated distribution.
+    EXPERIMENTAL Reparameterize to a conjugate updated distribution.
 
     This updates a prior distribution ``fn`` using the
     :meth:`~pyro.distributions.Distribution.conjugate_update`

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -655,6 +655,7 @@ def random_stable(stability, skew_scale_loc_shape):
 @pytest.mark.parametrize('obs_dim', [1, 2])
 @pytest.mark.parametrize('hidden_dim', [1, 3])
 @pytest.mark.parametrize('init_shape,trans_mat_shape,trans_dist_shape,obs_mat_shape,obs_dist_shape', [
+    ((), (), (), (), ()),
     ((), (4,), (), (), ()),
     ((), (), (4,), (), ()),
     ((), (), (), (4,), ()),
@@ -678,9 +679,10 @@ def test_stable_hmm_shape(init_shape, trans_mat_shape, trans_dist_shape,
     trans_dist = random_stable(stability, trans_dist_shape + (hidden_dim,)).to_event(1)
     obs_mat = torch.randn(obs_mat_shape + (hidden_dim, obs_dim))
     obs_dist = random_stable(stability, obs_dist_shape + (obs_dim,)).to_event(1)
-    d = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    d = dist.LinearHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist,
+                       duration=4)
 
-    shape = broadcast_shape(init_shape + (1,),
+    shape = broadcast_shape(init_shape + (4,),
                             trans_mat_shape,
                             trans_dist_shape,
                             obs_mat_shape,

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -324,6 +324,9 @@ def test_gaussian_hmm_shape(diag, init_shape, trans_mat_shape, trans_mvn_shape,
     assert final.batch_shape == d.batch_shape
     assert final.event_shape == (hidden_dim,)
 
+    z = d.rsample_posterior(data)
+    assert z.shape == expected_batch_shape + time_shape + (hidden_dim,)
+
 
 @pytest.mark.parametrize('sample_shape', [(), (5,)], ids=str)
 @pytest.mark.parametrize('batch_shape', [(), (4,), (3, 2)], ids=str)

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -255,6 +255,7 @@ def test_discrete_hmm_diag_normal(num_steps):
 @pytest.mark.parametrize('obs_dim', [1, 2])
 @pytest.mark.parametrize('hidden_dim', [1, 3])
 @pytest.mark.parametrize('init_shape,trans_mat_shape,trans_mvn_shape,obs_mat_shape,obs_mvn_shape', [
+    ((), (), (), (), ()),
     ((), (6,), (), (), ()),
     ((), (), (6,), (), ()),
     ((), (), (), (6,), ()),
@@ -281,9 +282,10 @@ def test_gaussian_hmm_shape(diag, init_shape, trans_mat_shape, trans_mvn_shape,
     if diag:
         scale = obs_dist.scale_tril.diagonal(dim1=-2, dim2=-1)
         obs_dist = dist.Normal(obs_dist.loc, scale).to_event(1)
-    d = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist)
+    d = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist,
+                         duration=6)
 
-    shape = broadcast_shape(init_shape + (1,),
+    shape = broadcast_shape(init_shape + (6,),
                             trans_mat_shape,
                             trans_mvn_shape,
                             obs_mat_shape,

--- a/tutorial/source/stable.ipynb
+++ b/tutorial/source/stable.ipynb
@@ -522,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Adds a `GaussianHMM.posterior_rsample()` method
2. Fixes an expand bug in `GaussianHMM.rsample()`
3. Fixes an expand bug in `LinearHMM.rsample()`
4. Marks conjugacy-related methods EXPERIMENTAL (those introduced since last release)

## Tested
- [x] unit test `GaussianHMM.posterior_rsample()`
- [x] regression test for `GaussianHMM.rsample()`
- [x] regression test for `LinearHMM.rsample()`