### PR TITLE
Optimizing slow inference tests

### DIFF
--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -27,7 +27,9 @@ def test_elbo_mapdata(batch_size, map_type):
     lam = torch.tensor([6.0, 4.0])
     data = []
     sum_data = torch.zeros(2)
-    params = {("iplate", 8) : (100, 0.018), ("iplate", None): (100, 0.013), ("range", 3) : (100, 0.018), ("range", 8): (100, 0.01), ("range", None): (100, 0.011)}
+    params = {("iplate", 8): (100, 0.018), ("iplate", None): (100, 0.013), 
+              ("range", 3): (100, 0.018), ("range", 8): (100, 0.01), ("range", None): (100, 0.011)}
+    
     def add_data_point(x, y):
         data.append(torch.tensor([x, y]))
         sum_data.data.add_(data[-1].data)
@@ -86,7 +88,8 @@ def test_elbo_mapdata(batch_size, map_type):
         else:
             pass
 
-    adam = optim.Adam({"lr": 0.0008 if (map_type, batch_size) not in params else params[(map_type, batch_size)][1], "betas": (0.95, 0.999)})
+    adam = optim.Adam({"lr": 0.0008 if (map_type, batch_size) not in params else 
+                       params[(map_type, batch_size)][1], "betas": (0.95, 0.999)})
     svi = SVI(model, guide, adam, loss=TraceGraph_ELBO())
 
     for k in range(n_steps):

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -27,9 +27,9 @@ def test_elbo_mapdata(batch_size, map_type):
     lam = torch.tensor([6.0, 4.0])
     data = []
     sum_data = torch.zeros(2)
-    params = {("iplate", 8): (100, 0.018), ("iplate", None): (100, 0.013), 
+    params = {("iplate", 8): (100, 0.018), ("iplate", None): (100, 0.013),
               ("range", 3): (100, 0.018), ("range", 8): (100, 0.01), ("range", None): (100, 0.011)}
-    
+
     def add_data_point(x, y):
         data.append(torch.tensor([x, y]))
         sum_data.data.add_(data[-1].data)
@@ -88,7 +88,7 @@ def test_elbo_mapdata(batch_size, map_type):
         else:
             pass
 
-    adam = optim.Adam({"lr": 0.0008 if (map_type, batch_size) not in params else 
+    adam = optim.Adam({"lr": 0.0008 if (map_type, batch_size) not in params else
                        params[(map_type, batch_size)][1], "betas": (0.95, 0.999)})
     svi = SVI(model, guide, adam, loss=TraceGraph_ELBO())
 

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -17,12 +17,12 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.stage("integration", "integration_batch_1")
 @pytest.mark.init(rng_seed=161)
-@pytest.mark.parametrize("map_type, batch_size, params", [("iplate", 3, (7000, 0.0008)), ("iplate", 8, (100, 0.018)),
-                                                          ("iplate", None, (100, 0.013)), ("range", 3, (100, 0.018)),
-                                                          ("range", 8, (100, 0.01)), ("range", None, (100, 0.011)),
-                                                          ("plate", 3, (7000, 0.0008)), ("plate", 8, (7000, 0.0008)),
-                                                          ("plate", None, (7000, 0.0008))])
-def test_elbo_mapdata(map_type, batch_size, params):
+@pytest.mark.parametrize("map_type,batch_size,n_steps,lr",  [("iplate", 3, 7000, 0.0008), ("iplate", 8, 100, 0.018),
+                                                             ("iplate", None, 100, 0.013), ("range", 3, 100, 0.018),
+                                                             ("range", 8, 100, 0.01), ("range", None, 100, 0.011),
+                                                             ("plate", 3, 7000, 0.0008), ("plate", 8, 7000, 0.0008),
+                                                             ("plate", None, 7000, 0.0008)])
+def test_elbo_mapdata(map_type, batch_size, n_steps, lr):
     # normal-normal: known covariance
     lam0 = torch.tensor([0.1, 0.1])   # precision of prior
     loc0 = torch.tensor([0.0, 0.5])   # prior mean
@@ -50,7 +50,6 @@ def test_elbo_mapdata(map_type, batch_size, params):
     analytic_log_sig_n = -0.5 * torch.log(analytic_lam_n)
     analytic_loc_n = sum_data * (lam / analytic_lam_n) +\
         loc0 * (lam0 / analytic_lam_n)
-    n_steps = params[0]
 
     logger.debug("DOING ELBO TEST [bs = {}, map_type = {}]".format(batch_size, map_type))
     pyro.clear_param_store()
@@ -89,7 +88,7 @@ def test_elbo_mapdata(map_type, batch_size, params):
         else:
             pass
 
-    adam = optim.Adam({"lr": params[1]})
+    adam = optim.Adam({"lr": lr})
     svi = SVI(model, guide, adam, loss=TraceGraph_ELBO())
 
     for k in range(n_steps):

--- a/tests/integration_tests/test_conjugate_gaussian_models.py
+++ b/tests/integration_tests/test_conjugate_gaussian_models.py
@@ -106,7 +106,7 @@ class GaussianChainTests(GaussianChain):
 
     def test_elbo_reparameterized_N_is_3(self):
         self.setup_chain(3)
-        self.do_elbo_test(True, 4000, 0.0015, 0.03, difficulty=1.0)
+        self.do_elbo_test(True, 1100, 0.0058, 0.03, difficulty=1.0)
 
     def test_elbo_reparameterized_N_is_8(self):
         self.setup_chain(8)
@@ -116,21 +116,21 @@ class GaussianChainTests(GaussianChain):
                       "Skip slow test in travis.")
     def test_elbo_reparameterized_N_is_17(self):
         self.setup_chain(17)
-        self.do_elbo_test(True, 5000, 0.0015, 0.03, difficulty=1.0)
+        self.do_elbo_test(True, 2700, 0.0044, 0.03, difficulty=1.0)
 
     def test_elbo_nonreparameterized_N_is_3(self):
         self.setup_chain(3)
-        self.do_elbo_test(False, 5000, 0.001, 0.04, difficulty=0.6)
+        self.do_elbo_test(False, 1700, 0.0049, 0.04, difficulty=0.6)
 
     def test_elbo_nonreparameterized_N_is_5(self):
         self.setup_chain(5)
-        self.do_elbo_test(False, 5000, 0.001, 0.06, difficulty=0.6)
+        self.do_elbo_test(False, 1000, 0.0061, 0.06, difficulty=0.6)
 
     @pytest.mark.skip("CI" in os.environ and os.environ["CI"] == "true",
                       "Skip slow test in travis.")
     def test_elbo_nonreparameterized_N_is_7(self):
         self.setup_chain(7)
-        self.do_elbo_test(False, 5000, 0.001, 0.05, difficulty=0.6)
+        self.do_elbo_test(False, 1800, 0.0035, 0.05, difficulty=0.6)
 
     def do_elbo_test(self, reparameterized, n_steps, lr, prec, difficulty=1.0):
         n_repa_nodes = torch.sum(self.which_nodes_reparam) if not reparameterized else self.N
@@ -238,7 +238,7 @@ class GaussianPyramidTests(TestCase):
 
     def test_elbo_reparameterized_three_layers(self):
         self.setup_pyramid(3)
-        self.do_elbo_test(True, 10000, 0.0015, 0.04, 0.92,
+        self.do_elbo_test(True, 1700, 0.01, 0.04, 0.92,
                           difficulty=0.8, model_permutation=False)
 
     @pytest.mark.skipif("CI" in os.environ, reason="slow test")
@@ -250,21 +250,21 @@ class GaussianPyramidTests(TestCase):
     @pytest.mark.stage("integration", "integration_batch_1")
     def test_elbo_nonreparameterized_two_layers(self):
         self.setup_pyramid(2)
-        self.do_elbo_test(False, 8000, 0.001, 0.04, 0.95, difficulty=0.5, model_permutation=False)
+        self.do_elbo_test(False, 500, 0.012, 0.04, 0.95, difficulty=0.5, model_permutation=False)
 
     def test_elbo_nonreparameterized_three_layers(self):
         self.setup_pyramid(3)
-        self.do_elbo_test(False, 15000, 0.001, 0.04, 0.95, difficulty=0.5, model_permutation=False)
+        self.do_elbo_test(False, 9100, 0.00506, 0.04, 0.95, difficulty=0.5, model_permutation=False)
 
     def test_elbo_nonreparameterized_two_layers_model_permuted(self):
         self.setup_pyramid(2)
-        self.do_elbo_test(False, 10000, 0.0007, 0.05, 0.96, difficulty=0.5, model_permutation=True)
+        self.do_elbo_test(False, 700, 0.018, 0.05, 0.96, difficulty=0.5, model_permutation=True)
 
     @pytest.mark.skip("CI" in os.environ and os.environ["CI"] == "true",
                       "Skip slow test in travis.")
     def test_elbo_nonreparameterized_three_layers_model_permuted(self):
         self.setup_pyramid(3)
-        self.do_elbo_test(False, 15000, 0.0007, 0.05, 0.96, difficulty=0.4, model_permutation=True)
+        self.do_elbo_test(False, 6500, 0.0071, 0.05, 0.96, difficulty=0.4, model_permutation=True)
 
     def calculate_variational_targets(self):
         # calculate (some of the) variational parameters corresponding to exact posterior

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -402,9 +402,9 @@ class RaoBlackwellizationTests(TestCase):
     # inside of a sequential plate with superfluous random torch.tensors to complexify the
     # graph structure and introduce additional baselines
     def test_plate_in_elbo_with_superfluous_rvs(self):
-        self._test_plate_in_elbo(n_superfluous_top=1, n_superfluous_bottom=1, n_steps=5000)
+        self._test_plate_in_elbo(n_superfluous_top=1, n_superfluous_bottom=1, n_steps=1800, lr=0.0112)
 
-    def _test_plate_in_elbo(self, n_superfluous_top, n_superfluous_bottom, n_steps):
+    def _test_plate_in_elbo(self, n_superfluous_top, n_superfluous_bottom, n_steps, lr=0.0012):
         pyro.clear_param_store()
         self.data_tensor = torch.zeros(9, 2)
         for _out in range(self.n_outer):
@@ -467,7 +467,7 @@ class RaoBlackwellizationTests(TestCase):
             if 'baseline' in param_name or 'baseline' in module_name:
                 return {"lr": 0.010, "betas": (0.95, 0.999)}
             else:
-                return {"lr": 0.0012, "betas": (0.95, 0.999)}
+                return {"lr": lr, "betas": (0.95, 0.999)}
 
         adam = optim.Adam(per_param_callable)
         svi = SVI(model, guide, adam, loss=TraceGraph_ELBO())

--- a/tests/integration_tests/test_tracegraph_elbo.py
+++ b/tests/integration_tests/test_tracegraph_elbo.py
@@ -402,7 +402,7 @@ class RaoBlackwellizationTests(TestCase):
     # inside of a sequential plate with superfluous random torch.tensors to complexify the
     # graph structure and introduce additional baselines
     def test_plate_in_elbo_with_superfluous_rvs(self):
-        self._test_plate_in_elbo(n_superfluous_top=1, n_superfluous_bottom=1, n_steps=1800, lr=0.0112)
+        self._test_plate_in_elbo(n_superfluous_top=1, n_superfluous_bottom=1, n_steps=2000, lr=0.0113)
 
     def _test_plate_in_elbo(self, n_superfluous_top, n_superfluous_bottom, n_steps, lr=0.0012):
         pyro.clear_param_store()


### PR DESCRIPTION
Related to #2324 

These optimizations reduce the running time of the tests, while still ensuring that they pass with high probability

- Updated the parameters of more slow tests
- Manually verified that the tests pass on GPU
- Also tried running multiple times with different seeds and verified that it passes with multiple seeds

Please let me know if this looks good or if there are any additional steps that I need to perform to verify these changes 


