### PR TITLE
cast to float in dmm.py

### DIFF
--- a/examples/dmm/dmm.py
+++ b/examples/dmm/dmm.py
@@ -406,9 +406,9 @@ def main(args):
 
         # compute the validation and test loss n_samples many times
         val_nll = svi.evaluate_loss(val_batch, val_batch_reversed, val_batch_mask,
-                                    val_seq_lengths) / torch.sum(val_seq_lengths)
+                                    val_seq_lengths) / float(torch.sum(val_seq_lengths))
         test_nll = svi.evaluate_loss(test_batch, test_batch_reversed, test_batch_mask,
-                                     test_seq_lengths) / torch.sum(test_seq_lengths)
+                                     test_seq_lengths) / float(torch.sum(test_seq_lengths))
 
         # put the RNN back into training mode (i.e. turn on drop-out if applicable)
         dmm.rnn.train()


### PR DESCRIPTION
i noticed that dmm.py was reporting integer NLLs on evaluation. i guess because pytorch has changed how casting works. i wonder if this might be happening elsewhere?