### PR TITLE
Add header check to lint stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ apidoc: FORCE
 
 lint: FORCE
 	flake8
+	python scripts/update_headers.py --check
 
 license: FORCE
 	python scripts/update_headers.py


### PR DESCRIPTION
This fixes a bug in update_headers.py and adds an automatic check to the lint stage on travis letting contributors know if they need to `make license`. If this ever becomes too flaky I'm happy to remove that check.