### PR TITLE
Update torchvision dataset url patching

### DIFF
--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -15,11 +15,19 @@ from pyro.distributions.torch_patch import patch_dependency
 
 @patch_dependency('torchvision.datasets.MNIST', torchvision)
 class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
+    # For older torchvision.
     urls = [
         "https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz",
         "https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz",
         "https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz",
         "https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz",
+    ]
+    # For newer torchvision.
+    resources = [
+        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz", "f68b3c2dcbeaaa9fbdd348bbdeb94873"),
+        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz", "d53e105ee54ea40749a09fcbcd1e9432"),
+        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz", "9fb629c4189551a2d022fa330f9573f3"),
+        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz", "ec29112dd5afa0611ce80d1b7f02629c")
     ]
 
 

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -23,12 +23,12 @@ class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
         "https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz",
     ]
     # For newer torchvision.
-    resources = [
-        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz", "f68b3c2dcbeaaa9fbdd348bbdeb94873"),
-        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-labels-idx1-ubyte.gz", "d53e105ee54ea40749a09fcbcd1e9432"),
-        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-images-idx3-ubyte.gz", "9fb629c4189551a2d022fa330f9573f3"),
-        ("https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/t10k-labels-idx1-ubyte.gz", "ec29112dd5afa0611ce80d1b7f02629c")
-    ]
+    resources = list(zip(urls, [
+        "f68b3c2dcbeaaa9fbdd348bbdeb94873",
+        "d53e105ee54ea40749a09fcbcd1e9432",
+        "9fb629c4189551a2d022fa330f9573f3",
+        "ec29112dd5afa0611ce80d1b7f02629c"
+    ]))
 
 
 def get_data_loader(dataset_name,

--- a/tutorial/source/vae.ipynb
+++ b/tutorial/source/vae.ipynb
@@ -104,6 +104,7 @@
     "\n",
     "import pyro\n",
     "import pyro.distributions as dist\n",
+    "import pyro.contrib.examples.util  # patches torchvision\n",
     "from pyro.infer import SVI, Trace_ELBO\n",
     "from pyro.optim import Adam"
    ]


### PR DESCRIPTION
This updates @neerajprad's dataset patches to torchvision's new `MNIST` class definition.

This is currently blocking all other PRs, causing CI to fail.