### PR TITLE
Improve the performance of rsample of GaussianHMM with Normal obs

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -504,14 +504,10 @@ class GaussianHMM(HiddenMarkovModel):
     def rsample(self, sample_shape=torch.Size()):
         assert self.duration is not None
         sample_shape = torch.Size(sample_shape)
-        obs_dim = self.obs_dim
-        hidden_dim = self.hidden_dim
         trans = self._trans + self._obs.marginalize(right=self.obs_dim).event_pad(left=self.hidden_dim)
         trans = trans.expand(trans.batch_shape[:-1] + (self.duration,))
         z = _sequential_gaussian_filter_sample(self._init, trans, sample_shape)
-        perm = torch.cat([torch.arange(hidden_dim, hidden_dim + obs_dim, device=z.device),
-                          torch.arange(hidden_dim, device=z.device)])
-        x = self._obs.event_permute(perm).condition(z).rsample()
+        x = self._obs.left_condition(z).rsample()
         return x
 
     def rsample_posterior(self, value, sample_shape=torch.Size()):

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -318,7 +318,8 @@ class AffineNormal:
         """
         Reparameterized sampler.
         """
-        assert self.matrix.size(-2) == 0
+        if self.matrix.size(-2) > 0:
+            raise NotImplementedError
         shape = sample_shape + self.batch_shape + self.loc.shape[-1:]
         noise = torch.randn(shape, dtype=self.loc.dtype, device=self.loc.device)
         return self.loc + noise * self.scale
@@ -357,8 +358,7 @@ class AffineNormal:
         return self.to_gaussian() + other
 
     def marginalize(self, left=0, right=0):
-        assert left == 0
-        if right == self.loc.size(-1):
+        if left == 0 and right == self.loc.size(-1):
             n = self.matrix.size(-2)
             precision = self.scale.new_zeros(self.batch_shape + (n, n))
             info_vec = self.scale.new_zeros(self.batch_shape + (n,))

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -7,6 +7,7 @@ import torch
 from torch.distributions.utils import lazy_property
 from torch.nn.functional import pad
 
+import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.tensor_utils import cholesky, matmul, matvecmul, triangular_solve
 
@@ -161,9 +162,11 @@ class Gaussian:
             g.log_density(x) == g.condition(right).log_density(left)
         """
         assert isinstance(value, torch.Tensor)
-        assert value.size(-1) <= self.info_vec.size(-1)
+        right = value.size(-1)
+        dim = self.dim()
+        assert right <= dim
 
-        n = self.dim() - value.size(-1)
+        n = dim - right
         info_a = self.info_vec[..., :n]
         info_b = self.info_vec[..., n:]
         P_aa = self.precision[..., :n, :n]
@@ -177,6 +180,30 @@ class Gaussian:
                           -0.5 * matvecmul(P_bb, b).mul(b).sum(-1) +
                           b.mul(info_b).sum(-1))
         return Gaussian(log_normalizer, info_vec, precision)
+
+    def left_condition(self, value):
+        """
+        Condition this Gaussian on a leading subset of its state.
+        This should satisfy::
+
+            g.condition(y).dim() == g.dim() - y.size(-1)
+
+        Note that since this is a non-normalized Gaussian, we include the
+        density of ``y`` in the result. Thus :meth:`condition` is similar to a
+        ``functools.partial`` binding of arguments::
+
+            left = x[..., :n]
+            right = x[..., n:]
+            g.log_density(x) == g.left_condition(left).log_density(right)
+        """
+        assert isinstance(value, torch.Tensor)
+        left = value.size(-1)
+        dim = self.dim()
+        assert left <= dim
+
+        perm = torch.cat([torch.arange(left, dim, device=value.device),
+                          torch.arange(left, device=value.device)])
+        return self.event_permute(perm).condition(value)
 
     def marginalize(self, left=0, right=0):
         """
@@ -251,33 +278,42 @@ class AffineNormal:
     """
     def __init__(self, matrix, loc, scale):
         assert loc.shape == scale.shape
+        assert matrix.shape[:-2] == loc.shape[:-1]
+        assert matrix.size(-1) == loc.size(-1)
         self.matrix = matrix
         self.loc = loc
         self.scale = scale
+        self._gaussian = None
 
-    @property
+    @lazy_property
     def batch_shape(self):
         return self.matrix.shape[:-2]
 
     def condition(self, value):
-        """
-        Condition on a ``Y`` value.
+        if value.size(-1) == self.loc.size(-1):
+            prec_sqrt = self.matrix / self.scale.unsqueeze(-2)
+            precision = matmul(prec_sqrt, prec_sqrt.transpose(-1, -2))
+            delta = (value - self.loc) / self.scale
+            info_vec = matvecmul(prec_sqrt, delta)
+            log_normalizer = (-0.5 * self.loc.size(-1) * math.log(2 * math.pi)
+                              - 0.5 * delta.pow(2).sum(-1) - self.scale.log().sum(-1))
+            return Gaussian(log_normalizer, info_vec, precision)
+        else:
+            return self.to_gaussian().condition(value)
 
-        :param torch.Tensor value: A value of ``Y``.
-        :return Gaussian: A gaussian likelihood over ``X``.
-        """
-        assert value.size(-1) == self.loc.size(-1)
-        prec_sqrt = self.matrix / self.scale.unsqueeze(-2)
-        precision = matmul(prec_sqrt, prec_sqrt.transpose(-1, -2))
-        delta = (value - self.loc) / self.scale
-        info_vec = matvecmul(prec_sqrt, delta)
-        log_normalizer = (-0.5 * self.loc.size(-1) * math.log(2 * math.pi)
-                          - 0.5 * delta.pow(2).sum(-1) - self.scale.log().sum(-1))
-        return Gaussian(log_normalizer, info_vec, precision)
+    def left_condition(self, value):
+        if value.size(-1) == self.matrix.size(-2):
+            loc = matvecmul(self.matrix.transpose(-1, -2), value) + self.loc
+            return dist.Normal(loc, self.scale).to_event(1)
+        else:
+            return self.to_gaussian().left_condition(value)
 
     def to_gaussian(self):
-        mvn = torch.distributions.MultivariateNormal(self.loc, scale_tril=self.scale.diag_embed())
-        return matrix_and_mvn_to_gaussian(self.matrix, mvn)
+        if self._gaussian is None:
+            mvn = dist.Normal(self.loc, scale=self.scale).to_event(1)
+            y_gaussian = mvn_to_gaussian(mvn)
+            self._gaussian = _matrix_and_gaussian_to_gaussian(self.matrix, y_gaussian)
+        return self._gaussian
 
     def expand(self, batch_shape):
         matrix = self.matrix.expand(batch_shape + self.matrix.shape[-2:])
@@ -305,7 +341,15 @@ class AffineNormal:
         return self.to_gaussian() + other
 
     def marginalize(self, left=0, right=0):
-        return self.to_gaussian().marginalize(left, right)
+        assert left == 0
+        if right == self.loc.size(-1):
+            n = self.matrix.size(-2)
+            precision = self.scale.new_zeros(self.batch_shape + (n, n))
+            info_vec = self.scale.new_zeros(self.batch_shape + (n,))
+            log_normalizer = self.scale.new_zeros(self.batch_shape)
+            return Gaussian(log_normalizer, info_vec, precision)
+        else:
+            return self.to_gaussian().marginalize(left, right)
 
 
 def mvn_to_gaussian(mvn):
@@ -337,6 +381,23 @@ def mvn_to_gaussian(mvn):
     return Gaussian(log_normalizer, info_vec, precision)
 
 
+def _matrix_and_gaussian_to_gaussian(matrix, y_gaussian):
+    P_yy = y_gaussian.precision
+    neg_P_xy = matmul(matrix, P_yy)
+    P_xy = -neg_P_xy
+    P_yx = P_xy.transpose(-1, -2)
+    P_xx = matmul(neg_P_xy, matrix.transpose(-1, -2))
+    precision = torch.cat([torch.cat([P_xx, P_xy], -1),
+                           torch.cat([P_yx, P_yy], -1)], -2)
+    info_y = y_gaussian.info_vec
+    info_x = -matvecmul(matrix, info_y)
+    info_vec = torch.cat([info_x, info_y], -1)
+    log_normalizer = y_gaussian.log_normalizer
+
+    result = Gaussian(log_normalizer, info_vec, precision)
+    return result
+
+
 def matrix_and_mvn_to_gaussian(matrix, mvn):
     """
     Convert a noisy affine function to a Gaussian. The noisy affine function is defined as::
@@ -363,19 +424,7 @@ def matrix_and_mvn_to_gaussian(matrix, mvn):
         return AffineNormal(matrix, mvn.base_dist.loc, mvn.base_dist.scale)
 
     y_gaussian = mvn_to_gaussian(mvn)
-    P_yy = y_gaussian.precision
-    neg_P_xy = matmul(matrix, P_yy)
-    P_xy = -neg_P_xy
-    P_yx = P_xy.transpose(-1, -2)
-    P_xx = matmul(neg_P_xy, matrix.transpose(-1, -2))
-    precision = torch.cat([torch.cat([P_xx, P_xy], -1),
-                           torch.cat([P_yx, P_yy], -1)], -2)
-    info_y = y_gaussian.info_vec
-    info_x = -matvecmul(matrix, info_y)
-    info_vec = torch.cat([info_x, info_y], -1)
-    log_normalizer = y_gaussian.log_normalizer
-
-    result = Gaussian(log_normalizer, info_vec, precision)
+    result = _matrix_and_gaussian_to_gaussian(matrix, y_gaussian)
     assert result.batch_shape == batch_shape
     assert result.dim() == x_dim + y_dim
     return result

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -3,6 +3,7 @@
 
 import logging
 import operator
+import os
 from functools import reduce
 
 import opt_einsum
@@ -332,6 +333,25 @@ def test_gaussian_hmm_shape(diag, init_shape, trans_mat_shape, trans_mvn_shape,
         d2 = d.prefix_condition(data[..., :t, :])
         assert d2.batch_shape == d.batch_shape
         assert d2.event_shape == (f, obs_dim)
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="slow and high memory consumption test")
+def test_gaussian_hmm_high_obs_dim():
+    hidden_dim = 1
+    obs_dim = 5000
+    duration = 1000
+    sample_shape = (100,)
+    init_dist = random_mvn((), hidden_dim)
+    trans_mat = torch.randn((duration,) + (hidden_dim, hidden_dim))
+    trans_dist = random_mvn((duration,), hidden_dim)
+    obs_mat = torch.randn((duration,) + (hidden_dim, obs_dim))
+    loc = torch.randn((duration, obs_dim))
+    scale = torch.randn((duration, obs_dim)).exp()
+    obs_dist = dist.Normal(loc, scale).to_event(1)
+    d = dist.GaussianHMM(init_dist, trans_mat, trans_dist, obs_mat, obs_dist,
+                         duration=duration)
+    x = d.rsample(sample_shape)
+    assert x.shape == sample_shape + (duration, obs_dim)
 
 
 @pytest.mark.parametrize('sample_shape', [(), (5,)], ids=str)

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -335,11 +335,10 @@ def test_gaussian_hmm_shape(diag, init_shape, trans_mat_shape, trans_mvn_shape,
         assert d2.event_shape == (f, obs_dim)
 
 
-@pytest.mark.skipif("CI" in os.environ, reason="slow and high memory consumption test")
 def test_gaussian_hmm_high_obs_dim():
     hidden_dim = 1
-    obs_dim = 5000
-    duration = 1000
+    obs_dim = 1000
+    duration = 10
     sample_shape = (100,)
     init_dist = random_mvn((), hidden_dim)
     trans_mat = torch.randn((duration,) + (hidden_dim, hidden_dim))

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -3,7 +3,6 @@
 
 import logging
 import operator
-import os
 from functools import reduce
 
 import opt_einsum

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -244,9 +244,8 @@ def test_affine_normal(batch_shape, x_dim, y_dim):
 
     x = torch.randn(batch_shape + (x_dim,))
     permute_actual = actual.left_condition(x)
-    assert (isinstance(permute_actual, torch.distributions.Independent) and
-            isinstance(permute_actual.base_dist, torch.distributions.Normal))
-    permute_actual = mvn_to_gaussian(permute_actual)
+    assert isinstance(permute_actual, AffineNormal)
+    permute_actual = permute_actual.to_gaussian()
 
     permute_expected = expected.left_condition(y)
     assert isinstance(permute_expected, Gaussian)

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -193,6 +193,14 @@ def test_condition(sample_shape, batch_shape, left, right):
     expected = gaussian.log_density(value)
     assert_close(actual, expected)
 
+    # test left_condition
+    permute_conditioned = gaussian.left_condition(left_value)
+    assert permute_conditioned.batch_shape == sample_shape + gaussian.batch_shape
+    assert permute_conditioned.dim() == right
+
+    permute_actual = permute_conditioned.log_density(right_value)
+    assert_close(permute_actual, expected)
+
 
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("dim", [1, 2, 3])
@@ -233,6 +241,19 @@ def test_affine_normal(batch_shape, x_dim, y_dim):
     assert_close(actual_like.log_normalizer, expected_like.log_normalizer)
     assert_close(actual_like.info_vec, expected_like.info_vec)
     assert_close(actual_like.precision, expected_like.precision)
+
+    x = torch.randn(batch_shape + (x_dim,))
+    permute_actual = actual.left_condition(x)
+    assert (isinstance(permute_actual, torch.distributions.Independent) and
+            isinstance(permute_actual.base_dist, torch.distributions.Normal))
+    permute_actual = mvn_to_gaussian(permute_actual)
+
+    permute_expected = expected.left_condition(y)
+    assert isinstance(permute_expected, Gaussian)
+
+    assert_close(permute_actual.log_normalizer, permute_actual.log_normalizer)
+    assert_close(permute_actual.info_vec, permute_actual.info_vec)
+    assert_close(permute_actual.precision, permute_actual.precision)
 
 
 @pytest.mark.parametrize("sample_shape", [(), (7,), (6, 5)], ids=str)


### PR DESCRIPTION
Resolves #2375.

Test for GaussianHMM with duration=10, obs=1000, we get 0.56s against 4.84s as before.

With duration=1000, obs=5000, it took 24s in my system. I can't test for the old implementation because of OOM.

TODO:
- [x] make sure all tests pass, test `left_condition`
- [x] profiling on a Gaussian with large obs_dim

@martinjankowiak Could you try on your problem? I believe this would be much faster than before.