### PR TITLE
Stop using deprecated PyTorch function signatures.

### DIFF
--- a/pyro/optim/clipped_adam.py
+++ b/pyro/optim/clipped_adam.py
@@ -68,11 +68,11 @@ class ClippedAdam(Optimizer):
                 state['step'] += 1
 
                 if group['weight_decay'] != 0:
-                    grad = grad.add(group['weight_decay'], p.data)
+                    grad = grad.add(p.data, alpha=group['weight_decay'])
 
                 # Decay the first and second moment running average coefficient
-                exp_avg.mul_(beta1).add_(1 - beta1, grad)
-                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
 
                 denom = exp_avg_sq.sqrt().add_(group['eps'])
 
@@ -80,6 +80,6 @@ class ClippedAdam(Optimizer):
                 bias_correction2 = 1 - beta2 ** state['step']
                 step_size = group['lr'] * math.sqrt(bias_correction2) / bias_correction1
 
-                p.data.addcdiv_(-step_size, exp_avg, denom)
+                p.data.addcdiv_(exp_avg, denom, value=-step_size)
 
         return loss


### PR DESCRIPTION
Various function overloads were previously "deprecated" in PyTorch in that they didn't show up as options in documentation or error messages.
 
These functions are listed here: https://github.com/pytorch/pytorch/blob/release/1.5/tools/autograd/deprecated.yaml.

PyTorch 1.5 now makes these UserWarnings, which trips up test_cevae because the pytest configuration is to error on non-Deprecation warnings.

This change should have no other effect.