### PR TITLE
Implement vectorized plate and subsampling in contrib.funsor

### DIFF
--- a/pyro/contrib/funsor/__init__.py
+++ b/pyro/contrib/funsor/__init__.py
@@ -4,11 +4,16 @@
 import pyroapi
 
 from pyro.primitives import (  # noqa: F401
-    clear_param_store, deterministic, factor, get_param_store, module, param, plate, random_module, sample, subsample,
+    clear_param_store, deterministic, factor, get_param_store, module, param, random_module, sample, subsample,
 )
 
 from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor  # noqa: F401
 from pyro.contrib.funsor.handlers import condition, do, markov  # noqa: F401
+from pyro.contrib.funsor.handlers import plate as _plate
+
+
+def plate(*args, **kwargs):
+    return _plate(None, *args, **kwargs)
 
 
 pyroapi.register_backend('contrib.funsor', {

--- a/pyro/contrib/funsor/handlers/__init__.py
+++ b/pyro/contrib/funsor/handlers/__init__.py
@@ -10,6 +10,7 @@ from pyro.poutine import (  # noqa: F401
 
 from .enum_messenger import EnumMessenger, queue  # noqa: F401
 from .named_messenger import MarkovMessenger, NamedMessenger
+from .plate_messenger import PlateMessenger
 from .replay_messenger import ReplayMessenger
 from .trace_messenger import TraceMessenger
 
@@ -18,6 +19,7 @@ _msngrs = [
     EnumMessenger,
     MarkovMessenger,
     NamedMessenger,
+    PlateMessenger,
     ReplayMessenger,
     TraceMessenger,
 ]

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -1,0 +1,114 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import OrderedDict
+
+import funsor
+
+from pyro.distributions.util import copy_docs_from
+from pyro.poutine.broadcast_messenger import BroadcastMessenger
+from pyro.poutine.indep_messenger import CondIndepStackFrame
+from pyro.poutine.subsample_messenger import SubsampleMessenger as OrigSubsampleMessenger
+
+from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
+from pyro.contrib.funsor.handlers.named_messenger import DimType, GlobalNamedMessenger
+
+funsor.set_backend("torch")
+
+
+class IndepMessenger(GlobalNamedMessenger):
+    """
+    Sketch of vectorized plate implementation using to_data instead of _DIM_ALLOCATOR.
+    """
+    def __init__(self, name=None, size=None, dim=None, indices=None):
+        assert size > 1
+        assert dim is None or dim < 0
+        super().__init__()
+        self.name = name
+        self.size = size
+        self.dim = dim
+        if not hasattr(self, "_full_size"):
+            self._full_size = size
+        if indices is None:
+            indices = funsor.ops.new_arange(funsor.tensor.get_default_prototype(), self.size)
+        assert len(indices) == size
+
+        self._indices = funsor.Tensor(
+            indices, OrderedDict([(self.name, funsor.bint(self.size))]), self._full_size
+        )
+
+    def __enter__(self):
+        super().__enter__()  # do this first to take care of globals recycling
+        name_to_dim = OrderedDict([(self.name, self.dim)])
+        indices = to_data(self._indices, name_to_dim=name_to_dim, dim_type=DimType.VISIBLE)
+        # extract the dimension allocated by to_data to match plate's current behavior
+        self.dim, self.indices = -indices.dim(), indices.squeeze()
+        return self
+
+    def _pyro_sample(self, msg):
+        frame = CondIndepStackFrame(self.name, self.dim, self.size, 0)
+        msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
+
+    def _pyro_param(self, msg):
+        frame = CondIndepStackFrame(self.name, self.dim, self.size, 0)
+        msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
+
+
+@copy_docs_from(OrigSubsampleMessenger)
+class SubsampleMessenger(IndepMessenger):
+
+    def __init__(self, name, size=None, subsample_size=None, subsample=None, dim=None,
+                 use_cuda=None, device=None):
+        size, subsample_size, indices = OrigSubsampleMessenger._subsample(
+            name, size, subsample_size, subsample, use_cuda, device)
+        self.subsample_size = subsample_size
+        self._full_size = size
+        self._scale = size / subsample_size
+        # initialize other things last
+        super().__init__(name, subsample_size, dim, indices)
+
+    def _pyro_sample(self, msg):
+        super()._pyro_sample(msg)
+        msg["scale"] = msg["scale"] * self._scale
+
+    def _pyro_param(self, msg):
+        super()._pyro_param(msg)
+        msg["scale"] = msg["scale"] * self._scale
+
+    def _subsample_site_value(self, value, event_dim=None):
+        if self.dim is not None and event_dim is not None and self.subsample_size < self._full_size:
+            event_shape = value.shape[len(value.shape) - event_dim:]
+            funsor_value = to_funsor(value, output=funsor.reals(*event_shape))
+            if self.name in funsor_value.inputs:
+                return to_data(funsor_value(**{self.name: self._indices}))
+        return value
+
+    def _pyro_post_param(self, msg):
+        event_dim = msg["kwargs"].get("event_dim")
+        new_value = self._subsample_site_value(msg["value"], event_dim)
+        if new_value is not msg["value"]:
+            if hasattr(msg["value"], "_pyro_unconstrained_param"):
+                param = msg["value"]._pyro_unconstrained_param
+            else:
+                param = msg["value"].unconstrained()
+
+            if not hasattr(param, "_pyro_subsample"):
+                param._pyro_subsample = {}  # TODO is this going to persist correctly?
+
+            param._pyro_subsample[self.dim - event_dim] = self.indices
+            new_value._pyro_unconstrained_param = param
+            msg["value"] = new_value
+
+    def _pyro_post_subsample(self, msg):
+        event_dim = msg["kwargs"].get("event_dim")
+        msg["value"] = self._subsample_site_value(msg["value"], event_dim)
+
+
+class PlateMessenger(SubsampleMessenger):
+    """
+    Combines new IndepMessenger implementation with existing BroadcastMessenger.
+    Should eventually be a drop-in replacement for pyro.plate.
+    """
+    def _pyro_sample(self, msg):
+        super()._pyro_sample(msg)
+        BroadcastMessenger._pyro_sample(msg)

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -18,7 +18,7 @@ funsor.set_backend("torch")
 
 class IndepMessenger(GlobalNamedMessenger):
     """
-    Sketch of vectorized plate implementation using to_data instead of _DIM_ALLOCATOR.
+    Vectorized plate implementation using to_data instead of _DIM_ALLOCATOR.
     """
     def __init__(self, name=None, size=None, dim=None, indices=None):
         assert size > 1
@@ -109,6 +109,10 @@ class PlateMessenger(SubsampleMessenger):
     Combines new IndepMessenger implementation with existing BroadcastMessenger.
     Should eventually be a drop-in replacement for pyro.plate.
     """
+    def __enter__(self):
+        super().__enter__()
+        return self.indices  # match pyro.plate behavior
+
     def _pyro_sample(self, msg):
         super()._pyro_sample(msg)
         BroadcastMessenger._pyro_sample(msg)

--- a/pyro/infer/enum.py
+++ b/pyro/infer/enum.py
@@ -164,9 +164,9 @@ def config_enumerate(guide=None, default="parallel", expand=False, num_samples=N
         if default == "sequential":
             raise ValueError('Local sampling does not support "sequential" sampling; '
                              'use "parallel" sampling instead.')
-    if tmc is not None:
-        if tmc not in ("mixture", "diagonal"):
-            raise ValueError("{} not a valid TMC strategy".format(tmc))
+    if tmc == "full" and num_samples is not None and num_samples > 1:
+        # tmc strategies validated elsewhere (within enum handler)
+        expand = True
 
     # Support usage as a decorator:
     if guide is None:

--- a/tests/contrib/funsor/test_valid_models_plate.py
+++ b/tests/contrib/funsor/test_valid_models_plate.py
@@ -1,0 +1,185 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import pytest
+import torch
+
+from pyro.ops.indexing import Vindex
+from tests.common import xfail_param
+
+# put all funsor-related imports here, so test collection works without funsor
+try:
+    import funsor
+    import pyro.contrib.funsor
+    from pyroapi import distributions as dist
+    from pyroapi import infer, pyro
+    from tests.contrib.funsor.test_valid_models_enum import assert_ok
+    funsor.set_backend("torch")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="funsor is not installed")
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize('enumerate_', [None, "parallel", "sequential"])
+def test_enum_discrete_non_enumerated_plate_ok(enumerate_):
+
+    def model():
+        pyro.sample("w", dist.Bernoulli(0.5), infer={'enumerate': 'parallel'})
+
+        with pyro.plate("non_enum", 2):
+            a = pyro.sample("a", dist.Bernoulli(0.5), infer={'enumerate': None})
+
+        p = (1.0 + a.sum(-1)) / (2.0 + a.shape[0])  # introduce dependency of b on a
+
+        with pyro.plate("enum_1", 3):
+            pyro.sample("b", dist.Bernoulli(p), infer={'enumerate': enumerate_})
+
+    assert_ok(model, max_plate_nesting=1)
+
+
+@pytest.mark.parametrize("plate_dims", [
+    (None, None, None, None),
+    (-3, None, None, None),
+    (None, -3, None, None),
+    (-2, -3, None, None),
+])
+def test_plate_dim_allocation_ok(plate_dims):
+
+    def model():
+        p = torch.tensor(0.5, requires_grad=True)
+        with pyro.plate("plate_outer", 5, dim=plate_dims[0]):
+            pyro.sample("x", dist.Bernoulli(p))
+            with pyro.plate("plate_inner_1", 6, dim=plate_dims[1]):
+                pyro.sample("y", dist.Bernoulli(p))
+                with pyro.plate("plate_inner_2", 7, dim=plate_dims[2]):
+                    pyro.sample("z", dist.Bernoulli(p))
+                    with pyro.plate("plate_inner_3", 8, dim=plate_dims[3]):
+                        pyro.sample("q", dist.Bernoulli(p))
+
+    assert_ok(model, max_plate_nesting=4)
+
+
+@pytest.mark.parametrize("tmc_strategy", [None, xfail_param("diagonal", reason="strategy not implemented yet")])
+@pytest.mark.parametrize("subsampling", [False, True])
+@pytest.mark.parametrize("reuse_plate", [False, True])
+def test_enum_recycling_plate(subsampling, reuse_plate, tmc_strategy):
+
+    @infer.config_enumerate(default="parallel", tmc=tmc_strategy, num_samples=2 if tmc_strategy else None)
+    def model():
+        p = pyro.param("p", torch.ones(3, 3))
+        q = pyro.param("q", torch.tensor([0.5, 0.5]))
+        plate_x = pyro.plate("plate_x", 4, subsample_size=3 if subsampling else None, dim=-1)
+        plate_y = pyro.plate("plate_y", 5, subsample_size=3 if subsampling else None, dim=-1)
+        plate_z = pyro.plate("plate_z", 6, subsample_size=3 if subsampling else None, dim=-2)
+
+        a = pyro.sample("a", dist.Bernoulli(q[0])).long()
+        w = 0
+        for i in pyro.markov(range(4)):
+            w = pyro.sample("w_{}".format(i), dist.Categorical(p[w]))
+
+        with plate_x:
+            b = pyro.sample("b", dist.Bernoulli(q[a])).long()
+            x = 0
+            for i in pyro.markov(range(4)):
+                x = pyro.sample("x_{}".format(i), dist.Categorical(p[x]))
+
+        with plate_y:
+            c = pyro.sample("c", dist.Bernoulli(q[a])).long()
+            y = 0
+            for i in pyro.markov(range(4)):
+                y = pyro.sample("y_{}".format(i), dist.Categorical(p[y]))
+
+        with plate_z:
+            d = pyro.sample("d", dist.Bernoulli(q[a])).long()
+            z = 0
+            for i in pyro.markov(range(4)):
+                z = pyro.sample("z_{}".format(i), dist.Categorical(p[z]))
+
+        with plate_x, plate_z:
+            # this part is tricky: how do we know to preserve b's dimension?
+            # also, how do we know how to make b and d have different dimensions?
+            e = pyro.sample("e", dist.Bernoulli(q[b if reuse_plate else a])).long()
+            xz = 0
+            for i in pyro.markov(range(4)):
+                xz = pyro.sample("xz_{}".format(i), dist.Categorical(p[xz]))
+
+        return a, b, c, d, e
+
+    assert_ok(model, max_plate_nesting=2)
+
+
+@pytest.mark.parametrize("enumerate_", [None, "parallel", "sequential"])
+@pytest.mark.parametrize("reuse_plate", [True, False])
+def test_enum_discrete_plates_dependency_ok(enumerate_, reuse_plate):
+
+    @infer.config_enumerate(default=enumerate_)
+    def model():
+        x_plate = pyro.plate("x_plate", 10, dim=-1)
+        y_plate = pyro.plate("y_plate", 11, dim=-2)
+        q = pyro.param("q", torch.tensor([0.5, 0.5]))
+        pyro.sample("a", dist.Bernoulli(0.5))
+        with x_plate:
+            b = pyro.sample("b", dist.Bernoulli(0.5)).long()
+        with y_plate:
+            # Note that it is difficult to check that c does not depend on b.
+            c = pyro.sample("c", dist.Bernoulli(0.5)).long()
+        with x_plate, y_plate:
+            pyro.sample("d", dist.Bernoulli(Vindex(q)[b] if reuse_plate else 0.5))
+
+        assert c.shape != b.shape or enumerate_ == "sequential"
+
+    assert_ok(model, max_plate_nesting=2)
+
+
+@pytest.mark.parametrize('subsampling', [False, True])
+@pytest.mark.parametrize('enumerate_', [None, "parallel", "sequential"])
+def test_enum_discrete_plate_shape_broadcasting_ok(subsampling, enumerate_):
+
+    @infer.config_enumerate(default=enumerate_)
+    def model():
+        x_plate = pyro.plate("x_plate", 5, subsample_size=2 if subsampling else None, dim=-1)
+        y_plate = pyro.plate("y_plate", 6, subsample_size=3 if subsampling else None, dim=-2)
+        with pyro.plate("num_particles", 50, dim=-3):
+            with x_plate:
+                b = pyro.sample("b", dist.Beta(torch.tensor(1.1), torch.tensor(1.1)))
+            with y_plate:
+                c = pyro.sample("c", dist.Bernoulli(0.5))
+            with x_plate, y_plate:
+                d = pyro.sample("d", dist.Bernoulli(b))
+
+        # check shapes
+        if enumerate_ == "parallel":
+            assert b.shape == (50, 1, x_plate.subsample_size)
+            assert c.shape == (2, 1, 1, 1)
+            assert d.shape == (2, 1, 1, 1, 1)
+        elif enumerate_ == "sequential":
+            assert b.shape == (50, 1, x_plate.subsample_size)
+            assert c.shape in ((), (1, 1, 1))  # both are valid
+            assert d.shape in ((), (1, 1, 1))  # both are valid
+        else:
+            assert b.shape == (50, 1, x_plate.subsample_size)
+            assert c.shape == (50, y_plate.subsample_size, 1)
+            assert d.shape == (50, y_plate.subsample_size, x_plate.subsample_size)
+
+    assert_ok(model, guide=model, max_plate_nesting=3)
+
+
+@pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
+@pytest.mark.parametrize("num_samples", [None, 2])
+def test_plate_subsample_primitive_ok(subsample_size, num_samples):
+
+    @infer.config_enumerate(num_samples=num_samples, tmc="full")
+    def model():
+        with pyro.plate("plate", 10, subsample_size=subsample_size, dim=None):
+            p0 = torch.tensor(0.)
+            p0 = pyro.subsample(p0, event_dim=0)
+            assert p0.shape == ()
+            p = 0.5 * torch.ones(10)
+            p = pyro.subsample(p, event_dim=0)
+            assert len(p) == (subsample_size if subsample_size else 10)
+            pyro.sample("x", dist.Bernoulli(p))
+
+    assert_ok(model, max_plate_nesting=1)

--- a/tests/contrib/funsor/test_valid_models_sequential_plate.py
+++ b/tests/contrib/funsor/test_valid_models_sequential_plate.py
@@ -1,0 +1,112 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import pytest
+import torch
+
+from pyro.ops.indexing import Vindex
+
+# put all funsor-related imports here, so test collection works without funsor
+try:
+    import funsor
+    import pyro.contrib.funsor
+    from pyroapi import distributions as dist
+    from pyroapi import infer, pyro
+    from tests.contrib.funsor.test_valid_models_enum import assert_ok
+    funsor.set_backend("torch")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="funsor is not installed")
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize('subsampling', [False, True])
+@pytest.mark.parametrize('enumerate_', [None, "parallel", "sequential"])
+def test_enum_discrete_iplate_plate_dependency_ok(subsampling, enumerate_):
+
+    def model():
+        pyro.sample("w", dist.Bernoulli(0.5), infer={'enumerate': 'parallel'})
+        inner_plate = pyro.plate("plate", 10, subsample_size=4 if subsampling else None)
+        for i in pyro.plate("iplate", 10, subsample=torch.arange(3) if subsampling else None):
+            pyro.sample("y_{}".format(i), dist.Bernoulli(0.5))
+            with inner_plate:
+                pyro.sample("x_{}".format(i), dist.Bernoulli(0.5),
+                            infer={'enumerate': enumerate_})
+
+    assert_ok(model, max_plate_nesting=1)
+
+
+def test_enum_iplate_iplate_ok():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        b_axis = pyro.plate("b_axis", 2)
+        c_axis = pyro.plate("c_axis", 2)
+        a = pyro.sample("a", dist.Categorical(probs_a))
+        b = [pyro.sample("b_{}".format(i), dist.Categorical(probs_b[a])) for i in b_axis]
+        c = [pyro.sample("c_{}".format(j), dist.Categorical(probs_c[a])) for j in c_axis]
+        for i in b_axis:
+            for j in c_axis:
+                pyro.sample("d_{}_{}".format(i, j),
+                            dist.Categorical(Vindex(probs_d)[b[i], c[j]]),
+                            obs=data[i, j])
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)
+
+
+def test_enum_plate_iplate_ok():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        b_axis = pyro.plate("b_axis", 2)
+        c_axis = pyro.plate("c_axis", 2)
+        a = pyro.sample("a", dist.Categorical(probs_a))
+        with b_axis:
+            b = pyro.sample("b", dist.Categorical(probs_b[a]))
+        with b_axis:
+            for j in c_axis:
+                c_j = pyro.sample("c_{}".format(j), dist.Categorical(probs_c[a]))
+                pyro.sample("d_{}".format(j),
+                            dist.Categorical(Vindex(probs_d)[b, c_j]),
+                            obs=data[:, j])
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)
+
+
+def test_enum_iplate_plate_ok():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        b_axis = pyro.plate("b_axis", 2)
+        c_axis = pyro.plate("c_axis", 2)
+        a = pyro.sample("a", dist.Categorical(probs_a))
+        with c_axis:
+            c = pyro.sample("c", dist.Categorical(probs_c[a]))
+        for i in b_axis:
+            b_i = pyro.sample("b_{}".format(i), dist.Categorical(probs_b[a]))
+            with c_axis:
+                pyro.sample("d_{}".format(i),
+                            dist.Categorical(Vindex(probs_d)[b_i, c]),
+                            obs=data[i])
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)


### PR DESCRIPTION
Addresses #2580. Blocked by #2589.

This PR adds a Funsor-based implementation of vectorized `pyro.plate` contexts with support for subsampling, including the `pyro.subsample` primitive.  An implementation of sequential plates will be added in a followup PR.

The tests in this PR are copied largely verbatim from `tests/infer/test_valid_models.py`, and make use of the `assert_ok` test utility added in #2589 to compare dimension allocation behavior of Pyro and `contrib.funsor`.