### PR TITLE
Fix label name in Bayesian Regression example (Part 2)

### DIFF
--- a/tutorial/source/bayesian_regression_ii.ipynb
+++ b/tutorial/source/bayesian_regression_ii.ipynb
@@ -507,7 +507,7 @@
    "source": [
     "fig, axs = plt.subplots(nrows=1, ncols=2, figsize=(12, 6))\n",
     "fig.suptitle(\"Cross-sections of the Posterior Distribution\", fontsize=16)\n",
-    "sns.kdeplot(svi_samples[\"bA\"], svi_samples[\"bR\"], ax=axs[0], label=\"HMC\")\n",
+    "sns.kdeplot(svi_samples[\"bA\"], svi_samples[\"bR\"], ax=axs[0], label=\"SVI (Diagonal Normal)\")\n",
     "sns.kdeplot(svi_mvn_samples[\"bA\"], svi_mvn_samples[\"bR\"], ax=axs[0], shade=True, label=\"SVI (Multivariate Normal)\")\n",
     "axs[0].set(xlabel=\"bA\", ylabel=\"bR\", xlim=(-2.5, -1.2), ylim=(-0.5, 0.1))\n",
     "sns.kdeplot(svi_samples[\"bR\"], svi_samples[\"bAR\"], ax=axs[1], label=\"SVI (Diagonal Normal)\")\n",


### PR DESCRIPTION
Corrected the label name from HMC to SVI (Diagonal Normal).