### PR TITLE
Added permutation of `AutoRegressiveNN` to buffer

### DIFF
--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -182,10 +182,11 @@ class ConditionalAutoRegressiveNN(nn.Module):
 
         if permutation is None:
             # By default set a random permutation of variables, which is important for performance with multiple steps
-            self.permutation = torch.randperm(input_dim, device='cpu').to(torch.Tensor().device)
+            P = torch.randperm(input_dim, device='cpu').to(torch.Tensor().device)
         else:
             # The permutation is chosen by the user
-            self.permutation = permutation.type(dtype=torch.int64)
+            P = permutation.type(dtype=torch.int64)
+        self.register_buffer('permutation', P)
 
         # Create masks
         self.masks, self.mask_skip = create_mask(


### PR DESCRIPTION
The `ConditionalAutoRegressiveNN` and `AutoRegressiveNN` classes did not register their permutation matrices in a buffer, which means that part of the object state will not get saved/loaded and introduces the potential for subtle bugs