### PR TITLE
`log_abs_det_jacobian` will be recalculated when necessary

### DIFF
--- a/pyro/distributions/transforms/affine_autoregressive.py
+++ b/pyro/distributions/transforms/affine_autoregressive.py
@@ -153,6 +153,12 @@ class AffineAutoregressive(TransformModule):
         """
         Calculates the elementwise determinant of the log Jacobian
         """
+        x_old, y_old = self._cached_x_y
+        if x is not x_old or y is not y_old:
+            # This call to the parent class Transform will update the cache
+            # as well as calling self._call and recalculating y and log_detJ
+            self(x)
+
         if self._cached_log_scale is not None:
             log_scale = self._cached_log_scale
         elif not self.stable:

--- a/pyro/distributions/transforms/block_autoregressive.py
+++ b/pyro/distributions/transforms/block_autoregressive.py
@@ -163,6 +163,11 @@ class BlockAutoregressive(TransformModule):
         """
         Calculates the elementwise determinant of the log jacobian
         """
+        x_old, y_old = self._cached_x_y
+        if x is not x_old or y is not y_old:
+            # This call to the parent class Transform will update the cache
+            # as well as calling self._call and recalculating y and log_detJ
+            self(x)
 
         return self._cached_logDetJ.sum(-1)
 

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -72,6 +72,12 @@ class ConditionedPlanar(Transform):
         """
         Calculates the elementwise determinant of the log Jacobian
         """
+        x_old, y_old = self._cached_x_y
+        if x is not x_old or y is not y_old:
+            # This call to the parent class Transform will update the cache
+            # as well as calling self._call and recalculating y and log_detJ
+            self(x)
+
         return self._cached_logDetJ
 
 

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -141,6 +141,12 @@ class Polynomial(TransformModule):
         """
         Calculates the elementwise determinant of the log Jacobian
         """
+        x_old, y_old = self._cached_x_y
+        if x is not x_old or y is not y_old:
+            # This call to the parent class Transform will update the cache
+            # as well as calling self._call and recalculating y and log_detJ
+            self(x)
+
         return self._cached_logDetJ
 
 

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -74,6 +74,12 @@ class ConditionedRadial(Transform):
         """
         Calculates the elementwise determinant of the log Jacobian
         """
+        x_old, y_old = self._cached_x_y
+        if x is not x_old or y is not y_old:
+            # This call to the parent class Transform will update the cache
+            # as well as calling self._call and recalculating y and log_detJ
+            self(x)
+
         return self._cached_logDetJ
 
 

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -138,6 +138,11 @@ class Sylvester(Householder):
         """
         Calculates the elementwise determinant of the log Jacobian
         """
+        x_old, y_old = self._cached_x_y
+        if x is not x_old or y is not y_old:
+            # This call to the parent class Transform will update the cache
+            # as well as calling self._call and recalculating y and log_detJ
+            self(x)
 
         return self._cached_logDetJ
 


### PR DESCRIPTION
This PR fixes a potential pitfall for bugs! Several of the transforms rely on cached values to calculate the log(abs(det(Jacobian))). However, you can call the `log_abs_det_jacobian` method with any inputs `x,y` you'd like, and if they don't match the values for the cached Jacobian then the wrong Jacobian is returned.

My solution is to compare `x,y` to the values that were used to calculate the Jacobian. If they don't match then the Jacobian is recached