### PR TITLE
Implement sequential plate in contrib.funsor

### DIFF
--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -136,12 +136,9 @@ class _SequentialPlateMessenger(Messenger):
         self.counter = 0
         super().__init__()
 
-    def __enter__(self):
-        self.counter = 0
-        return super().__enter__()
-
     def __iter__(self):
         with ignore_jit_warnings([("Iterating over a tensor", RuntimeWarning)]), self:
+            self.counter = 0
             for i in self.indices:
                 self.counter += 1
                 yield i if isinstance(i, Number) else i.item()

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
+from numbers import Number
 
 import funsor
 
 from pyro.distributions.util import copy_docs_from
 from pyro.poutine.broadcast_messenger import BroadcastMessenger
 from pyro.poutine.indep_messenger import CondIndepStackFrame
+from pyro.poutine.messenger import Messenger
 from pyro.poutine.subsample_messenger import SubsampleMessenger as OrigSubsampleMessenger
+from pyro.util import ignore_jit_warnings
 
 from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
 from pyro.contrib.funsor.handlers.named_messenger import DimType, GlobalNamedMessenger
@@ -116,3 +119,39 @@ class PlateMessenger(SubsampleMessenger):
     def _pyro_sample(self, msg):
         super()._pyro_sample(msg)
         BroadcastMessenger._pyro_sample(msg)
+
+    def __iter__(self):
+        return iter(_SequentialPlateMessenger(self.name, self.size, self._indices, self._scale))
+
+
+class _SequentialPlateMessenger(Messenger):
+    """
+    Implementation of sequential plate. Should not be used directly.
+    """
+    def __init__(self, name, size, indices, scale):
+        self.name = name
+        self.size = size
+        self.indices = indices
+        self.scale = scale
+        self.counter = 0
+        super().__init__()
+
+    def __enter__(self):
+        self.counter = 0
+        return super().__enter__()
+
+    def __iter__(self):
+        with ignore_jit_warnings([("Iterating over a tensor", RuntimeWarning)]), self:
+            for i in self.indices:
+                self.counter += 1
+                yield i if isinstance(i, Number) else i.item()
+
+    def _pyro_sample(self, msg):
+        frame = CondIndepStackFrame(self.name, None, self.size, self.counter)
+        msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
+        msg["scale"] = msg["scale"] * self._scale
+
+    def _pyro_param(self, msg):
+        frame = CondIndepStackFrame(self.name, None, self.size, self.counter)
+        msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
+        msg["scale"] = msg["scale"] * self._scale

--- a/tests/contrib/funsor/test_valid_models_sequential_plate.py
+++ b/tests/contrib/funsor/test_valid_models_sequential_plate.py
@@ -1,0 +1,143 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import pytest
+import torch
+
+import funsor
+
+from pyro.ops.indexing import Vindex
+
+import pyro.contrib.funsor
+from pyroapi import distributions as dist
+from pyroapi import infer, handlers, pyro
+
+from tests.contrib.funsor.test_valid_models import assert_ok
+
+
+funsor.set_backend("torch")
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize('subsampling', [False, True])
+@pytest.mark.parametrize('enumerate_', [None, "parallel", "sequential"])
+def test_enum_discrete_iplate_plate_dependency_ok(subsampling, enumerate_):
+
+    def model():
+        pyro.sample("w", dist.Bernoulli(0.5), infer={'enumerate': 'parallel'})
+        inner_plate = pyro.plate("plate", 10, subsample_size=4 if subsampling else None)
+        for i in pyro.plate("iplate", 10, subsample=torch.arange(3) if subsampling else None):
+            pyro.sample("y_{}".format(i), dist.Bernoulli(0.5))
+            with inner_plate:
+                pyro.sample("x_{}".format(i), dist.Bernoulli(0.5),
+                            infer={'enumerate': enumerate_})
+
+    assert_ok(model, max_plate_nesting=1)
+
+
+@pytest.mark.xfail(reason="empty samples incompatible with current Pyro")
+def test_enum_iplate_iplate_ok_1():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        @handlers.trace
+        def model_():
+            b_axis = pyro.plate("b_axis", 2)
+            c_axis = pyro.plate("c_axis", 2)
+            a = pyro.sample("a", dist.Categorical(probs_a))
+            b = [pyro.sample("b_{}".format(i), dist.Categorical(probs_b[a])) for i in b_axis]  # noqa: F841
+            c = [pyro.sample("c_{}".format(j), dist.Categorical(probs_c[a])) for j in c_axis]  # noqa: F841
+            for i in b_axis:
+                for j in c_axis:
+                    b_i, c_j = pyro.sample("b_{}".format(i)), pyro.sample("c_{}".format(j))
+                    pyro.sample("d_{}_{}".format(i, j),
+                                dist.Categorical(Vindex(probs_d)[b_i, c_j]),
+                                obs=data[i, j])
+
+        return model_()
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)
+
+
+# @pytest.mark.xfail(reason="semantic difference in sequential plates")
+def test_enum_iplate_iplate_ok_2():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        b_axis = pyro.plate("b_axis", 2)
+        c_axis = pyro.plate("c_axis", 2)
+        a = pyro.sample("a", dist.Categorical(probs_a))
+        b = [pyro.sample("b_{}".format(i), dist.Categorical(probs_b[a])) for i in b_axis]
+        c = [pyro.sample("c_{}".format(j), dist.Categorical(probs_c[a])) for j in c_axis]
+        for i in b_axis:
+            for j in c_axis:
+                pyro.sample("d_{}_{}".format(i, j),
+                            dist.Categorical(Vindex(probs_d)[b[i], c[j]]),
+                            obs=data[i, j])
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)
+
+
+def test_enum_plate_iplate_ok():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        b_axis = pyro.plate("b_axis", 2)
+        c_axis = pyro.plate("c_axis", 2)
+        a = pyro.sample("a", dist.Categorical(probs_a))
+        with b_axis:
+            b = pyro.sample("b", dist.Categorical(probs_b[a]))
+        with b_axis:
+            for j in c_axis:
+                c_j = pyro.sample("c_{}".format(j), dist.Categorical(probs_c[a]))
+                pyro.sample("d_{}".format(j),
+                            dist.Categorical(Vindex(probs_d)[b, c_j]),
+                            obs=data[:, j])
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)
+
+
+def test_enum_iplate_plate_ok():
+
+    @infer.config_enumerate
+    def model(data=None):
+        probs_a = torch.tensor([0.45, 0.55])
+        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
+        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
+        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
+
+        b_axis = pyro.plate("b_axis", 2)
+        c_axis = pyro.plate("c_axis", 2)
+        a = pyro.sample("a", dist.Categorical(probs_a))
+        with c_axis:
+            c = pyro.sample("c", dist.Categorical(probs_c[a]))
+        for i in b_axis:
+            b_i = pyro.sample("b_{}".format(i), dist.Categorical(probs_b[a]))
+            with c_axis:
+                pyro.sample("d_{}".format(i),
+                            dist.Categorical(Vindex(probs_d)[b_i, c]),
+                            obs=data[i])
+
+    data = torch.tensor([[0, 1], [0, 0]])
+    assert_ok(model, max_plate_nesting=1, data=data)

--- a/tests/contrib/funsor/test_valid_models_sequential_plate.py
+++ b/tests/contrib/funsor/test_valid_models_sequential_plate.py
@@ -38,38 +38,7 @@ def test_enum_discrete_iplate_plate_dependency_ok(subsampling, enumerate_):
     assert_ok(model, max_plate_nesting=1)
 
 
-@pytest.mark.xfail(reason="empty samples incompatible with current Pyro")
-def test_enum_iplate_iplate_ok_1():
-
-    @infer.config_enumerate
-    def model(data=None):
-        probs_a = torch.tensor([0.45, 0.55])
-        probs_b = torch.tensor([[0.6, 0.4], [0.4, 0.6]])
-        probs_c = torch.tensor([[0.75, 0.25], [0.55, 0.45]])
-        probs_d = torch.tensor([[[0.4, 0.6], [0.3, 0.7]], [[0.3, 0.7], [0.2, 0.8]]])
-
-        @handlers.trace
-        def model_():
-            b_axis = pyro.plate("b_axis", 2)
-            c_axis = pyro.plate("c_axis", 2)
-            a = pyro.sample("a", dist.Categorical(probs_a))
-            b = [pyro.sample("b_{}".format(i), dist.Categorical(probs_b[a])) for i in b_axis]  # noqa: F841
-            c = [pyro.sample("c_{}".format(j), dist.Categorical(probs_c[a])) for j in c_axis]  # noqa: F841
-            for i in b_axis:
-                for j in c_axis:
-                    b_i, c_j = pyro.sample("b_{}".format(i)), pyro.sample("c_{}".format(j))
-                    pyro.sample("d_{}_{}".format(i, j),
-                                dist.Categorical(Vindex(probs_d)[b_i, c_j]),
-                                obs=data[i, j])
-
-        return model_()
-
-    data = torch.tensor([[0, 1], [0, 0]])
-    assert_ok(model, max_plate_nesting=1, data=data)
-
-
-# @pytest.mark.xfail(reason="semantic difference in sequential plates")
-def test_enum_iplate_iplate_ok_2():
+def test_enum_iplate_iplate_ok():
 
     @infer.config_enumerate
     def model(data=None):

--- a/tests/contrib/funsor/test_valid_models_sequential_plate.py
+++ b/tests/contrib/funsor/test_valid_models_sequential_plate.py
@@ -6,18 +6,18 @@ import logging
 import pytest
 import torch
 
-import funsor
-
 from pyro.ops.indexing import Vindex
 
-import pyro.contrib.funsor
-from pyroapi import distributions as dist
-from pyroapi import infer, handlers, pyro
-
-from tests.contrib.funsor.test_valid_models import assert_ok
-
-
-funsor.set_backend("torch")
+# put all funsor-related imports here, so test collection works without funsor
+try:
+    import funsor
+    import pyro.contrib.funsor
+    from pyroapi import distributions as dist
+    from pyroapi import infer, pyro
+    from tests.contrib.funsor.test_valid_models_enum import assert_ok
+    funsor.set_backend("torch")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="funsor is not installed")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Addresses #2580. Blocked by #2593.

This PR adds support for sequential (as opposed to vectorized) `pyro.plate`s in `pyro.contrib.funsor`, sticking to the semantics of Pyro's sequential plates.

It also contains more tests ported from `tests/infer/test_valid_models.py` and making use of the `assert_ok` utility added in #2589.