### PR TITLE
Implement safe_log() to avoid infinite gradients

### DIFF
--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import math
-
 import torch
 
 from pyro.ops.einsum.util import Tensordot

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import torch
 
 from pyro.ops.einsum.util import Tensordot
+from pyro.ops.tensor_utils import safe_log
 
 
 def transpose(a, axes):
@@ -46,7 +49,7 @@ def einsum(equation, *operands):
             shift = shift.permute(*(dims.index(dim) for dim in output))
         shifts.append(shift)
 
-    result = torch.einsum(equation, exp_operands).log()
+    result = safe_log(torch.einsum(equation, exp_operands))
     return sum(shifts + [result])
 
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -6,6 +6,26 @@ import math
 import torch
 
 
+class _SafeLog(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        ctx.save_for_backward(x)
+        return x.log()
+
+    @staticmethod
+    def backward(ctx, grad):
+        x, = ctx.saved_tensors
+        return grad / x.clamp(min=torch.finfo(x.dtype).eps)
+
+
+def safe_log(x):
+    """
+    Like :func:`torch.log` but avoids infinite gradients at log(0)
+    by clamping them to at most ``1 / finfo.eps``.
+    """
+    return _SafeLog.apply(x)
+
+
 def block_diag_embed(mat):
     """
     Takes a tensor of shape (..., B, M, N) and returns a block diagonal tensor

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -7,13 +7,28 @@ import numpy as np
 import pytest
 import scipy.fftpack as fftpack
 import torch
+from torch.autograd import grad
 
 import pyro
 from pyro.ops.tensor_utils import (block_diag_embed, block_diagonal, convolve, dct, idct, next_fast_len,
-                                   periodic_cumsum, periodic_features, periodic_repeat, repeated_matmul)
+                                   periodic_cumsum, periodic_features, periodic_repeat, repeated_matmul, safe_log)
 from tests.common import assert_close, assert_equal
 
 pytestmark = pytest.mark.stage('unit')
+
+
+def test_safe_log():
+    # Test values.
+    x = torch.randn(1000).exp().requires_grad_()
+    expected = x.log()
+    actual = safe_log(x)
+    assert_equal(actual, expected)
+    assert_equal(grad(actual.sum(), [x])[0], grad(expected.sum(), [x])[0])
+
+    # Test gradients.
+    x = torch.tensor(0., requires_grad=True)
+    assert not torch.isfinite(grad(x.log(), [x])[0])
+    assert torch.isfinite(grad(safe_log(x), [x])[0])
 
 
 @pytest.mark.parametrize('batch_size', [1, 2, 3])


### PR DESCRIPTION
Addresses #2410 

This stabilizes gradients in `einsum(..., backend='torch_log')` for input tensors with lots of `-inf` entries, as required in variable elimination in spaces with large infeasible regions.

Note I've clamped to `finfo.eps` rather than `finfo.tiny` because tiny would result in infinite gradients whenever `|grad| > 1`.

## Tested
- [x] added a unit test
- [x] tested that this unblocks the complete enumeration strategy of #2410 