### PR TITLE
Implement sampling enumeration strategies and TraceTMC_ELBO in contrib.funsor

### DIFF
--- a/pyro/contrib/funsor/infer/__init__.py
+++ b/pyro/contrib/funsor/infer/__init__.py
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer import ELBO, SVI, config_enumerate  # noqa: F401
+
+from .tracetmc_elbo import TraceTMC_ELBO  # noqa: F401

--- a/pyro/contrib/funsor/infer/tracetmc_elbo.py
+++ b/pyro/contrib/funsor/infer/tracetmc_elbo.py
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import funsor
+
+from pyro.distributions.util import copy_docs_from
+from pyro.infer import ELBO
+from pyro.infer import TraceTMC_ELBO as OrigTraceTMC_ELBO
+from pyro.poutine.util import prune_subsample_sites
+
+from pyro.contrib.funsor import to_data
+from pyro.contrib.funsor.handlers import enum, replay, trace
+
+funsor.set_backend("torch")
+
+
+@copy_docs_from(OrigTraceTMC_ELBO)
+class TraceTMC_ELBO(ELBO):
+
+    def _get_trace(self, *args, **kwargs):
+        raise ValueError("shouldn't be here")
+
+    def differentiable_loss(self, model, guide, *args, **kwargs):
+        with enum(first_available_dim=-self.max_plate_nesting-1):
+            guide_tr = trace(guide).get_trace(*args, **kwargs)
+            model_tr = trace(replay(model, trace=guide_tr)).get_trace(*args, **kwargs)
+
+        log_factors, log_measures, measure_vars, plate_vars = [], [], frozenset(), frozenset()
+        for role, tr in zip(("model", "guide"), map(prune_subsample_sites, (model_tr, guide_tr))):
+            for name, node in tr.nodes.items():
+                if node["type"] != "sample":
+                    continue
+                # if a site is enumerated in the model, measure but no log_prob
+                if name in guide_tr.nodes or node['is_observed']:
+                    log_factors.append(
+                        node["funsor"]["log_prob"] if role == "model" else -node["funsor"]["log_prob"])
+                if node["funsor"].get("log_measure", None) is not None:
+                    log_measures.append(node["funsor"]["log_measure"])
+                    measure_vars |= frozenset(node["funsor"]["log_measure"].inputs)
+                plate_vars |= frozenset(f.name for f in node["cond_indep_stack"] if f.vectorized)
+                measure_vars |= frozenset(node["funsor"]["log_prob"].inputs)
+
+        with funsor.interpreter.interpretation(funsor.terms.lazy):
+            elbo = funsor.sum_product.sum_product(
+                funsor.ops.logaddexp, funsor.ops.add, log_measures + log_factors,
+                eliminate=measure_vars | plate_vars, plates=plate_vars
+            )
+        return -to_data(funsor.optimizer.apply_optimizer(elbo))

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ setup(
         'horovod': ['horovod[pytorch]>=0.19'],
         'funsor': [
             # TODO update to release branch (currently using a recent commit on master)
-            'funsor[torch] @ git+git://github.com/pyro-ppl/funsor.git@c7390318cd6c3f77798aee01638aff08e9582c96',
+            'funsor[torch] @ git+git://github.com/pyro-ppl/funsor.git@c944c2339868e33b00339fd6027027d03240c4af',
         ],
     },
     python_requires='>=3.5',

--- a/tests/contrib/funsor/test_tmc.py
+++ b/tests/contrib/funsor/test_tmc.py
@@ -1,0 +1,139 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import math
+
+import pytest
+import torch
+from torch.autograd import grad
+from torch.distributions import constraints
+
+import funsor
+import pyro.contrib.funsor
+
+from pyroapi import infer, pyro, pyro_backend
+from pyroapi import distributions as dist
+from tests.common import assert_equal  # , xfail_param
+
+
+funsor.set_backend("torch")
+torch.set_default_dtype(torch.float32)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("num_samples", [None, 200])
+@pytest.mark.parametrize("max_plate_nesting", [2, 3])
+@pytest.mark.parametrize("tmc_strategy", ["diagonal", "mixture"])
+def test_tmc_categoricals(depth, max_plate_nesting, num_samples, tmc_strategy):
+
+    def model():
+        x = pyro.sample("x0", dist.Categorical(pyro.param("q0")))
+        with pyro.plate("local", 3):
+            for i in range(1, depth):
+                x = pyro.sample("x{}".format(i),
+                                dist.Categorical(pyro.param("q{}".format(i))[..., x, :]))
+            with pyro.plate("data", 4):
+                pyro.sample("y", dist.Bernoulli(pyro.param("qy")[..., x]),
+                            obs=data)
+
+    with pyro_backend("pyro"):
+        # initialize
+        qs = [pyro.param("q0", torch.tensor([0.4, 0.6], requires_grad=True))]
+        for i in range(1, depth):
+            qs.append(pyro.param(
+                "q{}".format(i),
+                torch.randn(2, 2).abs().detach().requires_grad_(),
+                constraint=constraints.simplex
+            ))
+        qs.append(pyro.param("qy", torch.tensor([0.75, 0.25], requires_grad=True)))
+        qs = [q.unconstrained() for q in qs]
+        data = (torch.rand(4, 3) > 0.5).to(dtype=qs[-1].dtype, device=qs[-1].device)
+
+    with pyro_backend("pyro"):
+        elbo = infer.TraceTMC_ELBO(max_plate_nesting=max_plate_nesting)
+        enum_model = infer.config_enumerate(
+            model, default="parallel", expand=False, num_samples=num_samples, tmc=tmc_strategy)
+        expected_loss = (-elbo.differentiable_loss(enum_model, lambda: None)).exp()
+        expected_grads = grad(expected_loss, qs)
+
+    with pyro_backend("contrib.funsor"):
+        tmc = infer.TraceTMC_ELBO(max_plate_nesting=max_plate_nesting)
+        tmc_model = infer.config_enumerate(
+            model, default="parallel", expand=False, num_samples=num_samples, tmc=tmc_strategy)
+        actual_loss = (-tmc.differentiable_loss(tmc_model, lambda: None)).exp()
+        actual_grads = grad(actual_loss, qs)
+
+    prec = 0.05
+    assert_equal(actual_loss, expected_loss, prec=prec, msg="".join([
+        "\nexpected loss = {}".format(expected_loss),
+        "\n  actual loss = {}".format(actual_loss),
+    ]))
+
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        assert_equal(actual_grad, expected_grad, prec=prec, msg="".join([
+            "\nexpected grad = {}".format(expected_grad.detach().cpu().numpy()),
+            "\n  actual grad = {}".format(actual_grad.detach().cpu().numpy()),
+        ]))
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 4])
+@pytest.mark.parametrize("num_samples,expand", [(400, False)])
+@pytest.mark.parametrize("max_plate_nesting", [1])
+@pytest.mark.parametrize("guide_type", ["prior", "factorized", "nonfactorized"])
+@pytest.mark.parametrize("reparameterized", [False, True], ids=["dice", "pathwise"])
+@pytest.mark.parametrize("tmc_strategy", ["diagonal", "mixture"])
+def test_tmc_normals_chain_gradient(depth, num_samples, max_plate_nesting, expand,
+                                    guide_type, reparameterized, tmc_strategy):
+    def model(reparameterized):
+        Normal = dist.Normal if reparameterized else dist.testing.fakes.NonreparameterizedNormal
+        x = pyro.sample("x0", Normal(pyro.param("q2"), math.sqrt(1. / depth)))
+        for i in range(1, depth):
+            x = pyro.sample("x{}".format(i), Normal(x, math.sqrt(1. / depth)))
+        pyro.sample("y", Normal(x, 1.), obs=torch.tensor(float(1)))
+
+    def factorized_guide(reparameterized):
+        Normal = dist.Normal if reparameterized else dist.testing.fakes.NonreparameterizedNormal
+        pyro.sample("x0", Normal(pyro.param("q2"), math.sqrt(1. / depth)))
+        for i in range(1, depth):
+            pyro.sample("x{}".format(i), Normal(0., math.sqrt(float(i+1) / depth)))
+
+    def nonfactorized_guide(reparameterized):
+        Normal = dist.Normal if reparameterized else dist.testing.fakes.NonreparameterizedNormal
+        x = pyro.sample("x0", Normal(pyro.param("q2"), math.sqrt(1. / depth)))
+        for i in range(1, depth):
+            x = pyro.sample("x{}".format(i), Normal(x, math.sqrt(1. / depth)))
+
+    with pyro_backend("contrib.funsor"):
+        # compare reparameterized and nonreparameterized gradient estimates
+        q2 = pyro.param("q2", torch.tensor(0.5, requires_grad=True))
+        qs = (q2.unconstrained(),)
+
+        tmc = infer.TraceTMC_ELBO(max_plate_nesting=max_plate_nesting)
+        tmc_model = infer.config_enumerate(
+            model, default="parallel", expand=expand, num_samples=num_samples, tmc=tmc_strategy)
+        guide = factorized_guide if guide_type == "factorized" else \
+            nonfactorized_guide if guide_type == "nonfactorized" else \
+            lambda *args: None
+        tmc_guide = infer.config_enumerate(
+            guide, default="parallel", expand=expand, num_samples=num_samples, tmc=tmc_strategy)
+
+        # convert to linear space for unbiasedness
+        actual_loss = (-tmc.differentiable_loss(tmc_model, tmc_guide, reparameterized)).exp()
+        actual_grads = grad(actual_loss, qs)
+
+    # gold values from Funsor
+    expected_grads = (torch.tensor(
+        {1: 0.0999, 2: 0.0860, 3: 0.0802, 4: 0.0771}[depth]
+    ),)
+
+    grad_prec = 0.05 if reparameterized else 0.1
+
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads):
+        print(actual_loss)
+        assert_equal(actual_grad, expected_grad, prec=grad_prec, msg="".join([
+            "\nexpected grad = {}".format(expected_grad.detach().cpu().numpy()),
+            "\n  actual grad = {}".format(actual_grad.detach().cpu().numpy()),
+        ]))

--- a/tests/contrib/funsor/test_tmc.py
+++ b/tests/contrib/funsor/test_tmc.py
@@ -21,8 +21,6 @@ try:
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 
-torch.set_default_dtype(torch.float32)
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/contrib/funsor/test_tmc.py
+++ b/tests/contrib/funsor/test_tmc.py
@@ -9,15 +9,18 @@ import torch
 from torch.autograd import grad
 from torch.distributions import constraints
 
-import funsor
-import pyro.contrib.funsor
+from tests.common import assert_equal
 
-from pyroapi import infer, pyro, pyro_backend
-from pyroapi import distributions as dist
-from tests.common import assert_equal  # , xfail_param
+# put all funsor-related imports here, so test collection works without funsor
+try:
+    import funsor
+    import pyro.contrib.funsor
+    from pyroapi import distributions as dist
+    from pyroapi import infer, pyro, pyro_backend
+    funsor.set_backend("torch")
+except ImportError:
+    pytestmark = pytest.mark.skip(reason="funsor is not installed")
 
-
-funsor.set_backend("torch")
 torch.set_default_dtype(torch.float32)
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Addresses #2580. ~~Blocked by #2594.~~

This PR adds linear-time Monte Carlo enumeration strategies (diagonal and mixture, based on the ones already in Pyro) and a new implementation of `TraceTMC_ELBO` using the enumeration machinery in `pyro.contrib.funsor`.  I've intentionally kept the code looking similar to the one in Pyro (notably the continued use of `trace`/`replay` and the call to `sum_product`), but it's still a nice illustration of all the boilerplate cut out by `contrib.funsor` in the implementation of relatively complicated inference algorithms.  Funsor's simplified indexing behavior also trivially fixes the issues with the Monte Carlo strategies incorrectly sharing particle IDs across plate slices that I was worried about in #2258.

The tests in this PR are basically copied from `tests/infer/test_tmc.py`.  The shape behavior of the enumeration strategies is also tested more systematically in a followup PR containing `TraceEnum_ELBO`.