### PR TITLE
expose MaskedDistribution to pyro.distributions namespace

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -190,6 +190,13 @@ LKJCorrCholesky
     :undoc-members:
     :show-inheritance:
 
+MaskedDistribution
+------------------
+.. autoclass:: pyro.distributions.MaskedDistribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 MaskedMixture
 -------------
 .. autoclass:: pyro.distributions.MaskedMixture

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -27,7 +27,7 @@ from pyro.distributions.spanning_tree import SpanningTree
 from pyro.distributions.stable import Stable
 from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
-from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.torch_distribution import MaskedDistribution, TorchDistribution
 from pyro.distributions.torch_transform import ComposeTransformModule, TransformModule
 from pyro.distributions.unit import Unit
 from pyro.distributions.util import enable_validation, is_validation_enabled, validation_enabled
@@ -62,6 +62,7 @@ __all__ = [
     "InverseGamma",
     "LinearHMM",
     "LKJCorrCholesky",
+    "MaskedDistribution",
     "MaskedMixture",
     "MixtureOfDiagNormals",
     "MixtureOfDiagNormalsSharedCovariance",


### PR DESCRIPTION
Motivation: to have the same namespace for distributions used in funsor.