### PR TITLE
Fix nan issue of stable reparam

### DIFF
--- a/pyro/infer/reparam/stable.py
+++ b/pyro/infer/reparam/stable.py
@@ -179,7 +179,7 @@ class StableReparam(Reparam):
         t = _standard_stable(a, one, tu, te, coords="S0")
         a_inv = a.reciprocal()
         skew_abs = fn.skew.abs()
-        t_scale = skew_abs.pow(a_inv)
+        t_scale = skew_abs.clamp(min=torch.finfo(a.dtype).tiny).pow(a_inv)
         s_scale = (1 - skew_abs).pow(a_inv)
         shift = _safe_shift(a, skew_abs, t_scale)
         loc = fn.loc + fn.scale * fn.skew.sign() * (t * t_scale + shift)

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -36,7 +36,7 @@ def test_stable(Reparam, shape):
 
     def model():
         with pyro.plate_stack("plates", shape):
-            with pyro.plate("particles", 1000000):
+            with pyro.plate("particles", 100000):
                 return pyro.sample("x", dist.Stable(stability, skew, scale, loc))
 
     value = model()
@@ -58,8 +58,8 @@ def test_stable(Reparam, shape):
         expected_grads = grad(expected_m.sum(), params, retain_graph=True)
         actual_grads = grad(actual_m.sum(), params, retain_graph=True)
         assert_close(actual_grads[0], expected_grads[0], atol=0.2)
-        print(actual_grads[1], expected_grads[1])
-        assert_close(actual_grads[1], expected_grads[1], atol=0.1)
+        assert_close(actual_grads[1][skew != 0], expected_grads[1][skew != 0], atol=0.1)
+        assert_close(actual_grads[1][skew == 0], expected_grads[1][skew == 0], atol=0.3)
         assert_close(actual_grads[2], expected_grads[2], atol=0.1)
         assert_close(actual_grads[3], expected_grads[3], atol=0.1)
 

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -27,6 +27,9 @@ def get_moments(x):
 def test_stable(Reparam, shape):
     stability = torch.empty(shape).uniform_(1.5, 2.).requires_grad_()
     skew = torch.empty(shape).uniform_(-0.5, 0.5).requires_grad_()
+    # test edge case when skew is 0
+    if skew.dim() > 0 and skew.shape[-1] > 0:
+        skew.data[..., 0] = 0.
     scale = torch.empty(shape).uniform_(0.5, 1.0).requires_grad_()
     loc = torch.empty(shape).uniform_(-1., 1.).requires_grad_()
     params = [stability, skew, scale, loc]
@@ -55,7 +58,7 @@ def test_stable(Reparam, shape):
         expected_grads = grad(expected_m.sum(), params, retain_graph=True)
         actual_grads = grad(actual_m.sum(), params, retain_graph=True)
         assert_close(actual_grads[0], expected_grads[0], atol=0.2)
-        assert_close(actual_grads[1], expected_grads[1], atol=0.1)
+        assert_close(actual_grads[1][skew != 0], expected_grads[1][skew != 0], atol=0.1)
         assert_close(actual_grads[2], expected_grads[2], atol=0.1)
         assert_close(actual_grads[3], expected_grads[3], atol=0.1)
 

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -36,7 +36,7 @@ def test_stable(Reparam, shape):
 
     def model():
         with pyro.plate_stack("plates", shape):
-            with pyro.plate("particles", 100000):
+            with pyro.plate("particles", 1000000):
                 return pyro.sample("x", dist.Stable(stability, skew, scale, loc))
 
     value = model()
@@ -58,7 +58,8 @@ def test_stable(Reparam, shape):
         expected_grads = grad(expected_m.sum(), params, retain_graph=True)
         actual_grads = grad(actual_m.sum(), params, retain_graph=True)
         assert_close(actual_grads[0], expected_grads[0], atol=0.2)
-        assert_close(actual_grads[1][skew != 0], expected_grads[1][skew != 0], atol=0.1)
+        print(actual_grads[1], expected_grads[1])
+        assert_close(actual_grads[1], expected_grads[1], atol=0.1)
         assert_close(actual_grads[2], expected_grads[2], atol=0.1)
         assert_close(actual_grads[3], expected_grads[3], atol=0.1)
 


### PR DESCRIPTION
Resolves an issue of #2299.

TODO:
- [x] fix the instability around `skew ~ 0`. I want to make `skew` has a consistent sign there.
- [x] ~fix nan issue when learning rate is high~ this is an inference issue, not the instability of stable distribution.