### PR TITLE
Add super().__init__() call to Rejector

### DIFF
--- a/pyro/distributions/rejector.py
+++ b/pyro/distributions/rejector.py
@@ -18,12 +18,19 @@ class Rejector(TorchDistribution):
         proposals and returns a batch of log acceptance probabilities.
     :param log_scale: Total log probability of acceptance.
     """
+    arg_constraints = {}
     has_rsample = True
 
-    def __init__(self, propose, log_prob_accept, log_scale):
+    def __init__(self, propose, log_prob_accept, log_scale, *,
+                 batch_shape=None, event_shape=None):
         self.propose = propose
         self.log_prob_accept = log_prob_accept
         self._log_scale = log_scale
+        if batch_shape is None:
+            batch_shape = propose.batch_shape
+        if event_shape is None:
+            event_shape = propose.event_shape
+        super().__init__(batch_shape, event_shape)
 
         # These LRU(1) caches allow work to be shared across different method calls.
         self._log_prob_accept_cache = None, None

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -39,7 +39,8 @@ class RejectionStandardGamma(Rejector):
         # Compute log scale using Gamma.log_prob().
         x = new._d.detach()  # just an arbitrary x.
         log_scale = new.propose_log_prob(x) + new.log_prob_accept(x) - new.log_prob(x)
-        super(RejectionStandardGamma, new).__init__(new.propose, new.log_prob_accept, log_scale)
+        super(RejectionStandardGamma, new).__init__(new.propose, new.log_prob_accept, log_scale,
+                                                    batch_shape=batch_shape, event_shape=())
         new._validate_args = self._validate_args
         return new
 

--- a/pyro/distributions/testing/rejection_gamma.py
+++ b/pyro/distributions/testing/rejection_gamma.py
@@ -26,7 +26,8 @@ class RejectionStandardGamma(Rejector):
         # Compute log scale using Gamma.log_prob().
         x = self._d.detach()  # just an arbitrary x.
         log_scale = self.propose_log_prob(x) + self.log_prob_accept(x) - self.log_prob(x)
-        super().__init__(self.propose, self.log_prob_accept, log_scale)
+        super().__init__(self.propose, self.log_prob_accept, log_scale,
+                         batch_shape=concentration.shape, event_shape=())
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(RejectionStandardGamma, _instance)


### PR DESCRIPTION
Fixes a bug noticed by @dobos here: https://github.com/pyro-ppl/pyro/issues/790#issuecomment-605084361

## Breaking change

This will break some code, as in e.g. `RejectionStandardGamma`, but I see no way of obtaining the needed shape metadata without a little breakage.

## Tested
- refactoring is covered by existing tests