### PR TITLE
Support use of PyroParam and PyroSample as decorators

### DIFF
--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -25,7 +25,7 @@ from pyro.poutine.runtime import _PYRO_PARAM_STORE
 class PyroParam(namedtuple("PyroParam", ("init_value", "constraint", "event_dim"))):
     """
     Declares a Pyro-managed learnable attribute of a :class:`PyroModule`,
-    similar to :func:`pyro.param`.
+    similar to :func:`pyro.param <pyro.primitives.param>`.
 
     This can be used either to set attributes of :class:`PyroModule`
     instances::
@@ -89,7 +89,7 @@ PyroParam.__new__.__defaults__ = (None, constraints.real, None)
 class PyroSample(namedtuple("PyroSample", ("prior",))):
     """
     Declares a Pyro-managed random attribute of a :class:`PyroModule`, similar
-    to :func:`pyro.sample`.
+    to :func:`pyro.sample <pyro.primitives.sample>`.
 
     This can be used either to set attributes of :class:`PyroModule`
     instances::
@@ -215,7 +215,8 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
     To create a Pyro-managed parameter attribute, set that attribute using
     either :class:`torch.nn.Parameter` (for unconstrained parameters) or
     :class:`PyroParam` (for constrained parameters). Reading that attribute
-    will then trigger a :func:`pyro.param` statement. For example::
+    will then trigger a :func:`pyro.param <pyro.primitives.param>` statement.
+    For example::
 
         # Create Pyro-managed parameter attributes.
         my_module = PyroModule()
@@ -227,13 +228,13 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
         scale = my_module.scale  # Triggers another pyro.param statement.
 
     Note that, unlike normal :class:`torch.nn.Module` s, :class:`PyroModule` s
-    should not be registered with :func:`pyro.module` statements.
-    :class:`PyroModule` s can contain other :class:`PyroModule` s and normal
-    :class:`torch.nn.Module` s.  Accessing a normal :class:`torch.nn.Module`
-    attribute of a :class:`PyroModule` triggers a :func:`pyro.module`
-    statement.  If multiple :class:`PyroModule` s appear in a single Pyro model
-    or guide, they should be included in a single root :class:`PyroModule` for
-    that model.
+    should not be registered with :func:`pyro.module <pyro.primitives.module>`
+    statements.  :class:`PyroModule` s can contain other :class:`PyroModule` s
+    and normal :class:`torch.nn.Module` s.  Accessing a normal
+    :class:`torch.nn.Module` attribute of a :class:`PyroModule` triggers a
+    :func:`pyro.module <pyro.primitives.module>` statement.  If multiple
+    :class:`PyroModule` s appear in a single Pyro model or guide, they should
+    be included in a single root :class:`PyroModule` for that model.
 
     :class:`PyroModule` s synchronize data with the param store at each
     ``setattr``, ``getattr``, and ``delattr`` event, based on the nested name
@@ -268,7 +269,8 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
 
     To create a Pyro-managed random attribute, set that attribute using the
     :class:`PyroSample` helper, specifying a prior distribution. Reading that
-    attribute will then trigger a :func:`pyro.sample` statement. For example::
+    attribute will then trigger a :func:`pyro.sample <pyro.primitives.sample>`
+    statement. For example::
 
         # Create Pyro-managed random attributes.
         my_module.x = PyroSample(dist.Normal(0, 1))

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -13,7 +13,6 @@ the :class:`PyroSample` struct::
 
 """
 import functools
-import inspect
 from collections import OrderedDict, namedtuple
 
 import torch
@@ -123,8 +122,6 @@ class PyroSample(namedtuple("PyroSample", ("prior",))):
     def __init__(self, prior):
         super().__init__()
         if not hasattr(prior, "sample"):  # if not a distribution
-            assert len(inspect.signature(prior).parameters) == 1, \
-                "prior should take the single argument 'self'"
             # Ensure decorated function is accessible for pickling.
             self.name = prior.__name__
             prior.__name__ = "_pyro_prior_" + prior.__name__

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -77,7 +77,7 @@ class PyroParam(namedtuple("PyroParam", ("init_value", "constraint", "event_dim"
             setattr(obj, name, PyroParam(init_value, constraint, event_dim))
         return obj.__getattr__(name)
 
-    # Support decoration with kwargs, like @PyroParam(event_dim=0).
+    # Support decoration with optional kwargs, e.g. @PyroParam(event_dim=0).
     def __call__(self, init_value):
         assert self.init_value is None
         return PyroParam(init_value, self.constraint, self.event_dim)
@@ -88,7 +88,7 @@ PyroParam.__new__.__defaults__ = (None, constraints.real, None)
 
 class PyroSample(namedtuple("PyroSample", ("prior",))):
     """
-    Declare a Pyro-managed random attribute of a :class:`PyroModule`, similar
+    Declares a Pyro-managed random attribute of a :class:`PyroModule`, similar
     to :func:`pyro.sample`.
 
     This can be used either to set attributes of :class:`PyroModule`

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -144,7 +144,7 @@ class ParamStoreDict:
         :param init_constrained_value: initial constrained value
         :type init_constrained_value: torch.Tensor or callable returning a torch.Tensor
         :param constraint: torch constraint object
-        :type constraint: torch.distributions.constraints.Constraint
+        :type constraint: ~torch.distributions.constraints.Constraint
         :returns: constrained parameter value
         :rtype: torch.Tensor
         """


### PR DESCRIPTION
Addresses #2161 

See [generated docs](http://fritzo.org/temp/pyro/html/nn.html#pyro.nn.module.PyroParam).

This adds the ability to use `@PyroParam` and `@PyroSample` as decorators of methods of a `PyroModule` subclass. For example
```py
class Model(PyroModule):
    def __init__(self, size):
        super().__init__()
        self.size = size

    @PyroParam(constraint=constraints.real)
    def scale(self):
        return torch.ones(self.size)  # initial value

    @PyroSample
    def loc(self):
        return dist.Normal(0, 1)

    def forward(self, data):
        obs_dist = dist.Normal(self.loc, self.scale).to_event(1)
        with pyro.plate("data", len(data)):
            pyro.sample("obs", obs_dist, obs=data)
```

This requires remarkably little code beyond our existing `PyroParam` and `PyroSample` behavior. Most of the changes are documentation. I'll add more docs to the `PyroModule` tutorial after #2403 merges.

## Tested
- [x] smoke tests with shape checks
- [x] serialization test for `DecoratorModel`
- [x] added an assertion to check sample function arg signature