### PR TITLE
avoid finding init_params when unnecessary

### DIFF
--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -412,7 +412,8 @@ class MCMC:
             elif self.kernel.model:
                 _, _, self.transforms, _ = initialize_model(self.kernel.model,
                                                             model_args=args,
-                                                            model_kwargs=kwargs)
+                                                            model_kwargs=kwargs,
+                                                            initial_params={})
             # Assign default value
             else:
                 self.transforms = {}

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -243,11 +243,11 @@ class HMC(MCMCKernel):
             jit_options=self._jit_options,
             skip_jit_warnings=self._ignore_jit_warnings,
             init_strategy=self._init_strategy,
+            initial_params=self._initial_params,
         )
         self.potential_fn = potential_fn
         self.transforms = transforms
-        if self._initial_params is None:
-            self._initial_params = init_params
+        self._initial_params = init_params
         self._prototype_trace = trace
 
     def _initialize_adapter(self):

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -403,11 +403,11 @@ def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max
     trace_prob_evaluator = TraceEinsumEvaluator(model_trace,
                                                 has_enumerable_sites,
                                                 max_plate_nesting)
-    prototype_params = {k: transforms[k](v) for k, v in prototype_samples.items()}
 
     pe_maker = _PEMaker(model, model_args, model_kwargs, trace_prob_evaluator, transforms)
 
     if initial_params is None:
+        prototype_params = {k: transforms[k](v) for k, v in prototype_samples.items()}
         # Note that we deliberately do not exercise jit compilation here so as to
         # enable potential_fn to be picklable (a torch._C.Function cannot be pickled).
         initial_params = _find_valid_initial_params(model, model_args, model_kwargs, transforms,

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -331,7 +331,7 @@ def _find_valid_initial_params(model, model_args, model_kwargs, transforms, pote
 
 def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max_plate_nesting=None,
                      jit_compile=False, jit_options=None, skip_jit_warnings=False, num_chains=1,
-                     init_strategy=init_to_uniform):
+                     init_strategy=init_to_uniform, initial_params=None):
     """
     Given a Python callable with Pyro primitives, generates the following model-specific
     properties needed for inference using HMC/NUTS kernels:
@@ -364,6 +364,8 @@ def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max
         the returned `initial_params` will be a list with `num_chains` elements.
     :param callable init_strategy: A per-site initialization function.
         See :ref:`autoguide-initialization` section for available functions.
+    :param dict initial_params: dict containing initial tensors in unconstrained
+        space to initiate the markov chain.
     :returns: a tuple of (`initial_params`, `potential_fn`, `transforms`, `prototype_trace`)
     """
     # XXX `transforms` domains are sites' supports
@@ -405,13 +407,14 @@ def initialize_model(model, model_args=(), model_kwargs={}, transforms=None, max
 
     pe_maker = _PEMaker(model, model_args, model_kwargs, trace_prob_evaluator, transforms)
 
-    # Note that we deliberately do not exercise jit compilation here so as to
-    # enable potential_fn to be picklable (a torch._C.Function cannot be pickled).
-    init_params = _find_valid_initial_params(model, model_args, model_kwargs, transforms,
-                                             pe_maker.get_potential_fn(), prototype_params,
-                                             num_chains=num_chains, init_strategy=init_strategy)
+    if initial_params is None:
+        # Note that we deliberately do not exercise jit compilation here so as to
+        # enable potential_fn to be picklable (a torch._C.Function cannot be pickled).
+        initial_params = _find_valid_initial_params(model, model_args, model_kwargs, transforms,
+                                                    pe_maker.get_potential_fn(), prototype_params,
+                                                    num_chains=num_chains, init_strategy=init_strategy)
     potential_fn = pe_maker.get_potential_fn(jit_compile, skip_jit_warnings, jit_options)
-    return init_params, potential_fn, transforms, model_trace
+    return initial_params, potential_fn, transforms, model_trace
 
 
 def _safe(fn):

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -187,9 +187,10 @@ def markov(fn=None, history=1, keep=False, dim=None, name=None):
     Markov dependency declaration.
 
     This can be used in a variety of ways:
-    - as a context manager
-    - as a decorator for recursive functions
-    - as an iterator for markov chains
+
+        - as a context manager
+        - as a decorator for recursive functions
+        - as an iterator for markov chains
 
     :param int history: The number of previous contexts visible from the
         current context. Defaults to 1. If zero, this is similar to

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -119,6 +119,5 @@ def test_init_strategy_smoke(init_strategy):
     def model():
         pyro.sample("x", dist.LogNormal(0, 1))
 
-    value = torch.randn(()).exp() * 10
-    kernel = NUTS(model, init_strategy=partial(init_to_value, values={"x": value}))
+    kernel = NUTS(model, init_strategy=init_strategy)
     kernel.setup(warmup_steps=10)

--- a/tutorial/source/dmm.ipynb
+++ b/tutorial/source/dmm.ipynb
@@ -1,4 +1,4 @@
-﻿{
+{
  "cells": [
   {
    "cell_type": "markdown",

--- a/tutorial/source/modules.ipynb
+++ b/tutorial/source/modules.ipynb
@@ -553,7 +553,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`PyroSample` statements may also depend on other sample statements or parameters. In this case the `prior` can be a callable depending on `self`, rather than a constant distribution. For example consider the hierarcical model"
+    "`PyroSample` statements may also depend on other sample statements or parameters. In this case the `prior` can be a callable depending on `self`, rather than a constant distribution. For example consider the hierarchical model"
    ]
   },
   {
@@ -692,7 +692,7 @@
     "      def __init__(self):\n",
     "          self.x = PyroModule()\n",
     "-         self.y = PyroModule()  # Could lead to name conflict.\n",
-    "+         self.y = nn.Module()  # Has no Pyro names, so aviods conflict.\n",
+    "+         self.y = nn.Module()  # Has no Pyro names, so avoids conflict.\n",
     "```\n",
     "If there are only two `PyroModule`s then one must be an attribute of the other.\n",
     "```diff\n",
@@ -755,9 +755,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Addresses #2415.

This copies changes by @fritzo in #2410 to fix the issue. Thanks!

I also fixed some typos in `modules` tutorial.