### PR TITLE
Fix docs for MCMC

### DIFF
--- a/docs/source/pyro.infer.mcmc.txt
+++ b/docs/source/pyro.infer.mcmc.txt
@@ -6,6 +6,13 @@ MCMC
     :undoc-members:
     :show-inheritance:
 
+MCMCKernel
+----------
+.. autoclass:: pyro.infer.mcmc.mcmc_kernel.MCMCKernel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 HMC
 ---
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -273,7 +273,7 @@ class MCMC:
         excluding the samples discarded during the warmup phase.
     :param int warmup_steps: Number of warmup iterations. The samples generated
         during the warmup phase are discarded. If not provided, default is
-        half of `num_samples`.
+        is the same as `num_samples`.
     :param int num_chains: Number of MCMC chains to run in parallel. Depending on
         whether `num_chains` is 1 or more than 1, this class internally dispatches
         to either `_UnarySampler` or `_MultiSampler`.
@@ -350,6 +350,26 @@ class MCMC:
 
     @poutine.block
     def run(self, *args, **kwargs):
+        """
+        Run MCMC to generate samples and populate `self._samples`.
+
+        Example usage:
+
+        .. code-block:: python
+
+            def model(data):
+                ...
+
+            nuts_kernel = NUTS(model)
+            mcmc = MCMC(nuts_kernel, num_samples=500)
+            mcmc.run(data)
+            samples = mcmc.get_samples()
+
+        :param args: optional arguments taken by
+            :meth:`MCMCKernel.setup <pyro.infer.mcmc.mcmc_kernel.MCMCKernel.setup>`.
+        :param kwargs: optional keywords arguments taken by
+            :meth:`MCMCKernel.setup <pyro.infer.mcmc.mcmc_kernel.MCMCKernel.setup>`.
+        """
         self._args, self._kwargs = args, kwargs
         num_samples = [0] * self.num_chains
         z_flat_acc = [[] for _ in range(self.num_chains)]

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -104,7 +104,7 @@ def _make_handler(msngr_cls):
             raise ValueError(
                 "{} is not callable, did you mean to pass it as a keyword arg?".format(fn))
         msngr = msngr_cls(*args, **kwargs)
-        return functools.update_wrapper(msngr(fn), fn) if fn is not None else msngr
+        return functools.update_wrapper(msngr(fn), fn, updated=()) if fn is not None else msngr
 
     return handler
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -104,7 +104,7 @@ def _make_handler(msngr_cls):
             raise ValueError(
                 "{} is not callable, did you mean to pass it as a keyword arg?".format(fn))
         msngr = msngr_cls(*args, **kwargs)
-        return msngr(fn) if fn is not None else msngr
+        return functools.update_wrapper(msngr(fn), fn) if fn is not None else msngr
 
     return handler
 


### PR DESCRIPTION
 - add docs for `MCMC.run`.
 - adds `MCMCKernel` class to the docs.
 - updates documentation regarding default `num_warmup`.
