### PR TITLE
Expose initialization strategy in HMC

### DIFF
--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -6,7 +6,9 @@ from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta
                                          AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
                                          AutoMultivariateNormal, AutoNormal, AutoNormalizingFlow)
 from pyro.infer.autoguide.utils import mean_field_entropy
-from pyro.infer.autoguide.initialization import init_to_feasible, init_to_mean, init_to_median, init_to_sample
+from pyro.infer.autoguide.initialization import (init_to_feasible, init_to_mean, init_to_median,
+                                                 init_to_sample, init_to_uniform, init_to_value)
+
 
 __all__ = [
     'AutoCallable',

--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -26,5 +26,7 @@ __all__ = [
     'init_to_mean',
     'init_to_median',
     'init_to_sample',
+    'init_to_uniform',
+    'init_to_value',
     'mean_field_entropy',
 ]

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -100,7 +100,10 @@ def init_to_value(site, values={}):
 
     :param dict values: dictionary of initial values keyed by site name.
     """
-    return values[site["name"]] if site["name"] not in values else init_to_uniform(site)
+    if site["name"] in values:
+        return values[site["name"]]
+    else:
+        return init_to_uniform(site)
 
 
 class InitMessenger(Messenger):

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -82,6 +82,27 @@ def init_to_mean(site):
         return init_to_median(site)
 
 
+def init_to_uniform(site, radius=2):
+    """
+    Initialize to a random point in the area `(-radius, radius)` of unconstrained domain.
+
+    :param float radius: specifies the range to draw an initial point in the unconstrained domain.
+    """
+    value = site["fn"].sample().detach()
+    t = transform_to(site["fn"].support)
+    return t(torch.rand_like(t.inv(value)) * (2 * radius) - radius)
+
+
+def init_to_value(site, values={}):
+    """
+    Initialize to the value specified in `values`. We defer to
+    :func:`init_to_uniform` strategy for sites which do not appear in `values`.
+
+    :param dict values: dictionary of initial values keyed by site name.
+    """
+    return values[site["name"]] if site["name"] not in values else init_to_uniform(site)
+
+
 class InitMessenger(Messenger):
     """
     Initializes a site by replacing ``.sample()`` calls with values

--- a/pyro/infer/mcmc/nuts.py
+++ b/pyro/infer/mcmc/nuts.py
@@ -8,6 +8,7 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro.distributions.util import scalar_like
+from pyro.infer.autoguide import init_to_uniform
 from pyro.infer.mcmc.hmc import HMC
 from pyro.ops.integrator import velocity_verlet
 from pyro.util import optional, torch_isnan
@@ -95,6 +96,8 @@ class NUTS(HMC):
         so the sampling will be slower but more robust. Default to 0.8.
     :param int max_tree_depth: Max depth of the binary tree created during the doubling
         scheme of NUTS sampler. Default to 10.
+    :param callable init_strategy: A per-site initialization function.
+        See :ref:`autoguide-initialization` section for available functions.
 
     Example:
 
@@ -130,7 +133,8 @@ class NUTS(HMC):
                  jit_options=None,
                  ignore_jit_warnings=False,
                  target_accept_prob=0.8,
-                 max_tree_depth=10):
+                 max_tree_depth=10,
+                 init_strategy=init_to_uniform):
         super().__init__(model,
                          potential_fn,
                          step_size,
@@ -142,7 +146,8 @@ class NUTS(HMC):
                          jit_compile=jit_compile,
                          jit_options=jit_options,
                          ignore_jit_warnings=ignore_jit_warnings,
-                         target_accept_prob=target_accept_prob)
+                         target_accept_prob=target_accept_prob,
+                         init_strategy=init_strategy)
         self.use_multinomial_sampling = use_multinomial_sampling
         self._max_tree_depth = max_tree_depth
         # There are three conditions to stop doubling process:

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -14,10 +14,9 @@ from opt_einsum import shared_intermediates
 
 import pyro
 import pyro.poutine as poutine
-import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape, logsumexp
 from pyro.infer import config_enumerate
-from pyro.infer.autoguide import init_to_uniform
+from pyro.infer.autoguide.initialization import InitMessenger, init_to_uniform
 from pyro.infer.util import is_validation_enabled
 from pyro.ops import stats
 from pyro.ops.contract import contract_to_tensor
@@ -300,9 +299,9 @@ class _PEMaker:
         return self._potential_fn
 
 
-def find_valid_initial_params(model, model_args, model_kwargs, transforms, potential_fn,
-                              prototype_params, max_tries_initial_params=100, num_chains=1,
-                              init_strategy=init_to_uniform):
+def _find_valid_initial_params(model, model_args, model_kwargs, transforms, potential_fn,
+                               prototype_params, max_tries_initial_params=100, num_chains=1,
+                               init_strategy=init_to_uniform):
     params = prototype_params
 
     # For empty models, exit early
@@ -311,14 +310,11 @@ def find_valid_initial_params(model, model_args, model_kwargs, transforms, poten
 
     params_per_chain = defaultdict(list)
     num_found = 0
+    model = InitMessenger(init_strategy)(model)
     for attempt in range(num_chains * max_tries_initial_params):
-        if strategy == "uniform":
-            params = {k: dist.Uniform(v.new_full(v.shape, -2), v.new_full(v.shape, 2)).sample()
-                      for k, v in params.items()}
-        elif strategy == "prior":
-            trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
-            samples = {name: trace.nodes[name]["value"].detach() for name in params}
-            params = {k: transforms[k](v) for k, v in samples.items()}
+        trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
+        samples = {name: trace.nodes[name]["value"].detach() for name in params}
+        params = {k: transforms[k](v) for k, v in samples.items()}
         pe_grad, pe = potential_grad(potential_fn, params)
 
         if torch.isfinite(pe) and all(map(torch.all, map(torch.isfinite, pe_grad.values()))):
@@ -334,7 +330,8 @@ def find_valid_initial_params(model, model_args, model_kwargs, transforms, poten
 
 
 def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max_plate_nesting=None,
-                     jit_compile=False, jit_options=None, skip_jit_warnings=False, num_chains=1):
+                     jit_compile=False, jit_options=None, skip_jit_warnings=False, num_chains=1,
+                     init_strategy=init_to_uniform):
     """
     Given a Python callable with Pyro primitives, generates the following model-specific
     properties needed for inference using HMC/NUTS kernels:
@@ -365,6 +362,8 @@ def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max
         tracer when ``jit_compile=True``. Default is False.
     :param int num_chains: Number of parallel chains. If `num_chains > 1`,
         the returned `initial_params` will be a list with `num_chains` elements.
+    :param callable init_strategy: A per-site initialization function.
+        See :ref:`autoguide-initialization` section for available functions.
     :returns: a tuple of (`initial_params`, `potential_fn`, `transforms`, `prototype_trace`)
     """
     # XXX `transforms` domains are sites' supports
@@ -408,8 +407,9 @@ def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max
 
     # Note that we deliberately do not exercise jit compilation here so as to
     # enable potential_fn to be picklable (a torch._C.Function cannot be pickled).
-    init_params = _get_init_params(model, model_args, model_kwargs, transforms,
-                                   pe_maker.get_potential_fn(), prototype_params, num_chains=num_chains)
+    init_params = _find_valid_initial_params(model, model_args, model_kwargs, transforms,
+                                             pe_maker.get_potential_fn(), prototype_params,
+                                             num_chains=num_chains, init_strategy=init_strategy)
     potential_fn = pe_maker.get_potential_fn(jit_compile, skip_jit_warnings, jit_options)
     return init_params, potential_fn, transforms, model_trace
 

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -17,6 +17,7 @@ import pyro.poutine as poutine
 import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape, logsumexp
 from pyro.infer import config_enumerate
+from pyro.infer.autoguide import init_to_uniform
 from pyro.infer.util import is_validation_enabled
 from pyro.ops import stats
 from pyro.ops.contract import contract_to_tensor
@@ -299,9 +300,9 @@ class _PEMaker:
         return self._potential_fn
 
 
-# TODO: expose init_strategy using separate functions.
-def _get_init_params(model, model_args, model_kwargs, transforms, potential_fn, prototype_params,
-                     max_tries_initial_params=100, num_chains=1, strategy="uniform"):
+def find_valid_initial_params(model, model_args, model_kwargs, transforms, potential_fn,
+                              prototype_params, max_tries_initial_params=100, num_chains=1,
+                              init_strategy=init_to_uniform):
     params = prototype_params
     params_per_chain = defaultdict(list)
     n = 0

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -103,8 +103,8 @@ def test_mcmc_interface(num_draws, group_by_chain, num_chains):
         samples = {k: v.reshape((-1,) + v.shape[2:]) for k, v in samples.items()}
     sample_mean = samples['y'].mean()
     sample_std = samples['y'].std()
-    assert_close(sample_mean, torch.tensor(0.0), atol=0.05)
-    assert_close(sample_std, torch.tensor(1.0), atol=0.05)
+    assert_close(sample_mean, torch.tensor(0.0), atol=0.1)
+    assert_close(sample_std, torch.tensor(1.0), atol=0.1)
 
 
 @pytest.mark.parametrize("num_chains, cpu_count", [

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -1,12 +1,15 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from functools import partial
+
 import pytest
 import torch
 
 import pyro
 import pyro.distributions as dist
 from pyro.infer import Predictive
+from pyro.infer.autoguide import init_to_value
 from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.util import initialize_model
@@ -85,3 +88,13 @@ def test_model_with_subsample(subsample_size):
             mcmc.run()
     else:
         mcmc.run()
+
+
+def test_init_to_value():
+    def model():
+        pyro.sample("x", dist.LogNormal(0, 1))
+
+    value = torch.randn(()).exp() * 10
+    kernel = NUTS(model, init_strategy=partial(init_to_value, values={"x": value}))
+    kernel.setup(warmup_steps=10)
+    assert_close(value, kernel.initial_params['x'].exp())


### PR DESCRIPTION
Addresses part of https://github.com/pyro-ppl/pyro/issues/2415.

There is one issue is: if users want to change keywords of init strategies, they have to use `partial`, e.g. `partial(init_to_median, num_samples=20)`. I find that it is a bit inconvenient for users. In NumPyro, users can set `init_strategy=` `init_to_median(20)` or `init_to_uniform(3)`, `init_to_value({"x": 10})`, `init_to_feasible()`.