### PR TITLE
Fix bugs at reshape_batch LinearHMM

### DIFF
--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -326,13 +326,54 @@ def _(d, batch_shape):
     new.transition_dist = trans_dist
     new.observation_matrix = obs_mat
     new.observation_dist = obs_dist
+    transforms = []
     for transform in d.transforms:
-        assert isinstance(transform, (transforms.AbsTransform,
-                                      transforms.ExpTransform,
-                                      transforms.SigmoidTransform)), \
+        assert type(transform) in UNIVARIATE_TRANSFORMS, \
             "Currently, reshape_batch only supports AbsTransform, " + \
             "ExpTransform, SigmoidTransform transform"
-    new.transforms = d.transforms
+        current_shape = d.observation_dist.shape()
+        new_shape = obs_dist.shape()
+        transforms.append(reshape_transform_batch(transform, current_shape, new_shape))
+    new.transforms = transforms
     super(dist.LinearHMM, new).__init__(d.duration, batch_shape, d.event_shape,
                                         validate_args=d._validate_args)
     return new
+
+
+UNIVARIATE_TRANSFORMS = {
+    transforms.AbsTransform: (),
+    transforms.AffineTransform: ("loc", "scale"),
+    transforms.ExpTransform: (),
+    transforms.PowerTransform: ("exponent",),
+    transforms.SigmoidTransform: (),
+}
+
+
+@singledispatch
+def reshape_transform_batch(t, current_batch_shape, new_batch_shape):
+    """
+    EXPERIMENTAL Given a transform ``t``, reshape to different batch shape
+    of same number of elements.
+
+    This is typically used to correct the transform parameters' shapes after
+    reshaping the base distribution of a transformed distribution.
+
+    :param t: A transform.
+    :type t: ~torch.distributions.transforms.Transform
+    :param tuple current_batch_shape: The current batch shape.
+    :param tuple new_batch_shape: A new batch shape.
+    :returns: A transform with the same type but given new batch shape.
+    :rtype: ~torch.distributions.transforms.Transform
+    """
+    raise NotImplementedError("reshape_transform_batch() does not suport {}".format(type(t)))
+
+
+def _reshape_batch_univariate_transform(t, current_batch_shape, new_batch_shape):
+    params = {name: getattr(t, name).expand(current_batch_shape).reshape(new_batch_shape)
+              for name in UNIVARIATE_TRANSFORMS[type(t)]}
+    params["cache_size"] = t._cache_size
+    return type(t)(**params)
+
+
+for _type in UNIVARIATE_TRANSFORMS:
+    reshape_transform_batch.register(_type)(_reshape_batch_univariate_transform)

--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -4,7 +4,7 @@
 from functools import singledispatch
 
 import torch
-from torch.distributions import transform_to
+from torch.distributions import transform_to, transforms
 
 import pyro.distributions as dist
 from pyro.poutine.messenger import Messenger
@@ -326,6 +326,12 @@ def _(d, batch_shape):
     new.transition_dist = trans_dist
     new.observation_matrix = obs_mat
     new.observation_dist = obs_dist
+    for transform in d.transforms:
+        assert isinstance(transform, (transforms.AbsTransform,
+                                      transforms.ExpTransform,
+                                      transforms.SigmoidTransform)), \
+            "Currently, reshape_batch only supports AbsTransform, " + \
+            "ExpTransform, SigmoidTransform transform"
     new.transforms = d.transforms
     super(dist.LinearHMM, new).__init__(d.duration, batch_shape, d.event_shape,
                                         validate_args=d._validate_args)

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -4,8 +4,8 @@
 import torch
 from torch.distributions import constraints
 
-from pyro.distributions.torch import Categorical, Gamma, Independent, MultivariateNormal, Normal
-from pyro.distributions.torch_distribution import TorchDistribution, TorchDistributionMixin
+from pyro.distributions.torch import Categorical, Gamma, Independent, MultivariateNormal
+from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.gamma_gaussian import (GammaGaussian, gamma_and_mvn_to_gamma_gaussian, gamma_gaussian_tensordot,
                                      matrix_and_mvn_to_gamma_gaussian)
@@ -942,9 +942,6 @@ class LinearHMM(HiddenMarkovModel):
             else:
                 break
         if not observation_dist.event_shape:
-            if isinstance(observation_dist, torch.distributions.Normal) and \
-                    not isinstance(observation_dist, TorchDistributionMixin):
-                observation_dist = Normal(observation_dist.loc, observation_dist.scale)
             observation_dist = Independent(observation_dist, 1)
 
         self.hidden_dim = hidden_dim

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -983,7 +983,8 @@ class LinearHMM(HiddenMarkovModel):
 
     def rsample(self, sample_shape=torch.Size()):
         assert self.duration is not None
-        init = self.initial_dist.rsample(sample_shape)
+        # XXX we might not need to expand here because we already expand eagerly in the construction
+        init = self.initial_dist.expand(self.batch_shape).rsample(sample_shape)
         trans = self.transition_dist.expand(self.batch_shape + (self.duration,)).rsample(sample_shape)
         obs = self.observation_dist.expand(self.batch_shape + (self.duration,)).rsample(sample_shape)
         trans_matrix = self.transition_matrix.expand(self.batch_shape + (self.duration, -1, -1))

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -4,8 +4,8 @@
 import torch
 from torch.distributions import constraints
 
-from pyro.distributions.torch import Categorical, Gamma, Independent, MultivariateNormal
-from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.torch import Categorical, Gamma, Independent, MultivariateNormal, Normal
+from pyro.distributions.torch_distribution import TorchDistribution, TorchDistributionMixin
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.gamma_gaussian import (GammaGaussian, gamma_and_mvn_to_gamma_gaussian, gamma_gaussian_tensordot,
                                      matrix_and_mvn_to_gamma_gaussian)
@@ -942,6 +942,9 @@ class LinearHMM(HiddenMarkovModel):
             else:
                 break
         if not observation_dist.event_shape:
+            if isinstance(observation_dist, torch.distributions.Normal) and \
+                    not isinstance(observation_dist, TorchDistributionMixin):
+                observation_dist = Normal(observation_dist.loc, observation_dist.scale)
             observation_dist = Independent(observation_dist, 1)
 
         self.hidden_dim = hidden_dim

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -976,11 +976,14 @@ class LinearHMM(HiddenMarkovModel):
 
     def rsample(self, sample_shape=torch.Size()):
         assert self.duration is not None
-        # XXX we might not need to expand here because we already expand eagerly in the construction
-        init = self.initial_dist.expand(self.batch_shape).rsample(sample_shape)
-        trans = self.transition_dist.expand(self.batch_shape + (self.duration,)).rsample(sample_shape)
-        obs = self.observation_dist.expand(self.batch_shape + (self.duration,)).rsample(sample_shape)
-        trans_matrix = self.transition_matrix.expand(self.batch_shape + (self.duration, -1, -1))
+        assert self.initial_dist.batch_shape == self.batch_shape
+        assert self.transition_dist.batch_shape == self.batch_shape + (self.duration,)
+        assert self.observation_dist.batch_shape == self.batch_shape + (self.duration,)
+        assert self.transition_matrix.shape[:-2] == self.batch_shape + (self.duration,)
+        init = self.initial_dist.rsample(sample_shape)
+        trans = self.transition_dist.rsample(sample_shape)
+        obs = self.observation_dist.rsample(sample_shape)
+        trans_matrix = self.transition_matrix
         z = _linear_integrate(init, trans_matrix, trans)
         x = (z.unsqueeze(-2) @ self.observation_matrix).squeeze(-2) + obs
         for t in self.transforms:

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -101,6 +101,17 @@ class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
         return (-value - 1) * torch.nn.functional.softplus(self.logits) + self.logits
 
 
+class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
+    def __init__(self, loc, scale, validate_args=None):
+        base_dist = Normal(loc, scale)
+        super(torch.distributions.LogNormal, self).__init__(
+            base_dist, torch.distributions.transforms.ExpTransform(), validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(LogNormal, _instance)
+        return super(torch.distributions.LogNormal, self).expand(batch_shape, _instance=new)
+
+
 class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributionMixin):
     support = IndependentConstraint(constraints.real, 1)  # TODO move upstream
 
@@ -110,6 +121,10 @@ class MultivariateNormal(torch.distributions.MultivariateNormal, TorchDistributi
         identity = torch.eye(self.loc.size(-1), device=self.loc.device, dtype=self.loc.dtype)
         return torch.cholesky_solve(identity, self._unbroadcasted_scale_tril).expand(
             self._batch_shape + self._event_shape + self._event_shape)
+
+
+class Normal(torch.distributions.Normal, TorchDistributionMixin):
+    pass
 
 
 class Independent(torch.distributions.Independent, TorchDistributionMixin):

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -104,6 +104,8 @@ class Geometric(torch.distributions.Geometric, TorchDistributionMixin):
 class LogNormal(torch.distributions.LogNormal, TorchDistributionMixin):
     def __init__(self, loc, scale, validate_args=None):
         base_dist = Normal(loc, scale)
+        # This differs from torch.distributions.LogNormal only in that base_dist is
+        # a pyro.distributions.Normal rather than a torch.distributions.Normal.
         super(torch.distributions.LogNormal, self).__init__(
             base_dist, torch.distributions.transforms.ExpTransform(), validate_args=validate_args)
 


### PR DESCRIPTION
This fixes several issues at reshape_batch(LinearHMM):

+ In LinearHMM, we always expand init_dist, trans_dist, obs_dist; so when reshaping, we should also expand for consistency. This fixes a bug where `reshape_batch(hmm, (1,)).rsample().shape[0] != 1`.
+ Keep the `.transforms` after reshaping.
+ Workaround the case LinearHMM's observation_dist is LogNormal: `self.observation_dist` will be `torch.distributions.Normal`, which is not registered in forecast's UNIVARIATE_DIST.