### PR TITLE
Make pyro.deterministic not warn when called outside of inference

### DIFF
--- a/pyro/optim/dct_adam.py
+++ b/pyro/optim/dct_adam.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 
 import torch

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -81,7 +81,7 @@ def sample(name, fn, *args, **kwargs):
     # check if stack is empty
     # if stack empty, default behavior (defined here)
     if not am_i_wrapped():
-        if obs is not None:
+        if obs is not None and not infer.get("_deterministic"):
             warnings.warn("trying to observe a value outside of inference at " + name,
                           RuntimeWarning)
             return obs
@@ -145,7 +145,8 @@ def deterministic(name, value, event_dim=None):
     :param int event_dim: Optional event dimension, defaults to `value.ndim`.
     """
     event_dim = value.ndim if event_dim is None else event_dim
-    return sample(name, dist.Delta(value, event_dim=event_dim).mask(False), obs=value)
+    return sample(name, dist.Delta(value, event_dim=event_dim).mask(False),
+                  obs=value, infer={"_deterministic": True})
 
 
 class plate(PlateMessenger):

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -6,6 +6,8 @@ import pyro
 import pyro.distributions as dist
 import torch
 
+pytestmark = pytest.mark.stage('unit')
+
 
 def test_sample_ok():
     x = pyro.sample("x", dist.Normal(0, 1))

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,0 +1,31 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import pyro
+import pyro.distributions as dist
+import torch
+
+
+def test_sample_ok():
+    x = pyro.sample("x", dist.Normal(0, 1))
+    assert isinstance(x, torch.Tensor)
+    assert x.shape == ()
+
+
+def test_observe_warn():
+    with pytest.warns(RuntimeWarning):
+        pyro.sample("x", dist.Normal(0, 1),
+                    obs=torch.tensor(0.))
+
+
+def test_param_ok():
+    x = pyro.param("x", torch.tensor(0.))
+    assert isinstance(x, torch.Tensor)
+    assert x.shape == ()
+
+
+def test_deterministic_ok():
+    x = pyro.deterministic("x", torch.tensor(0.))
+    assert isinstance(x, torch.Tensor)
+    assert x.shape == ()


### PR DESCRIPTION
Resolves #2297 

This is a quick short-term solution to allow `pyro.determinisic()` outside of inference. This will probably eventually be replace by a custom primitive #2196.

## Tested
- [x] added unit tests for primitives called outside of inference