### PR TITLE
Misc fixes to contrib.epidemiology

### DIFF
--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -91,6 +91,7 @@ def infer(args, model):
                      heuristic_ess_threshold=args.ess_threshold,
                      warmup_steps=args.warmup_steps,
                      num_samples=args.num_samples,
+                     num_chains=args.num_chains,
                      max_tree_depth=args.max_tree_depth,
                      arrowhead_mass=args.arrowhead_mass,
                      num_quant_bins=args.num_bins,
@@ -293,6 +294,7 @@ if __name__ == "__main__":
     parser.add_argument("-np", "--num-particles", default=1024, type=int)
     parser.add_argument("-ess", "--ess-threshold", default=0.5, type=float)
     parser.add_argument("-w", "--warmup-steps", type=int)
+    parser.add_argument("-c", "--num-chains", default=1, type=int)
     parser.add_argument("-t", "--max-tree-depth", default=5, type=int)
     parser.add_argument("-a", "--arrowhead-mass", action="store_true")
     parser.add_argument("-r", "--rng-seed", default=0, type=int)

--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -79,6 +79,7 @@ def generate_data(args):
 
 
 def infer(args, model):
+    parallel = args.num_chains > 1
     energies = []
 
     def hook_fn(kernel, *unused):
@@ -92,16 +93,17 @@ def infer(args, model):
                      warmup_steps=args.warmup_steps,
                      num_samples=args.num_samples,
                      num_chains=args.num_chains,
+                     mp_context="spawn" if parallel else None,
                      max_tree_depth=args.max_tree_depth,
                      arrowhead_mass=args.arrowhead_mass,
                      num_quant_bins=args.num_bins,
                      haar=args.haar,
                      haar_full_mass=args.haar_full_mass,
                      jit_compile=args.jit,
-                     hook_fn=hook_fn)
+                     hook_fn=None if parallel else hook_fn)
 
     mcmc.summary()
-    if args.plot:
+    if args.plot and energies:
         import matplotlib.pyplot as plt
         plt.figure(figsize=(6, 3))
         plt.plot(energies)

--- a/pyro/contrib/epidemiology/distributions.py
+++ b/pyro/contrib/epidemiology/distributions.py
@@ -11,6 +11,7 @@ import pyro.distributions as dist
 from pyro.distributions.util import is_validation_enabled
 
 _RELAX = False
+_RELAX_MIN_VARIANCE = 0.1
 
 
 def _all(x):
@@ -98,7 +99,7 @@ def _validate_overdispersion(overdispersion):
             raise ValueError("Expected overdispersion < 2")
 
 
-def _relaxed_binomial(total_count, probs, *, min_variance=0.25):
+def _relaxed_binomial(total_count, probs):
     """
     Returns a moment-matched :class:`~pyro.distributions.Normal` approximating
     a :class:`~pyro.distributions.Binomial` but allowing arbitrary real
@@ -109,11 +110,11 @@ def _relaxed_binomial(total_count, probs, *, min_variance=0.25):
     mean = probs * total_count
     variance = total_count * probs * (1 - probs)
 
-    scale = variance.clamp(min=min_variance).sqrt()
+    scale = variance.clamp(min=_RELAX_MIN_VARIANCE).sqrt()
     return dist.Normal(mean, scale)
 
 
-def _relaxed_beta_binomial(concentration1, concentration0, total_count, *, min_variance=0.25):
+def _relaxed_beta_binomial(concentration1, concentration0, total_count):
     """
     Returns a moment-matched :class:`~pyro.distributions.Normal` approximating
     a :class:`~pyro.distributions.BetaBinomial` but allowing arbitrary real
@@ -128,7 +129,7 @@ def _relaxed_beta_binomial(concentration1, concentration0, total_count, *, min_v
     mean = beta_mean * total_count
     variance = beta_variance * total_count * (c + total_count)
 
-    scale = variance.clamp(min=min_variance).sqrt()
+    scale = variance.clamp(min=_RELAX_MIN_VARIANCE).sqrt()
     return dist.Normal(mean, scale)
 
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -408,8 +408,12 @@ class MCMC:
         # If transforms is not explicitly provided, infer automatically using
         # model args, kwargs.
         if self.transforms is None:
+            # Try to initialize kernel.transforms using kernel.setup().
+            if getattr(self.kernel, "transforms", None) is None:
+                warmup_steps = 0
+                self.kernel.setup(warmup_steps, *args, **kwargs)
             # Use `kernel.transforms` when available
-            if hasattr(self.kernel, 'transforms') and self.kernel.transforms is not None:
+            if getattr(self.kernel, "transforms", None) is not None:
                 self.transforms = self.kernel.transforms
             # Else, get transforms from model (e.g. in multiprocessing).
             elif self.kernel.model:

--- a/tests/contrib/epidemiology/test_distributions.py
+++ b/tests/contrib/epidemiology/test_distributions.py
@@ -9,7 +9,7 @@ from torch.distributions.transforms import SigmoidTransform
 
 import pyro.distributions as dist
 from pyro.contrib.epidemiology import beta_binomial_dist, binomial_dist, infection_dist
-from pyro.contrib.epidemiology.distributions import set_relaxed_distributions
+from pyro.contrib.epidemiology.distributions import _RELAX_MIN_VARIANCE, set_relaxed_distributions
 from tests.common import assert_close
 
 
@@ -199,7 +199,7 @@ def test_relaxed_binomial():
         d2 = binomial_dist(total_count, probs)
     assert isinstance(d2, dist.Normal)
     assert_close(d2.mean, d1.mean)
-    assert_close(d2.variance, d1.variance.clamp(min=0.25))
+    assert_close(d2.variance, d1.variance.clamp(min=_RELAX_MIN_VARIANCE))
 
 
 @pytest.mark.parametrize("overdispersion", [0.05, 0.1, 0.2, 0.5, 1.0])
@@ -214,7 +214,7 @@ def test_relaxed_overdispersed_binomial(overdispersion):
         d2 = binomial_dist(total_count, probs, overdispersion=overdispersion)
     assert isinstance(d2, dist.Normal)
     assert_close(d2.mean, d1.mean)
-    assert_close(d2.variance, d1.variance.clamp(min=0.25))
+    assert_close(d2.variance, d1.variance.clamp(min=_RELAX_MIN_VARIANCE))
 
 
 def test_relaxed_beta_binomial():
@@ -229,7 +229,7 @@ def test_relaxed_beta_binomial():
         d2 = beta_binomial_dist(concentration1, concentration0, total_count)
     assert isinstance(d2, dist.Normal)
     assert_close(d2.mean, d1.mean)
-    assert_close(d2.variance, d1.variance.clamp(min=0.25))
+    assert_close(d2.variance, d1.variance.clamp(min=_RELAX_MIN_VARIANCE))
 
 
 @pytest.mark.parametrize("overdispersion", [0.05, 0.1, 0.2, 0.5, 1.0])
@@ -247,4 +247,4 @@ def test_relaxed_overdispersed_beta_binomial(overdispersion):
                                 overdispersion=overdispersion)
     assert isinstance(d2, dist.Normal)
     assert_close(d2.mean, d1.mean)
-    assert_close(d2.variance, d1.variance.clamp(min=0.25))
+    assert_close(d2.variance, d1.variance.clamp(min=_RELAX_MIN_VARIANCE))

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -33,6 +33,9 @@ logger = logging.getLogger(__name__)
     {"jit_compile": True},
     {"jit_compile": True, "haar_full_mass": 2},
     {"jit_compile": True, "num_quant_bins": 2},
+    {"num_chains": 2},
+    {"num_chains": 2, "num_quant_bins": 2},
+    {"num_chains": 2, "jit_compile": True},
 ], ids=str)
 def test_simple_sir_smoke(duration, forecast, options):
     population = 100
@@ -54,6 +57,7 @@ def test_simple_sir_smoke(duration, forecast, options):
 
     # Predict and forecast.
     samples = model.predict(forecast=forecast)
+    num_samples *= options.get("num_chains", 1)
     assert samples["S"].shape == (num_samples, duration + forecast)
     assert samples["I"].shape == (num_samples, duration + forecast)
 

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -17,6 +17,7 @@ from tests.common import xfail_param
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.filterwarnings("ignore:num_chains")
 @pytest.mark.parametrize("duration", [3, 7])
 @pytest.mark.parametrize("forecast", [0, 7])
 @pytest.mark.parametrize("options", [

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -33,9 +33,9 @@ logger = logging.getLogger(__name__)
     {"jit_compile": True},
     {"jit_compile": True, "haar_full_mass": 2},
     {"jit_compile": True, "num_quant_bins": 2},
-    {"num_chains": 2},
-    {"num_chains": 2, "num_quant_bins": 2},
-    {"num_chains": 2, "jit_compile": True},
+    {"num_chains": 2, "mp_context": "spawn"},
+    {"num_chains": 2, "mp_context": "spawn", "num_quant_bins": 2},
+    {"num_chains": 2, "mp_context": "spawn", "jit_compile": True},
 ], ids=str)
 def test_simple_sir_smoke(duration, forecast, options):
     population = 100

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -34,6 +34,7 @@ CPU_EXAMPLES = [
     'contrib/autoname/tree_data.py --num-epochs=1',
     'contrib/cevae/synthetic.py --num-epochs=1',
     'contrib/epidemiology/sir.py --nojit -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2',
+    'contrib/epidemiology/sir.py --nojit -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -c=2',
     'contrib/epidemiology/sir.py --nojit -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -e=2',
     'contrib/epidemiology/sir.py --nojit -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -k=1',
     'contrib/epidemiology/sir.py --nojit -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2 -e=2 -k=1',


### PR DESCRIPTION
Addresses #2426 

This implements three fixes in preparation for a tutorial notebook:
1. Support parallel chain MCMC. This requires pickle support, so I've moved the local function `heuristic()` to a method `._heuristic()`.
2. Fixes a shape error (and resolves a TODO) in `._concat_series()`.
3. Refactors relaxed logic to refer to a global `_RELAX_MIN_VARIANCE` variable, and lowers the value from 0.25 to 0.1, which seems to improve inference. (I may change again in the future, but future changes will be one-line changes rather than 6-line changes across 2 files).

## Tested
- [x] unit tests for `num_chains=1`
- [x] refactoring covered by existing tests
- [x] verified shape and numerical changes in a notebook