### PR TITLE
Clean up docs for contrib.forecast

### DIFF
--- a/docs/source/contrib.forecast.rst
+++ b/docs/source/contrib.forecast.rst
@@ -1,5 +1,6 @@
 Forecasting
 ===========
+.. automodule:: pyro.contrib.forecast
 
 ``pyro.contrib.forecast`` is a lightweight framework for experimenting with a
 restricted class of time series models and inference algorithms using familiar
@@ -12,7 +13,7 @@ variational inference with Gaussian variable elimination based on the
 joint posterior samples at multiple future time steps.
 
 Hierarchical models use the familiar :class:`~pyro.plate` syntax for
-general hierarchical modeling in Pyro. Plates can be subsamplined, enabling
+general hierarchical modeling in Pyro. Plates can be subsampled, enabling
 training of joint models over thousands of time series. Multivariate
 observations are handled via multivariate likelihoods like
 :class:`~pyro.distributions.MultivariateNormal`, :class:`~pyro.distributions.GaussianHMM`, or
@@ -23,6 +24,8 @@ using :class:`~pyro.distributions.StudentT` or
 :class:`~pyro.infer.reparam.studentt.StudentTReparam`,
 :class:`~pyro.infer.reparam.stable.StableReparam`, and
 :class:`~pyro.infer.reparam.hmm.LinearHMMReparam`.
+
+See :mod:`pyro.contrib.timeseries` for ways to construct temporal Gaussian processes useful as likelihoods.
 
 See the `forecasting example <http://pyro.ai/examples/forecasting_simple.html>`_ for example usage. 
 

--- a/docs/source/contrib.forecast.rst
+++ b/docs/source/contrib.forecast.rst
@@ -1,13 +1,30 @@
 Forecasting
 ===========
 
-The forecasting module contains a framework for experimenting with a restricted
-class of time series models and inference algorithms. Models include
-hierarchical multivariate heavy-tailed time series of ~1000 time steps and
-~1000 separate series. Inference combines variational inference with Gaussian
-variable elimination based on the :class:`~pyro.distributions.GaussianHMM`
-class. Forecasts are in the form of joint posterior samples at multiple future
-time steps.
+``pyro.contrib.forecast`` is a lightweight framework for experimenting with a
+restricted class of time series models and inference algorithms using familiar
+Pyro modeling syntax and PyTorch neural networks.
+
+Models include hierarchical multivariate heavy-tailed time series of ~1000 time
+steps and ~1000 separate series. Inference combines subsample-compatible
+variational inference with Gaussian variable elimination based on the
+:class:`~pyro.distributions.GaussianHMM` class. Forecasts are in the form of
+joint posterior samples at multiple future time steps.
+
+Hierarchical models use the familiar :class:`~pyro.plate` syntax for
+general hierarchical modeling in Pyro. Plates can be subsamplined, enabling
+training of joint models over thousands of time series. Multivariate
+observations are handled via multivariate likelihoods like
+:class:`~pyro.distributions.MultivariateNormal`, :class:`~pyro.distributions.GaussianHMM`, or
+:class:`~pyro.distributions.LinearHMM`. Heavy tailed models are possible by
+using :class:`~pyro.distributions.StudentT` or
+:class:`~pyro.distributions.Stable` likelihoods, possibly together with
+:class:`~pyro.distributions.LinearHMM` and reparameterizers including
+:class:`~pyro.infer.reparam.studentt.StudentTReparam`,
+:class:`~pyro.infer.reparam.stable.StableReparam`, and
+:class:`~pyro.infer.reparam.hmm.LinearHMMReparam`.
+
+See the `forecasting example <http://pyro.ai/examples/forecasting_simple.html>`_ for example usage. 
 
 Forecaster Interface
 ---------------------

--- a/docs/source/contrib.timeseries.rst
+++ b/docs/source/contrib.timeseries.rst
@@ -1,5 +1,6 @@
 Time Series
 ===========
+.. automodule:: pyro.contrib.timeseries
 
 See the `GP example <http://pyro.ai/examples/independent_gps.html>`_ for example usage. 
 


### PR DESCRIPTION
Addresses #2311 

This adds a module intro and moves `MarkDCTParamMessenger` into util.py so it doesn't clutter docs.