### PR TITLE
Use SMC to initialize compartmental models

### DIFF
--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -109,9 +109,9 @@ class CompartmentalModel(ABC):
         feasible and HMC needs to start at a feasible solution to progress.
 
         The default implementation attempts to find a feasible state using
-        :class:`~pyro.infer.smcfilter.SMCFilter` proprosing from the prior.
-        However this method may be overridden in cases where SMC performs
-        poorly e.g. in high-dimensional models.
+        :class:`~pyro.infer.smcfilter.SMCFilter` with proprosals from the
+        prior.  However this method may be overridden in cases where SMC
+        performs poorly e.g. in high-dimensional models.
 
         :param int num_particles: Number of particles used for SMC.
         :returns: A dictionary mapping sample site name to tensor value.

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -460,21 +460,20 @@ class CompartmentalModel(ABC):
 
 class _SMCModel:
     """
-    Helper to initialize a CompartmentalModel to an feasible initial state.
+    Helper to initialize a CompartmentalModel to a feasible initial state.
     """
     def __init__(self, model):
         assert isinstance(model, CompartmentalModel)
         self.model = model
 
     def init(self, state):
-        self.t = 0
-
         with poutine.trace() as tr:
             params = self.model.global_model()
         for name, site in tr.trace.nodes.items():
             if site["type"] == "sample":
                 state[name] = site["value"]
 
+        self.t = 0
         state.update(self.model.initialize(params))
         self.step(state)  # Take one step since model.initialize is deterministic.
 
@@ -491,7 +490,7 @@ class _SMCModel:
 
 class _SMCGuide(_SMCModel):
     """
-    Like _SMCModel but does not observe and does not update state.
+    Like _SMCModel but does not update state and does not observe.
     """
     def init(self, state):
         super().init(state.copy())

--- a/pyro/contrib/epidemiology/sir.py
+++ b/pyro/contrib/epidemiology/sir.py
@@ -1,11 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-
 import pyro
 import pyro.distributions as dist
-from pyro.ops.tensor_utils import convolve
 
 from .compartmental import CompartmentalModel
 
@@ -42,34 +39,6 @@ class SimpleSIRModel(CompartmentalModel):
 
     series = ("S2I", "I2R", "obs")
     full_mass = [("R0", "rho")]
-
-    def old_heuristic(self):
-        # Start with a single infection.
-        S0 = self.population - 1
-        # Assume 50% <= response rate <= 100%.
-        S2I = self.data * min(2., (S0 / self.data.sum()).sqrt())
-        S_aux = S0 - S2I.cumsum(-1)
-        # Account for the single initial infection.
-        S2I[0] += 1
-        # Assume infection lasts less than a month.
-        recovery = torch.arange(30.).div(self.recovery_time).neg().exp()
-        I_aux = convolve(S2I, recovery)[:len(self.data)]
-
-        return {
-            "R0": torch.tensor(2.0),
-            "rho": torch.tensor(0.5),
-            "auxiliary": torch.stack([S_aux, I_aux]).clamp(min=0.5),
-        }
-
-    def heuristic(self):
-        sample = self.smc_heuristic()
-        S = sample["S"]
-        I = sample["I"]
-        return {
-            "R0": sample["R0"],
-            "rho": sample["rho"],
-            "auxiliary": torch.stack([S, I]).clamp(min=0.5),
-        }
 
     def global_model(self):
         tau = self.recovery_time

--- a/pyro/contrib/epidemiology/sir.py
+++ b/pyro/contrib/epidemiology/sir.py
@@ -43,7 +43,7 @@ class SimpleSIRModel(CompartmentalModel):
     series = ("S2I", "I2R", "obs")
     full_mass = [("R0", "rho")]
 
-    def heuristic(self):
+    def old_heuristic(self):
         # Start with a single infection.
         S0 = self.population - 1
         # Assume 50% <= response rate <= 100%.
@@ -59,6 +59,16 @@ class SimpleSIRModel(CompartmentalModel):
             "R0": torch.tensor(2.0),
             "rho": torch.tensor(0.5),
             "auxiliary": torch.stack([S_aux, I_aux]).clamp(min=0.5),
+        }
+
+    def heuristic(self):
+        sample = self.smc_heuristic()
+        S = sample["S"]
+        I = sample["I"]
+        return {
+            "R0": sample["R0"],
+            "rho": sample["rho"],
+            "auxiliary": torch.stack([S, I]).clamp(min=0.5),
         }
 
     def global_model(self):


### PR DESCRIPTION
Addresses #2426 

This replaces custom `.heuristic()` methods with a default generic `SMCFilter`-based initialization strategy, greatly simplifying the process of creating new compartmental models. Users can still override this default `.heuristic()` if needed.

:tada: hooray for composable inference :tada:

## Tested
- [x] refactoring covered by existing tests
- [x] ran `python sir.py -p 10000 -d 60 -f 30 --verbose --plot` and confirmed good posteriors and mixing:
```
         mean       std    median      5.0%     95.0%     n_eff     r_hat
 R0      1.48      0.08      1.47      1.36      1.61     16.89      1.09
rho      0.48      0.03      0.49      0.44      0.53     29.28      1.14
```
![image](https://user-images.githubusercontent.com/648532/80516784-da306500-8938-11ea-9ff9-0a0790473f54.png)
