### PR TITLE
Fix reraising logic

### DIFF
--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -166,7 +166,9 @@ class TraceHandler:
             except (ValueError, RuntimeError):
                 exc_type, exc_value, traceback = sys.exc_info()
                 shapes = self.msngr.trace.format_shapes()
-                raise exc_type(u"{}\n{}".format(exc_value, shapes)).with_traceback(traceback)
+                exc = exc_type(u"{}\n{}".format(exc_value, shapes))
+                exc = exc.with_traceback(traceback)
+                raise exc from None
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 


### PR DESCRIPTION
This fixes rerasing logic to use `raise e from None` as specified in [PEP 409](https://www.python.org/dev/peps/pep-0409/) and described in [this stackoverflow post](https://stackoverflow.com/questions/52725278/during-handling-of-the-above-exception-another-exception-occurred). This issue did not occur in Python 2.7, and now that we've moved to Python 3.5+ we can use newer syntax.

Before this PR we get an enormous pytest error with "During the above exception another exception was raised", e.g.

<details>

```
% pytest -vx tests/contrib/epidemiology/test_sir.py -k haar_full_mass --pdb
============================================== test session starts ===============================================
platform darwin -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /Users/fritzo/miniconda3/envs/pyro/bin/python
cachedir: .pytest_cache
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/fritzo/github/pyro-ppl/pyro, inifile: setup.cfg
plugins: nbval-0.9.5, benchmark-3.2.3, forked-1.1.3, xdist-1.27.0
collected 64 items / 60 deselected / 4 selected

tests/contrib/epidemiology/test_sir.py::test_simple_smoke[{'haar_full_mass': 2}-0-3] FAILED                [ 25%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stdout >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stderr >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
I 	 Running inference...
Warmup:   0%|          | 0/6 [00:00, ?it/s]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured log >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
INFO     pyro.contrib.epidemiology.compartmental:compartmental.py:353 Running inference...
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

self = <pyro.poutine.trace_messenger.TraceHandler object at 0x123db0a50>, args = (), kwargs = {}
exc_type = <class 'NotImplementedError'>
exc_value = NotImplementedError('SplitReparam does not support sampling')
traceback = <traceback object at 0x123dc3af0>
shapes = 'Trace Shapes:  \n Param Sites:  \nSample Sites:  \n      R0 dist |\n        value |\n     rho dist |\n        value |'

    def __call__(self, *args, **kwargs):
        """
        Runs the stochastic function stored in this poutine,
        with additional side effects.

        Resets self.trace to an empty trace,
        installs itself on the global execution stack,
        runs self.fn with the given arguments,
        uninstalls itself from the global execution stack,
        stores the arguments and return value of the function in special sites,
        and returns self.fn's return value
        """
        with self.msngr:
            self.msngr.trace.add_node("_INPUT",
                                      name="_INPUT", type="args",
                                      args=args, kwargs=kwargs)
            try:
>               ret = self.fn(*args, **kwargs)

pyro/poutine/trace_messenger.py:165:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

context = <pyro.poutine.enum_messenger.EnumMessenger object at 0x123db0b10>
fn = _bound_partial(functools.partial(<function _context_wrap at 0x123400c20>, <pyro.poutine.infer_config_messenger.InferConfigMessenger object at 0x123db0b50>, <pyro.poutine.reparam_messenger.ReparamHandler object at 0x123d908d0>))
args = (), kwargs = {}

    def _context_wrap(context, fn, *args, **kwargs):
        with context:
>           return fn(*args, **kwargs)

pyro/poutine/messenger.py:11:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

context = <pyro.poutine.infer_config_messenger.InferConfigMessenger object at 0x123db0b50>
fn = <pyro.poutine.reparam_messenger.ReparamHandler object at 0x123d908d0>, args = (), kwargs = {}

    def _context_wrap(context, fn, *args, **kwargs):
        with context:
>           return fn(*args, **kwargs)

pyro/poutine/messenger.py:11:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.poutine.reparam_messenger.ReparamHandler object at 0x123d908d0>, args = (), kwargs = {}

    def __call__(self, *args, **kwargs):
        # This saves args,kwargs for optional use by reparameterizers.
        self.msngr._args_kwargs = args, kwargs
        try:
            with self.msngr:
>               return self.fn(*args, **kwargs)

pyro/poutine/reparam_messenger.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.poutine.reparam_messenger.ReparamHandler object at 0x123d90cd0>, args = (), kwargs = {}

    def __call__(self, *args, **kwargs):
        # This saves args,kwargs for optional use by reparameterizers.
        self.msngr._args_kwargs = args, kwargs
        try:
            with self.msngr:
>               return self.fn(*args, **kwargs)

pyro/poutine/reparam_messenger.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.contrib.epidemiology.sir.SimpleSIRModel object at 0x123d900d0>

    def _vectorized_model(self):
        """
        Vectorized model used for inference.
        """
        C = len(self.compartments)
        T = self.duration
        Q = self.num_quant_bins
        R_shape = getattr(self.population, "shape", ())  # Region shape.

        # Sample global parameters.
        params = self.global_model()

        # Sample the continuous reparameterizing variable.
        shape = (C, T) + R_shape
        auxiliary = pyro.sample("auxiliary",
                                dist.Uniform(-0.5, self.population + 0.5)
>                                   .mask(False).expand(shape).to_event())

pyro/contrib/epidemiology/compartmental.py:541:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'auxiliary', fn = Independent(MaskedDistribution(), 2), args = (), kwargs = {}, obs = None, infer = {}
msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def sample(name, fn, *args, **kwargs):
        """
        Calls the stochastic function `fn` with additional side-effects depending
        on `name` and the enclosing context (e.g. an inference algorithm).
        See `Intro I <http://pyro.ai/examples/intro_part_i.html>`_ and
        `Intro II <http://pyro.ai/examples/intro_part_ii.html>`_ for a discussion.

        :param name: name of sample
        :param fn: distribution class or function
        :param obs: observed datum (optional; should only be used in context of
            inference) optionally specified in kwargs
        :param dict infer: Optional dictionary of inference parameters specified
            in kwargs. See inference documentation for details.
        :returns: sample
        """
        obs = kwargs.pop("obs", None)
        infer = kwargs.pop("infer", {}).copy()
        # check if stack is empty
        # if stack empty, default behavior (defined here)
        if not am_i_wrapped():
            if obs is not None and not infer.get("_deterministic"):
                warnings.warn("trying to observe a value outside of inference at " + name,
                              RuntimeWarning)
                return obs
            return fn(*args, **kwargs)
        # if stack not empty, apply everything in the stack?
        else:
            # initialize data structure to pass up/down the stack
            msg = {
                "type": "sample",
                "name": name,
                "fn": fn,
                "is_observed": False,
                "args": args,
                "kwargs": kwargs,
                "value": None,
                "infer": infer,
                "scale": 1.0,
                "mask": None,
                "cond_indep_stack": (),
                "done": False,
                "stop": False,
                "continuation": None
            }
            # handle observation
            if obs is not None:
                msg["value"] = obs
                msg["is_observed"] = True
            # apply the stack and return its return value
>           apply_stack(msg)

pyro/primitives.py:113:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

initial_msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def apply_stack(initial_msg):
        """
        Execute the effect stack at a single site according to the following scheme:

            1. For each ``Messenger`` in the stack from bottom to top,
               execute ``Messenger._process_message`` with the message;
               if the message field "stop" is True, stop;
               otherwise, continue
            2. Apply default behavior (``default_process_message``) to finish remaining site execution
            3. For each ``Messenger`` in the stack from top to bottom,
               execute ``_postprocess_message`` to update the message and internal messenger state with the site results
            4. If the message field "continuation" is not ``None``, call it with the message

        :param dict initial_msg: the starting version of the trace site
        :returns: ``None``
        """
        stack = _PYRO_STACK
        # TODO check at runtime if stack is valid

        # msg is used to pass information up and down the stack
        msg = initial_msg

        pointer = 0
        # go until time to stop?
        for frame in reversed(stack):

            pointer = pointer + 1

>           frame._process_message(msg)

pyro/poutine/runtime.py:193:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.poutine.reparam_messenger.ReparamMessenger object at 0x123d909d0>
msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def _process_message(self, msg):
        """
        :param msg: current message at a trace site
        :returns: None

        Process the message by calling appropriate method of itself based
        on message type. The message is updated in place.
        """
        method_name = "_pyro_{}".format(msg["type"])
        if hasattr(self, method_name):
>           return getattr(self, method_name)(msg)

pyro/poutine/messenger.py:135:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.poutine.reparam_messenger.ReparamMessenger object at 0x123d909d0>
msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def _pyro_sample(self, msg):
        if isinstance(self.config, dict):
            reparam = self.config.get(msg["name"])
        else:
            reparam = self.config(msg)
        if reparam is None:
            return

        reparam.args_kwargs = self._args_kwargs
        try:
>           new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])

pyro/poutine/reparam_messenger.py:49:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.infer.reparam.haar.HaarReparam object at 0x123d903d0>, name = 'auxiliary'
fn = Independent(MaskedDistribution(), 2), obs = None

    def __call__(self, name, fn, obs):
        assert obs is None, "TransformReparam does not support observe statements"
        assert fn.event_dim >= self.transform.event_dim, (
            "Cannot transform along batch dimension; "
            "try converting a batch dimension to an event dimension")

        # Draw noise from the base distribution.
        transform = ComposeTransform([_with_cache(biject_to(fn.support).inv),
                                      self.transform])
        x_trans = pyro.sample("{}_{}".format(name, self.suffix),
>                             dist.TransformedDistribution(fn, transform))

pyro/infer/reparam/unit_jacobian.py:42:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'auxiliary_haar', fn = TransformedDistribution(), args = (), kwargs = {}, obs = None, infer = {}
msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def sample(name, fn, *args, **kwargs):
        """
        Calls the stochastic function `fn` with additional side-effects depending
        on `name` and the enclosing context (e.g. an inference algorithm).
        See `Intro I <http://pyro.ai/examples/intro_part_i.html>`_ and
        `Intro II <http://pyro.ai/examples/intro_part_ii.html>`_ for a discussion.

        :param name: name of sample
        :param fn: distribution class or function
        :param obs: observed datum (optional; should only be used in context of
            inference) optionally specified in kwargs
        :param dict infer: Optional dictionary of inference parameters specified
            in kwargs. See inference documentation for details.
        :returns: sample
        """
        obs = kwargs.pop("obs", None)
        infer = kwargs.pop("infer", {}).copy()
        # check if stack is empty
        # if stack empty, default behavior (defined here)
        if not am_i_wrapped():
            if obs is not None and not infer.get("_deterministic"):
                warnings.warn("trying to observe a value outside of inference at " + name,
                              RuntimeWarning)
                return obs
            return fn(*args, **kwargs)
        # if stack not empty, apply everything in the stack?
        else:
            # initialize data structure to pass up/down the stack
            msg = {
                "type": "sample",
                "name": name,
                "fn": fn,
                "is_observed": False,
                "args": args,
                "kwargs": kwargs,
                "value": None,
                "infer": infer,
                "scale": 1.0,
                "mask": None,
                "cond_indep_stack": (),
                "done": False,
                "stop": False,
                "continuation": None
            }
            # handle observation
            if obs is not None:
                msg["value"] = obs
                msg["is_observed"] = True
            # apply the stack and return its return value
>           apply_stack(msg)

pyro/primitives.py:113:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

initial_msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def apply_stack(initial_msg):
        """
        Execute the effect stack at a single site according to the following scheme:

            1. For each ``Messenger`` in the stack from bottom to top,
               execute ``Messenger._process_message`` with the message;
               if the message field "stop" is True, stop;
               otherwise, continue
            2. Apply default behavior (``default_process_message``) to finish remaining site execution
            3. For each ``Messenger`` in the stack from top to bottom,
               execute ``_postprocess_message`` to update the message and internal messenger state with the site results
            4. If the message field "continuation" is not ``None``, call it with the message

        :param dict initial_msg: the starting version of the trace site
        :returns: ``None``
        """
        stack = _PYRO_STACK
        # TODO check at runtime if stack is valid

        # msg is used to pass information up and down the stack
        msg = initial_msg

        pointer = 0
        # go until time to stop?
        for frame in reversed(stack):

            pointer = pointer + 1

>           frame._process_message(msg)

pyro/poutine/runtime.py:193:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.poutine.reparam_messenger.ReparamMessenger object at 0x123d90c50>
msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def _process_message(self, msg):
        """
        :param msg: current message at a trace site
        :returns: None

        Process the message by calling appropriate method of itself based
        on message type. The message is updated in place.
        """
        method_name = "_pyro_{}".format(msg["type"])
        if hasattr(self, method_name):
>           return getattr(self, method_name)(msg)

pyro/poutine/messenger.py:135:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.poutine.reparam_messenger.ReparamMessenger object at 0x123d90c50>
msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def _pyro_sample(self, msg):
        if isinstance(self.config, dict):
            reparam = self.config.get(msg["name"])
        else:
            reparam = self.config(msg)
        if reparam is None:
            return

        reparam.args_kwargs = self._args_kwargs
        try:
>           new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])

pyro/poutine/reparam_messenger.py:49:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pyro.infer.reparam.split.SplitReparam object at 0x123d90a10>, name = 'auxiliary_haar'
fn = TransformedDistribution(), obs = None

    def __call__(self, name, fn, obs):
        assert fn.event_dim >= self.event_dim
        assert obs is None, "SplitReparam does not support observe statements"

        # Draw independent parts.
        dim = -self.event_dim
        left_shape = fn.event_shape[:dim]
        right_shape = fn.event_shape[:1 + dim]
        parts = []
        for i, size in enumerate(self.sections):
            event_shape = left_shape + (size,) + right_shape
            parts.append(pyro.sample(
                "{}_split_{}".format(name, i),
>               _ImproperUniform(fn.support, fn.batch_shape, event_shape)))

pyro/infer/reparam/split.py:78:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'auxiliary_haar_split_0'
fn = <[NotImplementedError() raised in repr()] _ImproperUniform object at 0x123dbe3d0>, args = (), kwargs = {}
obs = None, infer = {}, msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def sample(name, fn, *args, **kwargs):
        """
        Calls the stochastic function `fn` with additional side-effects depending
        on `name` and the enclosing context (e.g. an inference algorithm).
        See `Intro I <http://pyro.ai/examples/intro_part_i.html>`_ and
        `Intro II <http://pyro.ai/examples/intro_part_ii.html>`_ for a discussion.

        :param name: name of sample
        :param fn: distribution class or function
        :param obs: observed datum (optional; should only be used in context of
            inference) optionally specified in kwargs
        :param dict infer: Optional dictionary of inference parameters specified
            in kwargs. See inference documentation for details.
        :returns: sample
        """
        obs = kwargs.pop("obs", None)
        infer = kwargs.pop("infer", {}).copy()
        # check if stack is empty
        # if stack empty, default behavior (defined here)
        if not am_i_wrapped():
            if obs is not None and not infer.get("_deterministic"):
                warnings.warn("trying to observe a value outside of inference at " + name,
                              RuntimeWarning)
                return obs
            return fn(*args, **kwargs)
        # if stack not empty, apply everything in the stack?
        else:
            # initialize data structure to pass up/down the stack
            msg = {
                "type": "sample",
                "name": name,
                "fn": fn,
                "is_observed": False,
                "args": args,
                "kwargs": kwargs,
                "value": None,
                "infer": infer,
                "scale": 1.0,
                "mask": None,
                "cond_indep_stack": (),
                "done": False,
                "stop": False,
                "continuation": None
            }
            # handle observation
            if obs is not None:
                msg["value"] = obs
                msg["is_observed"] = True
            # apply the stack and return its return value
>           apply_stack(msg)

pyro/primitives.py:113:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

initial_msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def apply_stack(initial_msg):
        """
        Execute the effect stack at a single site according to the following scheme:

            1. For each ``Messenger`` in the stack from bottom to top,
               execute ``Messenger._process_message`` with the message;
               if the message field "stop" is True, stop;
               otherwise, continue
            2. Apply default behavior (``default_process_message``) to finish remaining site execution
            3. For each ``Messenger`` in the stack from top to bottom,
               execute ``_postprocess_message`` to update the message and internal messenger state with the site results
            4. If the message field "continuation" is not ``None``, call it with the message

        :param dict initial_msg: the starting version of the trace site
        :returns: ``None``
        """
        stack = _PYRO_STACK
        # TODO check at runtime if stack is valid

        # msg is used to pass information up and down the stack
        msg = initial_msg

        pointer = 0
        # go until time to stop?
        for frame in reversed(stack):

            pointer = pointer + 1

            frame._process_message(msg)

            if msg["stop"]:
                break

        print("DEBUG {}".format(" ".join(str(type(f).__name__) for f in stack)))
>       default_process_message(msg)

pyro/poutine/runtime.py:199:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

msg = {'args': (), 'cond_indep_stack': (), 'continuation': None, 'done': False, ...}

    def default_process_message(msg):
        """
        Default method for processing messages in inference.

        :param msg: a message to be processed
        :returns: None
        """
        if msg["done"] or msg["is_observed"] or msg["value"] is not None:
            msg["done"] = True
            return msg

>       msg["value"] = msg["fn"](*msg["args"], **msg["kwargs"])

pyro/poutine/runtime.py:159:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[NotImplementedError() raised in repr()] _ImproperUniform object at 0x123dbe3d0>
sample_shape = torch.Size([])

    def __call__(self, sample_shape=torch.Size()):
        """
        Samples a random value.

        This is reparameterized whenever possible, calling
        :meth:`~torch.distributions.distribution.Distribution.rsample` for
        reparameterized distributions and
        :meth:`~torch.distributions.distribution.Distribution.sample` for
        non-reparameterized distributions.

        :param sample_shape: the size of the iid batch to be drawn from the
            distribution.
        :type sample_shape: torch.Size
        :return: A random value or batch of random values (if parameters are
            batched). The shape of the result should be `self.shape()`.
        :rtype: torch.Tensor
        """
>       return self.rsample(sample_shape) if self.has_rsample else self.sample(sample_shape)

pyro/distributions/torch_distribution.py:45:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[NotImplementedError() raised in repr()] _ImproperUniform object at 0x123dbe3d0>
sample_shape = torch.Size([])

    def sample(self, sample_shape=torch.Size()):
>       raise NotImplementedError("SplitReparam does not support sampling")
E       NotImplementedError: SplitReparam does not support sampling

pyro/infer/reparam/split.py:35: NotImplementedError

During handling of the above exception, another exception occurred:

duration = 3, forecast = 0, options = {'haar_full_mass': 2}

    @pytest.mark.parametrize("duration", [3, 7])
    @pytest.mark.parametrize("forecast", [0, 7])
    @pytest.mark.parametrize("options", [
        {},
        {"haar": True},
        {"haar_full_mass": 2},
        {"num_quant_bins": 8},
        {"num_quant_bins": 12},
        {"num_quant_bins": 16},
        {"arrowhead_mass": True},
    ], ids=str)
    def test_simple_smoke(duration, forecast, options):
        population = 100
        recovery_time = 7.0

        # Generate data.
        model = SimpleSIRModel(population, recovery_time, [None] * duration)
        for attempt in range(100):
            data = model.generate({"R0": 1.5, "rho": 0.5})["obs"]
            if data.sum():
                break
        assert data.sum() > 0, "failed to generate positive data"

        # Infer.
        model = SimpleSIRModel(population, recovery_time, data)
        num_samples = 5
>       model.fit(warmup_steps=1, num_samples=num_samples, max_tree_depth=2, **options)

tests/contrib/epidemiology/test_sir.py:42:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pyro/contrib/epidemiology/compartmental.py:374: in fit
    mcmc.run()
pyro/poutine/messenger.py:11: in _context_wrap
    return fn(*args, **kwargs)
pyro/infer/mcmc/api.py:377: in run
    for x, chain_id in self.sampler.run(*args, **kwargs):
pyro/infer/mcmc/api.py:168: in run
    *args, **kwargs):
pyro/infer/mcmc/api.py:110: in _gen_samples
    kernel.setup(warmup_steps, *args, **kwargs)
pyro/infer/mcmc/hmc.py:303: in setup
    self._initialize_model_properties(args, kwargs)
pyro/infer/mcmc/hmc.py:255: in _initialize_model_properties
    initial_params=self._initial_params,
pyro/infer/mcmc/util.py:385: in initialize_model
    model_trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
pyro/poutine/trace_messenger.py:185: in get_trace
    self(*args, **kwargs)
pyro/poutine/trace_messenger.py:169: in __call__
    raise exc_type(u"{}\n{}".format(exc_value, shapes)).with_traceback(traceback)
pyro/poutine/trace_messenger.py:165: in __call__
    ret = self.fn(*args, **kwargs)
pyro/poutine/messenger.py:11: in _context_wrap
    return fn(*args, **kwargs)
pyro/poutine/messenger.py:11: in _context_wrap
    return fn(*args, **kwargs)
pyro/poutine/reparam_messenger.py:76: in __call__
    return self.fn(*args, **kwargs)
pyro/poutine/reparam_messenger.py:76: in __call__
    return self.fn(*args, **kwargs)
pyro/contrib/epidemiology/compartmental.py:541: in _vectorized_model
    .mask(False).expand(shape).to_event())
pyro/primitives.py:113: in sample
    apply_stack(msg)
pyro/poutine/runtime.py:193: in apply_stack
    frame._process_message(msg)
pyro/poutine/messenger.py:135: in _process_message
    return getattr(self, method_name)(msg)
pyro/poutine/reparam_messenger.py:49: in _pyro_sample
    new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
pyro/infer/reparam/unit_jacobian.py:42: in __call__
    dist.TransformedDistribution(fn, transform))
pyro/primitives.py:113: in sample
    apply_stack(msg)
pyro/poutine/runtime.py:193: in apply_stack
    frame._process_message(msg)
pyro/poutine/messenger.py:135: in _process_message
    return getattr(self, method_name)(msg)
pyro/poutine/reparam_messenger.py:49: in _pyro_sample
    new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
pyro/infer/reparam/split.py:78: in __call__
    _ImproperUniform(fn.support, fn.batch_shape, event_shape)))
pyro/primitives.py:113: in sample
    apply_stack(msg)
pyro/poutine/runtime.py:199: in apply_stack
    default_process_message(msg)
pyro/poutine/runtime.py:159: in default_process_message
    msg["value"] = msg["fn"](*msg["args"], **msg["kwargs"])
pyro/distributions/torch_distribution.py:45: in __call__
    return self.rsample(sample_shape) if self.has_rsample else self.sample(sample_shape)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[NotImplementedError() raised in repr()] _ImproperUniform object at 0x123dbe3d0>
sample_shape = torch.Size([])

    def sample(self, sample_shape=torch.Size()):
>       raise NotImplementedError("SplitReparam does not support sampling")
E       NotImplementedError: SplitReparam does not support sampling
E       Trace Shapes:
E        Param Sites:
E       Sample Sites:
E             R0 dist |
E               value |
E            rho dist |
E               value |

pyro/infer/reparam/split.py:35: NotImplementedError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /Users/fritzo/github/pyro-ppl/pyro/pyro/infer/reparam/split.py(35)sample()
-> raise NotImplementedError("SplitReparam does not support sampling")
```

</details>

After this PR we get a much simpler more readable trace, e.g.

<details>

```
% pytest -vx tests/contrib/epidemiology/test_sir.py -k haar_full_mass --pdb
============================================== test session starts ===============================================
platform darwin -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /Users/fritzo/miniconda3/envs/pyro/bin/python
cachedir: .pytest_cache
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/fritzo/github/pyro-ppl/pyro, inifile: setup.cfg
plugins: nbval-0.9.5, benchmark-3.2.3, forked-1.1.3, xdist-1.27.0
collected 64 items / 60 deselected / 4 selected

tests/contrib/epidemiology/test_sir.py::test_simple_smoke[{'haar_full_mass': 2}-0-3] FAILED                [ 25%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stdout >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stderr >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
I 	 Running inference...
Warmup:   0%|          | 0/6 [00:00, ?it/s]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured log >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
INFO     pyro.contrib.epidemiology.compartmental:compartmental.py:353 Running inference...
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

duration = 3, forecast = 0, options = {'haar_full_mass': 2}

    @pytest.mark.parametrize("duration", [3, 7])
    @pytest.mark.parametrize("forecast", [0, 7])
    @pytest.mark.parametrize("options", [
        {},
        {"haar": True},
        {"haar_full_mass": 2},
        {"num_quant_bins": 8},
        {"num_quant_bins": 12},
        {"num_quant_bins": 16},
        {"arrowhead_mass": True},
    ], ids=str)
    def test_simple_smoke(duration, forecast, options):
        population = 100
        recovery_time = 7.0

        # Generate data.
        model = SimpleSIRModel(population, recovery_time, [None] * duration)
        for attempt in range(100):
            data = model.generate({"R0": 1.5, "rho": 0.5})["obs"]
            if data.sum():
                break
        assert data.sum() > 0, "failed to generate positive data"

        # Infer.
        model = SimpleSIRModel(population, recovery_time, data)
        num_samples = 5
>       model.fit(warmup_steps=1, num_samples=num_samples, max_tree_depth=2, **options)

tests/contrib/epidemiology/test_sir.py:42:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pyro/contrib/epidemiology/compartmental.py:374: in fit
    mcmc.run()
pyro/poutine/messenger.py:11: in _context_wrap
    return fn(*args, **kwargs)
pyro/infer/mcmc/api.py:377: in run
    for x, chain_id in self.sampler.run(*args, **kwargs):
pyro/infer/mcmc/api.py:168: in run
    *args, **kwargs):
pyro/infer/mcmc/api.py:110: in _gen_samples
    kernel.setup(warmup_steps, *args, **kwargs)
pyro/infer/mcmc/hmc.py:303: in setup
    self._initialize_model_properties(args, kwargs)
pyro/infer/mcmc/hmc.py:255: in _initialize_model_properties
    initial_params=self._initial_params,
pyro/infer/mcmc/util.py:385: in initialize_model
    model_trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
pyro/poutine/trace_messenger.py:187: in get_trace
    self(*args, **kwargs)
pyro/poutine/trace_messenger.py:171: in __call__
    raise exc from None
pyro/poutine/trace_messenger.py:165: in __call__
    ret = self.fn(*args, **kwargs)
pyro/poutine/messenger.py:11: in _context_wrap
    return fn(*args, **kwargs)
pyro/poutine/messenger.py:11: in _context_wrap
    return fn(*args, **kwargs)
pyro/poutine/reparam_messenger.py:76: in __call__
    return self.fn(*args, **kwargs)
pyro/poutine/reparam_messenger.py:76: in __call__
    return self.fn(*args, **kwargs)
pyro/contrib/epidemiology/compartmental.py:541: in _vectorized_model
    .mask(False).expand(shape).to_event())
pyro/primitives.py:113: in sample
    apply_stack(msg)
pyro/poutine/runtime.py:193: in apply_stack
    frame._process_message(msg)
pyro/poutine/messenger.py:135: in _process_message
    return getattr(self, method_name)(msg)
pyro/poutine/reparam_messenger.py:49: in _pyro_sample
    new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
pyro/infer/reparam/unit_jacobian.py:42: in __call__
    dist.TransformedDistribution(fn, transform))
pyro/primitives.py:113: in sample
    apply_stack(msg)
pyro/poutine/runtime.py:193: in apply_stack
    frame._process_message(msg)
pyro/poutine/messenger.py:135: in _process_message
    return getattr(self, method_name)(msg)
pyro/poutine/reparam_messenger.py:49: in _pyro_sample
    new_fn, value = reparam(msg["name"], msg["fn"], msg["value"])
pyro/infer/reparam/split.py:78: in __call__
    _ImproperUniform(fn.support, fn.batch_shape, event_shape)))
pyro/primitives.py:113: in sample
    apply_stack(msg)
pyro/poutine/runtime.py:199: in apply_stack
    default_process_message(msg)
pyro/poutine/runtime.py:159: in default_process_message
    msg["value"] = msg["fn"](*msg["args"], **msg["kwargs"])
pyro/distributions/torch_distribution.py:45: in __call__
    return self.rsample(sample_shape) if self.has_rsample else self.sample(sample_shape)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[NotImplementedError() raised in repr()] _ImproperUniform object at 0x127d19250>
sample_shape = torch.Size([])

    def sample(self, sample_shape=torch.Size()):
>       raise NotImplementedError("SplitReparam does not support sampling")
E       NotImplementedError: SplitReparam does not support sampling
E       Trace Shapes:
E        Param Sites:
E       Sample Sites:
E             R0 dist |
E               value |
E            rho dist |
E               value |

pyro/infer/reparam/split.py:35: NotImplementedError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /Users/fritzo/github/pyro-ppl/pyro/pyro/infer/reparam/split.py(35)sample()
-> raise NotImplementedError("SplitReparam does not support sampling")
```

</details>