### PR TITLE
Remove uses of `@torch.jit.script`

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -13,7 +13,7 @@ from pyro.ops.gaussian import Gaussian, gaussian_tensordot, matrix_and_mvn_to_ga
 from pyro.ops.tensor_utils import cholesky, cholesky_solve
 
 
-@torch.jit.script
+@torch.jit._script_if_tracing
 def _linear_integrate(init, trans, shift):
     """
     Integrate the inhomogeneous linear shifterence equation::
@@ -43,7 +43,7 @@ def _logmatmulexp(x, y):
     return xy + x_shift + y_shift
 
 
-@torch.jit.script
+@torch.jit._script_if_tracing
 def _sequential_logmatmulexp(logits):
     """
     For a tensor ``x`` whose time dimension is -3, computes::


### PR DESCRIPTION
This changes uses of `@torch.jit.script` to `@torch.jit._script_if_tracing`. The TorchScript compiler has a lot of lazy static initialization, so including these decorators will impact the time to execute `import pyro` for everyone, not just jit users. https://github.com/pytorch/pytorch/pull/34935 added a workaround for this so that if a function has this lazy script decorator, it can still be used to handle control flow in tracing.

cc @fritzo 