### PR TITLE
Add walltime to backtest() results

### DIFF
--- a/pyro/contrib/forecast/evaluate.py
+++ b/pyro/contrib/forecast/evaluate.py
@@ -78,6 +78,7 @@ def backtest(data, covariates, model_fn, *,
              stride=1,
              seed=1234567890,
              num_samples=100,
+             batch_size=None,
              forecaster_options={}):
     """
     Backtest a forecasting model on a moving window of (train,test) data.
@@ -114,7 +115,9 @@ def backtest(data, covariates, model_fn, *,
         the min test window size. Defaults to 1.
     :param int stride: Optional stride for test/train split. Defaults to 1.
     :param int seed: Random number seed.
-    :param int num_samples: Number of samples for forecast.
+    :param int num_samples: Number of samples for forecast. Defaults to 100.
+    :param int batch_size: Batch size for forecast sampling. Defaults to
+        ``num_samples``.
     :param forecaster_options: Options dict to pass to forecaster, or callable
         inputting time window ``t0,t1,t2`` and returning such a dict. See
         :class:`~pyro.contrib.forecaster.Forecaster` for details.
@@ -178,7 +181,8 @@ def backtest(data, covariates, model_fn, *,
         # Forecast forward to testing window.
         test_covariates = covariates[..., t0:t2, :]
         start_time = default_timer()
-        pred = forecaster(train_data, test_covariates, num_samples=num_samples)
+        pred = forecaster(train_data, test_covariates, num_samples=num_samples,
+                          batch_size=batch_size)
         test_walltime = default_timer() - start_time
         truth = data[..., t1:t2, :]
 

--- a/pyro/contrib/forecast/evaluate.py
+++ b/pyro/contrib/forecast/evaluate.py
@@ -204,7 +204,8 @@ def backtest(data, covariates, model_fn, *,
         results.append(result)
         for name, fn in metrics.items():
             result[name] = fn(pred, truth)
-            logger.debug("{} = {}".format(name, result[name]))
+            if isinstance(result[name], (int, float)):
+                logger.debug("{} = {}".format(name, result[name]))
 
         del pred
 

--- a/tests/contrib/forecast/test_evaluate.py
+++ b/tests/contrib/forecast/test_evaluate.py
@@ -58,8 +58,10 @@ def test_simple(train_window, min_train_window, test_window, min_test_window, st
         assert any(window["t0"] == 0 for window in windows)
         if stride == 1:
             assert any(window["t2"] == duration for window in windows)
-        for name in DEFAULT_METRICS:
-            for window in windows:
+        for window in windows:
+            assert window["train_walltime"] >= 0
+            assert window["test_walltime"] >= 0
+            for name in DEFAULT_METRICS:
                 assert name in window
                 assert 0 < window[name] < math.inf
 


### PR DESCRIPTION
Addresses #2311

1. Adds two new fields to the `backtest()` metrics: "train_walltime" and "test_walltime" to measure performance of model training and forecasting, resp.
2. Plumbs the `batch_size` arg of #2363 through the `backtest()` helper.
3. Only log floats in `backtest()` (see https://github.com/pyro-ppl/Pyro-M5-Starter-Kit/pull/2/files#r391773110 )

## Tested
- [x] added walltime assertions to unit tests