### PR TITLE
Support batched forecasting

### DIFF
--- a/docs/source/contrib.forecast.rst
+++ b/docs/source/contrib.forecast.rst
@@ -47,7 +47,7 @@ Forecaster Interface
 ---------------------
 .. automodule:: pyro.contrib.forecast.forecaster
     :members:
-    :undoc-members:
+    :special-members: __call__
     :show-inheritance:
     :member-order: bysource
 

--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -281,27 +281,61 @@ class Forecaster(nn.Module):
         self.max_plate_nesting = elbo.max_plate_nesting
         self.losses = losses
 
-    @torch.no_grad()
-    def forward(self, data, covariates, num_samples):
+    def __call__(self, data, covariates, num_samples, batch_size=None):
+        """
+        Samples forecasted values of data for time steps in ``[t1,t2)``, where
+        ``t1 = data.size(-2)`` is the duration of observed data and ``t2 =
+        covariates.size(-2)`` is the extended duration of covariates. For
+        example to forecast 7 days forward conditioned on 30 days of
+        observations, set ``t1=30`` and ``t2=37``.
+
+        :param data: A tensor dataset with time dimension -2.
+        :type data: ~torch.Tensor
+        :param covariates: A tensor of covariates with time dimension -2.
+            For models not using covariates, pass a shaped empty tensor
+            ``torch.empty(duration, 0)``.
+        :type covariates: ~torch.Tensor
+        :param int num_samples: The number of samples to generate.
+        :param int batch_size: Optional batch size for sampling. This is useful
+            for generating many samples from models with large memory
+            footprint. By defaults to ``num_samples``.
+        :returns: A batch of joint posterior samples of shape
+            ``(num_samples, 1, ..., 1, t2 - t1, data.size(-1))``, where the
+            ``1``'s are inserted to avoid conflict with model plates.
+        :rtype: ~torch.Tensor
+        """
+        return super().__call__(data, covariates, num_samples, batch_size)
+
+    def forward(self, data, covariates, num_samples, batch_size=None):
         assert data.size(-2) < covariates.size(-2)
+        assert isinstance(num_samples, int) and num_samples > 0
+        if batch_size is not None:
+            batches = []
+            while num_samples > 0:
+                batch = self(data, covariates, min(num_samples, batch_size))
+                batches.append(batch)
+                num_samples -= batch_size
+            return torch.cat(batches)
+
         assert self.max_plate_nesting >= 1
         dim = -1 - self.max_plate_nesting
 
-        with poutine.trace() as tr:
-            with pyro.plate("particles", num_samples, dim=dim):
-                self.guide(data, covariates)
-        with PrefixReplayMessenger(tr.trace):
-            with PrefixConditionMessenger(self.model._prefix_condition_data):
+        with torch.no_grad():
+            with poutine.trace() as tr:
                 with pyro.plate("particles", num_samples, dim=dim):
-                    return self.model(data, covariates)
+                    self.guide(data, covariates)
+            with PrefixReplayMessenger(tr.trace):
+                with PrefixConditionMessenger(self.model._prefix_condition_data):
+                    with pyro.plate("particles", num_samples, dim=dim):
+                        return self.model(data, covariates)
 
 
 class HMCForecaster(nn.Module):
     """
     Forecaster for a :class:`ForecastingModel` using Hamiltonian Monte Carlo.
 
-    On initialization, this will run :class:`~pyro.infer.mcmc.nuts.NUTS` sampler
-    to get posterior samples of the model.
+    On initialization, this will run :class:`~pyro.infer.mcmc.nuts.NUTS`
+    sampler to get posterior samples of the model.
 
     After construction, this can be called to generate sample forecasts.
 
@@ -316,13 +350,14 @@ class HMCForecaster(nn.Module):
     :param int num_warmup: number of MCMC warmup steps.
     :param int num_samples: number of MCMC samples.
     :param int num_chains: number of parallel MCMC chains.
-    :param bool dense_mass: a flag to control whether the mass matrix is dense or diagonal.
-        Defaults to False.
+    :param bool dense_mass: a flag to control whether the mass matrix is dense
+        or diagonal. Defaults to False.
     :param bool jit_compile: whether to use the PyTorch JIT to trace the log
         density computation, and use this optimized executable trace in the
         integrator. Defaults to False.
-    :param int max_tree_depth: Max depth of the binary tree created during the doubling
-        scheme of the :class:`~pyro.infer.mcmc.nuts.NUTS` sampler. Defaults to 10.
+    :param int max_tree_depth: Max depth of the binary tree created during the
+        doubling scheme of the :class:`~pyro.infer.mcmc.nuts.NUTS` sampler.
+        Defaults to 10.
     """
     def __init__(self, model, data, covariates=None, *,
                  num_warmup=1000, num_samples=1000, num_chains=1,
@@ -354,20 +389,54 @@ class HMCForecaster(nn.Module):
             if name not in self._samples:
                 del self._trace.nodes[name]
 
-    @torch.no_grad()
-    def forward(self, data, covariates, num_samples):
+    def __call__(self, data, covariates, num_samples, batch_size=None):
+        """
+        Samples forecasted values of data for time steps in ``[t1,t2)``, where
+        ``t1 = data.size(-2)`` is the duration of observed data and ``t2 =
+        covariates.size(-2)`` is the extended duration of covariates. For
+        example to forecast 7 days forward conditioned on 30 days of
+        observations, set ``t1=30`` and ``t2=37``.
+
+        :param data: A tensor dataset with time dimension -2.
+        :type data: ~torch.Tensor
+        :param covariates: A tensor of covariates with time dimension -2.
+            For models not using covariates, pass a shaped empty tensor
+            ``torch.empty(duration, 0)``.
+        :type covariates: ~torch.Tensor
+        :param int num_samples: The number of samples to generate.
+        :param int batch_size: Optional batch size for sampling. This is useful
+            for generating many samples from models with large memory
+            footprint. By defaults to ``num_samples``.
+        :returns: A batch of joint posterior samples of shape
+            ``(num_samples, 1, ..., 1, t2 - t1, data.size(-1))``, where the
+            ``1``'s are inserted to avoid conflict with model plates.
+        :rtype: ~torch.Tensor
+        """
+        return super().__call__(data, covariates, num_samples, batch_size)
+
+    def forward(self, data, covariates, num_samples, batch_size=None):
         assert data.size(-2) < covariates.size(-2)
+        assert isinstance(num_samples, int) and num_samples > 0
+        if batch_size is not None:
+            batches = []
+            while num_samples > 0:
+                batch = self(data, covariates, min(num_samples, batch_size))
+                batches.append(batch)
+                num_samples -= batch_size
+            return torch.cat(batches)
+
         assert self.max_plate_nesting >= 1
         dim = -1 - self.max_plate_nesting
 
-        weights = torch.ones(self._num_samples, device=data.device)
-        indices = torch.multinomial(weights, num_samples, replacement=num_samples > self._num_samples)
-        for name, node in list(self._trace.nodes.items()):
-            sample = self._samples[name].index_select(0, indices)
-            node['value'] = sample.reshape(
-                (num_samples,) + (1,) * (node['value'].dim() - sample.dim()) + sample.shape[1:])
+        with torch.no_grad():
+            weights = torch.ones(self._num_samples, device=data.device)
+            indices = torch.multinomial(weights, num_samples, replacement=num_samples > self._num_samples)
+            for name, node in list(self._trace.nodes.items()):
+                sample = self._samples[name].index_select(0, indices)
+                node['value'] = sample.reshape(
+                    (num_samples,) + (1,) * (node['value'].dim() - sample.dim()) + sample.shape[1:])
 
-        with PrefixReplayMessenger(self._trace):
-            with PrefixConditionMessenger(self.model._prefix_condition_data):
-                with pyro.plate("particles", num_samples, dim=dim):
-                    return self.model(data, covariates)
+            with PrefixReplayMessenger(self._trace):
+                with PrefixConditionMessenger(self.model._prefix_condition_data):
+                    with pyro.plate("particles", num_samples, dim=dim):
+                        return self.model(data, covariates)

--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -298,10 +298,10 @@ class Forecaster(nn.Module):
         :param int num_samples: The number of samples to generate.
         :param int batch_size: Optional batch size for sampling. This is useful
             for generating many samples from models with large memory
-            footprint. By defaults to ``num_samples``.
+            footprint. Defaults to ``num_samples``.
         :returns: A batch of joint posterior samples of shape
-            ``(num_samples, 1, ..., 1, t2 - t1, data.size(-1))``, where the
-            ``1``'s are inserted to avoid conflict with model plates.
+            ``(num_samples,1,...,1) + data.shape[:-2] + (t2-t1,data.size(-1))``,
+            where the ``1``'s are inserted to avoid conflict with model plates.
         :rtype: ~torch.Tensor
         """
         return super().__call__(data, covariates, num_samples, batch_size)
@@ -406,10 +406,10 @@ class HMCForecaster(nn.Module):
         :param int num_samples: The number of samples to generate.
         :param int batch_size: Optional batch size for sampling. This is useful
             for generating many samples from models with large memory
-            footprint. By defaults to ``num_samples``.
+            footprint. Defaults to ``num_samples``.
         :returns: A batch of joint posterior samples of shape
-            ``(num_samples, 1, ..., 1, t2 - t1, data.size(-1))``, where the
-            ``1``'s are inserted to avoid conflict with model plates.
+            ``(num_samples,1,...,1) + data.shape[:-2] + (t2-t1,data.size(-1))``,
+            where the ``1``'s are inserted to avoid conflict with model plates.
         :rtype: ~torch.Tensor
         """
         return super().__call__(data, covariates, num_samples, batch_size)

--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -312,7 +312,7 @@ class Forecaster(nn.Module):
         if batch_size is not None:
             batches = []
             while num_samples > 0:
-                batch = self(data, covariates, min(num_samples, batch_size))
+                batch = self.forward(data, covariates, min(num_samples, batch_size))
                 batches.append(batch)
                 num_samples -= batch_size
             return torch.cat(batches)
@@ -420,7 +420,7 @@ class HMCForecaster(nn.Module):
         if batch_size is not None:
             batches = []
             while num_samples > 0:
-                batch = self(data, covariates, min(num_samples, batch_size))
+                batch = self.forward(data, covariates, min(num_samples, batch_size))
                 batches.append(batch)
                 num_samples -= batch_size
             return torch.cat(batches)

--- a/tests/contrib/forecast/test_forecaster.py
+++ b/tests/contrib/forecast/test_forecaster.py
@@ -125,6 +125,8 @@ def test_smoke(Model, batch_shape, t_obs, t_forecast, obs_dim, cov_dim, dct_grad
     num_samples = 5
     samples = forecaster(data, covariates, num_samples)
     assert samples.shape == (num_samples,) + batch_shape + (t_forecast, obs_dim,)
+    samples = forecaster(data, covariates, num_samples, batch_size=2)
+    assert samples.shape == (num_samples,) + batch_shape + (t_forecast, obs_dim,)
 
 
 class SubsampleModel3(ForecastingModel):
@@ -199,4 +201,6 @@ def test_subsample_smoke(Model, t_obs, t_forecast, obs_dim, cov_dim):
 
     num_samples = 5
     samples = forecaster(data, covariates, num_samples)
+    assert samples.shape == (num_samples,) + batch_shape + (t_forecast, obs_dim,)
+    samples = forecaster(data, covariates, num_samples, batch_size=2)
     assert samples.shape == (num_samples,) + batch_shape + (t_forecast, obs_dim,)


### PR DESCRIPTION
This adds support for drawing many samples in batches from `Forecaster.__call__()`.

The motivating use case is large models and short forecasts, where models may be trained using subsampling but where the `O(num_samples * full_data)` is too large to fit in memory for large `num_samples` (as e.g. in M5 forecasts). In this case we can sequentially draw say 10 samples at a time to generate very precise quantiles.

This also cleans up docs a bit.

Note I needed to move the `torch.no_grad()` context manager for HMC tests to pass.

## Tested
- [x] added batched call to unit tests