### PR TITLE
Implements relaxed inference for compartmental models

### DIFF
--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -49,8 +49,8 @@ def generate_data(args):
         obs_sum = int(obs.sum())
         new_I_sum = int(new_I[:args.duration].sum())
         if obs_sum >= args.min_observations:
-            logging.info("Observed {:d}/{:d} infections:\n{}".format(
-                obs_sum, new_I_sum, " ".join(str(int(x)) for x in obs)))
+            logging.info("Observed {:d}/{:d} infections in population of {}:\n{}".format(
+                obs_sum, new_I_sum, args.population, " ".join(str(int(x)) for x in obs)))
             return {"new_I": new_I, "obs": obs}
 
     raise ValueError("Failed to generate {} observations. Try increasing "
@@ -76,6 +76,7 @@ def infer(args, model):
                      num_quant_bins=args.num_bins,
                      haar=args.haar,
                      haar_full_mass=args.haar_full_mass,
+                     quantize=args.quantize,
                      hook_fn=hook_fn)
 
     mcmc.summary()
@@ -246,6 +247,7 @@ if __name__ == "__main__":
     parser.add_argument("-w", "--warmup-steps", default=100, type=int)
     parser.add_argument("-t", "--max-tree-depth", default=5, type=int)
     parser.add_argument("-a", "--arrowhead-mass", action="store_true")
+    parser.add_argument("-q", "--quantize", action="store_true")
     parser.add_argument("-r", "--rng-seed", default=0, type=int)
     parser.add_argument("-nb", "--num-bins", default=4, type=int)
     parser.add_argument("--double", action="store_true")

--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -76,7 +76,7 @@ def infer(args, model):
                      num_quant_bins=args.num_bins,
                      haar=args.haar,
                      haar_full_mass=args.haar_full_mass,
-                     quantize=args.quantize,
+                     relax=args.relax,
                      hook_fn=hook_fn)
 
     mcmc.summary()
@@ -247,9 +247,9 @@ if __name__ == "__main__":
     parser.add_argument("-w", "--warmup-steps", default=100, type=int)
     parser.add_argument("-t", "--max-tree-depth", default=5, type=int)
     parser.add_argument("-a", "--arrowhead-mass", action="store_true")
-    parser.add_argument("-q", "--quantize", action="store_true")
-    parser.add_argument("-r", "--rng-seed", default=0, type=int)
     parser.add_argument("-nb", "--num-bins", default=4, type=int)
+    parser.add_argument("--relax", action="store_true")
+    parser.add_argument("-r", "--rng-seed", default=0, type=int)
     parser.add_argument("--double", action="store_true")
     parser.add_argument("--cuda", action="store_true")
     parser.add_argument("--verbose", action="store_true")

--- a/pyro/contrib/epidemiology/models.py
+++ b/pyro/contrib/epidemiology/models.py
@@ -73,7 +73,7 @@ class SimpleSIRModel(CompartmentalModel):
         # Condition on observations.
         pyro.sample("obs_{}".format(t),
                     dist.ExtendedBinomial(S2I, rho),
-                    obs=self.data[t] if t < self.duration else None)
+                    obs=self.data[t] if isinstance(t, slice) or t < self.duration else None)
 
     def transition_bwd(self, params, prev, curr, t):
         R0, tau, rho = params

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -10,6 +10,7 @@ import torch
 import pyro.distributions as dist
 from pyro.contrib.epidemiology import (RegionalSIRModel, SimpleSEIRModel, SimpleSIRModel, SparseSIRModel,
                                        SuperspreadingSEIRModel, SuperspreadingSIRModel, UnknownStartSIRModel)
+from tests.common import xfail_if_not_implemented
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
     {"num_quant_bins": 12},
     {"num_quant_bins": 16},
     {"arrowhead_mass": True},
-    {"relax": True, "num_quant_bins": 2},
+    {"relax": True},
 ], ids=str)
 def test_simple_sir_smoke(duration, forecast, options):
     population = 100
@@ -57,6 +58,7 @@ def test_simple_sir_smoke(duration, forecast, options):
     {"haar": True},
     {"haar_full_mass": 2},
     {"num_quant_bins": 8},
+    {"relax": True},
 ], ids=str)
 def test_simple_seir_smoke(duration, forecast, options):
     population = 100
@@ -92,6 +94,7 @@ def test_simple_seir_smoke(duration, forecast, options):
     {"haar": True},
     {"haar_full_mass": 2},
     {"num_quant_bins": 8},
+    {"relax": True},
 ], ids=str)
 def test_superspreading_sir_smoke(duration, forecast, options):
     population = 100
@@ -123,6 +126,7 @@ def test_superspreading_sir_smoke(duration, forecast, options):
     {"haar": True},
     {"haar_full_mass": 2},
     {"num_quant_bins": 8},
+    {"relax": True},
 ], ids=str)
 def test_superspreading_seir_smoke(duration, forecast, options):
     population = 100
@@ -234,6 +238,7 @@ def test_sparse_smoke(duration, forecast, options):
     {"haar": True},
     {"haar_full_mass": 4},
     {"num_quant_bins": 8},
+    {"relax": True},
 ], ids=str)
 def test_unknown_start_smoke(duration, pre_obs_window, forecast, options):
     population = 100
@@ -272,6 +277,7 @@ def test_unknown_start_smoke(duration, pre_obs_window, forecast, options):
         assert I[ti] > 0
 
 
+@xfail_if_not_implemented()
 @pytest.mark.parametrize("duration", [3, 7])
 @pytest.mark.parametrize("forecast", [0, 7])
 @pytest.mark.parametrize("options", [
@@ -279,6 +285,7 @@ def test_unknown_start_smoke(duration, pre_obs_window, forecast, options):
     {"haar": True},
     {"haar_full_mass": 2},
     {"num_quant_bins": 8},
+    {"relax": True},
 ], ids=str)
 def test_regional_smoke(duration, forecast, options):
     num_regions = 6

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
     {"num_quant_bins": 12},
     {"num_quant_bins": 16},
     {"arrowhead_mass": True},
+    {"quantize": True, "num_quant_bins": 2},
 ], ids=str)
 def test_simple_sir_smoke(duration, forecast, options):
     population = 100

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
     {"num_quant_bins": 12},
     {"num_quant_bins": 16},
     {"arrowhead_mass": True},
-    {"quantize": True, "num_quant_bins": 2},
+    {"relax": True, "num_quant_bins": 2},
 ], ids=str)
 def test_simple_sir_smoke(duration, forecast, options):
     population = 100

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -41,6 +41,7 @@ CPU_EXAMPLES = [
     'contrib/epidemiology/sir.py -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -nb=8',
     'contrib/epidemiology/sir.py -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -hfm=3',
     'contrib/epidemiology/sir.py -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -a',
+    'contrib/epidemiology/sir.py -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 --relax',
     'contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2',
     'contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2 --haar',
     'contrib/epidemiology/regional.py -t=2 -w=2 -n=4 -r=3 -d=20 -p=1000 -f 2 -hfm=3',


### PR DESCRIPTION
Addresses #2426 
Replaces #2510 

This implements an asymptotically exact relaxed inference strategy for `CompartmentalModel` whereby:
1. An auxiliary variable is introduced such that the flow constraints are always satisfied (however constraints due to observations may still be violated, so SVI still doesn't work and SMC initialization is still required)
2. Rather than enumerating, gradients are computed using a `differentiably_quantize()` function that quantizes but keeps gradients. This avoids the cost of enumeration which is exponential in number of compartments, and also avoids coupling through time so that sparse observations are cheaper (do not require an additional auxiliary variable).

This method differs from bouncy ball MCMC [(Nimshimura, Dunson, Lu 2017)](https://arxiv.org/abs/1705.08510) in that we still use an L2 Gaussian kinetic energy rather than an L1 Laplace kinetic energy, thus permitting reuse of existing implementations of HMC and NUTS. And despite the gradients in (2) being approximate, this method is still asymptotically correct because the exact density is used (and hence the MH correction compensates for bad gradients). Indeed for Binomial potentials the gradients are quite accurate (see [notebook](https://github.com/fritzo/notebooks/blob/master/extended_distributions.ipynb)):
![image](https://user-images.githubusercontent.com/648532/83356091-8db1be00-a318-11ea-8c02-85b99db5178e.png)

## Mixing Issues

In practice this mixes poorly. I believe the cause is inability to propagate gradients to avoid feasibility boundaries. Experiments show that early in learning trajectories become infeasible, and HMC step size is reduced to very small.

<details>

```
$ python examples/contrib/epidemiology/sir.py -p 1000 -d 10 -f 10 -R0 3 --relax --plot
Simulating from a SimpleSIRModel
Observed 23/43 infections in population of 1000:
1 0 1 0 3 2 1 3 5 7
INFO 	 Running inference...
Warmup:   0%|                                                                              | 0/300 [00:00, ?it/s]INFO 	 Heuristic init: R0=1.9, rho=0.949
DEBUG infeasible
DEBUG infeasible
DEBUG infeasible
DEBUG infeasible
DEBUG infeasible
DEBUG infeasible
Warmup:   0%|                                     | 1/300 [00:00,  3.90it/s, step size=7.47e-02, acc. prob=0.013]DEBUG infeasible
DEBUG infeasible
Warmup:   6%|██                                  | 17/300 [00:03,  4.34it/s, step size=7.11e-04, acc. 
```

</details>

## Tested
- [x] smoke tests
- [x] example tests
- [ ] verify mixing on larger examples