### PR TITLE
Add smoothing parameter to Discrete Cosine transform and reparam

### DIFF
--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -45,7 +45,7 @@ class DiscreteCosineTransform(Transform):
             # Weight by frequency**smooth, where the DCT-II frequencies are:
             freq = torch.arange(0.5, size - 0.5, size, dtype=y.dtype, device=y.device)
             w = freq.pow_(self.smooth)
-            w /= w.log().mean().exp()  # Ensure orthogonality.
+            w /= w.log().mean().exp()  # Ensure |jacobian| = 1.
             self._weight_cache = w
         return self._weight_cache
 

--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -19,9 +19,9 @@ class DiscreteCosineTransform(Transform):
     :param int dim: Dimension along which to transform. Must be negative.
         This is an absolute dim counting from the right.
     :param float smooth: Smoothing parameter. When 0, this transforms white
-        noise to white noise; when 1 this transforms continuous brownian-like
-        motion to white noise; when 2 this transforms doubly-cumsummed white
-        noise to white noise; etc. Any real number is allowed.
+        noise to white noise; when 1 this transforms Brownian noise to to white
+        noise; when -1 this transforms violet noise to white noise; etc. Any
+        real number is allowed. https://en.wikipedia.org/wiki/Colors_of_noise.
     """
     domain = constraints.real
     codomain = constraints.real
@@ -43,7 +43,7 @@ class DiscreteCosineTransform(Transform):
         size = y.size(-1)
         if self._weight_cache is None or self._weight_cache.size(-1) != size:
             # Weight by frequency**smooth, where the DCT-II frequencies are:
-            freq = torch.arange(0.5, size - 0.5, size, dtype=y.dtype, device=y.device)
+            freq = torch.linspace(0.5, size - 0.5, size, dtype=y.dtype, device=y.device)
             w = freq.pow_(self.smooth)
             w /= w.log().mean().exp()  # Ensure |jacobian| = 1.
             self._weight_cache = w

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -28,9 +28,10 @@ class DiscreteCosineReparam(Reparam):
     :param int dim: Dimension along which to transform. Must be negative.
         This is an absolute dim counting from the right.
     """
-    def __init__(self, dim=-1):
+    def __init__(self, dim=-1, smooth=0.):
         assert isinstance(dim, int) and dim < 0
         self.dim = dim
+        self.smooth = float(smooth)
 
     def __call__(self, name, fn, obs):
         assert obs is None, "TransformReparam does not support observe statements"
@@ -40,8 +41,8 @@ class DiscreteCosineReparam(Reparam):
         # Draw noise from the base distribution.
         # TODO Use biject_to(fn.support).inv.with_cache(1) once the following merges:
         # https://github.com/probtorch/pytorch/pull/153
-        transform = ComposeTransform([biject_to(fn.support).inv,
-                                      DiscreteCosineTransform(dim=self.dim, cache_size=1)])
+        dct = DiscreteCosineTransform(dim=self.dim, smooth=self.smooth, cache_size=1)
+        transform = ComposeTransform([biject_to(fn.support).inv, dct])
         x_dct = pyro.sample("{}_dct".format(name),
                             dist.TransformedDistribution(fn, transform))
 

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -27,6 +27,10 @@ class DiscreteCosineReparam(Reparam):
 
     :param int dim: Dimension along which to transform. Must be negative.
         This is an absolute dim counting from the right.
+    :param float smooth: Smoothing parameter. When 0, this transforms white
+        noise to white noise; when 1 this transforms continuous brownian-like
+        motion to white noise; when 2 this transforms doubly-cumsummed white
+        noise to white noise; etc. Any real number is allowed.
     """
     def __init__(self, dim=-1, smooth=0.):
         assert isinstance(dim, int) and dim < 0

--- a/pyro/infer/reparam/discrete_cosine.py
+++ b/pyro/infer/reparam/discrete_cosine.py
@@ -23,14 +23,18 @@ class DiscreteCosineReparam(Reparam):
     diagonal guides in SVI and improving the effectiveness of a diagonal mass
     matrix in HMC.
 
+    When reparameterizing variables that are approximately continuous along the
+    time dimension, set ``smooth=1``. For variables that are approximately
+    continuously differentiable along the time axis, set ``smooth=2``.
+
     This reparameterization works only for latent variables, not likelihoods.
 
     :param int dim: Dimension along which to transform. Must be negative.
         This is an absolute dim counting from the right.
     :param float smooth: Smoothing parameter. When 0, this transforms white
-        noise to white noise; when 1 this transforms continuous brownian-like
-        motion to white noise; when 2 this transforms doubly-cumsummed white
-        noise to white noise; etc. Any real number is allowed.
+        noise to white noise; when 1 this transforms Brownian noise to to white
+        noise; when -1 this transforms violet noise to white noise; etc. Any
+        real number is allowed. https://en.wikipedia.org/wiki/Colors_of_noise.
     """
     def __init__(self, dim=-1, smooth=0.):
         assert isinstance(dim, int) and dim < 0

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -144,6 +144,9 @@ class TransformTests(TestCase):
     def test_discrete_cosine(self):
         # NOTE: Need following since helper function unimplemented
         self._test(lambda input_dim: T.DiscreteCosineTransform())
+        self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=0.5))
+        self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=1.0))
+        self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=2.0))
 
     def test_elu(self):
         # NOTE: Need following since helper function mistakenly doesn't take input dim

--- a/tests/infer/reparam/test_discrete_cosine.py
+++ b/tests/infer/reparam/test_discrete_cosine.py
@@ -24,13 +24,14 @@ def get_moments(x):
     return torch.cat([mean, std, corr])
 
 
+@pytest.mark.parametrize("smooth", [0., 0.5, 1.0, 2.0])
 @pytest.mark.parametrize("shape,dim", [
     ((6,), -1),
     ((2, 5,), -1),
     ((4, 2), -2),
     ((2, 3, 1), -2),
 ], ids=str)
-def test_normal(shape, dim):
+def test_normal(shape, dim, smooth):
     loc = torch.empty(shape).uniform_(-1., 1.).requires_grad_()
     scale = torch.empty(shape).uniform_(0.5, 1.5).requires_grad_()
 
@@ -42,7 +43,8 @@ def test_normal(shape, dim):
     value = poutine.trace(model).get_trace().nodes["x"]["value"]
     expected_probe = get_moments(value)
 
-    reparam_model = poutine.reparam(model, {"x": DiscreteCosineReparam(dim=dim)})
+    rep = DiscreteCosineReparam(dim=dim, smooth=smooth)
+    reparam_model = poutine.reparam(model, {"x": rep})
     trace = poutine.trace(reparam_model).get_trace()
     assert isinstance(trace.nodes["x_dct"]["fn"], dist.TransformedDistribution)
     assert isinstance(trace.nodes["x"]["fn"], dist.Delta)
@@ -57,13 +59,14 @@ def test_normal(shape, dim):
         assert_close(actual_grads[1], expected_grads[1], atol=0.05)
 
 
+@pytest.mark.parametrize("smooth", [0., 0.5, 1.0, 2.0])
 @pytest.mark.parametrize("shape,dim", [
     ((6,), -1),
     ((2, 5,), -1),
     ((4, 2), -2),
     ((2, 3, 1), -2),
 ], ids=str)
-def test_uniform(shape, dim):
+def test_uniform(shape, dim, smooth):
 
     def model():
         with pyro.plate_stack("plates", shape[:dim]):
@@ -73,7 +76,7 @@ def test_uniform(shape, dim):
     value = poutine.trace(model).get_trace().nodes["x"]["value"]
     expected_probe = get_moments(value)
 
-    reparam_model = poutine.reparam(model, {"x": DiscreteCosineReparam(dim=dim)})
+    reparam_model = poutine.reparam(model, {"x": DiscreteCosineReparam(dim=dim, smooth=smooth)})
     trace = poutine.trace(reparam_model).get_trace()
     assert isinstance(trace.nodes["x_dct"]["fn"], dist.TransformedDistribution)
     assert isinstance(trace.nodes["x"]["fn"], dist.Delta)


### PR DESCRIPTION
Addresses #2426 

This adds a `smooth` parameter to the `DiscreteCosineTransform` and `DiscreteCosineReparam` allowing the reparameterizer to automatically encode C-smooth functions. That is, `DiscreteCosineReparam(smooth=s)` transforms C-s functions to white noise, e.g. `DCR(smooth=1)` transforms brownian motion to white noise, and `DCR(smooth=2)` transforms cumsum(cumsum(white noise)) to white noise.

I am hoping this will be useful in SVI and HMC where by setting `smooth=1` e.g. we would avoid the need for `AutoNormal` or `HMC` adaptation to learn the frequency-proportional variance (or rather we would warm start those learned variances at a better place).

## Tested
- added unit test cases for transform and reparam