### PR TITLE
Fix .travis.yml to use sourceline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 addons:
     apt:
         sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
         packages:
             - gcc-8
             - g++-8


### PR DESCRIPTION
Blocking #2393 

As suggested here
https://travis-ci.community/t/disallowing-sources-ubuntu-toolchain-r-test-started-to-appear-recently/7971

Ready to merge if build succeeds.