### PR TITLE
Aesthetic improvements to transform docstrings

### DIFF
--- a/pyro/distributions/transforms/affine_autoregressive.py
+++ b/pyro/distributions/transforms/affine_autoregressive.py
@@ -14,25 +14,27 @@ from pyro.nn import AutoRegressiveNN
 @copy_docs_from(TransformModule)
 class AffineAutoregressive(TransformModule):
     """
-    An implementation of the bijective transform of Inverse Autoregressive Flow (IAF), using by default Eq (10)
-    from Kingma Et Al., 2016,
+    An implementation of the bijective transform of Inverse Autoregressive Flow
+    (IAF), using by default Eq (10) from Kingma Et Al., 2016,
 
         :math:`\\mathbf{y} = \\mu_t + \\sigma_t\\odot\\mathbf{x}`
 
-    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs, :math:`\\mu_t,\\sigma_t`
-    are calculated from an autoregressive network on :math:`\\mathbf{x}`, and :math:`\\sigma_t>0`.
+    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs,
+    :math:`\\mu_t,\\sigma_t` are calculated from an autoregressive network on
+    :math:`\\mathbf{x}`, and :math:`\\sigma_t>0`.
 
     If the stable keyword argument is set to True then the transformation used is,
 
         :math:`\\mathbf{y} = \\sigma_t\\odot\\mathbf{x} + (1-\\sigma_t)\\odot\\mu_t`
 
-    where :math:`\\sigma_t` is restricted to :math:`(0,1)`. This variant of IAF is claimed by the authors to
-    be more numerically stable than one using Eq (10), although in practice it leads to a restriction on the
-    distributions that can be represented, presumably since the input is restricted to rescaling by a number
+    where :math:`\\sigma_t` is restricted to :math:`(0,1)`. This variant of IAF is
+    claimed by the authors to be more numerically stable than one using Eq (10),
+    although in practice it leads to a restriction on the distributions that can be
+    represented, presumably since the input is restricted to rescaling by a number
     on :math:`(0,1)`.
 
-    Together with :class:`~pyro.distributions.TransformedDistribution` this provides a way to create richer
-    variational approximations.
+    Together with :class:`~pyro.distributions.TransformedDistribution` this provides
+    a way to create richer variational approximations.
 
     Example usage:
 
@@ -42,40 +44,47 @@ class AffineAutoregressive(TransformModule):
     >>> pyro.module("my_transform", transform)  # doctest: +SKIP
     >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
-    The inverse of the Bijector is required when, e.g., scoring the log density of a sample with
-    :class:`~pyro.distributions.TransformedDistribution`. This implementation caches the inverse of the Bijector
-    when its forward operation is called, e.g., when sampling from
-    :class:`~pyro.distributions.TransformedDistribution`. However, if the cached value isn't available, either because
-    it was overwritten during sampling a new value or an arbitary value is being scored, it will calculate it manually.
-    Note that this is an operation that scales as O(D) where D is the input dimension, and so should be avoided for
-    large dimensional uses. So in general, it is cheap to sample from IAF and score a value that was sampled by IAF,
-    but expensive to score an arbitrary value.
+    The inverse of the Bijector is required when, e.g., scoring the log density of a
+    sample with :class:`~pyro.distributions.TransformedDistribution`. This
+    implementation caches the inverse of the Bijector when its forward operation is
+    called, e.g., when sampling from
+    :class:`~pyro.distributions.TransformedDistribution`. However, if the cached
+    value isn't available, either because it was overwritten during sampling a new
+    value or an arbitary value is being scored, it will calculate it manually. Note
+    that this is an operation that scales as O(D) where D is the input dimension,
+    and so should be avoided for large dimensional uses. So in general, it is cheap
+    to sample from IAF and score a value that was sampled by IAF, but expensive to
+    score an arbitrary value.
 
-    :param autoregressive_nn: an autoregressive neural network whose forward call returns a real-valued
-        mean and logit-scale as a tuple
+    :param autoregressive_nn: an autoregressive neural network whose forward call
+        returns a real-valued mean and logit-scale as a tuple
     :type autoregressive_nn: nn.Module
-    :param log_scale_min_clip: The minimum value for clipping the log(scale) from the autoregressive NN
+    :param log_scale_min_clip: The minimum value for clipping the log(scale) from
+        the autoregressive NN
     :type log_scale_min_clip: float
-    :param log_scale_max_clip: The maximum value for clipping the log(scale) from the autoregressive NN
+    :param log_scale_max_clip: The maximum value for clipping the log(scale) from
+        the autoregressive NN
     :type log_scale_max_clip: float
-    :param sigmoid_bias: A term to add the logit of the input when using the stable tranform.
+    :param sigmoid_bias: A term to add the logit of the input when using the stable
+        tranform.
     :type sigmoid_bias: float
-    :param stable: When true, uses the alternative "stable" version of the transform (see above).
+    :param stable: When true, uses the alternative "stable" version of the transform
+        (see above).
     :type stable: bool
 
     References:
 
-    1. Improving Variational Inference with Inverse Autoregressive Flow [arXiv:1606.04934]
-    Diederik P. Kingma, Tim Salimans, Rafal Jozefowicz, Xi Chen, Ilya Sutskever, Max Welling
+    [1] Diederik P. Kingma, Tim Salimans, Rafal Jozefowicz, Xi Chen, Ilya Sutskever,
+    Max Welling. Improving Variational Inference with Inverse Autoregressive Flow.
+    [arXiv:1606.04934]
 
-    2. Variational Inference with Normalizing Flows [arXiv:1505.05770]
-    Danilo Jimenez Rezende, Shakir Mohamed
+    [2] Danilo Jimenez Rezende, Shakir Mohamed. Variational Inference with
+    Normalizing Flows. [arXiv:1505.05770]
 
-    3. MADE: Masked Autoencoder for Distribution Estimation [arXiv:1502.03509]
-    Mathieu Germain, Karol Gregor, Iain Murray, Hugo Larochelle
+    [3] Mathieu Germain, Karol Gregor, Iain Murray, Hugo Larochelle. MADE: Masked
+    Autoencoder for Distribution Estimation. [arXiv:1502.03509]
+
     """
 
     domain = constraints.real
@@ -113,8 +122,8 @@ class AffineAutoregressive(TransformModule):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         mean, log_scale = self.arn(x)
         log_scale = clamp_preserve_gradients(log_scale, self.log_scale_min_clip, self.log_scale_max_clip)
@@ -129,7 +138,8 @@ class AffineAutoregressive(TransformModule):
         :param y: the output of the bijection
         :type y: torch.Tensor
 
-        Inverts y => x. Uses a previously cached inverse if available, otherwise performs the inversion afresh.
+        Inverts y => x. Uses a previously cached inverse if available, otherwise
+        performs the inversion afresh.
         """
         x_size = y.size()[:-1]
         perm = self.arn.permutation
@@ -169,8 +179,8 @@ class AffineAutoregressive(TransformModule):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         mean, logit_scale = self.arn(x)
         logit_scale = logit_scale + self.sigmoid_bias
@@ -206,21 +216,27 @@ class AffineAutoregressive(TransformModule):
 
 def affine_autoregressive(input_dim, hidden_dims=None, **kwargs):
     """
-    A helper function to create an :class:`~pyro.distributions.transforms.AffineAutoregressive` object that takes care
-    of constructing an autoregressive network with the correct input/output dimensions.
+    A helper function to create an
+    :class:`~pyro.distributions.transforms.AffineAutoregressive` object that takes
+    care of constructing an autoregressive network with the correct input/output
+    dimensions.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
-    :param hidden_dims: The desired hidden dimensions of the autoregressive network. Defaults
-        to using [3*input_dim + 1]
+    :param hidden_dims: The desired hidden dimensions of the autoregressive network.
+        Defaults to using [3*input_dim + 1]
     :type hidden_dims: list[int]
-    :param log_scale_min_clip: The minimum value for clipping the log(scale) from the autoregressive NN
+    :param log_scale_min_clip: The minimum value for clipping the log(scale) from
+        the autoregressive NN
     :type log_scale_min_clip: float
-    :param log_scale_max_clip: The maximum value for clipping the log(scale) from the autoregressive NN
+    :param log_scale_max_clip: The maximum value for clipping the log(scale) from
+        the autoregressive NN
     :type log_scale_max_clip: float
-    :param sigmoid_bias: A term to add the logit of the input when using the stable tranform.
+    :param sigmoid_bias: A term to add the logit of the input when using the stable
+        tranform.
     :type sigmoid_bias: float
-    :param stable: When true, uses the alternative "stable" version of the transform (see above).
+    :param stable: When true, uses the alternative "stable" version of the transform
+        (see above).
     :type stable: bool
 
     """

--- a/pyro/distributions/transforms/batchnorm.py
+++ b/pyro/distributions/transforms/batchnorm.py
@@ -13,26 +13,29 @@ from pyro.distributions.util import copy_docs_from
 @copy_docs_from(TransformModule)
 class BatchNorm(TransformModule):
     """
-    A type of batch normalization that can be used to stabilize training in normalizing flows. The inverse operation
-    is defined as
+    A type of batch normalization that can be used to stabilize training in
+    normalizing flows. The inverse operation is defined as
 
         :math:`x = (y - \\hat{\\mu}) \\oslash \\sqrt{\\hat{\\sigma^2}} \\otimes \\gamma + \\beta`
 
-    that is, the standard batch norm equation, where :math:`x` is the input, :math:`y` is the output,
-    :math:`\\gamma,\\beta` are learnable parameters, and :math:`\\hat{\\mu}`/:math:`\\hat{\\sigma^2}` are smoothed
-    running averages of the sample mean and variance, respectively. The constraint :math:`\\gamma>0` is enforced to
-    ease calculation of the log-det-Jacobian term.
+    that is, the standard batch norm equation, where :math:`x` is the input,
+    :math:`y` is the output, :math:`\\gamma,\\beta` are learnable parameters, and
+    :math:`\\hat{\\mu}`/:math:`\\hat{\\sigma^2}` are smoothed running averages of
+    the sample mean and variance, respectively. The constraint :math:`\\gamma>0` is
+    enforced to ease calculation of the log-det-Jacobian term.
 
-    This is an element-wise transform, and when applied to a vector, learns two parameters (:math:`\\gamma,\\beta`)
-    for each dimension of the input.
+    This is an element-wise transform, and when applied to a vector, learns two
+    parameters (:math:`\\gamma,\\beta`) for each dimension of the input.
 
-    When the module is set to training mode, the moving averages of the sample mean and variance are updated every time
-    the inverse operator is called, e.g., when a normalizing flow scores a minibatch with the `log_prob` method.
+    When the module is set to training mode, the moving averages of the sample mean
+    and variance are updated every time the inverse operator is called, e.g., when a
+    normalizing flow scores a minibatch with the `log_prob` method.
 
-    Also, when the module is set to training mode, the sample mean and variance on the current minibatch are used in
-    place of the smoothed averages, :math:`\\hat{\\mu}` and :math:`\\hat{\\sigma^2}`, for the inverse operator. For this
-    reason it is not the case that :math:`x=g(g^{-1}(x))` during training, i.e., that the inverse operation is the
-    inverse of the forward one.
+    Also, when the module is set to training mode, the sample mean and variance on
+    the current minibatch are used in place of the smoothed averages,
+    :math:`\\hat{\\mu}` and :math:`\\hat{\\sigma^2}`, for the inverse operator. For
+    this reason it is not the case that :math:`x=g(g^{-1}(x))` during training,
+    i.e., that the inverse operation is the inverse of the forward one.
 
     Example usage:
 
@@ -43,8 +46,6 @@ class BatchNorm(TransformModule):
     >>> bn = BatchNorm(10)
     >>> flow_dist = dist.TransformedDistribution(base_dist, [iafs[0], bn, iafs[1]])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
     :param input_dim: the dimension of the input
     :type input_dim: int
@@ -55,14 +56,17 @@ class BatchNorm(TransformModule):
 
     References:
 
-    [1] Sergey Ioffe and Christian Szegedy. Batch Normalization: Accelerating Deep Network Training by Reducing
-    Internal Covariate Shift. In International Conference on Machine Learning, 2015. https://arxiv.org/abs/1502.03167
+    [1] Sergey Ioffe and Christian Szegedy. Batch Normalization: Accelerating Deep
+    Network Training by Reducing Internal Covariate Shift. In International
+    Conference on Machine Learning, 2015. https://arxiv.org/abs/1502.03167
 
-    [2] Laurent Dinh, Jascha Sohl-Dickstein, and Samy Bengio. Density Estimation using Real NVP.
-    In International Conference on Learning Representations, 2017. https://arxiv.org/abs/1605.08803
+    [2] Laurent Dinh, Jascha Sohl-Dickstein, and Samy Bengio. Density Estimation
+    using Real NVP. In International Conference on Learning Representations, 2017.
+    https://arxiv.org/abs/1605.08803
 
-    [3] George Papamakarios, Theo Pavlakou, and Iain Murray. Masked Autoregressive Flow for Density Estimation.
-    In Neural Information Processing Systems, 2017. https://arxiv.org/abs/1705.07057
+    [3] George Papamakarios, Theo Pavlakou, and Iain Murray. Masked Autoregressive
+    Flow for Density Estimation. In Neural Information Processing Systems, 2017.
+    https://arxiv.org/abs/1705.07057
 
     """
 
@@ -93,8 +97,8 @@ class BatchNorm(TransformModule):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         # Enforcing the constraint that gamma is positive
         return (x - self.beta) / self.constrained_gamma * \
@@ -135,8 +139,8 @@ class BatchNorm(TransformModule):
 
 def batchnorm(input_dim, **kwargs):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.BatchNorm` object for consistency with other
-    helpers.
+    A helper function to create a :class:`~pyro.distributions.transforms.BatchNorm`
+    object for consistency with other helpers.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -34,12 +34,14 @@ class CorrLCholeskyTransform(Transform):
     """
     Transforms a vector into the cholesky factor of a correlation matrix.
 
-    The input should have shape `[batch_shape] + [d * (d-1)/2]`. The output will have
-    shape `[batch_shape] + [d, d]`.
+    The input should have shape `[batch_shape] + [d * (d-1)/2]`. The output will
+    have shape `[batch_shape] + [d, d]`.
 
-    Reference:
+    References:
 
-    [1] `Cholesky Factors of Correlation Matrices`, Stan Reference Manual v2.18, Section 10.12
+    [1] Cholesky Factors of Correlation Matrices. Stan Reference Manual v2.18,
+    Section 10.12.
+
     """
     domain = constraints.real
     codomain = corr_cholesky_constraint

--- a/pyro/distributions/transforms/generalized_channel_permute.py
+++ b/pyro/distributions/transforms/generalized_channel_permute.py
@@ -9,35 +9,40 @@ from pyro.distributions.torch_transform import TransformModule
 @copy_docs_from(TransformModule)
 class GeneralizedChannelPermute(TransformModule):
     """
-    A bijection that generalizes a permutation on the channels of a batch of 2D image in :math:`[\\ldots,C,H,W]` format.
-    Specifically this transform performs the operation,
+    A bijection that generalizes a permutation on the channels of a batch of 2D
+    image in :math:`[\\ldots,C,H,W]` format. Specifically this transform performs
+    the operation,
 
         :math:`\\mathbf{y} = \\text{torch.nn.functional.conv2d}(\\mathbf{x}, W)`
 
-    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs, and
-    :math:`W\\sim C\\times C\\times 1\\times 1` is the filter matrix for a 1x1 convolution with :math:`C` input and
-    output channels.
+    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs,
+    and :math:`W\\sim C\\times C\\times 1\\times 1` is the filter matrix for a 1x1
+    convolution with :math:`C` input and output channels.
 
-    Ignoring the final two dimensions, :math:`W` is restricted to be the matrix product,
+    Ignoring the final two dimensions, :math:`W` is restricted to be the matrix
+    product,
 
         :math:`W = PLU`
 
-    where :math:`P\\sim C\\times C` is a permutation matrix on the channel dimensions, :math:`L\\sim C\\times C` is a
-    lower triangular matrix with ones on the diagonal, and :math:`U\\sim C\\times C` is an upper triangular matrix.
-    :math:`W` is initialized to a random orthogonal matrix. Then, :math:`P` is fixed and the learnable parameters set
-    to :math:`L,U`.
+    where :math:`P\\sim C\\times C` is a permutation matrix on the channel
+    dimensions, :math:`L\\sim C\\times C` is a lower triangular matrix with ones on
+    the diagonal, and :math:`U\\sim C\\times C` is an upper triangular matrix.
+    :math:`W` is initialized to a random orthogonal matrix. Then, :math:`P` is fixed
+    and the learnable parameters set to :math:`L,U`.
 
-    The input :math:`\\mathbf{x}` and output :math:`\\mathbf{y}` both have shape `[...,C,H,W]`, where `C` is the number
-    of channels set at initialization.
+    The input :math:`\\mathbf{x}` and output :math:`\\mathbf{y}` both have shape
+    `[...,C,H,W]`, where `C` is the number of channels set at initialization.
 
-    This operation was introduced in [1] for Glow normalizing flow, and is also known as 1x1 invertible convolution.
-    It appears in other notable work such as [2,3], and corresponds to the class `tfp.bijectors.MatvecLU` of TensorFlow
+    This operation was introduced in [1] for Glow normalizing flow, and is also
+    known as 1x1 invertible convolution. It appears in other notable work such as
+    [2,3], and corresponds to the class `tfp.bijectors.MatvecLU` of TensorFlow
     Probability.
 
     Example usage:
 
     >>> channels = 3
-    >>> base_dist = dist.Normal(torch.zeros(channels, 32, 32), torch.ones(channels, 32, 32))
+    >>> base_dist = dist.Normal(torch.zeros(channels, 32, 32),
+    ... torch.ones(channels, 32, 32))
     >>> inv_conv = GeneralizedChannelPermute(channels=channels)
     >>> flow_dist = dist.TransformedDistribution(base_dist, [inv_conv])
     >>> flow_dist.sample()  # doctest: +SKIP
@@ -45,14 +50,14 @@ class GeneralizedChannelPermute(TransformModule):
     :param channels: Number of channel dimensions in the input.
     :type channels: int
 
-    1. Glow: Generative Flow with Invertible 1x1 Convolutions. [arXiv:1807.03039]
-    Diederik P. Kingma, Prafulla Dhariwal.
+    [1] Diederik P. Kingma, Prafulla Dhariwal. Glow: Generative Flow with Invertible
+    1x1 Convolutions. [arXiv:1807.03039]
 
-    2. WaveGlow: A Flow-based Generative Network for Speech Synthesis. [arXiv:1811.00002]
-    Ryan Prenger, Rafael Valle, Bryan Catanzaro.
+    [2] Ryan Prenger, Rafael Valle, Bryan Catanzaro. WaveGlow: A Flow-based
+    Generative Network for Speech Synthesis. [arXiv:1811.00002]
 
-    3. Neural Spline Flows. [arXiv:1906.04032]
-    Conor Durkan, Artur Bekasov, Iain Murray, George Papamakarios.
+    [3] Conor Durkan, Artur Bekasov, Iain Murray, George Papamakarios. Neural Spline
+    Flows. [arXiv:1906.04032]
 
     """
 
@@ -87,8 +92,8 @@ class GeneralizedChannelPermute(TransformModule):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
 
         # Extract the lower and upper matrices from the packed LU matrix
@@ -111,8 +116,8 @@ class GeneralizedChannelPermute(TransformModule):
         """
 
         """
-        NOTE: This method is equivalent to the following two lines. Using Tensor.inverse() would be
-        numerically unstable, however.
+        NOTE: This method is equivalent to the following two lines. Using
+        Tensor.inverse() would be numerically unstable, however.
 
         U = self.LU.triu()
         L = self.LU.tril()
@@ -141,7 +146,8 @@ class GeneralizedChannelPermute(TransformModule):
 
     def log_abs_det_jacobian(self, x, y):
         """
-        Calculates the elementwise determinant of the log Jacobian, i.e. log(abs(det(dy/dx))).
+        Calculates the elementwise determinant of the log Jacobian, i.e.
+        log(abs(det(dy/dx))).
         """
 
         h, w = x.shape[-2:]
@@ -152,7 +158,8 @@ class GeneralizedChannelPermute(TransformModule):
 
 def generalized_channel_permute(**kwargs):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.GeneralizedChannelPermute` object for
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.GeneralizedChannelPermute` object for
     consistency with other helpers.
 
     :param channels: Number of channel dimensions in the input.

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -15,23 +15,26 @@ from pyro.distributions.util import copy_docs_from
 @copy_docs_from(TransformModule)
 class Householder(TransformModule):
     """
-    Represents multiple applications of the Householder bijective transformation. A single Householder
-    transformation takes the form,
+    Represents multiple applications of the Householder bijective transformation. A
+    single Householder transformation takes the form,
 
         :math:`\\mathbf{y} = (I - 2*\\frac{\\mathbf{u}\\mathbf{u}^T}{||\\mathbf{u}||^2})\\mathbf{x}`
 
-    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs, and the learnable parameters
-    are :math:`\\mathbf{u}\\in\\mathbb{R}^D` for input dimension :math:`D`.
+    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs,
+    and the learnable parameters are :math:`\\mathbf{u}\\in\\mathbb{R}^D` for input
+    dimension :math:`D`.
 
-    The transformation represents the reflection of :math:`\\mathbf{x}` through the plane passing through the
-    origin with normal :math:`\\mathbf{u}`.
+    The transformation represents the reflection of :math:`\\mathbf{x}` through the
+    plane passing through the origin with normal :math:`\\mathbf{u}`.
 
-    :math:`D` applications of this transformation are able to transform standard i.i.d. standard Gaussian noise
-    into a Gaussian variable with an arbitrary covariance matrix. With :math:`K<D` transformations, one is able
-    to approximate a full-rank Gaussian distribution using a linear transformation of rank :math:`K`.
+    :math:`D` applications of this transformation are able to transform standard
+    i.i.d. standard Gaussian noise into a Gaussian variable with an arbitrary
+    covariance matrix. With :math:`K<D` transformations, one is able to approximate
+    a full-rank Gaussian distribution using a linear transformation of rank
+    :math:`K`.
 
-    Together with :class:`~pyro.distributions.TransformedDistribution` this provides a way to create richer
-    variational approximations.
+    Together with :class:`~pyro.distributions.TransformedDistribution` this provides
+    a way to create richer variational approximations.
 
     Example usage:
 
@@ -40,18 +43,17 @@ class Householder(TransformModule):
     >>> pyro.module("my_transform", p) # doctest: +SKIP
     >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
     :param input_dim: the dimension of the input (and output) variable.
     :type input_dim: int
-    :param count_transforms: number of applications of Householder transformation to apply.
+    :param count_transforms: number of applications of Householder transformation to
+        apply.
     :type count_transforms: int
 
     References:
 
-    Improving Variational Auto-Encoders using Householder Flow, [arXiv:1611.09630]
-    Tomczak, J. M., & Welling, M.
+    [1] Jakub M. Tomczak, Max Welling. Improving Variational Auto-Encoders using
+    Householder Flow. [arXiv:1611.09630]
 
     """
 
@@ -90,8 +92,8 @@ over-parametrization!".format(count_transforms, input_dim))
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
 
         y = x
@@ -106,8 +108,9 @@ over-parametrization!".format(count_transforms, input_dim))
         :param y: the output of the bijection
         :type y: torch.Tensor
 
-        Inverts y => x. The Householder transformation, H, is "involutory," i.e. H^2 = I. If you reflect a
-        point around a plane, then the same operation will reflect it back
+        Inverts y => x. The Householder transformation, H, is "involutory," i.e.
+        H^2 = I. If you reflect a point around a plane, then the same operation will
+        reflect it back
         """
 
         x = y
@@ -120,8 +123,8 @@ over-parametrization!".format(count_transforms, input_dim))
 
     def log_abs_det_jacobian(self, x, y):
         """
-        Calculates the elementwise determinant of the log jacobian. Householder flow is measure preserving,
-        so :math:`\\log(|detJ|) = 0`
+        Calculates the elementwise determinant of the log jacobian. Householder flow
+        is measure preserving, so :math:`\\log(|detJ|) = 0`
         """
 
         return torch.zeros(x.size()[:-1], dtype=x.dtype, layout=x.layout, device=x.device)
@@ -129,12 +132,14 @@ over-parametrization!".format(count_transforms, input_dim))
 
 def householder(input_dim, count_transforms=None):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.Householder` object for consistency with
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.Householder` object for consistency with
     other helpers.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
-    :param count_transforms: number of applications of Householder transformation to apply.
+    :param count_transforms: number of applications of Householder transformation to
+        apply.
     :type count_transforms: int
 
     """

--- a/pyro/distributions/transforms/lower_cholesky_affine.py
+++ b/pyro/distributions/transforms/lower_cholesky_affine.py
@@ -11,13 +11,17 @@ from pyro.distributions.util import copy_docs_from
 @copy_docs_from(Transform)
 class LowerCholeskyAffine(Transform):
     """
-    A bijection of the form :math:`\\mathbf{y} = \\mathbf{L} \\mathbf{x} + \\mathbf{r}`
+    A bijection of the form,
+
+        :math:`\\mathbf{y} = \\mathbf{L} \\mathbf{x} + \\mathbf{r}`
+
     where `\\mathbf{L}` is a lower triangular matrix and `\\mathbf{r}` is a vector.
 
     :param loc: the fixed D-dimensional vector to shift the input by.
     :type loc: torch.tensor
     :param scale_tril: the D x D lower triangular matrix used in the transformation.
     :type scale_tril: torch.tensor
+
     """
     codomain = constraints.real_vector
     bijective = True
@@ -38,8 +42,8 @@ class LowerCholeskyAffine(Transform):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         return torch.matmul(self.scale_tril, x.unsqueeze(-1)).squeeze(-1) + self.loc
 
@@ -55,7 +59,8 @@ class LowerCholeskyAffine(Transform):
 
     def log_abs_det_jacobian(self, x, y):
         """
-        Calculates the elementwise determinant of the log Jacobian, i.e. log(abs(dy/dx)).
+        Calculates the elementwise determinant of the log Jacobian, i.e.
+        log(abs(dy/dx)).
         """
         return torch.ones(x.size()[:-1], dtype=x.dtype, layout=x.layout, device=x.device) * \
             self.scale_tril.diag().log().sum()

--- a/pyro/distributions/transforms/neural_autoregressive.py
+++ b/pyro/distributions/transforms/neural_autoregressive.py
@@ -42,7 +42,8 @@ class ELUTransform(Transform):
 
 def elu():
     """
-    A helper function to create an :class:`~pyro.distributions.transform.ELUTransform` object for consistency with
+    A helper function to create an
+    :class:`~pyro.distributions.transform.ELUTransform` object for consistency with
     other helpers.
     """
     return ELUTransform()
@@ -72,8 +73,9 @@ class LeakyReLUTransform(Transform):
 
 def leaky_relu():
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.LeakyReLUTransform` object for consistency
-    with other helpers.
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.LeakyReLUTransform` object for
+    consistency with other helpers.
     """
     return LeakyReLUTransform()
 
@@ -107,8 +109,9 @@ class TanhTransform(Transform):
 
 def tanh():
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.TanhTransform` object for consistency with
-    other helpers.
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.TanhTransform` object for consistency
+    with other helpers.
     """
     return TanhTransform()
 
@@ -116,8 +119,9 @@ def tanh():
 @copy_docs_from(TransformModule)
 class NeuralAutoregressive(TransformModule):
     """
-    An implementation of the deep Neural Autoregressive Flow (NAF) bijective transform of the
-    "IAF flavour" that can be used for sampling and scoring samples drawn from it (but not arbitrary ones).
+    An implementation of the deep Neural Autoregressive Flow (NAF) bijective
+    transform of the "IAF flavour" that can be used for sampling and scoring samples
+    drawn from it (but not arbitrary ones).
 
     Example usage:
 
@@ -128,25 +132,27 @@ class NeuralAutoregressive(TransformModule):
     >>> pyro.module("my_transform", transform)  # doctest: +SKIP
     >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
-    The inverse operation is not implemented. This would require numerical inversion, e.g., using a
-    root finding method - a possibility for a future implementation.
+    The inverse operation is not implemented. This would require numerical
+    inversion, e.g., using a root finding method - a possibility for a future
+    implementation.
 
-    :param autoregressive_nn: an autoregressive neural network whose forward call returns a tuple of three
-        real-valued tensors, whose last dimension is the input dimension, and whose penultimate dimension
-        is equal to hidden_units.
+    :param autoregressive_nn: an autoregressive neural network whose forward call
+        returns a tuple of three real-valued tensors, whose last dimension is the
+        input dimension, and whose penultimate dimension is equal to hidden_units.
     :type autoregressive_nn: nn.Module
-    :param hidden_units: the number of hidden units to use in the NAF transformation (see Eq (8) in reference)
+    :param hidden_units: the number of hidden units to use in the NAF transformation
+        (see Eq (8) in reference)
     :type hidden_units: int
-    :param activation: Activation function to use. One of 'ELU', 'LeakyReLU', 'sigmoid', or 'tanh'.
+    :param activation: Activation function to use. One of 'ELU', 'LeakyReLU',
+        'sigmoid', or 'tanh'.
     :type activation: string
 
     Reference:
 
-    Neural Autoregressive Flows [arXiv:1804.00779]
-    Chin-Wei Huang, David Krueger, Alexandre Lacoste, Aaron Courville
+    [1] Chin-Wei Huang, David Krueger, Alexandre Lacoste, Aaron Courville. Neural
+    Autoregressive Flows. [arXiv:1804.00779]
+
 
     """
 
@@ -183,8 +189,8 @@ class NeuralAutoregressive(TransformModule):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         # A, W, b ~ batch_shape x hidden_units x event_shape
         A, W_pre, b = self.arn(x)
@@ -227,17 +233,21 @@ class NeuralAutoregressive(TransformModule):
 
 def neural_autoregressive(input_dim, hidden_dims=None, activation='sigmoid', width=16):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.NeuralAutoregressive` object that takes care
-    of constructing an autoregressive network with the correct input/output dimensions.
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.NeuralAutoregressive` object that takes
+    care of constructing an autoregressive network with the correct input/output
+    dimensions.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
-    :param hidden_dims: The desired hidden dimensions of the autoregressive network. Defaults
-        to using [3*input_dim + 1]
+    :param hidden_dims: The desired hidden dimensions of the autoregressive network.
+        Defaults to using [3*input_dim + 1]
     :type hidden_dims: list[int]
-    :param activation: Activation function to use. One of 'ELU', 'LeakyReLU', 'sigmoid', or 'tanh'.
+    :param activation: Activation function to use. One of 'ELU', 'LeakyReLU',
+        'sigmoid', or 'tanh'.
     :type activation: string
-    :param width: The width of the "multilayer perceptron" in the transform (see paper). Defaults to 16
+    :param width: The width of the "multilayer perceptron" in the transform (see
+        paper). Defaults to 16
     :type width: int
 
     """

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -12,13 +12,17 @@ from pyro.distributions.util import copy_docs_from
 @copy_docs_from(Transform)
 class Permute(Transform):
     """
-    A bijection that reorders the input dimensions, that is, multiplies the input by a permutation matrix.
-    This is useful in between :class:`~pyro.distributions.transforms.AffineAutoregressive` transforms to increase the
-    flexibility of the resulting distribution and stabilize learning. Whilst not being an autoregressive transform,
-    the log absolute determinate of the Jacobian is easily calculable as 0. Note that reordering the input dimension
-    between two layers of :class:`~pyro.distributions.transforms.AffineAutoregressive` is not equivalent to reordering
-    the dimension inside the MADE networks that those IAFs use; using a :class:`~pyro.distributions.transforms.Permute`
-    transform results in a distribution with more flexibility.
+    A bijection that reorders the input dimensions, that is, multiplies the input by
+    a permutation matrix. This is useful in between
+    :class:`~pyro.distributions.transforms.AffineAutoregressive` transforms to
+    increase the flexibility of the resulting distribution and stabilize learning.
+    Whilst not being an autoregressive transform, the log absolute determinate of
+    the Jacobian is easily calculable as 0. Note that reordering the input dimension
+    between two layers of
+    :class:`~pyro.distributions.transforms.AffineAutoregressive` is not equivalent
+    to reordering the dimension inside the MADE networks that those IAFs use; using
+    a :class:`~pyro.distributions.transforms.Permute` transform results in a
+    distribution with more flexibility.
 
     Example usage:
 
@@ -30,8 +34,6 @@ class Permute(Transform):
     >>> iaf2 = AffineAutoregressive(AutoRegressiveNN(10, [40]))
     >>> flow_dist = dist.TransformedDistribution(base_dist, [iaf1, ff, iaf2])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
     :param permutation: a permutation ordering that is applied to the inputs.
     :type permutation: torch.LongTensor
@@ -62,8 +64,8 @@ class Permute(Transform):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
 
         return x[..., self.permutation]
@@ -80,10 +82,11 @@ class Permute(Transform):
 
     def log_abs_det_jacobian(self, x, y):
         """
-        Calculates the elementwise determinant of the log Jacobian, i.e. log(abs([dy_0/dx_0, ..., dy_{N-1}/dx_{N-1}])).
-        Note that this type of transform is not autoregressive, so the log Jacobian is not the sum of the previous
-        expression. However, it turns out it's always 0 (since the determinant is -1 or +1), and so returning a
-        vector of zeros works.
+        Calculates the elementwise determinant of the log Jacobian, i.e.
+        log(abs([dy_0/dx_0, ..., dy_{N-1}/dx_{N-1}])). Note that this type of
+        transform is not autoregressive, so the log Jacobian is not the sum of the
+        previous expression. However, it turns out it's always 0 (since the
+        determinant is -1 or +1), and so returning a vector of zeros works.
         """
 
         return torch.zeros(x.size()[:-1], dtype=x.dtype, layout=x.layout, device=x.device)
@@ -91,13 +94,13 @@ class Permute(Transform):
 
 def permute(input_dim, permutation=None):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.Permute` object for consistency with other
-    helpers.
+    A helper function to create a :class:`~pyro.distributions.transforms.Permute`
+    object for consistency with other helpers.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
-    :param permutation: Torch tensor of integer indices representing permutation. Defaults
-        to a random permutation.
+    :param permutation: Torch tensor of integer indices representing permutation.
+        Defaults to a random permutation.
     :type permutation: torch.LongTensor
 
     """

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -40,8 +40,8 @@ class ConditionedPlanar(Transform):
         :param x: the input into the bijection
         :type x: torch.Tensor
         Invokes the bijection x => y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
 
         # x ~ (batch_size, dim_size, 1)
@@ -61,9 +61,10 @@ class ConditionedPlanar(Transform):
         """
         :param y: the output of the bijection
         :type y: torch.Tensor
-        Inverts y => x. As noted above, this implementation is incapable of inverting arbitrary values
-        `y`; rather it assumes `y` is the result of a previously computed application of the bijector
-        to some `x` (which was cached on the forward call)
+        Inverts y => x. As noted above, this implementation is incapable of
+        inverting arbitrary values `y`; rather it assumes `y` is the result of a
+        previously computed application of the bijector to some `x` (which was
+        cached on the forward call)
         """
 
         raise KeyError("ConditionedPlanar object expected to find key in intermediates cache but didn't")
@@ -82,13 +83,14 @@ class Planar(ConditionedPlanar, TransformModule):
 
         :math:`\\mathbf{y} = \\mathbf{x} + \\mathbf{u}\\tanh(\\mathbf{w}^T\\mathbf{z}+b)`
 
-    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs, and the learnable parameters
-    are :math:`b\\in\\mathbb{R}`, :math:`\\mathbf{u}\\in\\mathbb{R}^D`, :math:`\\mathbf{w}\\in\\mathbb{R}^D` for input
-    dimension :math:`D`. For this to be an invertible transformation, the condition
-    :math:`\\mathbf{w}^T\\mathbf{u}>-1` is enforced.
+    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs,
+    and the learnable parameters are :math:`b\\in\\mathbb{R}`,
+    :math:`\\mathbf{u}\\in\\mathbb{R}^D`, :math:`\\mathbf{w}\\in\\mathbb{R}^D` for
+    input dimension :math:`D`. For this to be an invertible transformation, the
+    condition :math:`\\mathbf{w}^T\\mathbf{u}>-1` is enforced.
 
-    Together with :class:`~pyro.distributions.TransformedDistribution` this provides a way to create richer
-    variational approximations.
+    Together with :class:`~pyro.distributions.TransformedDistribution` this provides
+    a way to create richer variational approximations.
 
     Example usage:
 
@@ -97,20 +99,19 @@ class Planar(ConditionedPlanar, TransformModule):
     >>> pyro.module("my_transform", transform)  # doctest: +SKIP
     >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
-    The inverse of this transform does not possess an analytical solution and is left unimplemented. However,
-    the inverse is cached when the forward operation is called during sampling, and so samples drawn using
-    the planar transform can be scored.
+    The inverse of this transform does not possess an analytical solution and is
+    left unimplemented. However, the inverse is cached when the forward operation is
+    called during sampling, and so samples drawn using the planar transform can be
+    scored.
 
     :param input_dim: the dimension of the input (and output) variable.
     :type input_dim: int
 
     References:
 
-    Variational Inference with Normalizing Flows [arXiv:1505.05770]
-    Danilo Jimenez Rezende, Shakir Mohamed
+    [1] Danilo Jimenez Rezende, Shakir Mohamed. Variational Inference with
+    Normalizing Flows. [arXiv:1505.05770]
 
     """
 
@@ -142,14 +143,16 @@ class ConditionalPlanar(ConditionalTransformModule):
 
         :math:`\\mathbf{y} = \\mathbf{x} + \\mathbf{u}\\tanh(\\mathbf{w}^T\\mathbf{z}+b)`
 
-    where :math:`\\mathbf{x}` are the inputs with dimension :math:`D`, :math:`\\mathbf{y}` are the outputs,
-    and the pseudo-parameters :math:`b\\in\\mathbb{R}`, :math:`\\mathbf{u}\\in\\mathbb{R}^D`, and
-    :math:`\\mathbf{w}\\in\\mathbb{R}^D` are the output of a function, e.g. a NN, with input
-    :math:`z\\in\\mathbb{R}^{M}` representing the context variable to condition on. For this to be an
-    invertible transformation, the condition :math:`\\mathbf{w}^T\\mathbf{u}>-1` is enforced.
+    where :math:`\\mathbf{x}` are the inputs with dimension :math:`D`,
+    :math:`\\mathbf{y}` are the outputs, and the pseudo-parameters
+    :math:`b\\in\\mathbb{R}`, :math:`\\mathbf{u}\\in\\mathbb{R}^D`, and
+    :math:`\\mathbf{w}\\in\\mathbb{R}^D` are the output of a function, e.g. a NN,
+    with input :math:`z\\in\\mathbb{R}^{M}` representing the context variable to
+    condition on. For this to be an invertible transformation, the condition
+    :math:`\\mathbf{w}^T\\mathbf{u}>-1` is enforced.
 
-    Together with :class:`~pyro.distributions.ConditionalTransformedDistribution` this provides a way to create
-    richer variational approximations.
+    Together with :class:`~pyro.distributions.ConditionalTransformedDistribution`
+    this provides a way to create richer variational approximations.
 
     Example usage:
 
@@ -158,22 +161,25 @@ class ConditionalPlanar(ConditionalTransformModule):
     >>> context_dim = 5
     >>> batch_size = 3
     >>> base_dist = dist.Normal(torch.zeros(input_dim), torch.ones(input_dim))
-    >>> hypernet = DenseNN(context_dim, [50, 50], param_dims=[1, input_dim, input_dim])
+    >>> param_dims = [1, input_dim, input_dim]
+    >>> hypernet = DenseNN(context_dim, [50, 50], param_dims)
     >>> transform = ConditionalPlanar(hypernet)
     >>> z = torch.rand(batch_size, context_dim)
-    >>> flow_dist = dist.ConditionalTransformedDistribution(base_dist, [transform]).condition(z)
+    >>> flow_dist = dist.ConditionalTransformedDistribution(base_dist,
+    ... [transform]).condition(z)
     >>> flow_dist.sample(sample_shape=torch.Size([batch_size])) # doctest: +SKIP
 
-    The inverse of this transform does not possess an analytical solution and is left unimplemented. However,
-    the inverse is cached when the forward operation is called during sampling, and so samples drawn using
-    the planar transform can be scored.
+    The inverse of this transform does not possess an analytical solution and is
+    left unimplemented. However, the inverse is cached when the forward operation is
+    called during sampling, and so samples drawn using the planar transform can be
+    scored.
 
-    :param nn: a function inputting the context variable and outputting a triplet of real-valued parameters
-        of dimensions :math:`(1, D, D)`.
+    :param nn: a function inputting the context variable and outputting a triplet of
+        real-valued parameters of dimensions :math:`(1, D, D)`.
     :type nn: callable
 
     References:
-    Variational Inference with Normalizing Flows [arXiv:1505.05770]
+    [1] Variational Inference with Normalizing Flows [arXiv:1505.05770]
     Danilo Jimenez Rezende, Shakir Mohamed
 
     """
@@ -194,8 +200,8 @@ class ConditionalPlanar(ConditionalTransformModule):
 
 def planar(input_dim):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.Planar` object for consistency with other
-    helpers.
+    A helper function to create a :class:`~pyro.distributions.transforms.Planar`
+    object for consistency with other helpers.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
@@ -207,8 +213,9 @@ def planar(input_dim):
 
 def conditional_planar(input_dim, context_dim, hidden_dims=None):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.ConditionalPlanar` object that takes care of
-    constructing a dense network with the correct input/output dimensions.
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.ConditionalPlanar` object that takes care
+    of constructing a dense network with the correct input/output dimensions.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
@@ -217,7 +224,6 @@ def conditional_planar(input_dim, context_dim, hidden_dims=None):
     :param hidden_dims: The desired hidden dimensions of the dense network. Defaults
         to using [input_dim * 10, input_dim * 10]
     :type hidden_dims: list[int]
-
 
     """
 

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -15,16 +15,19 @@ from pyro.nn import AutoRegressiveNN
 @copy_docs_from(TransformModule)
 class Polynomial(TransformModule):
     """
-    An autoregressive bijective transform as described in Jaini et al. (2019) applying following equation element-wise,
+    An autoregressive bijective transform as described in Jaini et al. (2019)
+    applying following equation element-wise,
 
         :math:`y_n = c_n + \\int^{x_n}_0\\sum^K_{k=1}\\left(\\sum^R_{r=0}a^{(n)}_{r,k}u^r\\right)du`
 
-    where :math:`x_n` is the :math:`n`th input, :math:`y_n` is the :math:`n`th output, and :math:`c_n\\in\\mathbb{R}`,
-    :math:`\\left\\{a^{(n)}_{r,k}\\in\\mathbb{R}\\right\\}` are learnable parameters that are the output of an
-    autoregressive NN inputting :math:`x_{\\prec n}={x_1,x_2,\\ldots,x_{n-1}}`.
+    where :math:`x_n` is the :math:`n`th input, :math:`y_n` is the :math:`n`th
+    output, and :math:`c_n\\in\\mathbb{R}`,
+    :math:`\\left\\{a^{(n)}_{r,k}\\in\\mathbb{R}\\right\\}` are learnable parameters
+    that are the output of an autoregressive NN inputting
+    :math:`x_{\\prec n}={x_1,x_2,\\ldots,x_{n-1}}`.
 
-    Together with :class:`~pyro.distributions.TransformedDistribution` this provides a way to create richer
-    variational approximations.
+    Together with :class:`~pyro.distributions.TransformedDistribution` this provides
+    a way to create richer variational approximations.
 
     Example usage:
 
@@ -33,30 +36,35 @@ class Polynomial(TransformModule):
     >>> count_degree = 4
     >>> count_sum = 3
     >>> base_dist = dist.Normal(torch.zeros(input_dim), torch.ones(input_dim))
-    >>> arn = AutoRegressiveNN(input_dim, [input_dim*10], param_dims=[(count_degree + 1)*count_sum])
-    >>> transform = Polynomial(arn, input_dim=input_dim, count_degree=count_degree, count_sum=count_sum)
+    >>> param_dims = [(count_degree + 1)*count_sum]
+    >>> arn = AutoRegressiveNN(input_dim, [input_dim*10], param_dims)
+    >>> transform = Polynomial(arn, input_dim=input_dim, count_degree=count_degree,
+    ... count_sum=count_sum)
     >>> pyro.module("my_transform", transform)  # doctest: +SKIP
     >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
-    The inverse of this transform does not possess an analytical solution and is left unimplemented. However,
-    the inverse is cached when the forward operation is called during sampling, and so samples drawn using
-    a polynomial transform can be scored.
+    The inverse of this transform does not possess an analytical solution and is
+    left unimplemented. However, the inverse is cached when the forward operation is
+    called during sampling, and so samples drawn using a polynomial transform can be
+    scored.
 
-    :param autoregressive_nn: an autoregressive neural network whose forward call returns a tensor of real-valued
+    :param autoregressive_nn: an autoregressive neural network whose forward call
+        returns a tensor of real-valued
         numbers of size (batch_size, (count_degree+1)*count_sum, input_dim)
     :type autoregressive_nn: nn.Module
-    :param count_degree: The degree of the polynomial to use for each element-wise transformation.
+    :param count_degree: The degree of the polynomial to use for each element-wise
+        transformation.
     :type count_degree: int
-    :param count_sum: The number of polynomials to sum in each element-wise transformation.
+    :param count_sum: The number of polynomials to sum in each element-wise
+        transformation.
     :type count_sum: int
 
     References:
 
-    Sum-of-squares polynomial flow. [arXiv:1905.02325]
-    Priyank Jaini, Kira A. Shelby, Yaoliang Yu
+    [1] Priyank Jaini, Kira A. Shelby, Yaoliang Yu. Sum-of-squares polynomial flow.
+    [arXiv:1905.02325]
+
     """
 
     domain = constraints.real
@@ -99,8 +107,8 @@ class Polynomial(TransformModule):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         # Calculate the polynomial coefficients
         # ~ (batch_size, count_sum, count_degree+1, input_dim)
@@ -130,9 +138,10 @@ class Polynomial(TransformModule):
         :param y: the output of the bijection
         :type y: torch.Tensor
 
-        Inverts y => x. As noted above, this implementation is incapable of inverting arbitrary values
-        `y`; rather it assumes `y` is the result of a previously computed application of the bijector
-        to some `x` (which was cached on the forward call)
+        Inverts y => x. As noted above, this implementation is incapable of
+        inverting arbitrary values `y`; rather it assumes `y` is the result of a
+        previously computed application of the bijector to some `x` (which was
+        cached on the forward call)
         """
 
         raise KeyError("Polynomial object expected to find key in intermediates cache but didn't")
@@ -146,13 +155,14 @@ class Polynomial(TransformModule):
 
 def polynomial(input_dim, hidden_dims=None):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.Polynomial` object that takes care of
-    constructing an autoregressive network with the correct input/output dimensions.
+    A helper function to create a :class:`~pyro.distributions.transforms.Polynomial`
+    object that takes care of constructing an autoregressive network with the
+    correct input/output dimensions.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
-    :param hidden_dims: The desired hidden dimensions of of the autoregressive network. Defaults
-        to using [input_dim * 10]
+    :param hidden_dims: The desired hidden dimensions of of the autoregressive
+        network. Defaults to using [input_dim * 10]
 
     """
 

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -63,9 +63,10 @@ class ConditionedRadial(Transform):
         """
         :param y: the output of the bijection
         :type y: torch.Tensor
-        Inverts y => x. As noted above, this implementation is incapable of inverting arbitrary values
-        `y`; rather it assumes `y` is the result of a previously computed application of the bijector
-        to some `x` (which was cached on the forward call)
+        Inverts y => x. As noted above, this implementation is incapable of
+        inverting arbitrary values `y`; rather it assumes `y` is the result of a
+        previously computed application of the bijector to some `x` (which was
+        cached on the forward call)
         """
 
         raise KeyError("ConditionedRadial object expected to find key in intermediates cache but didn't")
@@ -84,13 +85,15 @@ class Radial(ConditionedRadial, TransformModule):
 
         :math:`\\mathbf{y} = \\mathbf{x} + \\beta h(\\alpha,r)(\\mathbf{x} - \\mathbf{x}_0)`
 
-    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs, and the learnable parameters
-    are :math:`\\alpha\\in\\mathbb{R}^+`, :math:`\\beta\\in\\mathbb{R}`, :math:`\\mathbf{x}_0\\in\\mathbb{R}^D`,
-    for input dimension :math:`D`, :math:`r=||\\mathbf{x}-\\mathbf{x}_0||_2`, :math:`h(\\alpha,r)=1/(\\alpha+r)`.
-    For this to be an invertible transformation, the condition :math:`\\beta>-\\alpha` is enforced.
+    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs,
+    and the learnable parameters are :math:`\\alpha\\in\\mathbb{R}^+`,
+    :math:`\\beta\\in\\mathbb{R}`, :math:`\\mathbf{x}_0\\in\\mathbb{R}^D`, for input
+    dimension :math:`D`, :math:`r=||\\mathbf{x}-\\mathbf{x}_0||_2`,
+    :math:`h(\\alpha,r)=1/(\\alpha+r)`. For this to be an invertible transformation,
+    the condition :math:`\\beta>-\\alpha` is enforced.
 
-    Together with :class:`~pyro.distributions.TransformedDistribution` this provides a way to create richer
-    variational approximations.
+    Together with :class:`~pyro.distributions.TransformedDistribution` this provides
+    a way to create richer variational approximations.
 
     Example usage:
 
@@ -99,20 +102,19 @@ class Radial(ConditionedRadial, TransformModule):
     >>> pyro.module("my_transform", transform)  # doctest: +SKIP
     >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
     >>> flow_dist.sample()  # doctest: +SKIP
-        tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
-                0.1389, -0.4629,  0.0986])
 
-    The inverse of this transform does not possess an analytical solution and is left unimplemented. However,
-    the inverse is cached when the forward operation is called during sampling, and so samples drawn using
-    the radial transform can be scored.
+    The inverse of this transform does not possess an analytical solution and is
+    left unimplemented. However, the inverse is cached when the forward operation is
+    called during sampling, and so samples drawn using the radial transform can be
+    scored.
 
     :param input_dim: the dimension of the input (and output) variable.
     :type input_dim: int
 
     References:
 
-    Variational Inference with Normalizing Flows [arXiv:1505.05770]
-    Danilo Jimenez Rezende, Shakir Mohamed
+    [1] Danilo Jimenez Rezende, Shakir Mohamed. Variational Inference with
+    Normalizing Flows. [arXiv:1505.05770]
 
     """
 
@@ -155,8 +157,8 @@ class ConditionalRadial(ConditionalTransformModule):
 
 def radial(input_dim):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.Radial` object for consistency with other
-    helpers.
+    A helper function to create a :class:`~pyro.distributions.transforms.Radial`
+    object for consistency with other helpers.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
@@ -168,8 +170,9 @@ def radial(input_dim):
 
 def conditional_radial(input_dim, context_dim, hidden_dims=None):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.ConditionalRadial` object that takes care of
-    constructing a dense network with the correct input/output dimensions.
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.ConditionalRadial` object that takes care
+    of constructing a dense network with the correct input/output dimensions.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -13,20 +13,23 @@ from pyro.distributions.util import copy_docs_from
 @copy_docs_from(TransformModule)
 class Sylvester(Householder):
     """
-    An implementation of the Sylvester bijective transform of the Householder variety (Van den Berg Et Al., 2018),
+    An implementation of the Sylvester bijective transform of the Householder
+    variety (Van den Berg Et Al., 2018),
 
         :math:`\\mathbf{y} = \\mathbf{x} + QR\\tanh(SQ^T\\mathbf{x}+\\mathbf{b})`
 
-    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs, :math:`R,S\\sim D\\times D`
-    are upper triangular matrices for input dimension :math:`D`, :math:`Q\\sim D\\times D` is an orthogonal
-    matrix, and :math:`\\mathbf{b}\\sim D` is learnable bias term.
+    where :math:`\\mathbf{x}` are the inputs, :math:`\\mathbf{y}` are the outputs,
+    :math:`R,S\\sim D\\times D` are upper triangular matrices for input dimension
+    :math:`D`, :math:`Q\\sim D\\times D` is an orthogonal matrix, and
+    :math:`\\mathbf{b}\\sim D` is learnable bias term.
 
-    The Sylvester transform is a generalization of :class:`~pyro.distributions.transforms.Planar`. In the
-    Householder type of the Sylvester transform, the orthogonality of :math:`Q` is enforced by representing it as
-    the product of Householder transformations.
+    The Sylvester transform is a generalization of
+    :class:`~pyro.distributions.transforms.Planar`. In the Householder type of the
+    Sylvester transform, the orthogonality of :math:`Q` is enforced by representing
+    it as the product of Householder transformations.
 
-    Together with :class:`~pyro.distributions.TransformedDistribution` it provides a way to create richer
-    variational approximations.
+    Together with :class:`~pyro.distributions.TransformedDistribution` it provides a
+    way to create richer variational approximations.
 
     Example usage:
 
@@ -38,15 +41,15 @@ class Sylvester(Householder):
         tensor([-0.4071, -0.5030,  0.7924, -0.2366, -0.2387, -0.1417,  0.0868,
                 0.1389, -0.4629,  0.0986])
 
-    The inverse of this transform does not possess an analytical solution and is left unimplemented. However,
-    the inverse is cached when the forward operation is called during sampling, and so samples drawn using
-    the Sylvester transform can be scored.
+    The inverse of this transform does not possess an analytical solution and is
+    left unimplemented. However, the inverse is cached when the forward operation is
+    called during sampling, and so samples drawn using the Sylvester transform can
+    be scored.
 
     References:
 
-    Rianne van den Berg, Leonard Hasenclever, Jakub M. Tomczak, Max Welling. Sylvester Normalizing Flows for
-    Variational Inference. In proceedings of The 34th Conference on Uncertainty in Artificial Intelligence
-    (UAI 2018).
+    [1] Rianne van den Berg, Leonard Hasenclever, Jakub M. Tomczak, Max Welling.
+    Sylvester Normalizing Flows for Variational Inference. UAI 2018.
 
     """
 
@@ -107,8 +110,8 @@ class Sylvester(Householder):
         :type x: torch.Tensor
 
         Invokes the bijection x=>y; in the prototypical context of a
-        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from the base distribution (or the output
-        of a previous transform)
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
         """
         Q = self.Q(x)
         R = self.R()
@@ -127,9 +130,10 @@ class Sylvester(Householder):
         """
         :param y: the output of the bijection
         :type y: torch.Tensor
-        Inverts y => x. As noted above, this implementation is incapable of inverting arbitrary values
-        `y`; rather it assumes `y` is the result of a previously computed application of the bijector
-        to some `x` (which was cached on the forward call)
+        Inverts y => x. As noted above, this implementation is incapable of
+        inverting arbitrary values `y`; rather it assumes `y` is the result of a
+        previously computed application of the bijector to some `x` (which was
+        cached on the forward call)
         """
 
         raise KeyError("Sylvester object expected to find key in intermediates cache but didn't")
@@ -144,13 +148,13 @@ class Sylvester(Householder):
 
 def sylvester(input_dim, count_transforms=None):
     """
-    A helper function to create a :class:`~pyro.distributions.transforms.Sylvester` object for consistency with
-    other helpers.
+    A helper function to create a :class:`~pyro.distributions.transforms.Sylvester`
+    object for consistency with other helpers.
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
-    :param count_transforms: Number of Sylvester operations to apply. Defaults to input_dim // 2 + 1.
-    :type count_transforms: int
+    :param count_transforms: Number of Sylvester operations to apply. Defaults to
+        input_dim // 2 + 1. :type count_transforms: int
 
     """
 


### PR DESCRIPTION
The main purpose of this PR is to restrict the docstrings of `pyro.distributions.transforms` classes to be 80 chars long, for easy readability in Jupyter.

I have also made some other cosmetic changes like a consistent format for the references and removing the sample numbers after each code example in the docstring, which was the same for all transforms