### PR TITLE
Enable AutoNormal,AutoMultivariateNormal in contrib.epidemiology

### DIFF
--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("algo,options", [
     ("svi", {}),
     ("svi", {"haar": False}),
+    ("svi", {"guide_rank": None}),
+    ("svi", {"guide_rank": 2}),
+    ("svi", {"guide_rank": "full"}),
     ("mcmc", {}),
     ("mcmc", {"haar": True}),
     ("mcmc", {"haar_full_mass": 2}),


### PR DESCRIPTION
Addresses #2426 

This adds support for `AutoNormal` and `AutoMultivariateNormal` guides to `CompartmentalModel`, whereas previously only `AutoLowRankMultivariateNormal` was supported.

This PR also switches to `AutoNormal` as the default guide. My reasoning is that `AutoNormal` is 2-3x faster and more robust than `AutoLowRankMultivariateNormal` (the current default), and if we **optimize for new users** writing new models, the cheap `AutoNormal` will be the first guide they will try to use, and thus is a good default. I've started using this workflow in my own modeling and have been happy with the ~30sec turnaround time between model changes and inference results.

## Tested
- [x] added new smoke tests
- [x] ran new guides locally