### PR TITLE
Fix LocScaleReparam, log params in backtest()

### DIFF
--- a/pyro/contrib/forecast/evaluate.py
+++ b/pyro/contrib/forecast/evaluate.py
@@ -200,12 +200,19 @@ def backtest(data, covariates, model_fn, *,
             "num_samples": num_samples,
             "train_walltime": train_walltime,
             "test_walltime": test_walltime,
+            "params": {},
         }
         results.append(result)
         for name, fn in metrics.items():
             result[name] = fn(pred, truth)
-            if isinstance(result[name], (int, float)):
-                logger.debug("{} = {}".format(name, result[name]))
+        for name, value in pyro.get_param_store().items():
+            if value.numel() == 1:
+                value = value.cpu().item()
+                result["params"][name] = value
+        for dct in (result, result["params"]):
+            for key, value in sorted(dct.items()):
+                if isinstance(value, (int, float)):
+                    logger.debug("{} = {:0.6g}".format(key, value))
 
         del pred
 

--- a/pyro/infer/reparam/loc_scale.py
+++ b/pyro/infer/reparam/loc_scale.py
@@ -56,7 +56,7 @@ class LocScaleReparam(Reparam):
         # Apply a partial decentering transform.
         params = {key: getattr(fn, key) for key in self.shape_params}
         if self.centered is None:
-            centered = pyro.param("{}_centered",
+            centered = pyro.param("{}_centered".format(name),
                                   lambda: fn.loc.new_full(event_shape, 0.5),
                                   constraint=constraints.unit_interval)
         params["loc"] = fn.loc * centered


### PR DESCRIPTION
1. Fixes a naming bug in `LocScaleReparam` whereby all loc-scale-reparameterized sites shared a single centeredness parameter. After this PR each such site learns a separate centeredness parameter (as originally intended).

2. Also adds param logging to `contrib.forecast.evaluate.backtest()`, which logging led me to discover the loc-scale bug. After this PR all scalar params will be printed and saved (as floats) to backtest results. My immediate motivation is to inspect global parameters `stability`, `skew` and `df` of `Stable` and `StudentT` distributions.

## Tested
- [x] covered by existing tests
- [x] ran locally and examined logging output