### PR TITLE
Support replay of plate(..., subsample=...)

### DIFF
--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -5,7 +5,7 @@ import torch
 
 from pyro.distributions.distribution import Distribution
 from pyro.poutine.util import is_validation_enabled
-from pyro.util import ignore_jit_warnings, jit_compatible_arange
+from pyro.util import ignore_jit_warnings
 
 from .indep_messenger import CondIndepStackFrame, IndepMessenger
 from .runtime import apply_stack
@@ -47,7 +47,7 @@ class _Subsample(Distribution):
             raise NotImplementedError
         subsample_size = self.subsample_size
         if subsample_size is None or subsample_size >= self.size:
-            result = jit_compatible_arange(self.size, device=self.device)
+            result = torch.arange(self.size, device=self.device)
         else:
             result = torch.multinomial(torch.ones(self.size), self.subsample_size,
                                        replacement=False).to(self.device)
@@ -87,7 +87,7 @@ class SubsampleMessenger(IndepMessenger):
             assert subsample is None
             size = -1  # This is PyTorch convention for "arbitrary size"
             subsample_size = -1
-        elif subsample is None:
+        else:
             msg = {
                 "type": "sample",
                 "name": name,
@@ -95,7 +95,7 @@ class SubsampleMessenger(IndepMessenger):
                 "is_observed": False,
                 "args": (),
                 "kwargs": {},
-                "value": None,
+                "value": subsample,
                 "infer": {},
                 "scale": 1.0,
                 "mask": None,

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -445,11 +445,5 @@ class timed:
         return self.elapsed
 
 
-# work around https://github.com/pytorch/pytorch/issues/11829
-def jit_compatible_arange(end, dtype=None, device=None):
-    dtype = torch.long if dtype is None else dtype
-    return torch.cumsum(torch.ones(end, dtype=dtype, device=device), dim=0) - 1
-
-
 def torch_float(x):
     return x.float() if isinstance(x, torch.Tensor) else float(x)


### PR DESCRIPTION
Follows up #2323 by allowing `pyro.plate(..., subsample=...)` syntax in the `create_plates()` function used in autoguides and the `contrib.forecast` module.

The motivation is the [hierarchical bart forecasting tutorial](https://pyro.ai/examples/forecasting_iii.html#Subsampling), which I'd like to switch to dependent subsampling as in the unit test in this PR; I'll wait until after this PR merges.

This will introduce a small amount of overhead in that some new `_Subsample` sites will appear in traces, but those appear to be needed so as to support trace-replay behavior. I believe this should not add any tensor op overhead. In fact I believe this removes a `torch.arange()` in some cases, since the same `arange` can be used by the guide and model. This also simplifies the non-subsample case by replacing our old `jit_compatible_arange()` with a cheaper `torch.arange()`.

## Tested
- [x] added a regression test
- [x] tested locally on a model that wasn't working before this PR