### PR TITLE
Address numerical stability of Geometric log_prob

### DIFF
--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -154,6 +154,7 @@ UNIVARIATE_DISTS = {
     dist.Exponential: ("rate",),
     dist.Gamma: ("concentration", "rate"),
     dist.GammaPoisson: ("concentration", "rate"),
+    dist.Geometric: ("logits",),
     dist.InverseGamma: ("concentration", "rate"),
     dist.Laplace: ("loc", "scale"),
     dist.LogNormal: ("loc", "scale"),

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -97,6 +97,7 @@ class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributi
 
 
 class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
+    # TODO: move upstream
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -3,6 +3,7 @@
 
 import torch
 from torch.distributions import constraints
+from torch.distributions.utils import lazy_property
 
 from pyro.distributions.constraints import IndependentConstraint
 from pyro.distributions.torch_distribution import TorchDistributionMixin
@@ -92,16 +93,23 @@ class Gamma(torch.distributions.Gamma, TorchDistributionMixin):
         return updated, log_normalizer
 
 
-class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
-    support = IndependentConstraint(constraints.real, 1)  # TODO move upstream
-
-
 class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
     # TODO: move upstream
     def log_prob(self, value):
         if self._validate_args:
             self._validate_sample(value)
         return (-value - 1) * torch.nn.functional.softplus(self.logits) + self.logits
+
+
+class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
+    support = IndependentConstraint(constraints.real, 1)  # TODO move upstream
+
+    # TODO: remove this in the PyTorch release > 1.4.0
+    @lazy_property
+    def precision_matrix(self):
+        identity = torch.eye(self.loc.size(-1), device=self.loc.device, dtype=self.loc.dtype)
+        return torch.cholesky_solve(identity, self._unbroadcasted_scale_tril).expand(
+            self._batch_shape + self._event_shape + self._event_shape)
 
 
 class Independent(torch.distributions.Independent, TorchDistributionMixin):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -3,7 +3,6 @@
 
 import torch
 from torch.distributions import constraints
-from torch.distributions.utils import lazy_property
 
 from pyro.distributions.constraints import IndependentConstraint
 from pyro.distributions.torch_distribution import TorchDistributionMixin
@@ -96,12 +95,12 @@ class Gamma(torch.distributions.Gamma, TorchDistributionMixin):
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
     support = IndependentConstraint(constraints.real, 1)  # TODO move upstream
 
-    # TODO: remove this in the PyTorch release > 1.4.0
-    @lazy_property
-    def precision_matrix(self):
-        identity = torch.eye(self.loc.size(-1), device=self.loc.device, dtype=self.loc.dtype)
-        return torch.cholesky_solve(identity, self._unbroadcasted_scale_tril).expand(
-            self._batch_shape + self._event_shape + self._event_shape)
+
+class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        return (-value - 1) * torch.nn.functional.softplus(self.logits) + self.logits
 
 
 class Independent(torch.distributions.Independent, TorchDistributionMixin):

--- a/tests/contrib/forecast/test_util.py
+++ b/tests/contrib/forecast/test_util.py
@@ -21,6 +21,7 @@ DISTS = [
     dist.Gamma,
     dist.GammaPoisson,
     dist.GaussianHMM,
+    dist.Geometric,
     dist.IndependentHMM,
     dist.InverseGamma,
     dist.Laplace,

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -427,6 +427,23 @@ discrete_dists = [
             scipy_arg_fn=lambda rate: ((np.array(rate),), {}),
             prec=0.08,
             is_discrete=True),
+    Fixture(pyro_dist=dist.Geometric,
+            scipy_dist=sp.geom,
+            examples=[
+                {'logits': [2.0],
+                 'test_data': [0.]},
+                {'logits': [3.0],
+                 'test_data': [1.]},
+                {'logits': [-6.0],
+                 'test_data': [4.]},
+                {'logits': [2.0, 3.0, -6.0],
+                 'test_data': [[0., 1., 4.], [0., 1., 4.]]},
+                {'logits': [[2.0], [3.0], [-6.0]],
+                 'test_data': [[0.], [1.], [4.]]}
+            ],
+            scipy_arg_fn=lambda probs: ((np.array(probs), -1), {}),
+            prec=0.08,
+            is_discrete=True),
 ]
 
 

--- a/tests/distributions/dist_fixture.py
+++ b/tests/distributions/dist_fixture.py
@@ -74,7 +74,7 @@ class Fixture:
     def _convert_logits_to_ps(self, dist_params):
         if 'logits' in dist_params:
             logits = torch.tensor(dist_params.pop('logits'))
-            is_multidimensional = self.get_test_distribution_name() != 'Bernoulli'
+            is_multidimensional = self.get_test_distribution_name() not in ['Bernoulli', 'Geometric']
             probs = logits_to_probs(logits, is_binary=not is_multidimensional)
             dist_params['probs'] = list(probs.detach().cpu().numpy())
         return dist_params


### PR DESCRIPTION
This PR computes the log_prob of Geometric distribution based on `logits` instead of `probs`. Currently, the log_prob is defined as follows
```python
def log_prob(self, value):
    ...
    return value * (-probs).log1p() + self.probs.log()
```
which will lead to `nan` when `probs=0` or `probs=1`.

@fritzo I also add Geometric to forecast univariate dist. This likelihood is quite stable for many univariate count series (with a lot of zeros) that I tested on.