### PR TITLE
Add periodic ops for seasonal forecasting

### DIFF
--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -61,7 +61,7 @@ def periodic_repeat(tensor, size, dim):
     """
     assert isinstance(size, int) and size >= 0
     assert isinstance(dim, int)
-    if dim > 0:
+    if dim >= 0:
         dim -= tensor.dim()
 
     period = tensor.size(dim)
@@ -89,7 +89,7 @@ def periodic_cumsum(tensor, period, dim):
     """
     assert isinstance(period, int) and period > 0
     assert isinstance(dim, int)
-    if dim > 0:
+    if dim >= 0:
         dim -= tensor.dim()
 
     # Pad to even size.


### PR DESCRIPTION
Addresses #2311 

This adds two helpers for defining fine-grained seasonal components in forecasting models. While these helpers are linear dynamical systems and could in principle be encoded in `GaussianHMM` matrices, they would lead to prohibitively high-dimensional latent state, e.g. 168 dimensions for an hour-of-week model. By instead keeping this part of the model variational, we can retain O(1) cost per time step, independent of period.

Example using #2309 :
```py
def model(self, zero_data, covariates):
    period = 24
    duration = zero_data.size(-2)

    # This time-independent noise will be variationally inferred.
    with pyro.plate("init_season_plate", period,  dim=-1):
        init_season = pyro.sample("init_season", dist.Normal(0, 1))
    with time_plate:
        noise_season = pyro.sample("noise_season", dist.Normal(0, 0.01))

    # This is cheap and deterministic:
    season = (periodic_repeat(init_season, duration, dim=-1) +
              periodic_cumsum(noise_season, period, dim=-1))

    prediction = season.unsqueeze(-1)
    noise_dist = ...
    self.predict(noise_dist, prediction)
```
I plan to use these in a future `contrib.forecast` tutorial.

## Tested
- [x] unit test for `periodic_repeat()`
- [x] unit test for `periodic_cumsum()`