### PR TITLE
Fix backward printing in warn_if_nan, warn_if_inf

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,8 @@ def test_warn_if_nan():
         warnings.simplefilter("always")
         x = float('inf')
         msg = "example message"
-        util.warn_if_nan(x, msg)
+        y = util.warn_if_nan(x, msg)
+        assert y is x
         assert len(w) == 0
 
         x = float('nan')
@@ -53,7 +54,8 @@ def test_warn_if_inf():
         warnings.simplefilter("always")
         x = 3
         msg = "example message"
-        util.warn_if_inf(x, msg, allow_posinf=True, allow_neginf=True)
+        y = util.warn_if_inf(x, msg, allow_posinf=True, allow_neginf=True)
+        assert y is x
         assert len(w) == 0
         x = float('inf')
         util.warn_if_inf(x, msg, allow_posinf=True)


### PR DESCRIPTION
This ensures that backward nans warn with the correct (filename,lineno).

This also makes the `warn_if_*(-)` functions return their value, so it can be used in-line as in:
```diff
- x = y.log()
+ x = warn_if_nan(y.log())
```
and that line is now printed in the warning message.

This also updates to replace `float('inf')` with `math.inf`.

## Tested
- [x] verified output locally
- [x] updated tests