### PR TITLE
Return `pyro.distributions.TransformedDistribution` instead of `torch.distributions.TransformedDistribution` when conditioning

### DIFF
--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -3,9 +3,10 @@
 
 from abc import ABC, abstractmethod
 
-import pyro
 import torch
 import torch.nn
+
+from .torch import TransformedDistribution
 
 
 class ConditionalDistribution(ABC):
@@ -64,4 +65,4 @@ class ConditionalTransformedDistribution(ConditionalDistribution):
     def condition(self, context):
         base_dist = self.base_dist.condition(context)
         transforms = [t.condition(context) for t in self.transforms]
-        return pyro.distributions.TransformedDistribution(base_dist, transforms)
+        return TransformedDistribution(base_dist, transforms)

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 
+import pyro
 import torch
 import torch.nn
 
@@ -63,4 +64,4 @@ class ConditionalTransformedDistribution(ConditionalDistribution):
     def condition(self, context):
         base_dist = self.base_dist.condition(context)
         transforms = [t.condition(context) for t in self.transforms]
-        return torch.distributions.TransformedDistribution(base_dist, transforms)
+        return pyro.distributions.TransformedDistribution(base_dist, transforms)


### PR DESCRIPTION
Hi all,

I started working with Pyro's conditional transforms. However, the `ConditionalTransformedDistribution` returns a pytorch `TransformedDistribution` instead of the pyro version. If you want to use this distribution with `pyro.sample(.)` it needs to base the pyro version though.