### PR TITLE
Simplify compartmental model interface

### DIFF
--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -11,14 +11,14 @@ import logging
 import torch
 
 import pyro
-from pyro.contrib.epidemiology import SIRModel
+from pyro.contrib.epidemiology import SimpleSIRModel
 
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 
 
 def generate_data(args):
     extended_data = [None] * (args.duration + args.forecast)
-    model = SIRModel(args.population, args.recovery_time, extended_data)
+    model = SimpleSIRModel(args.population, args.recovery_time, extended_data)
     for attempt in range(100):
         samples = model.generate({"R0": args.basic_reproduction_number,
                                   "rho": args.response_rate})
@@ -49,6 +49,7 @@ def infer(args, model):
     mcmc = model.fit(warmup_steps=args.warmup_steps,
                      num_samples=args.num_samples,
                      max_tree_depth=args.max_tree_depth,
+                     num_quant_bins=args.num_bins,
                      dct=args.dct,
                      hook_fn=hook_fn)
 
@@ -131,8 +132,7 @@ def main(args):
     obs = dataset["obs"]
 
     # Run inference.
-    model = SIRModel(args.population, args.recovery_time, obs,
-                     num_quant_bins=args.num_bins)
+    model = SimpleSIRModel(args.population, args.recovery_time, obs)
     samples = infer(args, model)
 
     # Evaluate fit.

--- a/pyro/contrib/epidemiology/__init__.py
+++ b/pyro/contrib/epidemiology/__init__.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .compartmental import CompartmentalModel
-from .sir import SIRModel
+from .sir import SimpleSIRModel
 
 __all__ = [
     "CompartmentalModel",
-    "SIRModel",
+    "SimpleSIRModel",
 ]

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -73,8 +73,6 @@ class CompartmentalModel(ABC):
     :param list compartments: A list of strings of compartment names.
     :param int duration:
     :param int population:
-    :param int num_quant_bins: The number of quantization bins to use. Note that
-        computational cost is exponential in `num_quant_bins`. Defaults to 4.
     """
 
     def __init__(self, compartments, duration, population, *,
@@ -93,10 +91,6 @@ class CompartmentalModel(ABC):
         assert all(isinstance(name, str) for name in compartments)
         assert len(compartments) == len(set(compartments))
         self.compartments = compartments
-
-        assert isinstance(num_quant_bins, int)
-        assert num_quant_bins >= 2
-        self.num_quant_bins = num_quant_bins
 
         # Inference state.
         self.samples = {}
@@ -223,13 +217,18 @@ class CompartmentalModel(ABC):
             :class:`~pyro.infer.mcmc.nuts.NUTS` kernel.
         :param full_mass: (Default ``False``). Specification of mass matrix
             of the :class:`~pyro.infer.mcmc.nuts.NUTS` kernel.
+        :param int num_quant_bins: The number of quantization bins to use. Note
+            that computational cost is exponential in `num_quant_bins`.
+            Defaults to 4.
         :param float dct: If provided, use a discrete cosine reparameterizer
             with this value as smoothness.
         :returns: An MCMC object for diagnostics, e.g. ``MCMC.summary()``.
         :rtype: ~pyro.infer.mcmc.api.MCMC
         """
         logger.info("Running inference...")
-        self._dct = options.pop("dct", None)  # Save for .predict().
+        # Save these options for .predict().
+        self.num_quant_bins = options.pop("num_quant_bins", 4)
+        self._dct = options.pop("dct", None)
 
         # Heuristically initialze to feasible latents.
         init_values = self.heuristic()

--- a/pyro/contrib/epidemiology/sir.py
+++ b/pyro/contrib/epidemiology/sir.py
@@ -26,13 +26,9 @@ class SimpleSIRModel(CompartmentalModel):
         ``I``). Must be greater than 1.
     :param iterable data: Time series of new observed infections.
     :param int data: Time series of new observed infections.
-    :param int num_quant_bins: The number of quantization bins to use.
-        Note that computational cost is exponential in `num_quant_bins`.
-        Defaults to 4.
     """
 
-    def __init__(self, population, recovery_time, data, *,
-                 num_quant_bins=4):
+    def __init__(self, population, recovery_time, data):
         compartments = ("S", "I")  # R is implicit.
         duration = len(data)
         super().__init__(compartments, duration, population)

--- a/pyro/contrib/epidemiology/sir.py
+++ b/pyro/contrib/epidemiology/sir.py
@@ -10,26 +10,35 @@ from pyro.ops.tensor_utils import convolve
 from .compartmental import CompartmentalModel
 
 
-class SIRModel(CompartmentalModel):
+class SimpleSIRModel(CompartmentalModel):
     """
     Susceptible-Infected-Recovered model.
 
-    :param int population:
-    :param float recovery_time:
+    To customize this model we recommend forking and editing this class.
+
+    This is a stochastic discrete-time discrete-state model with three
+    compartments: "S" for susceptible, "I" for infected, and "R" for
+    recovered individuals (the recovered individuals are implicit: ``R =
+    population - S - I``) with transitions ``S -> I -> R``.
+
+    :param int population: Total ``population = S + I + R``.
+    :param float recovery_time: Mean recovery time (duration in state
+        ``I``). Must be greater than 1.
     :param iterable data: Time series of new observed infections.
     :param int data: Time series of new observed infections.
-    :param int num_quant_bins: The number of quantization bins to use. Note that
-            computational cost is exponential in `num_quant_bins`. Defaults to 4.
+    :param int num_quant_bins: The number of quantization bins to use.
+        Note that computational cost is exponential in `num_quant_bins`.
+        Defaults to 4.
     """
 
     def __init__(self, population, recovery_time, data, *,
                  num_quant_bins=4):
         compartments = ("S", "I")  # R is implicit.
         duration = len(data)
-        super().__init__(compartments, duration, population, num_quant_bins=num_quant_bins)
+        super().__init__(compartments, duration, population)
 
         assert isinstance(recovery_time, float)
-        assert recovery_time > 0
+        assert recovery_time > 1
         self.recovery_time = recovery_time
 
         self.data = data
@@ -61,7 +70,7 @@ class SIRModel(CompartmentalModel):
 
         # Convert interpretable parameters to distribution parameters.
         rate_s = -R0 / (tau * self.population)
-        prob_i = 1 / (1 + tau)
+        prob_i = 1 / tau
 
         return rate_s, prob_i, rho
 


### PR DESCRIPTION
Addresses #2426 

This is a refactoring to prepare for a future SEIR model.

1. Moves the `num_quant_bins` from `.__init__()` (which henceforth accept only model-related args) to `.fit()` (which accepts inference-related args). This reduces the burden of creating a new model class.
2. Renames `SIRModel` to `SimpleSIRModel` and adds documentation that "this model is intended to be forked, not customized"
3. Fixes definition of timescale `tau` so that it is actually the mean (there was an off-by-1 error).

## Tested
- [x] added new test configs to test/contrib/epidemiology