### PR TITLE
Optimizing tests in GaussianChainTests

### DIFF
--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -110,7 +110,7 @@ class GaussianChainTests(GaussianChain):
 
     def test_elbo_reparameterized_N_is_8(self):
         self.setup_chain(8)
-        self.do_elbo_test(True, 5000, 0.0015, 0.03, difficulty=1.0)
+        self.do_elbo_test(True, 1000, 0.008, 0.03, difficulty=1.0)
 
     @pytest.mark.skip("CI" in os.environ and os.environ["CI"] == "true",
                       "Skip slow test in travis.")

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -110,7 +110,7 @@ class GaussianChainTests(GaussianChain):
 
     def test_elbo_reparameterized_N_is_8(self):
         self.setup_chain(8)
-        self.do_elbo_test(True, 1000, 0.008, 0.03, difficulty=1.0)
+        self.do_elbo_test(True, 1100, 0.0059, 0.03, difficulty=1.0)
 
     @pytest.mark.skip("CI" in os.environ and os.environ["CI"] == "true",
                       "Skip slow test in travis.")


### PR DESCRIPTION
Hi,

Some integration tests like `test_elbo_reparameterized_N_is_8` in `GaussianChainTests` take much longer to run than other tests. Reducing the iterations and adjusting the learning rate seems to reduce the running time (from ~`49s` to ~`10s` on my local machine). Note that all assertions still pass with these new values of parameters. 

Do you think that it is worth optimizing such tests? If yes, I can help optimize other slow running tests. Please let me know what you guys think and if you have any other suggestions/directions to look into.

Thanks!
