### PR TITLE
Add a horovod optimizer and example

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,6 +193,7 @@ intersphinx_mapping = {
     'opt_einsum': ('https://optimized-einsum.readthedocs.io/en/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'Bio': ('https://biopython.readthedocs.io/en/latest/', None),
+    'horovod': ('https://horovod.readthedocs.io/en/stable/', None),
 }
 
 # document class constructors (__init__ methods):

--- a/docs/source/pyro.optim.txt
+++ b/docs/source/pyro.optim.txt
@@ -28,6 +28,13 @@ Pyro Optimizers
     :show-inheritance:
     :member-order: bysource
 
+.. automodule:: pyro.optim.horovod
+    :members:
+    :undoc-members:
+    :special-members: __call__
+    :show-inheritance:
+    :member-order: bysource
+
 PyTorch Optimizers
 ------------------
 

--- a/examples/svi_horovod.py
+++ b/examples/svi_horovod.py
@@ -1,0 +1,141 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+# Distributed training via Horovod.
+#
+# This tutorial demonstrates how to distribute SVI training across multiple
+# machines (or multiple GPUs on one or more machines) using the Horovod
+# library. Horovod enables data-parallel training by aggregating stochastic
+# gradients at each step of training. Horovod is not intended for model
+# parallelism. We focus on integration between Horovod and Pyro. For further
+# details on distributed computing with Horovod, see
+# https://horovod.readthedocs.io/en/stable
+#
+# This assumes you have installed horovod, e.g. via
+#   pip install pyro[horovod]
+# For detailed instructions see
+#   https://horovod.readthedocs.io/en/stable/install.html
+# On my mac laptop I was able to install horovod with
+#   CFLAGS=-mmacosx-version-min=10.15 HOROVOD_WITH_PYTORCH=1 \
+#   pip install --no-cache-dir 'horovod[pytorch]'
+
+import argparse
+
+import torch
+import torch.multiprocessing as mp
+
+import pyro
+import pyro.distributions as dist
+from pyro.infer import SVI, Trace_ELBO
+from pyro.infer.autoguide import AutoNormal
+from pyro.nn import PyroModule
+from pyro.optim import Adam, HorovodOptimizer
+
+
+# We define a model as usual, with no reference to Horovod. This model is data
+# parallel and supports subsampling.
+class Model(PyroModule):
+    def __init__(self, size):
+        super().__init__()
+        self.size = size
+
+    def forward(self, covariates, data=None):
+        coeff = pyro.sample("coeff", dist.Normal(0, 1))
+        bias = pyro.sample("bias", dist.Normal(0, 1))
+        scale = pyro.sample("scale", dist.LogNormal(0, 1))
+        with pyro.plate("data", self.size, len(covariates)):
+            loc = bias + coeff * covariates
+            return pyro.sample("obs", dist.Normal(loc, scale),
+                               obs=data)
+
+
+# The following is a standard training loop. The distributed parts are gated
+# by if args.horovod, and can safely be removed.
+def main(args):
+    if args.horovod:
+        # Initialize Horovod and set PyTorch globals.
+        import horovod.torch as hvd
+        hvd.init()
+        torch.set_num_threads(1)
+        if args.cuda:
+            torch.cuda.set_device(hvd.local_rank())
+
+    # Initialize random seed after initializing Horovod.
+    pyro.set_rng_seed(args.seed)
+
+    # Create a model, synthetic data, and a guide.
+    model = Model(args.size)
+    covariates = torch.randn(args.size)
+    data = model(covariates)
+    guide = AutoNormal(model)
+
+    if args.horovod:
+        # Initialize parameters and broadcast to all workers.
+        guide(covariates[:1], data[:1])  # Initializes model and guide.
+        hvd.broadcast_parameters(guide.state_dict(), root_rank=0)
+        hvd.broadcast_parameters(model.state_dict(), root_rank=0)
+
+    # Create an ELBO loss and a Pyro optimizer.
+    elbo = Trace_ELBO()
+    optim = Adam({"lr": args.learning_rate})
+
+    if args.horovod:
+        # Wrap the basic optimizer in a distributed optimizer.
+        optim = HorovodOptimizer(optim)
+
+    # Create a dataloader.
+    dataset = torch.utils.data.TensorDataset(covariates, data)
+    if args.horovod:
+        # Horovod requires a distributed sampler.
+        sampler = torch.utils.data.distributed.DistributedSampler(
+            dataset, hvd.size(), hvd.rank())
+    else:
+        sampler = torch.utils.data.RandomSampler(dataset)
+    config = {"batch_size": args.batch_size, "sampler": sampler}
+    if args.cuda:
+        config["num_workers"] = 1
+        config["pin_memory"] = True
+        # Try to use forkserver to spawn workers instead of fork.
+        if (hasattr(mp, "_supports_context") and mp._supports_context and
+                "forkserver" in mp.get_all_start_methods()):
+            config["multiprocessing_context"] = "forkserver"
+    dataloader = torch.utils.data.DataLoader(dataset, **config)
+
+    # Run stochastic variational inference.
+    svi = SVI(model, guide, optim, elbo)
+    for epoch in range(args.num_epochs):
+        if args.horovod:
+            # Set rng seeds on distributed samplers. This is required.
+            sampler.set_epoch(epoch)
+
+        for step, (covariates_batch, data_batch) in enumerate(dataloader):
+            loss = svi.step(covariates_batch, data_batch)
+            if step % 100 == 0:
+                print("epoch {} step {} loss = {:0.4g}".format(epoch, step, loss))
+
+    if args.horovod:
+        # Shutdown before saving.
+        hvd.shutdown()
+
+    if args.outfile:
+        torch.save({"model": model, "guide": guide}, args.outfile)
+
+
+if __name__ == "__main__":
+    assert pyro.__version__.startswith('1.4.0')
+    parser = argparse.ArgumentParser(description="Distributed training via Horovod")
+    parser.add_argument("--outfile")
+    parser.add_argument("--size", default=1000000, type=int)
+    parser.add_argument("--batch-size", default=100, type=int)
+    parser.add_argument("--num-epochs", default=10, type=int)
+    parser.add_argument("--learning-rate", default=0.01, type=float)
+    parser.add_argument("--cuda", action="store_true")
+    parser.add_argument("--horovod", action="store_true", default=True)
+    parser.add_argument("--no-horovod", action="store_false", dest="horovod")
+    parser.add_argument("--seed", default=20200723, type=int)
+    args = parser.parse_args()
+
+    if args.cuda:
+        torch.set_default_tensor_type("torch.cuda.FloatTensor")
+
+    main(args)

--- a/pyro/optim/__init__.py
+++ b/pyro/optim/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.optim.multi  # noqa F403
+from pyro.optim.horovod import HorovodOptimizer
 from pyro.optim.lr_scheduler import PyroLRScheduler
 from pyro.optim.optim import AdagradRMSProp, ClippedAdam, DCTAdam, PyroOptim
 from pyro.optim.pytorch_optimizers import *  # noqa F403
@@ -11,6 +12,7 @@ __all__ = [
     "AdagradRMSProp",
     "ClippedAdam",
     "DCTAdam",
+    "HorovodOptimizer",
     "PyroOptim",
     "PyroLRScheduler",
 ]

--- a/pyro/optim/horovod.py
+++ b/pyro/optim/horovod.py
@@ -16,7 +16,7 @@ class HorovodOptimizer(PyroOptim):
 
     .. note::
 
-        This requires :mod:`horovod.torch` is installed, e.g. via
+        This requires :mod:`horovod.torch` to be installed, e.g. via
         ``pip install pyro[horovod]``. For details see
         https://horovod.readthedocs.io/en/stable/install.html
 

--- a/pyro/optim/horovod.py
+++ b/pyro/optim/horovod.py
@@ -1,0 +1,42 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pyro
+
+from .optim import PyroOptim
+
+
+class HorovodOptimizer(PyroOptim):
+    r"""
+    Distributed wrapper for a :class:`~pyro.optim.optim.PyroOptim` optimizer.
+
+    This class wraps a ``PyroOptim`` object similar to the way
+    :func:`horovod.torch.DistributedOptimizer` wraps a
+    :class:`torch.optim.Optimizer`.
+
+    .. note::
+
+        This requires :mod:`horovod.torch` is installed, e.g. via
+        ``pip install pyro[horovod]``. For details see
+        https://horovod.readthedocs.io/en/stable/install.html
+
+    :param: A Pyro optimizer instance.
+    :type pyro_optim: ~pyro.optim.optim.PyroOptim
+    :param \*\*horovod_kwargs: Extra parameters passed to
+        :func:`horovod.torch.DistributedOptimizer`.
+    """
+    def __init__(self, pyro_optim, **horovod_kwargs):
+        param_store = pyro.get_param_store()
+
+        def optim_constructor(params, **pt_kwargs):
+            import horovod.torch as hvd
+            pt_optim = pyro_optim.pt_optim_constructor(params, **pt_kwargs)
+            named_parameters = [(param_store.param_name(p), p) for p in params]
+            hvd_optim = hvd.DistributedOptimizer(
+                pt_optim,
+                named_parameters=named_parameters,
+                **horovod_kwargs,
+            )
+            return hvd_optim
+
+        super().__init__(optim_constructor, pyro_optim.pt_optim_args, pyro_optim.pt_clip_args)

--- a/pyro/optim/horovod.py
+++ b/pyro/optim/horovod.py
@@ -40,3 +40,8 @@ class HorovodOptimizer(PyroOptim):
             return hvd_optim
 
         super().__init__(optim_constructor, pyro_optim.pt_optim_args, pyro_optim.pt_clip_args)
+
+    def __call__(self, params, *args, **kwargs):
+        # Sort by name to ensure deterministic processing order.
+        params = sorted(params, key=pyro.get_param_store().param_name)
+        super().__call__(params, *args, **kwargs)

--- a/pyro/optim/horovod.py
+++ b/pyro/optim/horovod.py
@@ -26,12 +26,12 @@ class HorovodOptimizer(PyroOptim):
         :func:`horovod.torch.DistributedOptimizer`.
     """
     def __init__(self, pyro_optim, **horovod_kwargs):
-        param_store = pyro.get_param_store()
+        param_name = pyro.get_param_store().param_name
 
         def optim_constructor(params, **pt_kwargs):
             import horovod.torch as hvd
             pt_optim = pyro_optim.pt_optim_constructor(params, **pt_kwargs)
-            named_parameters = [(param_store.param_name(p), p) for p in params]
+            named_parameters = [(param_name(p), p) for p in params]
             hvd_optim = hvd.DistributedOptimizer(
                 pt_optim,
                 named_parameters=named_parameters,

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -48,15 +48,12 @@ class PyroOptim:
 
     def __call__(self, params,  *args, **kwargs):
         """
-        :param params: a list of parameter values
-        :type params: an iterable of :class:`torch.Tensor` s
+        :param params: a list of parameters
+        :type params: an iterable of strings
 
         Do an optimization step for each param in params. If a given param has never been seen before,
         initialize an optimizer for it.
         """
-        # Sort by name to ensure deterministic processing order.
-        params = sorted(params, key=pyro.get_param_store().param_name)
-
         for p in params:
             # if we have not seen this param before, we instantiate an optim object to deal with it
             if p not in self.optim_objs:

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -48,12 +48,15 @@ class PyroOptim:
 
     def __call__(self, params,  *args, **kwargs):
         """
-        :param params: a list of parameters
-        :type params: an iterable of strings
+        :param params: a list of parameter values
+        :type params: an iterable of :class:`torch.Tensor` s
 
         Do an optimization step for each param in params. If a given param has never been seen before,
         initialize an optimizer for it.
         """
+        # Sort by name to ensure deterministic processing order.
+        params = sorted(params, key=pyro.get_param_store().param_name)
+
         for p in params:
             # if we have not seen this param before, we instantiate an optim object to deal with it
             if p not in self.optim_objs:

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setup(
             'sphinx_rtd_theme',
             'yapf',
         ],
+        'horovod': ['horovod[pytorch]>=0.19'],
     },
     python_requires='>=3.5',
     keywords='machine learning statistics probabilistic programming bayesian modeling pytorch',

--- a/tests/common.py
+++ b/tests/common.py
@@ -60,6 +60,13 @@ def TemporaryDirectory():
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(),
                                    reason="cuda is not available")
 
+try:
+    import horovod
+except ImportError:
+    horovod = None
+requires_horovod = pytest.mark.skipif(horovod is None,
+                                      reason="horovod is not available")
+
 
 def get_cpu_type(t):
     assert t.__module__ == 'torch.cuda'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,7 +8,7 @@ from subprocess import check_call
 
 import pytest
 
-from tests.common import EXAMPLES_DIR, requires_cuda, xfail_param
+from tests.common import EXAMPLES_DIR, requires_cuda, requires_horovod, xfail_param
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.stage('test_examples')
@@ -97,6 +97,8 @@ CPU_EXAMPLES = [
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide custom',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide auto',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide easy',
+    'svi_horovod.py --num-steps=2 --no-horovod',
+    pytest.param('svi_horovod.py --num-steps=2', marks=[requires_horovod]),
     'toy_mixture_model_discrete_enumeration.py  --num-steps=1',
     xfail_param('sparse_regression.py --num-steps=2 --num-data=50 --num-dimensions 20',
                 reason='https://github.com/pyro-ppl/pyro/issues/2082'),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,6 +7,7 @@ import sys
 from subprocess import check_call
 
 import pytest
+import torch
 
 from tests.common import EXAMPLES_DIR, requires_cuda, requires_horovod, xfail_param
 
@@ -97,8 +98,7 @@ CPU_EXAMPLES = [
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide custom',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide auto',
     'sparse_gamma_def.py --num-epochs=2 --eval-particles=2 --eval-frequency=1 --guide easy',
-    'svi_horovod.py --num-steps=2 --no-horovod',
-    pytest.param('svi_horovod.py --num-steps=2', marks=[requires_horovod]),
+    'svi_horovod.py --num-epochs=2 --size=400 --no-horovod',
     'toy_mixture_model_discrete_enumeration.py  --num-steps=1',
     xfail_param('sparse_regression.py --num-steps=2 --num-data=50 --num-dimensions 20',
                 reason='https://github.com/pyro-ppl/pyro/issues/2082'),
@@ -145,6 +145,7 @@ CUDA_EXAMPLES = [
     'sir_hmc.py -t=2 -w=2 -n=4 -d=2 -m=1 --enum --cuda',
     'sir_hmc.py -t=2 -w=2 -n=4 -d=2 -p=10000 --sequential --cuda',
     'sir_hmc.py -t=2 -w=2 -n=4 -d=100 -p=10000 --cuda',
+    'svi_horovod.py --num-epochs=2 --size=400 --cuda --no-horovod',
     'vae/vae.py --num-epochs=1 --cuda',
     'vae/ss_vae_M2.py --num-epochs=1 --cuda',
     'vae/ss_vae_M2.py --num-epochs=1 --aux-loss --cuda',
@@ -197,6 +198,12 @@ JIT_EXAMPLES = [
     'vae/vae_comparison.py --num-epochs=1 --jit',
 ]
 
+HOROVOD_EXAMPLES = [
+    'svi_horovod.py --num-epochs=2 --size=400',
+    pytest.param('svi_horovod.py --num-epochs=2 --size=400 --cuda',
+                 marks=[requires_cuda]),
+]
+
 
 def test_coverage():
     cpu_tests = set((e if isinstance(e, str) else e.values[0]).split()[0] for e in CPU_EXAMPLES)
@@ -245,3 +252,17 @@ def test_jit(example):
     filename, args = example[0], example[1:]
     filename = os.path.join(EXAMPLES_DIR, filename)
     check_call([sys.executable, filename] + args)
+
+
+@requires_horovod
+@pytest.mark.parametrize('np', [1, 2])
+@pytest.mark.parametrize('example', HOROVOD_EXAMPLES)
+def test_horovod(np, example):
+    if 'cuda' in example and np > torch.cuda.device_count():
+        pytest.skip()
+    horovodrun = 'horovodrun -np {} --mpi-args=--oversubscribe'.format(np)
+    logger.info('Running:\n{} python examples/{}'.format(horovodrun, example))
+    example = example.split()
+    filename, args = example[0], example[1:]
+    filename = os.path.join(EXAMPLES_DIR, filename)
+    check_call(horovodrun.split() + [sys.executable, filename] + args)

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -85,6 +85,7 @@ Welcome to Pyro Examples and Tutorials!
    epi_regional
    sir_hmc
    toy_mixture_model_discrete_enumeration
+   svi_horovod
 
 Indices and tables
 ==================

--- a/tutorial/source/svi_horovod.rst
+++ b/tutorial/source/svi_horovod.rst
@@ -1,0 +1,20 @@
+Distributed training via Horovod
+================================
+
+Unlike other examples, this example must be run under horovodrun_, for example
+
+.. _horovodrun: https://github.com/horovod/horovod/blob/master/docs/running.rst
+
+.. code-block:: none
+
+    $ horovodrun -np 2 examples/svi_horovod.py
+
+`View svi_horovod.py on github`__
+
+.. _github: https://github.com/pyro-ppl/pyro/blob/dev/examples/svi_horovod.py
+
+__ github_
+
+.. literalinclude:: ../../examples/svi_horovod.py
+    :language: python
+

--- a/tutorial/source/svi_horovod.rst
+++ b/tutorial/source/svi_horovod.rst
@@ -9,6 +9,10 @@ Unlike other examples, this example must be run under horovodrun_, for example
 
     $ horovodrun -np 2 examples/svi_horovod.py
 
+The only Horovod-specific component of Pyro is the HorovodOptimizer_ class.
+
+.. _HorovodOptimizer: https://docs.pyro.ai/en/latest/optimization.html#pyro.optim.horovod.HorovodOptimizer
+
 `View svi_horovod.py on github`__
 
 .. _github: https://github.com/pyro-ppl/pyro/blob/dev/examples/svi_horovod.py


### PR DESCRIPTION
Resolves #2570 

This integrates with [Horovod](https://github.com/horovod/horovod) by implementing a `pyro.optim.HorovodOptimizer` that combines behavior of Pyro's `PyroOptim` and Horovod's `DistributedOptimizer`. The new `HorovodOptimizer` can wrap any other Pyro optimizer e.g. `optim = HorovodOptimizer(ClippedAdam({'lr': 1e-3}))`. I've also added an example demonstrating how to distribute training using the optimizer.

I have avoided adding horovod as a default dependency since it requires other system dependencies (MPI and maybe gloo). Instead I've added a `pyro[horovod]` extras require which points to `horovod[pytorch]`. I've also added a test decorator `requires_horovod` that skips on current CI.

## Tested
Tests with `--no-horovod` are run on CI. Other tests require `horovodrun` and are not run on CI. Because horovod must be run under a separate process, I have added only example tests and no pytest-driven unit tests.

- [x] smoke test `--no-horovod`
- [x] smoke test `--num-proc 1`
- [x] smoke test `--num-proc 2`
- [x] smoke test `--no-horovod` `--cuda`
- [x] smoke test `--num-proc 1` `--cuda`
- [x] smoke test `--num-proc 2` `--cuda`
- [x] verify convergence