### PR TITLE
Add helper to convert Bio.Phylo trees to PyTorch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,6 +192,7 @@ intersphinx_mapping = {
     'funsor': ('http://funsor.pyro.ai/en/stable/', None),
     'opt_einsum': ('https://optimized-einsum.readthedocs.io/en/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'Bio': ('https://biopython.readthedocs.io/en/latest/', None),
 }
 
 # document class constructors (__init__ methods):

--- a/docs/source/contrib.epidemiology.rst
+++ b/docs/source/contrib.epidemiology.rst
@@ -39,3 +39,5 @@ Distributions
     :show-inheritance:
     :member-order: bysource
     :special-members: __call__
+
+.. autofunction:: pyro.distributions.coalescent.bio_phylo_to_times

--- a/pyro/contrib/epidemiology/__init__.py
+++ b/pyro/contrib/epidemiology/__init__.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from pyro.distributions.coalescent import bio_phylo_to_times
+
 from .compartmental import CompartmentalModel
 from .distributions import beta_binomial_dist, binomial_dist, infection_dist
 
@@ -8,5 +10,6 @@ __all__ = [
     "CompartmentalModel",
     "beta_binomial_dist",
     "binomial_dist",
+    "bio_phylo_to_times",
     "infection_dist",
 ]

--- a/pyro/distributions/coalescent.py
+++ b/pyro/distributions/coalescent.py
@@ -304,11 +304,12 @@ class CoalescentRateLikelihood:
 
 def bio_phylo_to_times(tree, *, get_time=None):
     """
-    Extracts coalescent summary statistics from a phylogeny.
+    Extracts coalescent summary statistics from a phylogeny, suitable for use
+    with :class:`~pyro.distributions.CoalescentRateLikelihood`.
 
     :param Bio.Phylo.BaseTree.Clade tree: A phylogenetic tree.
     :param callable get_time: Optional function to extract the time point of
-        each sub-:class:`Bio.Phylo.BaseTree.Clade`. If absent, times will be
+        each sub-:class:`~Bio.Phylo.BaseTree.Clade`. If absent, times will be
         computed by cumulative `.branch_length`.
     :returns: A pair of :class:`~torch.Tensor` s ``(leaf_times, coal_times)``
         where ``leaf_times`` are times of sampling events (leaf nodes in the

--- a/scripts/update_headers.py
+++ b/scripts/update_headers.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-blacklist = ["/build/", "/dist/"]
+blacklist = ["/build/", "/dist/", "/pyro/_version.py"]
 file_types = [
     ("*.py", "# {}"),
     ("*.cpp", "// {}"),

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ EXTRAS_REQUIRE = [
     'matplotlib>=1.3',
     'torchvision>=0.6.0',
     'visdom>=0.1.4',
+    'biopython>=1.54',
     'pandas',
     'seaborn',
     'wget',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ EXTRAS_REQUIRE = [
     'matplotlib>=1.3',
     'torchvision>=0.6.0',
     'visdom>=0.1.4',
-    'biopython>=1.54',
+    # 'biopython>=1.54',  # requires Python 3.6
     'pandas',
     'seaborn',
     'wget',

--- a/tests/distributions/test_coalescent.py
+++ b/tests/distributions/test_coalescent.py
@@ -150,7 +150,7 @@ def test_likelihood_sequential(num_leaves, num_steps, batch_shape, clamped):
     assert_close(actual, expected)
 
 
-TREE_NWK = """
+TREE_NEXUS = """
 #NEXUS
 Begin Trees;
  Tree tree1=((EPI_ISL_408009:0.00000[&date=2020.08],
@@ -194,10 +194,10 @@ End;
 @pytest.fixture
 def tree():
     Phylo = pytest.importorskip("Bio.Phylo")
-    tree_file = io.StringIO(TREE_NWK)
-    for tree in Phylo.parse(tree_file, "newick"):
-        if len(tree.root) > 1:
-            return tree
+    tree_file = io.StringIO(TREE_NEXUS)
+    trees = list(Phylo.parse(tree_file, "nexus"))
+    assert len(trees) == 1
+    return trees[0]
 
 
 def test_bio_phylo_to_times(tree):

--- a/tests/distributions/test_coalescent.py
+++ b/tests/distributions/test_coalescent.py
@@ -211,8 +211,6 @@ def test_bio_phylo_to_times(tree):
     signs = signs[index]
     lineages = signs.flip([0]).cumsum(0).flip([0])
     assert (lineages >= 0).all()
-    print(leaf_times)
-    print(coal_times)
 
 
 def test_bio_phylo_to_times_custom(tree):
@@ -231,6 +229,3 @@ def test_bio_phylo_to_times_custom(tree):
     signs = signs[index]
     lineages = signs.flip([0]).cumsum(0).flip([0])
     assert (lineages >= 0).all()
-
-    print(leaf_times)
-    print(coal_times)


### PR DESCRIPTION
Addresses #2426 

This adds a helper `bio_phylo_to_times()` to extract coalescent time statistics from a [Bio.Phylo](https://biopython.readthedocs.io/en/latest/api/Bio.Phylo.BaseTree.html#Bio.Phylo.BaseTree.Clade) tree object. This is convenient because `Bio.Phylo` provides parsers for most phylogeny tree formats, including Newick and NEXUS. Note this does not add a new dependency to Pyro: the code is duck typed and works whenever `biopython` is installed (it is not installed by default because `biopython` requires Python 3.6+).

I plan to document this helper in a new tutorial section #2558. I had already used a version of this helper in previous tutorial sketches.

## Tested
- [x] added unit tests
- [x] built docs locally.