### PR TITLE
Expose ImproperUniform distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -176,6 +176,13 @@ GaussianScaleMixture
     :undoc-members:
     :show-inheritance:
 
+ImproperUniform
+---------------
+.. autoclass:: pyro.distributions.improper_uniform.ImproperUniform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 IndependentHMM
 --------------
 .. autoclass:: pyro.distributions.IndependentHMM

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -16,6 +16,7 @@ from pyro.distributions.extended import ExtendedBetaBinomial, ExtendedBinomial
 from pyro.distributions.folded import FoldedDistribution
 from pyro.distributions.gaussian_scale_mixture import GaussianScaleMixture
 from pyro.distributions.hmm import DiscreteHMM, GammaGaussianHMM, GaussianHMM, GaussianMRF, IndependentHMM, LinearHMM
+from pyro.distributions.improper_uniform import ImproperUniform
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.lkj import LKJCorrCholesky
 from pyro.distributions.mixture import MaskedMixture
@@ -62,6 +63,7 @@ __all__ = [
     "GaussianHMM",
     "GaussianMRF",
     "GaussianScaleMixture",
+    "ImproperUniform",
     "IndependentHMM",
     "InverseGamma",
     "LinearHMM",

--- a/pyro/distributions/improper_uniform.py
+++ b/pyro/distributions/improper_uniform.py
@@ -37,12 +37,12 @@ class ImproperUniform(TorchDistribution):
 
     :param support: The support of the distribution.
     :type support: ~torch.distributions.constraints.Constraint
-    :param torch.Size batch_shape: Defaults to empty.
-    :param torch.Size event_shape: Defaults to empty.
+    :param torch.Size batch_shape: The batch shape.
+    :param torch.Size event_shape: The event shape.
     """
     arg_constraints = {}
 
-    def __init__(self, support, batch_shape=torch.Size(), event_shape=torch.Size()):
+    def __init__(self, support, batch_shape, event_shape):
         assert isinstance(support, constraints.Constraint)
         self._support = support
         super().__init__(batch_shape, event_shape)

--- a/pyro/distributions/improper_uniform.py
+++ b/pyro/distributions/improper_uniform.py
@@ -1,0 +1,67 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch.distributions import constraints
+
+from .torch_distribution import TorchDistribution
+from .util import broadcast_shape
+
+
+class ImproperUniform(TorchDistribution):
+    """
+    Improper distribution with zero :meth:`log_prob` and undefined
+    :meth:`sample`.
+
+    This is useful for transforming a model from generative dag form to factor
+    graph form for use in HMC. For example the following are equal in
+    distribution::
+
+        # Version 1. a generative dag
+        x = pyro.sample("x", Normal(0, 1))
+        y = pyro.sample("y", Normal(x, 1))
+        z = pyro.sample("z", Normal(y, 1))
+
+        # Version 2. a factor graph
+        xyz = pyro.sample("xyz", ImproperUniform(constraints.real, (), (3,)))
+        x, y, z = xyz.unbind(-1)
+        pyro.sample("x", Normal(0, 1), obs=x)
+        pyro.sample("y", Normal(x, 1), obs=y)
+        pyro.sample("z", Normal(y, 1), obs=z)
+
+    Note this distribution errors when :meth:`sample` is called. To create a
+    similar distribution that instead samples from a specified distribution
+    consider using ``.mask(False)`` as in::
+
+        xyz = dist.Normal(0, 1).expand([3]).to_event(1).mask(False)
+
+    :param support: The support of the distribution.
+    :type support: ~torch.distributions.constraints.Constraint
+    :param torch.Size batch_shape: Defaults to empty.
+    :param torch.Size event_shape: Defaults to empty.
+    """
+    arg_constraints = {}
+
+    def __init__(self, support, batch_shape=torch.Size(), event_shape=torch.Size()):
+        assert isinstance(support, constraints.Constraint)
+        self._support = support
+        super().__init__(batch_shape, event_shape)
+
+    @constraints.dependent_property
+    def support(self):
+        return self._support
+
+    def expand(self, batch_shape, _instance=None):
+        batch_shape = torch.Size(batch_shape)
+        new = self._get_checked_instance(ImproperUniform, _instance)
+        new._support = self._support
+        super(ImproperUniform, new).__init__(batch_shape, self.event_shape)
+        return new
+
+    def log_prob(self, value):
+        batch_shape = value.shape[:value.dim() - self.event_dim]
+        batch_shape = broadcast_shape(batch_shape, self.batch_shape)
+        return torch.zeros(()).expand(batch_shape)
+
+    def sample(self, sample_shape=torch.Size()):
+        raise NotImplementedError("ImproperUniform does not support sampling")

--- a/tests/distributions/test_improper_uniform.py
+++ b/tests/distributions/test_improper_uniform.py
@@ -1,0 +1,28 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from torch.distributions import constraints, transform_to
+
+import pyro.distributions as dist
+from tests.common import assert_equal
+
+
+@pytest.mark.parametrize("constraint", [
+    constraints.real,
+    constraints.positive,
+    constraints.unit_interval,
+], ids=str)
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("event_shape", [(), (4,), (3, 2)], ids=str)
+def test_improper_uniform(constraint, batch_shape, event_shape):
+    d = dist.ImproperUniform(constraint, batch_shape, event_shape)
+
+    value = transform_to(constraint)(torch.randn(batch_shape + event_shape))
+    assert_equal(d.log_prob(value), torch.zeros(batch_shape))
+
+    with pytest.raises(NotImplementedError):
+        d.sample()
+    with pytest.raises(NotImplementedError):
+        d.sample(sample_shape=(5, 6))


### PR DESCRIPTION
Addresses #2426 
Follows up on @fehiepsi's comment https://github.com/pyro-ppl/pyro/pull/2495#pullrequestreview-415691686

This exposes `ImproperUniform` as a public distribution. It is currently used only in `SplitReparam`. I plan to use it also for sampling auxiliary variables in `CompartmentalModel._sequential_model()` and `._vectorized_model()`. Those classes currently use `dist.Uniform(...).mask(False).expand(shape).to_event()`, but I would like to generalize the logic to arbitrary constraints, while adding the safety of a not-implemented `.sample()` method.

## Tested
- [x] refactoring is covered by existing `SplitReparam` tests
- [x] added some unit tests