### PR TITLE
Add pairwise correlation plot to sir.py

### DIFF
--- a/pyro/contrib/epidemiology/seir.py
+++ b/pyro/contrib/epidemiology/seir.py
@@ -52,7 +52,7 @@ class SimpleSEIRModel(CompartmentalModel):
         tau_e = self.incubation_time
         tau_i = self.recovery_time
         R0 = pyro.sample("R0", dist.LogNormal(0., 1.))
-        rho = pyro.sample("rho", dist.Uniform(0, 1))
+        rho = pyro.sample("rho", dist.Beta(2, 2))
         return R0, tau_e, tau_i, rho
 
     def initialize(self, params):
@@ -181,7 +181,7 @@ class OverdispersedSEIRModel(CompartmentalModel):
         tau_i = self.recovery_time
         R0 = pyro.sample("R0", dist.LogNormal(0., 1.))
         k = pyro.sample("k", dist.Exponential(1.))
-        rho = pyro.sample("rho", dist.Uniform(0, 1))
+        rho = pyro.sample("rho", dist.Beta(2, 2))
         return R0, k, tau_e, tau_i, rho
 
     def initialize(self, params):

--- a/pyro/contrib/epidemiology/sir.py
+++ b/pyro/contrib/epidemiology/sir.py
@@ -48,7 +48,7 @@ class SimpleSIRModel(CompartmentalModel):
     def global_model(self):
         tau = self.recovery_time
         R0 = pyro.sample("R0", dist.LogNormal(0., 1.))
-        rho = pyro.sample("rho", dist.Uniform(0, 1))
+        rho = pyro.sample("rho", dist.Beta(2, 2))
         return R0, tau, rho
 
     def initialize(self, params):
@@ -162,7 +162,7 @@ class OverdispersedSIRModel(CompartmentalModel):
         tau = self.recovery_time
         R0 = pyro.sample("R0", dist.LogNormal(0., 1.))
         k = pyro.sample("k", dist.Exponential(1.))
-        rho = pyro.sample("rho", dist.Uniform(0, 1))
+        rho = pyro.sample("rho", dist.Beta(2, 2))
         return R0, k, tau, rho
 
     def initialize(self, params):
@@ -263,7 +263,7 @@ class SparseSIRModel(CompartmentalModel):
     def global_model(self):
         tau = self.recovery_time
         R0 = pyro.sample("R0", dist.LogNormal(0., 1.))
-        rho = pyro.sample("rho", dist.Uniform(0, 1))
+        rho = pyro.sample("rho", dist.Beta(2, 2))
         return R0, tau, rho
 
     def initialize(self, params):
@@ -390,8 +390,8 @@ class UnknownStartSIRModel(CompartmentalModel):
         # Assume two different response rates: rho0 before any observations
         # were made (in pre_obs_window), followed by a higher response rate rho1
         # after observations were made (in post_obs_window).
-        rho0 = pyro.sample("rho0", dist.Uniform(0, 1))
-        rho1 = pyro.sample("rho1", dist.Uniform(0, 1))
+        rho0 = pyro.sample("rho0", dist.Beta(2, 2))
+        rho1 = pyro.sample("rho1", dist.Beta(2, 2))
         # Whereas each of rho0,rho1 are scalars (possibly batched over samples),
         # we construct a time series rho with an extra time dim on the right.
         rho = torch.cat([


### PR DESCRIPTION
Addresses #2426 

This PR:
1. Adds a pairwise correlation plot to examples/contrib/epidemiology/sir.py
2. Changes the `rho` prior from `Uniform(0,1)` to `Beta(2,2)` to avoid unreasonably hight initial estimates of `rho` by SMC; this fixes a regression in quality introduced in #2452 

## Example

```sh
python examples/contrib/epidemiology/sir.py -p=10000 -d=64 -n=400 -m=100 --plot
```

![image](https://user-images.githubusercontent.com/648532/81114255-87295580-8ed6-11ea-8e2b-2e264cb5d38e.png)
