### PR TITLE
Fix behavior of disable_validation=False

### DIFF
--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -375,7 +375,7 @@ class CompartmentalModel(ABC):
             kernel.mass_matrix_adapter = ArrowheadMassMatrix()
 
         # Run mcmc.
-        options.setdefault("disable_validation", False)
+        options.setdefault("disable_validation", None)
         mcmc = MCMC(kernel, **options)
         mcmc.run()
         self.samples = mcmc.get_samples()

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -375,6 +375,7 @@ class CompartmentalModel(ABC):
             kernel.mass_matrix_adapter = ArrowheadMassMatrix()
 
         # Run mcmc.
+        options.setdefault("disable_validation", False)
         mcmc = MCMC(kernel, **options)
         mcmc.run()
         self.samples = mcmc.get_samples()

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -375,7 +375,7 @@ class MCMC:
         self._args, self._kwargs = args, kwargs
         num_samples = [0] * self.num_chains
         z_flat_acc = [[] for _ in range(self.num_chains)]
-        with optional(pyro.validation_enabled(not self._disable_validation),
+        with optional(pyro.validation_enabled(not self.disable_validation),
                       self.disable_validation is not None):
             for x, chain_id in self.sampler.run(*args, **kwargs):
                 if num_samples[chain_id] == 0:

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -22,11 +22,12 @@ import torch
 import torch.multiprocessing as mp
 
 import pyro
-from pyro.infer.mcmc.hmc import HMC
-from pyro.infer.mcmc.nuts import NUTS
-from pyro.infer.mcmc.logger import initialize_logger, DIAGNOSTIC_MSG, TqdmHandler, ProgressBar
-from pyro.infer.mcmc.util import diagnostics, initialize_model, print_summary
 import pyro.poutine as poutine
+from pyro.infer.mcmc.hmc import HMC
+from pyro.infer.mcmc.logger import DIAGNOSTIC_MSG, ProgressBar, TqdmHandler, initialize_logger
+from pyro.infer.mcmc.nuts import NUTS
+from pyro.infer.mcmc.util import diagnostics, initialize_model, print_summary
+from pyro.util import optional
 
 MAX_SEED = 2**32 - 1
 
@@ -291,7 +292,7 @@ class MCMC:
     :param bool disable_progbar: Disable progress bar and diagnostics update.
     :param bool disable_validation: Disables distribution validation check. This is
         disabled by default, since divergent transitions will lead to exceptions.
-        Switch to `True` for debugging purposes.
+        Switch to ``False`` for debugging purposes.
     :param dict transforms: dictionary that specifies a transform for a sample site
         with constrained support to unconstrained space.
     """
@@ -373,7 +374,7 @@ class MCMC:
         self._args, self._kwargs = args, kwargs
         num_samples = [0] * self.num_chains
         z_flat_acc = [[] for _ in range(self.num_chains)]
-        with pyro.validation_enabled(not self.disable_validation):
+        with optional(pyro.validation_enabled(False), self.disable_validation):
             for x, chain_id in self.sampler.run(*args, **kwargs):
                 if num_samples[chain_id] == 0:
                     num_samples[chain_id] += 1

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -290,9 +290,10 @@ class MCMC:
         Only applicable for Python 3.5 and above. Use `mp_context="spawn"` for
         CUDA.
     :param bool disable_progbar: Disable progress bar and diagnostics update.
-    :param bool disable_validation: Disables distribution validation check. This is
-        disabled by default, since divergent transitions will lead to exceptions.
-        Switch to ``False`` for debugging purposes.
+    :param bool disable_validation: Disables distribution validation check.
+        Defaults to ``True``, disabling validation, since divergent transitions
+        will lead to exceptions. Switch to ``False`` to enable validation, or
+        to ``None`` to preserve existing global values.
     :param dict transforms: dictionary that specifies a transform for a sample site
         with constrained support to unconstrained space.
     """
@@ -374,7 +375,8 @@ class MCMC:
         self._args, self._kwargs = args, kwargs
         num_samples = [0] * self.num_chains
         z_flat_acc = [[] for _ in range(self.num_chains)]
-        with optional(pyro.validation_enabled(False), self.disable_validation):
+        with optional(pyro.validation_enabled(not self._disable_validation),
+                      self.disable_validation is not None):
             for x, chain_id in self.sampler.run(*args, **kwargs):
                 if num_samples[chain_id] == 0:
                     num_samples[chain_id] += 1


### PR DESCRIPTION
This avoids clobbering existing values of validation, which can have 2**4 many values.

## pyro.infer.mcmc

`MCMC` accepts a kwarg `disable_validation` which defaults to `True` so as to avoid frequent exceptions due to divergent proposals. However there is currently no way to "not disable validation", i.e. to avoid touching globally set values; users can set `disable_validation=False` but this overwrites all existing state:
```py
torch.distributions.Distribution._validate_args = True
pyro.distributions.util._VALIDATION_ENABLED = True
pyro.poutine.util._VALIDATION_ENABLED = True
pyro.infer.util._VALIDATION_ENABLED = True
```

This PR adds a gentler option `disable_validation = None` which preserves existing validation values. Ideally I would have called this `disable_validation = False`, but to preserve backwards compatibility I think it is safer to add a new value `None`.

## pyro.contrib.epidemiology

This PR also avoids disabling validation in `CompartmentalModel` where I have never seen a divergence and where it is especially difficult to write correct models and where we thus prefer to set a global value via
```py
pyro.enable_validation(__debug__)
```
@martinjankowiak you may want to run experiments with the `-O` flag e.g.
```sh
python -O examples/contrib/epidemiology/sir.py
```
or explicitly set `pyro.enable_validation(False)`.