### PR TITLE
Add ESS thoreshold logic to SMCFilter

### DIFF
--- a/examples/contrib/epidemiology/regional.py
+++ b/examples/contrib/epidemiology/regional.py
@@ -52,6 +52,7 @@ def infer(args, model):
             logging.info("potential = {:0.6g}".format(e))
 
     mcmc = model.fit(heuristic_num_particles=args.num_particles,
+                     heuristic_ess_threshold=args.ess_threshold,
                      warmup_steps=args.warmup_steps,
                      num_samples=args.num_samples,
                      max_tree_depth=args.max_tree_depth,
@@ -136,6 +137,7 @@ if __name__ == "__main__":
     parser.add_argument("-rho", "--response-rate", default=0.5, type=float)
     parser.add_argument("-n", "--num-samples", default=200, type=int)
     parser.add_argument("-np", "--num-particles", default=1024, type=int)
+    parser.add_argument("-ess", "--ess-threshold", default=0.5, type=float)
     parser.add_argument("-w", "--warmup-steps", default=100, type=int)
     parser.add_argument("-t", "--max-tree-depth", default=5, type=int)
     parser.add_argument("-nb", "--num-bins", default=4, type=int)

--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -67,6 +67,7 @@ def infer(args, model):
             logging.info("potential = {:0.6g}".format(e))
 
     mcmc = model.fit(heuristic_num_particles=args.num_particles,
+                     heuristic_ess_threshold=args.ess_threshold,
                      warmup_steps=args.warmup_steps,
                      num_samples=args.num_samples,
                      max_tree_depth=args.max_tree_depth,
@@ -207,6 +208,7 @@ if __name__ == "__main__":
                         help="smoothing for discrete cosine reparameterizer")
     parser.add_argument("-n", "--num-samples", default=200, type=int)
     parser.add_argument("-np", "--num-particles", default=1024, type=int)
+    parser.add_argument("-ess", "--ess-threshold", default=0.5, type=float)
     parser.add_argument("-w", "--warmup-steps", default=100, type=int)
     parser.add_argument("-t", "--max-tree-depth", default=5, type=int)
     parser.add_argument("-a", "--arrowhead-mass", action="store_true")

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -43,7 +43,6 @@ class CompartmentalModel(ABC):
         # First implement a concrete derived class.
         class MyModel(CompartmentalModel):
             def __init__(self, ...): ...
-            def heuristic(self): ...
             def global_model(self): ...
             def initialize(self, params): ...
             def transition_fwd(self, params, state, t): ...
@@ -145,7 +144,7 @@ class CompartmentalModel(ABC):
 
     @torch.no_grad()
     @set_approx_sample_thresh(1000)
-    def heuristic(self, num_particles=1024):
+    def heuristic(self, num_particles=1024, ess_threshold=0.5):
         """
         Finds an initial feasible guess of all latent variables, consistent
         with observed data. This is needed because not all hypotheses are
@@ -157,6 +156,7 @@ class CompartmentalModel(ABC):
         performs poorly e.g. in high-dimensional models.
 
         :param int num_particles: Number of particles used for SMC.
+        :param float ess_threshold: Effective sample size threshold for SMC.
         :returns: A dictionary mapping sample site name to tensor value.
         :rtype: dict
         """
@@ -164,6 +164,7 @@ class CompartmentalModel(ABC):
         model = _SMCModel(self)
         guide = _SMCGuide(self)
         smc = SMCFilter(model, guide, num_particles=num_particles,
+                        ess_threshold=ess_threshold,
                         max_plate_nesting=self.max_plate_nesting)
         smc.init()
         for t in range(1, self.duration):


### PR DESCRIPTION
Addresses #2426 

This adds an ESS-based threshold to `SMCFilter` to decide when to importance resample (resolving a long-standing TODO). The default is to resample when `ESS < num_particles / 2`. I've also threaded this through the epidemiological `CompartmentalModel` because I've found a lower threshold can help preserve diversity and find a feasible solution in #2468.

I've also added a couple checks to raise `ValueError` asap when `SMCFilter` fails to find a feasible hypothesis.

## Tested
- [x] logic updates are covered by existing tests for both `SMCFilter` and `CompartmentalModel`
- [x] manually logged ess values to sanity check dynamics
- [x] evaluated improved performance on epidemiological models in #2468