### PR TITLE
Allow bounded support in DiscreteCosineReparam

### DIFF
--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -38,6 +38,8 @@ class DiscreteCosineReparam(Reparam):
                                            "try converting a batch dimension to an event dimension")
 
         # Draw noise from the base distribution.
+        # TODO Use biject_to(fn.support).inv.with_cache(1) once the following merges:
+        # https://github.com/probtorch/pytorch/pull/153
         transform = ComposeTransform([biject_to(fn.support).inv,
                                       DiscreteCosineTransform(dim=self.dim, cache_size=1)])
         x_dct = pyro.sample("{}_dct".format(name),

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -1,6 +1,9 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from torch.distributions import biject_to
+from torch.distributions.transforms import ComposeTransform
+
 import pyro
 import pyro.distributions as dist
 from pyro.distributions.transforms.discrete_cosine import DiscreteCosineTransform
@@ -35,7 +38,8 @@ class DiscreteCosineReparam(Reparam):
                                            "try converting a batch dimension to an event dimension")
 
         # Draw noise from the base distribution.
-        transform = DiscreteCosineTransform(dim=self.dim, cache_size=1)
+        transform = ComposeTransform([biject_to(fn.support).inv,
+                                      DiscreteCosineTransform(dim=self.dim, cache_size=1)])
         x_dct = pyro.sample("{}_dct".format(name),
                             dist.TransformedDistribution(fn, transform))
 

--- a/tests/infer/reparam/test_discrete_cosine.py
+++ b/tests/infer/reparam/test_discrete_cosine.py
@@ -55,3 +55,28 @@ def test_normal(shape, dim):
         actual_grads = grad(actual_m.sum(), [loc, scale], retain_graph=True)
         assert_close(actual_grads[0], expected_grads[0], atol=0.05)
         assert_close(actual_grads[1], expected_grads[1], atol=0.05)
+
+
+@pytest.mark.parametrize("shape,dim", [
+    ((6,), -1),
+    ((2, 5,), -1),
+    ((4, 2), -2),
+    ((2, 3, 1), -2),
+], ids=str)
+def test_uniform(shape, dim):
+
+    def model():
+        with pyro.plate_stack("plates", shape[:dim]):
+            with pyro.plate("particles", 10000):
+                pyro.sample("x", dist.Uniform(0, 1).expand(shape).to_event(-dim))
+
+    value = poutine.trace(model).get_trace().nodes["x"]["value"]
+    expected_probe = get_moments(value)
+
+    reparam_model = poutine.reparam(model, {"x": DiscreteCosineReparam(dim=dim)})
+    trace = poutine.trace(reparam_model).get_trace()
+    assert isinstance(trace.nodes["x_dct"]["fn"], dist.TransformedDistribution)
+    assert isinstance(trace.nodes["x"]["fn"], dist.Delta)
+    value = trace.nodes["x"]["value"]
+    actual_probe = get_moments(value)
+    assert_close(actual_probe, expected_probe, atol=0.1)


### PR DESCRIPTION
This adds support for bounded domains to `DiscreteCosineReparam`.

The motivation is to use `DiscreteCosineReparam` in compartmental models, whose latent variables have support `positive` or `interval(0, population)`. After this PR, those variables will be exp- or sigmoid- transformed to match the DCT domain of `real`.

## Tested
- [x] added a moment test with `Uniform`