### PR TITLE
Dense MatrixExponential Transform

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -497,6 +497,13 @@ Householder
     :undoc-members:
     :show-inheritance:
 
+MatrixExponential
+-----------------
+.. autoclass:: pyro.distributions.transforms.MatrixExponential
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 NeuralAutoregressive
 --------------------
 .. autoclass:: pyro.distributions.transforms.NeuralAutoregressive
@@ -640,6 +647,10 @@ householder
 leaky_relu
 ----------
 .. autofunction:: pyro.distributions.transforms.leaky_relu
+
+matrix_exponential
+------------------
+.. autofunction:: pyro.distributions.transforms.matrix_exponential
 
 neural_autoregressive
 ---------------------

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -25,6 +25,7 @@ from pyro.distributions.transforms.haar import HaarTransform
 from pyro.distributions.transforms.householder import (ConditionalHouseholder, Householder, conditional_householder,
                                                        householder)
 from pyro.distributions.transforms.lower_cholesky_affine import LowerCholeskyAffine
+from pyro.distributions.transforms.matrix_exponential import MatrixExponential, matrix_exponential
 from pyro.distributions.transforms.neural_autoregressive import (ConditionalNeuralAutoregressive, NeuralAutoregressive,
                                                                  conditional_neural_autoregressive,
                                                                  neural_autoregressive)
@@ -32,8 +33,8 @@ from pyro.distributions.transforms.permute import Permute, permute
 from pyro.distributions.transforms.planar import ConditionalPlanar, Planar, conditional_planar, planar
 from pyro.distributions.transforms.polynomial import Polynomial, polynomial
 from pyro.distributions.transforms.radial import ConditionalRadial, Radial, conditional_radial, radial
-from pyro.distributions.transforms.spline_autoregressive import SplineAutoregressive, spline_autoregressive
 from pyro.distributions.transforms.spline import ConditionalSpline, Spline, conditional_spline, spline
+from pyro.distributions.transforms.spline_autoregressive import SplineAutoregressive, spline_autoregressive
 from pyro.distributions.transforms.spline_coupling import SplineCoupling, spline_coupling
 from pyro.distributions.transforms.sylvester import Sylvester, sylvester
 
@@ -88,6 +89,7 @@ __all__ = [
     'Householder',
     'LeakyReLUTransform',
     'LowerCholeskyAffine',
+    'MatrixExponential',
     'NeuralAutoregressive',
     'Permute',
     'Planar',
@@ -113,6 +115,7 @@ __all__ = [
     'generalized_channel_permute',
     'householder',
     'leaky_relu',
+    'matrix_exponential',
     'neural_autoregressive',
     'permute',
     'planar',

--- a/pyro/distributions/transforms/affine_autoregressive.py
+++ b/pyro/distributions/transforms/affine_autoregressive.py
@@ -90,8 +90,8 @@ class AffineAutoregressive(TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     sign = +1
@@ -308,8 +308,8 @@ class ConditionalAffineAutoregressive(ConditionalTransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/affine_coupling.py
+++ b/pyro/distributions/transforms/affine_coupling.py
@@ -85,8 +85,8 @@ class AffineCoupling(TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
 
     def __init__(self, split_dim, hypernet, *, dim=-1, log_scale_min_clip=-5., log_scale_max_clip=3.):
@@ -237,8 +237,8 @@ class ConditionalAffineCoupling(ConditionalTransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/block_autoregressive.py
+++ b/pyro/distributions/transforms/block_autoregressive.py
@@ -69,8 +69,8 @@ class BlockAutoregressive(TransformModule):
     [arXiv:1904.04676]
 
     """
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     autoregressive = True

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -43,7 +43,7 @@ class CorrLCholeskyTransform(Transform):
     Section 10.12.
 
     """
-    domain = constraints.real
+    domain = constraints.real_vector
     codomain = corr_cholesky_constraint
     bijective = True
     sign = +1

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -16,8 +16,8 @@ from pyro.nn import DenseNN
 
 
 class ConditionedHouseholder(Transform):
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     volume_preserving = True
@@ -121,8 +121,8 @@ class Householder(ConditionedHouseholder, TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     volume_preserving = True
@@ -202,8 +202,8 @@ class ConditionalHouseholder(ConditionalTransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/matrix_exponential.py
+++ b/pyro/distributions/transforms/matrix_exponential.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import torch
+import torch.nn as nn
+from torch.distributions import Transform, constraints
+
+from pyro.distributions.torch_transform import TransformModule
+from pyro.distributions.util import copy_docs_from
+
+
+@copy_docs_from(Transform)
+class ConditionedMatrixExponential(Transform):
+    domain = constraints.real
+    codomain = constraints.real
+    bijective = True
+    event_dim = 1
+
+    def __init__(self, weights=None, iterations=8, spectral_norm=0.5):
+        super().__init__(cache_size=1)
+        assert iterations > 0
+        self.weights = weights
+        self.iterations = iterations
+        self.spectral_norm = spectral_norm
+
+    def _exp(self, x, M):
+        """
+        Performs power series approximation to the vector product of x with the
+        matrix exponential of M.
+        """
+        power_term = x.unsqueeze(-1)
+        y = x.unsqueeze(-1)
+        for idx in range(self.iterations):
+            power_term = torch.matmul(M, power_term) / (idx + 1)
+            y = y + power_term
+
+        return y.squeeze(-1)
+
+    def _trace(self, M):
+        """
+        Calculate the trace of a matrix and is able to do broadcasting over batch
+        dimensions, unlike `torch.trace`.
+
+        Broadcasting is necessary for the conditional version of the transform,
+        where `self.weights` may have batch dimensions corresponding the batch
+        dimensions of the context variable that was conditioned upon.
+        """
+        return M.diagonal(dim1=-2, dim2=-1).sum(-1)
+
+    def _call(self, x):
+        """
+        :param x: the input into the bijection
+        :type x: torch.Tensor
+        Invokes the bijection x => y; in the prototypical context of a
+        :class:`~pyro.distributions.TransformedDistribution` `x` is a sample from
+        the base distribution (or the output of a previous transform)
+        """
+
+        # TODO: Apply spectral norm
+        M = self.weights
+
+        return self._exp(x, M)
+
+    def _inverse(self, y):
+        """
+        :param y: the output of the bijection
+        :type y: torch.Tensor
+        Inverts y => x.
+        """
+
+        # TODO: Apply spectral norm
+        M = self.weights
+
+        return self._exp(y, -M)
+
+    def log_abs_det_jacobian(self, x, y):
+        """
+        Calculates the elementwise determinant of the log Jacobian
+        """
+
+        # TODO: Apply spectral norm
+        M = self.weights
+
+        return self._trace(M)
+
+
+@copy_docs_from(ConditionedMatrixExponential)
+class MatrixExponential(ConditionedMatrixExponential, TransformModule):
+    r"""
+    A 'planar' bijective transform with equation,
+
+        :math:`\mathbf{y} = \mathbf{x} + \mathbf{u}\tanh(\mathbf{w}^T\mathbf{z}+b)`
+
+    where :math:`\mathbf{x}` are the inputs, :math:`\mathbf{y}` are the outputs,
+    and the learnable parameters are :math:`b\in\mathbb{R}`,
+    :math:`\mathbf{u}\in\mathbb{R}^D`, :math:`\mathbf{w}\in\mathbb{R}^D` for
+    input dimension :math:`D`. For this to be an invertible transformation, the
+    condition :math:`\mathbf{w}^T\mathbf{u}>-1` is enforced.
+
+    Example usage:
+
+    >>> base_dist = dist.Normal(torch.zeros(10), torch.ones(10))
+    >>> transform = Planar(10)
+    >>> pyro.module("my_transform", transform)  # doctest: +SKIP
+    >>> flow_dist = dist.TransformedDistribution(base_dist, [transform])
+    >>> flow_dist.sample()  # doctest: +SKIP
+
+    :param input_dim: the dimension of the input (and output) variable.
+    :type input_dim: int
+
+    References:
+
+    [1] Danilo Jimenez Rezende, Shakir Mohamed. Variational Inference with
+    Normalizing Flows. [arXiv:1505.05770]
+
+    """
+
+    domain = constraints.real
+    codomain = constraints.real
+    bijective = True
+    event_dim = 1
+
+    def __init__(self, input_dim):
+        super().__init__()
+
+        self.weights = nn.Parameter(torch.Tensor(input_dim, input_dim))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        stdv = 1. / math.sqrt(self.weights.size(0))
+        self.weights.data.uniform_(-stdv, stdv)
+
+
+def matrix_exponential(input_dim):
+    """
+    A helper function to create a
+    :class:`~pyro.distributions.transforms.MatrixExponential` object for consistency
+    with other helpers.
+
+    :param input_dim: Dimension of input variable
+    :type input_dim: int
+
+    """
+
+    return MatrixExponential(input_dim)

--- a/pyro/distributions/transforms/matrix_exponential.py
+++ b/pyro/distributions/transforms/matrix_exponential.py
@@ -13,8 +13,8 @@ from pyro.distributions.util import copy_docs_from
 
 @copy_docs_from(Transform)
 class ConditionedMatrixExponential(Transform):
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 
@@ -48,7 +48,7 @@ class ConditionedMatrixExponential(Transform):
 
     def _trace(self, M):
         """
-        Calculate the trace of a matrix and is able to do broadcasting over batch
+        Calculates the trace of a matrix and is able to do broadcasting over batch
         dimensions, unlike `torch.trace`.
 
         Broadcasting is necessary for the conditional version of the transform,

--- a/pyro/distributions/transforms/neural_autoregressive.py
+++ b/pyro/distributions/transforms/neural_autoregressive.py
@@ -58,8 +58,8 @@ class NeuralAutoregressive(TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     eps = 1e-8
@@ -182,8 +182,8 @@ class ConditionalNeuralAutoregressive(ConditionalTransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/permute.py
+++ b/pyro/distributions/transforms/permute.py
@@ -43,7 +43,7 @@ class Permute(Transform):
 
     """
 
-    codomain = constraints.real
+    codomain = constraints.real_vector
     bijective = True
     volume_preserving = True
 

--- a/pyro/distributions/transforms/planar.py
+++ b/pyro/distributions/transforms/planar.py
@@ -17,8 +17,8 @@ from pyro.nn import DenseNN
 
 @copy_docs_from(Transform)
 class ConditionedPlanar(Transform):
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 
@@ -120,8 +120,8 @@ class Planar(ConditionedPlanar, TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 
@@ -193,8 +193,8 @@ class ConditionalPlanar(ConditionalTransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/polynomial.py
+++ b/pyro/distributions/transforms/polynomial.py
@@ -67,8 +67,8 @@ class Polynomial(TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     autoregressive = True

--- a/pyro/distributions/transforms/radial.py
+++ b/pyro/distributions/transforms/radial.py
@@ -17,8 +17,8 @@ from pyro.nn import DenseNN
 
 @copy_docs_from(Transform)
 class ConditionedRadial(Transform):
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 
@@ -124,8 +124,8 @@ class Radial(ConditionedRadial, TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 
@@ -190,8 +190,8 @@ class ConditionalRadial(ConditionalTransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/spline_autoregressive.py
+++ b/pyro/distributions/transforms/spline_autoregressive.py
@@ -66,8 +66,8 @@ class SplineAutoregressive(TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
     autoregressive = True

--- a/pyro/distributions/transforms/spline_coupling.py
+++ b/pyro/distributions/transforms/spline_coupling.py
@@ -73,8 +73,8 @@ class SplineCoupling(TransformModule):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -53,8 +53,8 @@ class Sylvester(Householder):
 
     """
 
-    domain = constraints.real
-    codomain = constraints.real
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
     bijective = True
     event_dim = 1
 

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -244,6 +244,9 @@ class TransformTests(TestCase):
 
         self._test(transform_factory)
 
+    def test_matrix_exponential(self):
+        self._test(T.matrix_exponential, inverse=True, jacobian=True)
+
     def test_neural_autoregressive(self):
         for activation in ['ELU', 'LeakyReLU', 'sigmoid', 'tanh']:
             self._test(partial(T.neural_autoregressive, activation=activation), inverse=False)

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -245,7 +245,7 @@ class TransformTests(TestCase):
         self._test(transform_factory)
 
     def test_matrix_exponential(self):
-        self._test(T.matrix_exponential, inverse=True, jacobian=True)
+        self._test(T.matrix_exponential)
 
     def test_neural_autoregressive(self):
         for activation in ['ELU', 'LeakyReLU', 'sigmoid', 'tanh']:


### PR DESCRIPTION
This is an implementation of the `MatrixExponential` transform for a dense linear operator, y = exp(M)x. The transform was introduced in this recent paper: [The Convolution Exponential and Generalized Sylvester Flows](https://arxiv.org/abs/2006.01910).

The strength of the method is that it allows you to take any linear operation and make it into a bijection with an explicit inverse and tractable log-determinate-Jacobian. I've implemented a dense linear `MatrixExponential` transform here, although the method really shines for structured M on images and graphs (I leave `ConvMatrixExponential` and `GraphMatrixExponential` as well as `GeneralizedSylvester` for future PRs)

