### PR TITLE
Fix BatchNorm TransformModule

### DIFF
--- a/pyro/distributions/transforms/batchnorm.py
+++ b/pyro/distributions/transforms/batchnorm.py
@@ -79,7 +79,7 @@ class BatchNorm(TransformModule):
         super().__init__()
 
         self.input_dim = input_dim
-        self.gamma = nn.Parameter(torch.zeros(input_dim))
+        self.gamma = nn.Parameter(torch.ones(input_dim))
         self.beta = nn.Parameter(torch.zeros(input_dim))
         self.momentum = momentum
         self.epsilon = epsilon
@@ -115,9 +115,10 @@ class BatchNorm(TransformModule):
         if self.training:
             mean, var = y.mean(0), y.var(0)
 
-            # NOTE: The momentum variable agrees with the definition in e.g. `torch.nn.BatchNorm1d`
-            self.moving_mean.mul_(1 - self.momentum).add_(mean * self.momentum)
-            self.moving_variance.mul_(1 - self.momentum).add_(var * self.momentum)
+            with torch.no_grad():
+                # NOTE: The momentum variable agrees with the definition in e.g. `torch.nn.BatchNorm1d`
+                self.moving_mean.mul_(1 - self.momentum).add_(mean * self.momentum)
+                self.moving_variance.mul_(1 - self.momentum).add_(var * self.momentum)
 
         # During test time, use smoothed averages rather than the sample ones
         else:


### PR DESCRIPTION
I wanted the reproduce the [notebook](https://github.com/ericjang/normalizing-flows-tutorial/blob/master/nf_part2_modern.ipynb) by Eric Jang in PyTorch and found the TransformModules in this repository very useful. However, the BatchNorm seems to have some bugs. 

- I had to initialize gamma as 1 instead of 0 (or rather 1e-6) to be able to learn anything useful.
- And I had to wrap the running statistics  with `torch.no_grad()` to avoid unbounded memory allocation (found that solution in this [issue](https://github.com/pytorch/pytorch/issues/20275))

I am not sure if the first change will break other code, but you can try to run the attached script (converted from my notebook) [NormalizingFlow.zip](https://github.com/pyro-ppl/pyro/files/4565565/NormalizingFlow.zip) with and without the fix.

Also I didn't see an elegant way to pass the parameters of all TransfromModules to the optimizer (without Permute Transfrom complaining that it is not a `nn.module`). Did I miss something here, or should I open an issue about that?
