### PR TITLE
Fix comments in CEVAE example

### DIFF
--- a/pyro/contrib/cevae/__init__.py
+++ b/pyro/contrib/cevae/__init__.py
@@ -342,9 +342,9 @@ class Guide(PyroModule):
     Inference model for causal effect estimation with latent confounder ``z``
     and binary treatment ``t``::
 
-        t ~ p(t|x)      # treatment
-        y ~ p(y|t,x)    # outcome
-        z ~ p(t|y,t,x)  # latent confounder, an embedding
+        t ~ q(t|x)      # treatment
+        y ~ q(y|t,x)    # outcome
+        z ~ q(z|y,t,x)  # latent confounder, an embedding
 
     Each of these distributions is defined by a neural network.  The ``y`` and
     ``z`` distributions are defined by disjoint pairs of neural networks


### PR DESCRIPTION
Fix 1. The z in the guide is sampled from the variational approximation of the true posterior z|y,t,x not t |y,t,x
Fix 2. using p for both the true dist and the variational approximation is poor notation and inconsistent with 
standard practice and the original paper. replacing p with q, to differentiate between the true and the 
variational distribution.