### PR TITLE
Allow unused params in CSIS inference

### DIFF
--- a/pyro/infer/csis.py
+++ b/pyro/infer/csis.py
@@ -111,7 +111,7 @@ class CSIS(Importance):
             if grads:
                 guide_params = set(site["value"].unconstrained()
                                    for site in particle_param_capture.trace.nodes.values())
-                guide_grads = torch.autograd.grad(particle_loss, guide_params)
+                guide_grads = torch.autograd.grad(particle_loss, guide_params, allow_unused=True)
                 for guide_grad, guide_param in zip(guide_grads, guide_params):
                     guide_param.grad = guide_grad if guide_param.grad is None else guide_param.grad + guide_grad
 


### PR DESCRIPTION
Addresses a comment on the forum
https://forum.pyro.ai/t/how-to-turn-on-allow-unused-true-through-pyro/1725