### PR TITLE
Support warm-starting in forecasting module

### DIFF
--- a/pyro/contrib/forecast/evaluate.py
+++ b/pyro/contrib/forecast/evaluate.py
@@ -150,8 +150,7 @@ def backtest(data, covariates, model_fn, guide_fn=None, *,
 
         # Train a forecaster on the training window.
         pyro.set_rng_seed(seed)
-        if forecaster_options_fn is not None:
-            forecaster_options = forecaster_options_fn(t0=t0, t1=t1, t2=t2)
+        forecaster_options = forecaster_options_fn(t0=t0, t1=t1, t2=t2)
         if not forecaster_options.get("warm_start"):
             pyro.clear_param_store()
         train_data = data[..., t0:t1, :]

--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -216,7 +216,7 @@ class Forecaster(nn.Module):
         Defaults to True. Set to False for models with dynamic control flow.
     :param bool warm_start: Whether to warm start parameters from a smaller
         time window. Note this may introduce statistical leakage; usage is
-        recommended for model expoloration purposes only and should be disabled
+        recommended for model exploration purposes only and should be disabled
         when publishing metrics.
     :param int log_every: Number of training steps between logging messages.
     """

--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -76,8 +76,7 @@ class PrefixWarmStartMessenger(Messenger):
         assert new.shape[dim + 1:] == old.shape[dim + 1:]
         split = old.size(dim)
         index = (slice(None),) * dim + (slice(split, None),)
-        print("{}.dim = {}".format(name, dim))
-        new = torch.cat([new, old[index]], dim=dim)
+        new = torch.cat([old, new[index]], dim=dim)
         store[name] = t(new)
 
 

--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -78,11 +78,7 @@ class PrefixWarmStartMessenger(Messenger):
         index = (slice(None),) * dim + (slice(split, None),)
         print("{}.dim = {}".format(name, dim))
         new = torch.cat([new, old[index]], dim=dim)
-        new = t(new)
-
-        store[name] = new
-        msg["value"] = new
-        msg["done"] = True
+        store[name] = t(new)
 
 
 class PrefixReplayMessenger(Messenger):

--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -4,10 +4,12 @@
 from functools import singledispatch
 
 import torch
+from torch.distributions import transform_to
 
 import pyro.distributions as dist
 from pyro.poutine.messenger import Messenger
 from pyro.poutine.util import site_is_subsample
+from pyro.primitives import get_param_store
 
 
 class MarkDCTParamMessenger(Messenger):
@@ -34,6 +36,53 @@ class MarkDCTParamMessenger(Messenger):
                 event_dim += value.unconstrained().dim() - value.dim()
                 value.unconstrained()._pyro_dct_dim = frame.dim - event_dim
                 return
+
+
+class PrefixWarmStartMessenger(Messenger):
+    """
+    EXPERIMENTAL Assuming the global param store has been populated with params
+    defined on a short time window, re-initialize by splicing old params with
+    new initial params defined on a longer time window.
+    """
+    def _pyro_param(self, msg):
+        store = get_param_store()
+        name = msg["name"]
+        if name not in store:
+            return
+
+        if len(msg["args"]) >= 2:
+            new = msg["args"][1]
+        elif "init_tensor" in msg["kwargs"]:
+            new = msg["kwargs"]["init_tensor"]
+        else:
+            return  # no init tensor specified
+
+        if callable(new):
+            new = new()
+        old = store[name]
+        assert new.dim() == old.dim()
+        if new.shape == old.shape:
+            return
+
+        # Splice old (warm start) and new (init) tensors.
+        # This only works for time-homogeneous constraints.
+        t = transform_to(store._constraints[name])
+        new = t.inv(new)
+        old = t.inv(old)
+        for dim in range(new.dim()):
+            if new.size(dim) != old.size(dim):
+                break
+        assert new.size(dim) > old.size(dim)
+        assert new.shape[dim + 1:] == old.shape[dim + 1:]
+        split = old.size(dim)
+        index = (slice(None),) * dim + (slice(split, None),)
+        print("{}.dim = {}".format(name, dim))
+        new = torch.cat([new, old[index]], dim=dim)
+        new = t(new)
+
+        store[name] = new
+        msg["value"] = new
+        msg["done"] = True
 
 
 class PrefixReplayMessenger(Messenger):

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -369,14 +369,14 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
             self._pyro_params[name] = constraint, event_dim
             if self._pyro_context.active:
                 fullname = self._pyro_get_fullname(name)
-                if fullname in _PYRO_PARAM_STORE:
-                    # Update PyroModule <--- ParamStore.
-                    unconstrained_value = _PYRO_PARAM_STORE._params[fullname]
-                    if not isinstance(unconstrained_value, torch.nn.Parameter):
-                        # Update PyroModule ---> ParamStore (type only; data is preserved).
-                        unconstrained_value = torch.nn.Parameter(unconstrained_value)
-                        _PYRO_PARAM_STORE._params[fullname] = unconstrained_value
-                        _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
+                constrained_value = pyro.param(fullname, constrained_value,
+                                               constraint=constraint, event_dim=event_dim)
+                unconstrained_value = constrained_value.unconstrained()
+                if not isinstance(unconstrained_value, torch.nn.Parameter):
+                    # Update PyroModule ---> ParamStore (type only; data is preserved).
+                    unconstrained_value = torch.nn.Parameter(unconstrained_value)
+                    _PYRO_PARAM_STORE._params[fullname] = unconstrained_value
+                    _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
                 else:
                     unconstrained_value = _unconstrain(constrained_value, constraint)
             else:  # Cannot determine supermodule and hence cannot compute fullname.

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -369,8 +369,8 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
             self._pyro_params[name] = constraint, event_dim
             if self._pyro_context.active:
                 fullname = self._pyro_get_fullname(name)
-                constrained_value = pyro.param(fullname, constrained_value,
-                                               constraint=constraint, event_dim=event_dim)
+                pyro.param(fullname, constrained_value, constraint=constraint, event_dim=event_dim)
+                constrained_value = pyro.param(fullname)
                 unconstrained_value = constrained_value.unconstrained()
                 if not isinstance(unconstrained_value, torch.nn.Parameter):
                     # Update PyroModule ---> ParamStore (type only; data is preserved).

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -377,8 +377,6 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
                     unconstrained_value = torch.nn.Parameter(unconstrained_value)
                     _PYRO_PARAM_STORE._params[fullname] = unconstrained_value
                     _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
-                else:
-                    unconstrained_value = _unconstrain(constrained_value, constraint)
             else:  # Cannot determine supermodule and hence cannot compute fullname.
                 unconstrained_value = _unconstrain(constrained_value, constraint)
             super().__setattr__(name + "_unconstrained", unconstrained_value)

--- a/tests/contrib/forecast/test_evaluate.py
+++ b/tests/contrib/forecast/test_evaluate.py
@@ -97,3 +97,22 @@ def test_poisson(train_window, min_train_window, test_window, min_test_window, s
         for window in windows:
             assert name in window
             assert 0 < window[name] < math.inf
+
+
+def test_custom_warm_start():
+    duration = 30
+    obs_dim = 2
+    covariates = torch.zeros(duration, 0)
+    data = torch.randn(duration, obs_dim) + 4
+    min_train_window = 10
+
+    def forecaster_options(t0, t1, t2):
+        if t1 == min_train_window:
+            return {"num_steps": 2, "warm_start": True}
+        else:
+            return {"num_steps": 0, "warm_start": True}
+
+    backtest(data, covariates, Model,
+             min_train_window=min_train_window,
+             test_window=10,
+             forecaster_options=forecaster_options)

--- a/tests/contrib/forecast/test_evaluate.py
+++ b/tests/contrib/forecast/test_evaluate.py
@@ -36,11 +36,13 @@ WINDOWS = [
 
 
 @pytest.mark.parametrize("train_window,min_train_window,test_window,min_test_window,stride", WINDOWS)
-def test_simple(train_window, min_train_window, test_window, min_test_window, stride):
+@pytest.mark.parametrize("warm_start", [False, True], ids=["cold", "warm"])
+def test_simple(train_window, min_train_window, test_window, min_test_window, stride, warm_start):
     duration = 30
     obs_dim = 2
     covariates = torch.zeros(duration, 0)
     data = torch.randn(duration, obs_dim) + 4
+    forecaster_options = {"num_steps": 2, "warm_start": warm_start}
 
     windows = backtest(data, covariates, Model,
                        train_window=train_window,
@@ -48,7 +50,7 @@ def test_simple(train_window, min_train_window, test_window, min_test_window, st
                        test_window=test_window,
                        min_test_window=min_test_window,
                        stride=stride,
-                       forecaster_options={"num_steps": 2})
+                       forecaster_options=forecaster_options)
 
     assert any(window["t0"] == 0 for window in windows)
     if stride == 1:


### PR DESCRIPTION
Addresses #2311 
Replaces #2329

This supports warm-starting of forecasts, typically used in backtesting. Usage:
```py
windows = backtest(data, covariates, Model, ...,
                   forecaster_options={"warm_start": True, ...})
```

## Tested
- [x] `PyroModule.__setattr__()` refactoring is covered by existing tests
- [x] added a shape smoke test
- [x] tested by @martinjankowiak on real data