### PR TITLE
Add a helper to handle seasonality via regression

### DIFF
--- a/docs/source/contrib.forecast.rst
+++ b/docs/source/contrib.forecast.rst
@@ -25,9 +25,14 @@ using :class:`~pyro.distributions.StudentT` or
 :class:`~pyro.infer.reparam.stable.StableReparam`, and
 :class:`~pyro.infer.reparam.hmm.LinearHMMReparam`.
 
+Seasonality can be handled using the helpers
+:func:`~pyro.ops.tensor_utils.periodic_repeat`,
+:func:`~pyro.ops.tensor_utils.periodic_cumsum`, and
+:func:`~pyro.ops.tennsor_utils.periodic_features`.
+
 See :mod:`pyro.contrib.timeseries` for ways to construct temporal Gaussian processes useful as likelihoods.
 
-See the `forecasting example <http://pyro.ai/examples/forecasting_simple.html>`_ for example usage. 
+See the `forecasting example <http://pyro.ai/examples/forecasting_simple.html>`_ for example usage.
 
 Forecaster Interface
 ---------------------

--- a/docs/source/contrib.forecast.rst
+++ b/docs/source/contrib.forecast.rst
@@ -28,7 +28,7 @@ using :class:`~pyro.distributions.StudentT` or
 Seasonality can be handled using the helpers
 :func:`~pyro.ops.tensor_utils.periodic_repeat`,
 :func:`~pyro.ops.tensor_utils.periodic_cumsum`, and
-:func:`~pyro.ops.tennsor_utils.periodic_features`.
+:func:`~pyro.ops.tensor_utils.periodic_features`.
 
 See :mod:`pyro.contrib.timeseries` for ways to construct temporal Gaussian processes useful as likelihoods.
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -118,8 +118,8 @@ def periodic_features(duration, max_period=None, min_period=None, **options):
     treated via regression. When only ``max_period`` is specified this
     generates periodic features at all length scales. When also ``min_period``
     is specified this generates periodic features at large length scales, but
-    omits high frequecy features. This is useful when combining regression for
-    long seasonality with other techinques like :func:`periodic_repeat` and
+    omits high frequency features. This is useful when combining regression for
+    long seasonality with other techniques like :func:`periodic_repeat` and
     :func:`periodic_cumsum` for short time scales. For example, to combine
     regress yearly seasonality down to the scale of one week one could set
     ``max_period=365.25`` and ``min_period=7``.

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -111,20 +111,27 @@ def periodic_cumsum(tensor, period, dim):
 
 def periodic_features(duration, max_period=None, min_period=None, **options):
     r"""
-    Create periodic (sin,cos) features from max_period down to min_period.
+    Create periodic (sin,cos) features from ``max_period`` down to
+    ``min_period``.
 
     This is useful in time series models where long uneven seasonality can be
-    treated via regression, and short seasonality can be treated via the
-    :func:`periodic_repeat` and :func:`periodic_cumsum` helpers. For example,
-    to combine yearly with weekly seasonality one could set
+    treated via regression. When only ``max_period`` is specified this
+    generates periodic features at all length scales. When also ``min_period``
+    is specified this generates periodic features at large length scales, but
+    omits high frequecy features. This is useful when combining regression for
+    long seasonality with other techinques like :func:`periodic_repeat` and
+    :func:`periodic_cumsum` for short time scales. For example, to combine
+    regress yearly seasonality down to the scale of one week one could set
     ``max_period=365.25`` and ``min_period=7``.
 
     :param int duration: Number of discrete time steps.
     :param float max_period: Optional max period, defaults to ``duration``.
-    :param float min_period: Optional min period (exclusive), defaults to 2 = Nyquist cutoff.
-    :param \*\*options: Tensor construction options, e.g. ``dtype`` and ``device``.
-    :returns: A ``(duration, 2 * ceil(max_period - min_period) - 2)``-shaped tensor of features
-        normalized to lie in [-1,1].
+    :param float min_period: Optional min period (exclusive), defaults to
+        2 = Nyquist cutoff.
+    :param \*\*options: Tensor construction options, e.g. ``dtype`` and
+        ``device``.
+    :returns: A ``(duration, 2 * ceil(max_period / min_period) - 2)``-shaped
+        tensor of features normalized to lie in [-1,1].
     :rtype: ~torch.Tensor
     """
     assert isinstance(duration, int) and duration >= 0


### PR DESCRIPTION
Addresses #2311 

This adds a `periodic_features()` helper that can be used to generate covariates for forecasting models.

## Tested
- [x] added shape and bound tests