### PR TITLE
Resurrect num_quant_bins=2 in contrib.epidemiology

### DIFF
--- a/pyro/contrib/epidemiology/util.py
+++ b/pyro/contrib/epidemiology/util.py
@@ -106,7 +106,7 @@ W16 = [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.1562511562511555e-07],
 W16 = numpy.array(W16)
 
 
-def compute_bin_probs(s, num_quant_bins=3):
+def compute_bin_probs(s, num_quant_bins):
     """
     Compute categorical probabilities for a quantization scheme with num_quant_bins many
     bins. `s` is a real-valued tensor with values in [0, 1]. Returns probabilities

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
     {},
     {"haar": True},
     {"haar_full_mass": 2},
+    {"num_quant_bins": 2},
     {"num_quant_bins": 8},
     {"num_quant_bins": 12},
     {"num_quant_bins": 16},

--- a/tests/contrib/epidemiology/test_quant.py
+++ b/tests/contrib/epidemiology/test_quant.py
@@ -8,7 +8,7 @@ import torch
 from pyro.contrib.epidemiology.util import compute_bin_probs
 
 
-@pytest.mark.parametrize("num_quant_bins", [4, 8, 12, 16])
+@pytest.mark.parametrize("num_quant_bins", [2, 4, 8, 12, 16])
 def test_quantization_scheme(num_quant_bins, num_samples=1000 * 1000):
     min, max = 0, 7
     probs = torch.zeros(max + 1)


### PR DESCRIPTION
Addresses #2426 

This resurrects the old `compute_bin_probs(s, num_quant_bins=2)`. While this works horribly for general inference, I'd like to use that helper for another spline purpose.

I've also switched from case-checking to return-early-with-fallthrough-exception to make further modifications simpler.

## Tested
- [x] added unit test cases