### PR TITLE
Revise binomial approximation interface

### DIFF
--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -144,7 +144,7 @@ class CompartmentalModel(ABC):
     full_mass = False
 
     @torch.no_grad()
-    @set_approx_sample_thresh(1000)
+    @set_approx_sample_thresh(100)  # This is robust to gross approximation.
     def heuristic(self, num_particles=1024, ess_threshold=0.5, retries=10):
         """
         Finds an initial feasible guess of all latent variables, consistent
@@ -258,6 +258,7 @@ class CompartmentalModel(ABC):
     # Inference interface ########################################
 
     @torch.no_grad()
+    @set_approx_sample_thresh(1000)
     def generate(self, fixed={}):
         """
         Generate data from the prior.
@@ -361,6 +362,7 @@ class CompartmentalModel(ABC):
         return mcmc  # E.g. so user can run mcmc.summary().
 
     @torch.no_grad()
+    @set_approx_sample_thresh(10000)
     def predict(self, forecast=0):
         """
         Predict latent variables and optionally forecast forward.

--- a/pyro/contrib/epidemiology/distributions.py
+++ b/pyro/contrib/epidemiology/distributions.py
@@ -8,25 +8,36 @@ import torch
 
 import pyro.distributions as dist
 
-_APPROX_SAMPLE_THRESH = 10000
-
 
 @contextmanager
 def set_approx_sample_thresh(thresh):
     """
-    Temporarily set global approx_sample_thresh in ``infection_dist``.
-    The default global value is 10000.
+    EXPERIMENTAL Temporarily set the global default value of
+    ``Binomial.approx_sample_thresh``, thereby decreasing the computational
+    complexity of sampling from :class:`~pyro.distributions.Binomial`,
+    :class:`~pyro.distributions.BetaBinomial`,
+    :class:`~pyro.distributions.ExtendedBinomial`,
+    :class:`~pyro.distributions.ExtendedBetaBinomial`, and distributions
+    returned by :func:`infection_dist`.
+
+    This is useful for sampling from very large ``total_count``.
+
+    This is used internally by
+    :class:`~pyro.contrib.epidemiology.compartmental.CompartmentalModel`.
 
     :param thresh: New temporary threshold.
     :type thresh: int or float.
     """
-    global _APPROX_SAMPLE_THRESH
-    old = _APPROX_SAMPLE_THRESH
+    assert isinstance(thresh, (float, int))
+    assert thresh > 0
+    old = dist.Binomial.approx_sample_thresh
     try:
-        _APPROX_SAMPLE_THRESH = thresh
+        dist.Binomial.approx_sample_thresh = thresh
+        print("DEBUG", dist.Binomial.approx_sample_thresh)
         yield
     finally:
-        _APPROX_SAMPLE_THRESH = old
+        dist.Binomial.approx_sample_thresh = old
+        print("DEBUG", dist.Binomial.approx_sample_thresh)
 
 
 def infection_dist(*,
@@ -34,8 +45,7 @@ def infection_dist(*,
                    num_infectious,
                    num_susceptible=math.inf,
                    population=math.inf,
-                   concentration=math.inf,
-                   approx_sample_thresh=None):
+                   concentration=math.inf):
     """
     Create a :class:`~pyro.distributions.Distribution` over the number of new
     infections at a discrete time step.
@@ -82,10 +92,6 @@ def infection_dist(*,
     :param concentration: The concentration or dispersion parameter ``k`` in
         overdispersed models of superspreaders [1,2]. This defaults to minimum
         variance ``concentration = ∞``.
-    :param approx_sample_thresh: Population threshold above which Binomial
-        samples will be approximated as clamped Poisson samples, including
-        internally in BetaBinomial sampling. Defaults to the global value which
-        defaults to 10000.
     """
     # Convert to colloquial variable names.
     R = individual_rate
@@ -110,19 +116,15 @@ def infection_dist(*,
         # Combine infections from all individuals.
         combined_p = p.neg().log1p().mul(I).expm1().neg()  # = 1 - (1 - p)**I
         combined_p = combined_p.clamp(min=1e-6)
-        if approx_sample_thresh is None:
-            approx_sample_thresh = _APPROX_SAMPLE_THRESH
 
         if isinstance(k, float) and k == math.inf:
             # Return a pure Binomial model, combining the independent Binomial
             # models of each infectious individual.
-            return dist.ExtendedBinomial(
-                S, combined_p, approx_sample_thresh=approx_sample_thresh)
+            return dist.ExtendedBinomial(S, combined_p)
         else:
             # Return an overdispersed Beta-Binomial model, combining
             # independent BetaBinomial(c1,c0,S) models for each infectious
             # individual.
             c1 = (k * I).clamp(min=1e-6)
             c0 = c1 * (combined_p.reciprocal() - 1).clamp(min=1e-6)
-            return dist.ExtendedBetaBinomial(
-                c1, c0, S, approx_sample_thresh=approx_sample_thresh)
+            return dist.ExtendedBetaBinomial(c1, c0, S)

--- a/pyro/contrib/epidemiology/distributions.py
+++ b/pyro/contrib/epidemiology/distributions.py
@@ -33,11 +33,9 @@ def set_approx_sample_thresh(thresh):
     old = dist.Binomial.approx_sample_thresh
     try:
         dist.Binomial.approx_sample_thresh = thresh
-        print("DEBUG", dist.Binomial.approx_sample_thresh)
         yield
     finally:
         dist.Binomial.approx_sample_thresh = old
-        print("DEBUG", dist.Binomial.approx_sample_thresh)
 
 
 def infection_dist(*,

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import numbers
 
 import torch
@@ -41,25 +40,17 @@ class BetaBinomial(TorchDistribution):
     :param float or torch.Tensor concentration0: 2nd concentration parameter (beta) for the
         Beta distribution.
     :param int or torch.Tensor total_count: number of Bernoulli trials.
-    :param approx_sample_thresh: EXPERIMENTAL total_count above which sampling
-        will use a clamped Poisson approximation for Binomial samples. This is useful
-        for sampling very large populations.
-    :type approx_sample_thresh: int or float
     """
     arg_constraints = {'concentration1': constraints.positive, 'concentration0': constraints.positive,
                        'total_count': constraints.nonnegative_integer}
     has_enumerate_support = True
     support = Binomial.support
 
-    def __init__(self, concentration1, concentration0, total_count=1, validate_args=None,
-                 *, approx_sample_thresh=math.inf):
-        assert isinstance(approx_sample_thresh, numbers.Number)
-        assert approx_sample_thresh >= 0
+    def __init__(self, concentration1, concentration0, total_count=1, validate_args=None):
         concentration1, concentration0, total_count = broadcast_all(
             concentration1, concentration0, total_count)
         self._beta = Beta(concentration1, concentration0)
         self.total_count = total_count
-        self.approx_sample_thresh = approx_sample_thresh
         super().__init__(self._beta._batch_shape, validate_args=validate_args)
 
     @property
@@ -75,15 +66,13 @@ class BetaBinomial(TorchDistribution):
         batch_shape = torch.Size(batch_shape)
         new._beta = self._beta.expand(batch_shape)
         new.total_count = self.total_count.expand_as(new._beta.concentration0)
-        new.approx_sample_thresh = self.approx_sample_thresh
         super(BetaBinomial, new).__init__(batch_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new
 
     def sample(self, sample_shape=()):
         probs = self._beta.sample(sample_shape)
-        return Binomial(self.total_count, probs,
-                        approx_sample_thresh=self.approx_sample_thresh).sample()
+        return Binomial(self.total_count, probs, validate_args=False).sample()
 
     def log_prob(self, value):
         if self._validate_args:

--- a/tests/distributions/test_binomial.py
+++ b/tests/distributions/test_binomial.py
@@ -4,6 +4,7 @@
 import pytest
 
 import pyro.distributions as dist
+from pyro.contrib.epidemiology.distributions import set_approx_sample_thresh
 from tests.common import assert_close
 
 
@@ -11,10 +12,10 @@ from tests.common import assert_close
 @pytest.mark.parametrize("prob", [0.01, 0.1, 0.5, 0.9, 0.99])
 def test_binomial_approx_sample(total_count, prob):
     sample_shape = (10000,)
-    d1 = dist.Binomial(total_count, prob)
-    d2 = dist.Binomial(total_count, prob, approx_sample_thresh=200)
-    expected = d1.sample(sample_shape)
-    actual = d2.sample(sample_shape)
+    d = dist.Binomial(total_count, prob)
+    expected = d.sample(sample_shape)
+    with set_approx_sample_thresh(200):
+        actual = d.sample(sample_shape)
 
     assert_close(expected.mean(), actual.mean(), rtol=0.05)
     assert_close(expected.std(), actual.std(), rtol=0.05)
@@ -25,11 +26,10 @@ def test_binomial_approx_sample(total_count, prob):
 @pytest.mark.parametrize("concentration0", [0.1, 1.0, 10.])
 def test_beta_binomial_approx_sample(concentration1, concentration0, total_count):
     sample_shape = (10000,)
-    d1 = dist.BetaBinomial(concentration1, concentration0, total_count)
-    d2 = dist.BetaBinomial(concentration1, concentration0, total_count,
-                           approx_sample_thresh=200)
-    expected = d1.sample(sample_shape)
-    actual = d2.sample(sample_shape)
+    d = dist.BetaBinomial(concentration1, concentration0, total_count)
+    expected = d.sample(sample_shape)
+    with set_approx_sample_thresh(200):
+        actual = d.sample(sample_shape)
 
     assert_close(expected.mean(), actual.mean(), rtol=0.1)
     assert_close(expected.std(), actual.std(), rtol=0.1)


### PR DESCRIPTION
Addresses #2426 

The aim of this PR is to lower compute cost of large regional models. Before this PR, regional models with large population are prohibitively slow to initialize due to `Binomial.sample()` cost. After this PR I can easily run regional models with large heterogeneous populations.

This follows #2484 by:
1. generalizing the Binomial approximation logic to allow heterogeneous `total_count` (e.g. for regional models with different populations in different regions);
2. making the binomial approximation a global variable (rather than an __init__ arg), thereby enabling approximation of all distributions used in `contrib.epidemiology` without user intervention; and
3. setting approximation thresholds for three methods of `CompartmentalModel`:
    - for `.heuristic()`, threshold = 100
    - for `.generate()`, threshold = 1000
    - for `.predict()`, threshold = 10000

## Tested
- [x] refactoring is covered by existing tests
- [x] ran a model that freezes my compute before this PR and works after:
    `python examples/contrib/epidemiology/regional.py -p 1000000 -r 10 -d 60`
- [x] successfully ran a colab notebook with large heterogeneous population.