### PR TITLE
Add git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
to let github recognize this is a Python repo, rather than a Jupyter repo.