### PR TITLE
Speed up SubsampleMessenger

### DIFF
--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -49,8 +49,7 @@ class _Subsample(Distribution):
         if subsample_size is None or subsample_size >= self.size:
             result = torch.arange(self.size, device=self.device)
         else:
-            result = torch.multinomial(torch.ones(self.size), self.subsample_size,
-                                       replacement=False).to(self.device)
+            result = torch.randperm(self.size, device=self.device)[:subsample_size].clone()
         return result.cuda() if self.use_cuda else result
 
     def log_prob(self, x):


### PR DESCRIPTION
This replaces a poor use of `torch.multinomial()` with a better use of `torch.randperm()`.

Ideally we can eventually replace this with the faster https://github.com/pytorch/pytorch/pull/18624

I also tried to use `torch.randint()`: that is much faster on CPU but much slower on GPU.

## Profiled

Using the following script, I see a >40x speedup on CPU and ~400x speedup on GPU:

<details>

```py
import timeit

cases = [
    "torch.multinomial(torch.ones(1000000, device='cpu'), 1000, replacement=False)",
    "torch.randperm(1000000, device='cpu')[:1000].clone()",
    "torch.multinomial(torch.ones(1000000), 1000, replacement=False).cuda(); torch.cuda.synchronize()",
    "torch.randperm(1000000, device='cuda')[:1000].clone(); torch.cuda.synchronize()",
]
n = 10
for case in cases:
    print(case)
    time = timeit.timeit(case, "import torch", number=n)
    print("# {:0.3} sec".format(time / n))
```

</details>

```py
torch.multinomial(torch.ones(1000000, device='cpu'), 1000, replacement=False)
# 0.8 sec
torch.randperm(1000000, device='cpu')[:1000].clone()
# 0.0287 sec
torch.multinomial(torch.ones(1000000), 1000, replacement=False).cuda(); torch.cuda.synchronize()
# 1.22 sec
torch.randperm(1000000, device='cuda')[:1000].clone(); torch.cuda.synchronize()
# 0.00269 sec
```