### PR TITLE
Patch so that `cache_size=1` is default in `torch.distributions.transforms.Transform` and elsewhere

### DIFF
--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -21,7 +21,7 @@ class DiscreteCosineTransform(Transform):
     codomain = constraints.real
     bijective = True
 
-    def __init__(self, dim=-1, cache_size=0):
+    def __init__(self, dim=-1, cache_size=1):
         assert isinstance(dim, int) and dim < 0
         self.event_dim = -dim
         super().__init__(cache_size=cache_size)

--- a/pyro/distributions/transforms/lower_cholesky_affine.py
+++ b/pyro/distributions/transforms/lower_cholesky_affine.py
@@ -28,8 +28,8 @@ class LowerCholeskyAffine(Transform):
     event_dim = 1
     volume_preserving = False
 
-    def __init__(self, loc, scale_tril):
-        super().__init__(cache_size=1)
+    def __init__(self, loc, scale_tril, cache_size=1):
+        super().__init__(cache_size=cache_size)
         self.loc = loc
         self.scale_tril = scale_tril
         assert loc.size(-1) == scale_tril.size(-1) == scale_tril.size(-2), \


### PR DESCRIPTION
This PR addresses #2076  

Essentially, when you compose a transform that requires caching for its inverse, and some of the element-wise transforms from PyTorch you can get into strife because the latter don't always do caching by default, and some don't even give you the option of setting caching (e.g. `TanhTransform` and `SigmoidTransform`)!

Here is an example of code that will raise an exception without the patches to the PyTorch transform module:

```py
import torch
import pyro.distributions as dist
import pyro.distributions.transforms as T

torch.manual_seed(0)
dim = 2
mu = torch.zeros(dim)
log_std = torch.zeros(dim)
transforms = [T.Sylvester(input_dim=dim), T.TanhTransform()]
d = dist.TransformedDistribution(dist.Normal(mu, log_std.exp()), transforms)

y = d.sample()
print(d.log_prob(y))

```

I add the discussion label because I just want to run past @fritzo, do you think it's okay to set `Transform` to do caching by default, rather than adding a `cache_size=1` keyword argument to every element-wise transform?