### PR TITLE
Add a shifted Stirling approximation to log Beta function

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -34,6 +34,15 @@ Newton Optimizers
     :show-inheritance:
     :member-order: bysource
 
+Special Functions
+-----------------
+
+.. automodule:: pyro.ops.special
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
+
 Tensor Utilities
 ----------------
 

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -23,7 +23,7 @@ from pyro.infer.reparam import HaarReparam, SplitReparam
 from pyro.infer.smcfilter import SMCFailed
 from pyro.util import warn_if_nan
 
-from .distributions import set_approx_sample_thresh
+from .distributions import set_approx_log_prob_tol, set_approx_sample_thresh
 from .util import align_samples, cat2, clamp, quantize, quantize_enumerate
 
 logger = logging.getLogger(__name__)
@@ -144,6 +144,7 @@ class CompartmentalModel(ABC):
     full_mass = False
 
     @torch.no_grad()
+    @set_approx_log_prob_tol(0.1)
     @set_approx_sample_thresh(100)  # This is robust to gross approximation.
     def heuristic(self, num_particles=1024, ess_threshold=0.5, retries=10):
         """

--- a/pyro/contrib/epidemiology/distributions.py
+++ b/pyro/contrib/epidemiology/distributions.py
@@ -42,9 +42,10 @@ def set_approx_sample_thresh(thresh):
 def set_approx_log_prob_tol(tol):
     """
     EXPERIMENTAL Temporarily set the global default value of
-    ``BetaBinomial.approx_log_prob_tol``, thereby decreasing the computational
-    complexity of scoring :class:`~pyro.distributions.BetaBinomial`
-    distributions.
+    ``Binomial.approx_log_prob_tol`` and ``BetaBinomial.approx_log_prob_tol``,
+    thereby decreasing the computational complexity of scoring
+    :class:`~pyro.distributions.Binomial` and
+    :class:`~pyro.distributions.BetaBinomial` distributions.
 
     This is used internally by
     :class:`~pyro.contrib.epidemiology.compartmental.CompartmentalModel`.
@@ -54,12 +55,15 @@ def set_approx_log_prob_tol(tol):
     """
     assert isinstance(tol, (float, int))
     assert tol > 0
-    old = dist.BetaBinomial.approx_log_prob_tol
+    old1 = dist.Binomial.approx_log_prob_tol
+    old2 = dist.BetaBinomial.approx_log_prob_tol
     try:
+        dist.Binomial.approx_log_prob_tol = tol
         dist.BetaBinomial.approx_log_prob_tol = tol
         yield
     finally:
-        dist.BetaBinomial.approx_log_prob_tol = old
+        dist.Binomial.approx_log_prob_tol = old1
+        dist.BetaBinomial.approx_log_prob_tol = old2
 
 
 def infection_dist(*,

--- a/pyro/contrib/epidemiology/distributions.py
+++ b/pyro/contrib/epidemiology/distributions.py
@@ -38,6 +38,30 @@ def set_approx_sample_thresh(thresh):
         dist.Binomial.approx_sample_thresh = old
 
 
+@contextmanager
+def set_approx_log_prob_tol(tol):
+    """
+    EXPERIMENTAL Temporarily set the global default value of
+    ``BetaBinomial.approx_log_prob_tol``, thereby decreasing the computational
+    complexity of scoring :class:`~pyro.distributions.BetaBinomial`
+    distributions.
+
+    This is used internally by
+    :class:`~pyro.contrib.epidemiology.compartmental.CompartmentalModel`.
+
+    :param tol: New temporary tolold.
+    :type tol: int or float.
+    """
+    assert isinstance(tol, (float, int))
+    assert tol > 0
+    old = dist.BetaBinomial.approx_log_prob_tol
+    try:
+        dist.BetaBinomial.approx_log_prob_tol = tol
+        yield
+    finally:
+        dist.BetaBinomial.approx_log_prob_tol = old
+
+
 def infection_dist(*,
                    individual_rate,
                    num_infectious,

--- a/pyro/ops/special.py
+++ b/pyro/ops/special.py
@@ -42,8 +42,8 @@ def log_beta_stirling(x, y, tol=0.1):
 
     :param torch.Tensor x: A positive tensor.
     :param torch.Tensor y: A positive tensor.
-    :param float tol: Bound on maximum absolute error. Defaults to 0.1.
-        For very small ``tol``, this function simply defers to :func:`log_beta`.
+    :param float tol: Bound on maximum absolute error. Defaults to 0.1. For
+        very small ``tol``, this function simply defers to :func:`log_beta`.
     """
     assert isinstance(tol, (float, int)) and tol >= 0
     if tol < 0.02:

--- a/pyro/ops/special.py
+++ b/pyro/ops/special.py
@@ -1,0 +1,65 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import functools
+import math
+import operator
+
+
+def log_beta(x, y):
+    """
+    Log Beta function.
+
+    :param torch.Tensor x: A positive tensor.
+    :param torch.Tensor y: A positive tensor.
+    """
+    return x.lgamma() + y.lgamma() - (x + y).lgamma()
+
+
+def log_beta_stirling(x, y, tol=0.1):
+    """
+    Shifted Stirling's approximation to the log Beta function.
+
+    This adapts Stirling's approximation of the log Gamma function::
+
+       lgamma(z) ~ (z - 1/2) * log(z) - z + log(2 * pi) / 2
+
+    to the log Beta function::
+
+        log_beta(x, y) ~ ((x-1/2) * log(x) + (y-1/2) * log(y)
+                         - (x+y-1/2) * log(x+y) + log(2*pi)/2)
+
+    This additionally improves accuracy near zero by iteratively shifting
+    the ``lgamma`` approximation using the recursion::
+
+        lgamma(x) = lgamma(x + 1) - log(x)
+
+    If this recursion is applied ``n`` times, then absolute error is bounded by
+    ``error < 0.082 / n < tol``, where ``n`` is chosen based on user provided
+    ``tol``.
+
+    :param torch.Tensor x: A positive tensor.
+    :param torch.Tensor y: A positive tensor.
+    :param float tol: Bound on maximum absolute error. Defaults to 0.1.
+        For very small ``tol``, :func:`log_beta` is used.
+    """
+    assert isinstance(tol, (float, int)) and tol >= 0
+    if tol < 0.01:
+        # Eventually it is cheaper to simply use torch.lgamma().
+        return log_beta(x, y)
+
+    # This bound holds for arbitrary x,y. We could do better with large x,y.
+    shift = int(math.ceil(0.082 / tol))
+
+    xy = x + y
+    factors = []
+    for _ in range(shift):
+        factors.append(xy / (x * y))
+        x = x + 1
+        y = y + 1
+        xy = xy + 1
+
+    log_factor = functools.reduce(operator.mul, factors).log() if factors else 0
+
+    return (log_factor + (x - 0.5) * x.log() + (y - 0.5) * y.log()
+            - (xy - 0.5) * xy.log() + (math.log(2 * math.pi) / 2 - shift))

--- a/pyro/ops/special.py
+++ b/pyro/ops/special.py
@@ -20,32 +20,34 @@ def log_beta_stirling(x, y, tol=0.1):
     """
     Shifted Stirling's approximation to the log Beta function.
 
+    This is useful as a cheaper alternative to :func:`log_beta`.
+
     This adapts Stirling's approximation of the log Gamma function::
 
-       lgamma(z) ~ (z - 1/2) * log(z) - z + log(2 * pi) / 2
+        lgamma(z) ≈ (z - 1/2) * log(z) - z + log(2 * pi) / 2
 
-    to the log Beta function::
+    to approximate the log Beta function::
 
-        log_beta(x, y) ~ ((x-1/2) * log(x) + (y-1/2) * log(y)
-                         - (x+y-1/2) * log(x+y) + log(2*pi)/2)
+        log_beta(x, y) ≈ ((x-1/2) * log(x) + (y-1/2) * log(y)
+                          - (x+y-1/2) * log(x+y) + log(2*pi)/2)
 
     This additionally improves accuracy near zero by iteratively shifting
-    the ``lgamma`` approximation using the recursion::
+    the log Gamma approximation using the recursion::
 
         lgamma(x) = lgamma(x + 1) - log(x)
 
     If this recursion is applied ``n`` times, then absolute error is bounded by
-    ``error < 0.082 / n < tol``, where ``n`` is chosen based on user provided
-    ``tol``.
+    ``error < 0.082 / n < tol``, thus we choose ``n`` based on the user
+    provided ``tol``.
 
     :param torch.Tensor x: A positive tensor.
     :param torch.Tensor y: A positive tensor.
     :param float tol: Bound on maximum absolute error. Defaults to 0.1.
-        For very small ``tol``, :func:`log_beta` is used.
+        For very small ``tol``, this function simply defers to :func:`log_beta`.
     """
     assert isinstance(tol, (float, int)) and tol >= 0
-    if tol < 0.01:
-        # Eventually it is cheaper to simply use torch.lgamma().
+    if tol < 0.02:
+        # Eventually it is cheaper to defer to torch.lgamma().
         return log_beta(x, y)
 
     # This bound holds for arbitrary x,y. We could do better with large x,y.
@@ -59,7 +61,7 @@ def log_beta_stirling(x, y, tol=0.1):
         y = y + 1
         xy = xy + 1
 
-    log_factor = functools.reduce(operator.mul, factors).log() if factors else 0
+    log_factor = functools.reduce(operator.mul, factors).log()
 
     return (log_factor + (x - 0.5) * x.log() + (y - 0.5) * y.log()
             - (xy - 0.5) * xy.log() + (math.log(2 * math.pi) / 2 - shift))

--- a/tests/distributions/test_binomial.py
+++ b/tests/distributions/test_binomial.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
 
 import pyro.distributions as dist
-from pyro.contrib.epidemiology.distributions import set_approx_sample_thresh
+from pyro.contrib.epidemiology.distributions import set_approx_log_prob_tol, set_approx_sample_thresh
 from tests.common import assert_close
 
 
@@ -33,3 +34,19 @@ def test_beta_binomial_approx_sample(concentration1, concentration0, total_count
 
     assert_close(expected.mean(), actual.mean(), rtol=0.1)
     assert_close(expected.std(), actual.std(), rtol=0.1)
+
+
+@pytest.mark.parametrize("tol", [
+    1e-8, 1e-6, 1e-4, 1e-2, 0.02, 0.05, 0.1, 0.2, 0.1, 1.,
+])
+def test_binomial_approx_log_prob(tol):
+    logits = torch.linspace(-10., 10., 100)
+    k = torch.arange(100.).unsqueeze(-1)
+    n_minus_k = torch.arange(100.).unsqueeze(-1).unsqueeze(-1)
+    n = k + n_minus_k
+
+    expected = torch.distributions.Binomial(n, logits=logits).log_prob(k)
+    with set_approx_log_prob_tol(tol):
+        actual = dist.Binomial(n, logits=logits).log_prob(k)
+
+    assert_close(actual, expected, atol=tol)

--- a/tests/ops/test_special.py
+++ b/tests/ops/test_special.py
@@ -4,18 +4,33 @@
 import pytest
 import torch
 
-from pyro.ops.special import log_beta, log_beta_stirling
+from pyro.ops.special import log_beta, log_binomial
 
 
 @pytest.mark.parametrize("tol", [
     1e-8, 1e-6, 1e-4, 1e-2, 0.02, 0.05, 0.1, 0.2, 0.1, 1.,
 ])
 def test_log_beta_stirling(tol):
-    x = torch.logspace(-5, 5, 100)
+    x = torch.logspace(-5, 5, 200)
     y = x.unsqueeze(-1)
 
     expected = log_beta(x, y)
-    actual = log_beta_stirling(x, y, tol=tol)
+    actual = log_beta(x, y, tol=tol)
 
     assert (actual <= expected).all()
     assert (expected < actual + tol).all()
+
+
+@pytest.mark.parametrize("tol", [
+    1e-8, 1e-6, 1e-4, 1e-2, 0.02, 0.05, 0.1, 0.2, 0.1, 1.,
+])
+def test_log_binomial_stirling(tol):
+    k = torch.arange(200.)
+    n_minus_k = k.unsqueeze(-1)
+    n = k + n_minus_k
+
+    # Test binomial coefficient choose(n, k).
+    expected = (n + 1).lgamma() - (k + 1).lgamma() - (n_minus_k + 1).lgamma()
+    actual = log_binomial(n, k, tol=tol)
+
+    assert (actual - expected).abs().max() < tol

--- a/tests/ops/test_special.py
+++ b/tests/ops/test_special.py
@@ -1,0 +1,21 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pyro.ops.special import log_beta, log_beta_stirling
+
+
+@pytest.mark.parametrize("tol", [
+    1e-8, 1e-6, 1e-4, 1e-2, 0.02, 0.05, 0.1, 0.2, 0.1, 1.,
+])
+def test_log_beta_stirling(tol):
+    x = torch.logspace(-5, 5, 100)
+    y = x.unsqueeze(-1)
+
+    expected = log_beta(x, y)
+    actual = log_beta_stirling(x, y, tol=tol)
+
+    assert (actual <= expected).all()
+    assert (expected < actual + tol).all()


### PR DESCRIPTION
Addresses #2426 
Blocking #2498 
See [derivation notebook](https://github.com/fritzo/notebooks/blob/master/beta_function.ipynb).

This implements a cheap approximate `log_beta()` function for use in `Binomial.log_prob()` and `BetaBinomial.log_prob()`. This is motivated by profiling results of #2498 which showed that `torch.lgamma()` was taking more than half of inference time. This PR also refactors to use the new approximation in `CompartimentalModel.heuristic()`, and I plan to use the approximation in more places in #2498.

## Accuracy

Users specify a `tol` parameter which is absolute error (in log space) and is worst for small values of `x,y` in `log_beta(x,y)`. When does this happen in `pyro.contrib.epidemiology`? The only circumstance when one of `x,y` is small is in superspreading models with small `k` and tiny infectious population, so `k * I <= 1`; in all other cases this approximation is more accurate than the stated `tol`.

## Speed

This approximation speeds up `log_beta()` by about 2.5x at loosest tolerance 0.1.

| time | function |
|-|-|
| 116ms | `log_beta(x, y)` |
| **46ms** | `log_beta_stirling(x, y, tol=0.1)` |
| 74ms | `log_beta_stirling(x, y, tol=0.05)` |
| 171ms | `log_beta_stirling(x, y, tol=0.02)` |

## Tested
- [x] added unit tests for `log_beta()` and `log_binomial()` at a variety of tolerances
- [x] added unit test of `Binomial.log_prob()` at a variety of tolerances
- [x] refactoring of `BetaBinomial` is covered by existing tests
- [x] new usage in `CompartmentalModel.heuristic` is covered by superspreader smoke tests