### PR TITLE
add HaarTransform

### DIFF
--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -17,6 +17,7 @@ from pyro.distributions.transforms.basic import ELUTransform, LeakyReLUTransform
 from pyro.distributions.transforms.block_autoregressive import BlockAutoregressive, block_autoregressive
 from pyro.distributions.transforms.cholesky import CorrLCholeskyTransform
 from pyro.distributions.transforms.discrete_cosine import DiscreteCosineTransform
+from pyro.distributions.transforms.haar import HaarTransform
 from pyro.distributions.transforms.generalized_channel_permute import (ConditionalGeneralizedChannelPermute,
                                                                        GeneralizedChannelPermute,
                                                                        conditional_generalized_channel_permute,
@@ -82,6 +83,7 @@ __all__ = [
     'DiscreteCosineTransform',
     'ELUTransform',
     'GeneralizedChannelPermute',
+    'HaarTransform',
     'Householder',
     'LeakyReLUTransform',
     'LowerCholeskyAffine',

--- a/pyro/distributions/transforms/discrete_cosine.py
+++ b/pyro/distributions/transforms/discrete_cosine.py
@@ -23,8 +23,8 @@ class DiscreteCosineTransform(Transform):
         noise; when -1 this transforms violet noise to white noise; etc. Any
         real number is allowed. https://en.wikipedia.org/wiki/Colors_of_noise.
     """
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
 
     def __init__(self, dim=-1, smooth=0., cache_size=0):
@@ -72,7 +72,7 @@ class DiscreteCosineTransform(Transform):
         return x
 
     def log_abs_det_jacobian(self, x, y):
-        return x.new_zeros((1,) * self.event_dim)
+        return x.new_zeros(x.shape[:-self.event_dim])
 
     def with_cache(self, cache_size=1):
         if self._cache_size == cache_size:

--- a/pyro/distributions/transforms/haar.py
+++ b/pyro/distributions/transforms/haar.py
@@ -34,7 +34,8 @@ class HaarTransform(Transform):
         super().__init__(cache_size=cache_size)
 
     def __eq__(self, other):
-        return (type(self) == type(other) and self.event_dim == other.event_dim)
+        return (type(self) == type(other) and self.event_dim == other.event_dim and
+                self.flip == other.flip)
 
     def _call(self, x):
         dim = -self.event_dim

--- a/pyro/distributions/transforms/haar.py
+++ b/pyro/distributions/transforms/haar.py
@@ -23,8 +23,8 @@ class HaarTransform(Transform):
     :param bool flip: Whether to flip the time axis before applying the
         Haar transform. Defaults to false.
     """
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
 
     def __init__(self, dim=-1, flip=False, cache_size=0):
@@ -60,4 +60,4 @@ class HaarTransform(Transform):
         return x
 
     def log_abs_det_jacobian(self, x, y):
-        return x.new_zeros((1,) * self.event_dim)
+        return x.new_zeros(x.shape[:-self.event_dim])

--- a/pyro/distributions/transforms/haar.py
+++ b/pyro/distributions/transforms/haar.py
@@ -1,0 +1,62 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from torch.distributions import constraints
+from torch.distributions.transforms import Transform
+
+from pyro.ops.tensor_utils import haar_transform, inverse_haar_transform
+
+
+class HaarTransform(Transform):
+    """
+    Discrete Haar transform.
+
+    This uses :func:`~pyro.ops.tensor_utils.haar_transform` and
+    :func:`~pyro.ops.tensor_utils.inverse_haar_transform` to compute
+    (orthonormal) Haar and inverse Haar transforms. The jacobian is 1.
+    For sequences with length `T` not a power of two, this implementation
+    is equivalent to a block-structured Haar transform in which block
+    sizes decrease by factors of one half from left to right.
+
+    :param int dim: Dimension along which to transform. Must be negative.
+        This is an absolute dim counting from the right.
+    :param bool flip: Whether to flip the time axis before applying the
+        Haar transform. Defaults to false.
+    """
+    domain = constraints.real
+    codomain = constraints.real
+    bijective = True
+
+    def __init__(self, dim=-1, flip=False, cache_size=0):
+        assert isinstance(dim, int) and dim < 0
+        self.event_dim = -dim
+        self.flip = flip
+        super().__init__(cache_size=cache_size)
+
+    def __eq__(self, other):
+        return (type(self) == type(other) and self.event_dim == other.event_dim)
+
+    def _call(self, x):
+        dim = -self.event_dim
+        if dim != -1:
+            x = x.transpose(dim, -1)
+        if self.flip:
+            x = x.flip(-1)
+        y = haar_transform(x)
+        if dim != -1:
+            y = y.transpose(dim, -1)
+        return y
+
+    def _inverse(self, y):
+        dim = -self.event_dim
+        if dim != -1:
+            y = y.transpose(dim, -1)
+        x = inverse_haar_transform(y)
+        if self.flip:
+            x = x.flip(-1)
+        if dim != -1:
+            x = x.transpose(dim, -1)
+        return x
+
+    def log_abs_det_jacobian(self, x, y):
+        return x.new_zeros((1,) * self.event_dim)

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -6,7 +6,7 @@ import math
 import torch
 
 
-root_two_inverse = 1.0 / math.sqrt(2.0)
+_ROOT_TWO_INVERSE = 1.0 / math.sqrt(2.0)
 
 
 class _SafeLog(torch.autograd.Function):
@@ -365,8 +365,8 @@ def haar_transform(x):
     """
     n = x.size(-1) // 2
     even, odd, end = x[..., 0:n+n:2], x[..., 1:n+n:2], x[..., n+n:]
-    hi = root_two_inverse * (even - odd)
-    lo = root_two_inverse * (even + odd)
+    hi = _ROOT_TWO_INVERSE * (even - odd)
+    lo = _ROOT_TWO_INVERSE * (even + odd)
     if n >= 2:
         lo = haar_transform(lo)
     x = torch.cat([lo, hi, end], dim=-1)
@@ -385,8 +385,8 @@ def inverse_haar_transform(x):
     lo, hi, end = x[..., :n], x[..., n:n+n], x[..., n+n:]
     if n >= 2:
         lo = inverse_haar_transform(lo)
-    even = root_two_inverse * (lo + hi)
-    odd = root_two_inverse * (lo - hi)
+    even = _ROOT_TWO_INVERSE * (lo + hi)
+    odd = _ROOT_TWO_INVERSE * (lo - hi)
     even_odd = torch.stack([even, odd], dim=-1).reshape(even.shape[:-1] + (-1,))
     x = torch.cat([even_odd, end], dim=-1)
     return x

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -6,6 +6,9 @@ import math
 import torch
 
 
+root_two_inverse = 1.0 / math.sqrt(2.0)
+
+
 class _SafeLog(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x):
@@ -348,6 +351,45 @@ def idct(x, dim=-1):
     y = torch.irfft(Y, 1, onesided=True, signal_sizes=(N,))
     # Step 3
     return torch.stack([y, y.flip(-1)], axis=-1).reshape(x.shape[:-1] + (-1,))[..., :N]
+
+
+def haar_transform(x):
+    """
+    Discrete Haar transform.
+
+    Performs a Haar transform along the final dimension.
+    This is the inverse of :func:`inverse_haar_transform`.
+
+    :param Tensor x: The input signal.
+    :rtype: Tensor
+    """
+    n = x.size(-1) // 2
+    even, odd, end = x[..., 0:n+n:2], x[..., 1:n+n:2], x[..., n+n:]
+    hi = root_two_inverse * (even - odd)
+    lo = root_two_inverse * (even + odd)
+    if n >= 2:
+        lo = haar_transform(lo)
+    x = torch.cat([lo, hi, end], dim=-1)
+    return x
+
+
+def inverse_haar_transform(x):
+    """
+    Performs an inverse Haar transform along the final dimension.
+    This is the inverse of :func:`haar_transform`.
+
+    :param Tensor x: The input signal.
+    :rtype: Tensor
+    """
+    n = x.size(-1) // 2
+    lo, hi, end = x[..., :n], x[..., n:n+n], x[..., n+n:]
+    if n >= 2:
+        lo = inverse_haar_transform(lo)
+    even = root_two_inverse * (lo + hi)
+    odd = root_two_inverse * (lo - hi)
+    even_odd = torch.stack([even, odd], dim=-1).reshape(even.shape[:-1] + (-1,))
+    x = torch.cat([even_odd, end], dim=-1)
+    return x
 
 
 def cholesky(x):

--- a/tests/distributions/test_haar.py
+++ b/tests/distributions/test_haar.py
@@ -1,0 +1,13 @@
+import torch
+
+import pytest
+from pyro.distributions.transforms import HaarTransform
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize('size', [1, 3, 4, 7, 8, 9])
+def test_haar_ortho(size):
+    haar = HaarTransform()
+    eye = torch.eye(size)
+    mat = haar(eye)
+    assert_equal(eye, mat @ mat.t())

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -192,6 +192,11 @@ class TransformTests(TestCase):
         self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=1.0))
         self._test(lambda input_dim: T.DiscreteCosineTransform(smooth=2.0))
 
+    def test_haar_transform(self):
+        # NOTE: Need following since helper function unimplemented
+        self._test(lambda input_dim: T.HaarTransform(flip=True))
+        self._test(lambda input_dim: T.HaarTransform(flip=False))
+
     def test_elu(self):
         # NOTE: Need following since helper function mistakenly doesn't take input dim
         self._test(lambda input_dim: T.elu())


### PR DESCRIPTION
this discrete transformation can be useful in the context of time series models, where it can improve mixing in HMC inference.

this implementation is based on a recursive formulation suggested by @fritzo and @fehiepsi.