### PR TITLE
improve stability of SymmetricStableReparam

### DIFF
--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -79,7 +79,13 @@ class SymmetricStableReparam(Reparam):
     [1] Alvaro Cartea and Sam Howison (2009)
         "Option Pricing with Levy-Stable Processes"
         https://pdfs.semanticscholar.org/4d66/c91b136b2a38117dd16c2693679f5341c616.pdf
+
+    :param float epsilon: Small numerical factor that helps with stability at the price of a
+        small bias in the auxiliary sampler. Defaults to 1.0e-4. Set to 0.0 to avoid bias.
     """
+    def __init__(self, epsilon=1.0e-4):
+        self.epsilon = epsilon
+
     def __call__(self, name, fn, obs):
         fn, event_dim = self._unwrap(fn)
         assert isinstance(fn, dist.Stable) and fn.coords == "S0"
@@ -94,7 +100,7 @@ class SymmetricStableReparam(Reparam):
         half_pi = proto.new_full(proto.shape, math.pi / 2)
         one = proto.new_ones(proto.shape)
         u = pyro.sample("{}_uniform".format(name),
-                        self._wrap(dist.Uniform(-half_pi, half_pi), event_dim))
+                        self._wrap(dist.Uniform(-half_pi + self.epsilon, half_pi - self.epsilon), event_dim))
         e = pyro.sample("{}_exponential".format(name),
                         self._wrap(dist.Exponential(one), event_dim))
 


### PR DESCRIPTION
i've been running into NaN gradients using SymmetricStableReparam. restricting the range of the uniform auxiliary seems to help. suggestions for better/other ways to improve stability?

to reproduce numerical issues run 

`python multivariate.py --noise-model stable --clip-norm 5.0 --learning-rate 0.01`

on the `stablets` branch of pyro-ppl/sandbox (see folder `2020-03-forecasting`). 

if you set `epsilon=0.0` you should see NaN parameters shortly after

`INFO     Training on window [0:619], testing on window [619:620]`

with this diff the script should run to completion.
