### PR TITLE
Clean up contrib.epidemiology docs

### DIFF
--- a/docs/source/contrib.epidemiology.rst
+++ b/docs/source/contrib.epidemiology.rst
@@ -24,8 +24,6 @@ Base Compartmental Model
 Example Models
 --------------
 .. automodule:: pyro.contrib.epidemiology.models
-    :members:
-    :member-order: bysource
 
 Distributions
 -------------

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -600,7 +600,7 @@ class CompartmentalModel(ABC):
         # Record transition factors.
         with poutine.block(), poutine.trace() as tr:
             with pyro.plate("time", T, dim=-1 - self.max_plate_nesting):
-                t = slice(0, T)  # Used to slice data tensors.
+                t = slice(None)  # Used to slice data tensors.
                 self.transition_bwd(params, prev, curr, t)
         tr.trace.compute_log_prob()
         for name, site in tr.trace.nodes.items():

--- a/pyro/contrib/epidemiology/models.py
+++ b/pyro/contrib/epidemiology/models.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import re
+
 import torch
 from torch.nn.functional import pad
 
@@ -1101,3 +1103,20 @@ class RegionalSIRModel(CompartmentalModel):
             pyro.sample("obs_{}".format(t),
                         dist.ExtendedBinomial(S2I, rho),
                         obs=self.data[t])
+
+
+# Create sphinx documentation.
+__all__ = []
+for _name, _Model in list(locals().items()):
+    if isinstance(_Model, type) and issubclass(_Model, CompartmentalModel):
+        if _Model is not CompartmentalModel:
+            __all__.append(_name)
+__all__.sort(key=lambda name, vals=locals(): vals[name].__init__.__code__.co_firstlineno)
+__doc__ = "\n\n".join([
+    """
+    {}
+    ----------------------------------------------------------------
+    .. autoclass:: pyro.contrib.epidemiology.models.{}
+    """.format(re.sub("([A-Z][a-z]+)", r"\1 ", _name[:-5]), _name)
+    for _name in __all__
+])


### PR DESCRIPTION
Addresses #2426 

This PR:
1. Moves `CompartmentalModel.heuristic()` down in the class definition, since we no longer need custom overrides.
2. Adds example models to the docs TOC, making them more discoverable:
![image](https://user-images.githubusercontent.com/648532/83341105-6d402000-a294-11ea-8b0b-0ebe6d8dfc80.png)

## Tested
- [x] built docs locally
