### PR TITLE
Add initialization strategy that randomly samples values

### DIFF
--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -5,10 +5,9 @@ from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta
                                          AutoDiscreteParallel, AutoGuide, AutoGuideList, AutoIAFNormal,
                                          AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
                                          AutoMultivariateNormal, AutoNormal, AutoNormalizingFlow)
-from pyro.infer.autoguide.utils import mean_field_entropy
-from pyro.infer.autoguide.initialization import (init_to_feasible, init_to_mean, init_to_median,
+from pyro.infer.autoguide.initialization import (init_to_feasible, init_to_generated, init_to_mean, init_to_median,
                                                  init_to_sample, init_to_uniform, init_to_value)
-
+from pyro.infer.autoguide.utils import mean_field_entropy
 
 __all__ = [
     'AutoCallable',
@@ -25,6 +24,7 @@ __all__ = [
     'AutoNormal',
     'AutoNormalizingFlow',
     'init_to_feasible',
+    'init_to_generated',
     'init_to_mean',
     'init_to_median',
     'init_to_sample',

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -144,10 +144,18 @@ class _InitToGenerated:
 
 def init_to_generated(site=None, generate=lambda: init_to_uniform):
     """
-    Initialize to the value specified in the ``values`` dict returned by
-    ``values_fn``. This is similar to ``init_to_value(values=values_fn())`` but
-    calls ``values_fn`` once per model execution, thereby permitting multiple
-    randomized initializations.
+    Initialize to another initialization strategy returned by the callback
+    ``generate`` which is called once per model execution.
+
+    This is like :func:`init_to_value` but can produce different (e.g. random)
+    values once per model execution. For example to generate values and return
+    ``init_to_value`` you could define::
+
+        def generate():
+            values = {"x": torch.randn(100), "y": torch.rand(5)}
+            return init_to_value(values=values)
+
+        my_init_fn = init_to_generated(generate=generate)
 
     :param callable generate: A callable returning another initialization
         function, e.g. returning an ``init_to_value(values={...})`` populated

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -9,8 +9,8 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro.infer import Predictive
-from pyro.infer.autoguide import (init_to_feasible, init_to_mean, init_to_median,
-                                  init_to_sample, init_to_uniform, init_to_value)
+from pyro.infer.autoguide import (init_to_feasible, init_to_generated, init_to_mean, init_to_median, init_to_sample,
+                                  init_to_uniform, init_to_value)
 from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.util import initialize_model
@@ -114,7 +114,9 @@ def test_init_to_value():
     init_to_sample(),
     init_to_uniform(radius=0.1),
     init_to_value(values={"x": torch.tensor(3.)}),
-])
+    init_to_generated(
+        generate=lambda: init_to_value(values={"x": torch.randn(())})),
+], ids=str)
 def test_init_strategy_smoke(init_strategy):
     def model():
         pyro.sample("x", dist.LogNormal(0, 1))

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -115,7 +115,7 @@ def test_init_to_value():
     init_to_uniform(radius=0.1),
     init_to_value(values={"x": torch.tensor(3.)}),
     init_to_generated(
-        generate=lambda: init_to_value(values={"x": torch.randn(())})),
+        generate=lambda: init_to_value(values={"x": torch.rand(())})),
 ], ids=str)
 def test_init_strategy_smoke(init_strategy):
     def model():

--- a/tests/infer/test_initialization.py
+++ b/tests/infer/test_initialization.py
@@ -1,0 +1,34 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import pyro
+import pyro.distributions as dist
+from pyro.infer.autoguide.initialization import InitMessenger, init_to_generated, init_to_value
+
+
+def test_init_to_generated():
+    def model():
+        x = pyro.sample("x", dist.Normal(0, 1))
+        y = pyro.sample("y", dist.Normal(0, 1))
+        z = pyro.sample("z", dist.Normal(0, 1))
+        return x, y, z
+
+    class MockGenerate:
+        def __init__(self):
+            self.counter = 0
+
+        def __call__(self):
+            values = {"x": torch.tensor(self.counter + 0.0),
+                      "y": torch.tensor(self.counter + 0.5)}
+            self.counter += 1
+            return init_to_value(values=values)
+
+    mock_generate = MockGenerate()
+    with InitMessenger(init_to_generated(generate=mock_generate)):
+        for i in range(5):
+            x, y, z = model()
+            assert x == i
+            assert y == i + 0.5
+    assert mock_generate.counter == 5


### PR DESCRIPTION
Addresses #2426 

This adds a new autoguide init strategy `init_to_generated` motivated by use in MCMC where 100 attempts are made to initialize the model. Previously those attempts were identical because `init_to_value` is unchanged across attempt. After this PR those attempts may randomly generate new samples.

## Tested
- [x] unit tests
- [x] updated `CompartmentalModel` to use `init_to_generated`