### PR TITLE
Get global isort working again; add to lint stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
         - stage: lint
           name: lint
           python: 3.6
-          before_install: pip install flake8 nbstripout nbformat
+          before_install: pip install flake8 isort>=5.0 nbstripout nbformat
           install:
           script:
               - make lint

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,14 @@ tutorial: FORCE
 
 lint: FORCE
 	flake8
+	isort --check .
 	python scripts/update_headers.py --check
 
 license: FORCE
 	python scripts/update_headers.py
+
+format: license FORCE
+	isort .
 
 version: FORCE
 	python scripts/update_version.py
@@ -33,9 +37,6 @@ scrub: FORCE
 
 doctest: FORCE
 	python -m pytest -p tests.doctest_fixtures --doctest-modules -o filterwarnings=ignore pyro
-
-format: FORCE
-	isort --recursive *.py pyro/ examples/ tests/ profiler/*.py docs/source/conf.py
 
 perf-test: FORCE
 	bash scripts/perf_test.sh ${ref}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,6 @@ import sys
 
 import sphinx_rtd_theme
 
-
 # import pkg_resources
 
 # -*- coding: utf-8 -*-

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -14,10 +14,10 @@ from collections import namedtuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from modules import MLP, Decoder, Encoder, Identity, Predict
 
 import pyro
 import pyro.distributions as dist
-from modules import MLP, Decoder, Encoder, Identity, Predict
 
 
 # Default prior success probability for z_pres.

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -19,15 +19,15 @@ from functools import partial
 import numpy as np
 import torch
 import visdom
+from air import AIR, latents_to_tensor
+from viz import draw_many, tensor_to_objs
 
 import pyro
 import pyro.contrib.examples.multi_mnist as multi_mnist
 import pyro.optim as optim
 import pyro.poutine as poutine
-from air import AIR, latents_to_tensor
 from pyro.contrib.examples.util import get_data_directory
 from pyro.infer import SVI, JitTraceGraph_ELBO, TraceGraph_ELBO
-from viz import draw_many, tensor_to_objs
 
 
 def count_accuracy(X, true_counts, air, batch_size):

--- a/examples/capture_recapture/cjs.py
+++ b/examples/capture_recapture/cjs.py
@@ -39,10 +39,9 @@ import torch
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.infer.autoguide import AutoDiagonalNormal
 from pyro.infer import SVI, TraceEnum_ELBO, TraceTMC_ELBO
+from pyro.infer.autoguide import AutoDiagonalNormal
 from pyro.optim import Adam
-
 
 """
 Our first and simplest CJS model variant only has two continuous

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+
 import torch
 from torch.distributions import constraints
 
 import pyro
-import pyro.optim
 import pyro.distributions as dist
-
-from pyro.infer import SVI, config_enumerate, TraceEnum_ELBO
-
+import pyro.optim
 from pyro.contrib.autoname import scope
+from pyro.infer import SVI, TraceEnum_ELBO, config_enumerate
 
 
 def model(K, data):

--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -13,9 +13,15 @@ import torch
 from torch.distributions import biject_to, constraints
 
 import pyro
-from pyro.contrib.epidemiology.models import (HeterogeneousSIRModel, OverdispersedSEIRModel, OverdispersedSIRModel,
-                                              SimpleSEIRModel, SimpleSIRModel, SuperspreadingSEIRModel,
-                                              SuperspreadingSIRModel)
+from pyro.contrib.epidemiology.models import (
+    HeterogeneousSIRModel,
+    OverdispersedSEIRModel,
+    OverdispersedSIRModel,
+    SimpleSEIRModel,
+    SimpleSIRModel,
+    SuperspreadingSEIRModel,
+    SuperspreadingSIRModel,
+)
 
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 

--- a/examples/contrib/funsor/hmm.py
+++ b/examples/contrib/funsor/hmm.py
@@ -64,7 +64,6 @@ except ImportError:
 from pyroapi import distributions as dist
 from pyroapi import handlers, infer, optim, pyro, pyro_backend
 
-
 logging.basicConfig(format='%(relativeCreated) 9d %(message)s', level=logging.DEBUG)
 
 # Add another handler for logging debugging events (e.g. for profiling)

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -39,7 +39,7 @@ from torchvision import transforms
 import pyro
 import pyro.contrib.gp as gp
 import pyro.infer as infer
-from pyro.contrib.examples.util import get_data_loader, get_data_directory
+from pyro.contrib.examples.util import get_data_directory, get_data_loader
 
 
 class CNN(nn.Module):

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -3,20 +3,22 @@
 
 import argparse
 from functools import partial
-import torch
-from torch.distributions import constraints
+
 import numpy as np
+import torch
+from gp_bayes_opt import GPBayesOptimizer
+from torch.distributions import constraints
 
 import pyro
-from pyro import optim
-from pyro.infer import TraceEnum_ELBO
-from pyro.contrib.oed.eig import vi_eig
 import pyro.contrib.gp as gp
+from pyro import optim
+from pyro.contrib.oed.eig import vi_eig
 from pyro.contrib.oed.glmm import (
-    zero_mean_unit_obs_sd_lm, group_assignment_matrix, analytic_posterior_cov
+    analytic_posterior_cov,
+    group_assignment_matrix,
+    zero_mean_unit_obs_sd_lm,
 )
-
-from gp_bayes_opt import GPBayesOptimizer
+from pyro.infer import TraceEnum_ELBO
 
 """
 Example builds on the Bayesian regression tutorial [1]. It demonstrates how

--- a/examples/contrib/oed/gp_bayes_opt.py
+++ b/examples/contrib/oed/gp_bayes_opt.py
@@ -7,8 +7,8 @@ import torch.optim as optim
 from torch.distributions import transform_to
 
 import pyro.contrib.gp as gp
-from pyro.infer import TraceEnum_ELBO
 import pyro.optim
+from pyro.infer import TraceEnum_ELBO
 
 
 class GPBayesOptimizer(pyro.optim.multi.MultiOptimizer):

--- a/examples/contrib/timeseries/gp_models.py
+++ b/examples/contrib/timeseries/gp_models.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
+from os.path import exists
+from urllib.request import urlopen
+
 import numpy as np
 import torch
 
 import pyro
 from pyro.contrib.timeseries import IndependentMaternGP, LinearlyCoupledMaternGP
-
-import argparse
-from os.path import exists
-from urllib.request import urlopen
 
 
 # download dataset from UCI archive

--- a/examples/cvae/baseline.py
+++ b/examples/cvae/baseline.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import numpy as np
 from pathlib import Path
-from tqdm import tqdm
+
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from tqdm import tqdm
 
 
 class BaselineNet(nn.Module):

--- a/examples/cvae/cvae.py
+++ b/examples/cvae/cvae.py
@@ -1,14 +1,16 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 from pathlib import Path
-import pyro
-import pyro.distributions as dist
-from pyro.infer import SVI, Trace_ELBO
+
+import numpy as np
 import torch
 import torch.nn as nn
 from tqdm import tqdm
+
+import pyro
+import pyro.distributions as dist
+from pyro.infer import SVI, Trace_ELBO
 
 
 class Encoder(nn.Module):

--- a/examples/cvae/main.py
+++ b/examples/cvae/main.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import pandas as pd
-import pyro
-import torch
+
 import baseline
 import cvae
-from util import get_data, visualize, generate_table
+import pandas as pd
+import torch
+from util import generate_table, get_data, visualize
+
+import pyro
 
 
 def main(args):

--- a/examples/cvae/mnist.py
+++ b/examples/cvae/mnist.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import torch
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader, Dataset
 from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, functional
 

--- a/examples/cvae/util.py
+++ b/examples/cvae/util.py
@@ -1,17 +1,19 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
-import matplotlib.pyplot as plt
-import pandas as pd
 from pathlib import Path
-from pyro.infer import Predictive, Trace_ELBO
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 import torch
+from baseline import MaskedBCELoss
+from mnist import get_data
 from torch.utils.data import DataLoader
 from torchvision.utils import make_grid
 from tqdm import tqdm
-from baseline import MaskedBCELoss
-from mnist import get_data
+
+from pyro.infer import Predictive, Trace_ELBO
 
 
 def imshow(inp, image_path=None):

--- a/examples/dmm.py
+++ b/examples/dmm.py
@@ -30,7 +30,14 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions import TransformedDistribution
 from pyro.distributions.transforms import affine_autoregressive
-from pyro.infer import SVI, JitTrace_ELBO, Trace_ELBO, TraceEnum_ELBO, TraceTMC_ELBO, config_enumerate
+from pyro.infer import (
+    SVI,
+    JitTrace_ELBO,
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    config_enumerate,
+)
 from pyro.optim import ClippedAdam
 
 

--- a/examples/eight_schools/data.py
+++ b/examples/eight_schools/data.py
@@ -3,7 +3,6 @@
 
 import torch
 
-
 J = 8
 y = torch.tensor([28,  8, -3,  7, -1,  1, 18, 12]).type(torch.Tensor)
 sigma = torch.tensor([15, 10, 16, 11,  9, 11, 10, 18]).type(torch.Tensor)

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -4,9 +4,9 @@
 import argparse
 import logging
 
+import data
 import torch
 
-import data
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -5,11 +5,11 @@ import argparse
 import logging
 
 import torch
+from data import J, sigma, y
 from torch.distributions import constraints, transforms
 
 import pyro
 import pyro.distributions as dist
-from data import J, sigma, y
 from pyro.infer import SVI, JitTrace_ELBO, Trace_ELBO
 from pyro.optim import Adam
 

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -47,8 +47,8 @@ import pyro
 import pyro.contrib.examples.polyphonic_data_loader as poly
 import pyro.distributions as dist
 from pyro import poutine
-from pyro.infer.autoguide import AutoDelta
 from pyro.infer import SVI, JitTraceEnum_ELBO, TraceEnum_ELBO, TraceTMC_ELBO
+from pyro.infer.autoguide import AutoDelta
 from pyro.ops.indexing import Vindex
 from pyro.optim import Adam
 from pyro.util import ignore_jit_warnings

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+
 import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc import NUTS
+from pyro.infer.mcmc.api import MCMC
 
 """
 This simple example is intended to demonstrate how to use an LKJ prior with

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -11,8 +11,8 @@ import argparse
 
 import torch
 
-from pyro.generic import distributions as dist
 # We use the pyro.generic interface to support dynamic choice of backend.
+from pyro.generic import distributions as dist
 from pyro.generic import infer, ops, optim, pyro, pyro_backend
 
 

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -2,19 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import os
-import json
-import uuid
 import functools
+import json
+import os
+import uuid
 
 import torch
+from model import guide_generic, model_generic
+from seal_data import prepare_seal
 
 import pyro
 import pyro.poutine as poutine
 from pyro.infer import TraceEnum_ELBO
-
-from model import model_generic, guide_generic
-from seal_data import prepare_seal
 
 
 def aic_num_parameters(model, guide=None):

--- a/examples/mixed_hmm/seal_data.py
+++ b/examples/mixed_hmm/seal_data.py
@@ -5,9 +5,7 @@ import os
 from urllib.request import urlopen
 
 import pandas as pd
-
 import torch
-
 
 MISSING = 1e-6
 

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -9,17 +9,16 @@ Taken from:
 [1] https://gscontras.github.io/probLang/chapters/07-generics.html
 """
 
-import torch
-
 import argparse
-import numbers
 import collections
+import numbers
+
+import torch
+from search_inference import HashingMarginal, Search, memoize
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-
-from search_inference import HashingMarginal, memoize, Search
 
 torch.set_default_dtype(torch.float64)  # double precision for numerical stability
 

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -7,16 +7,15 @@ Interpreting hyperbole with RSA models of pragmatics.
 Taken from: https://gscontras.github.io/probLang/chapters/03-nonliteral.html
 """
 
-import torch
-
-import collections
 import argparse
+import collections
+
+import torch
+from search_inference import HashingMarginal, Search, memoize
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-
-from search_inference import HashingMarginal, memoize, Search
 
 torch.set_default_dtype(torch.float64)  # double precision for numerical stability
 

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -11,12 +11,13 @@ by recursively reasoning about one another.
 Taken from: http://forestdb.org/models/schelling.html
 """
 import argparse
+
 import torch
+from search_inference import HashingMarginal, Search
 
 import pyro
 import pyro.poutine as poutine
 from pyro.distributions import Bernoulli
-from search_inference import HashingMarginal, Search
 
 
 def location(preference):

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -12,12 +12,13 @@ by recursively reasoning about one another.
 Taken from: http://forestdb.org/models/schelling-falsebelief.html
 """
 import argparse
+
 import torch
+from search_inference import HashingMarginal, Search
 
 import pyro
 import pyro.poutine as poutine
 from pyro.distributions import Bernoulli
-from search_inference import HashingMarginal, Search
 
 
 def location(preference):

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -8,10 +8,10 @@ Adapted from: http://dippl.org/chapters/03-enumeration.html
 """
 
 import collections
+import functools
+import queue
 
 import torch
-import queue
-import functools
 
 import pyro.distributions as dist
 import pyro.poutine as poutine

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -7,15 +7,14 @@ Combining models of RSA pragmatics and CCG-based compositional semantics.
 Taken from: http://dippl.org/examples/zSemanticPragmaticMashup.html
 """
 
-import torch
-
 import argparse
 import collections
 
+import torch
+from search_inference import BestFirstSearch, HashingMarginal, memoize
+
 import pyro
 import pyro.distributions as dist
-
-from search_inference import HashingMarginal, BestFirstSearch, memoize
 
 torch.set_default_dtype(torch.float64)
 

--- a/examples/scanvi/data.py
+++ b/examples/scanvi/data.py
@@ -8,11 +8,11 @@ https://github.com/YosefLab/scvi-tutorials/blob/50dd3269abfe0c375ec47114f2c20725
 """
 
 import math
-import numpy as np
-from scipy import sparse
 
+import numpy as np
 import torch
 import torch.nn as nn
+from scipy import sparse
 
 
 class BatchDataLoader(object):
@@ -122,8 +122,8 @@ def get_data(dataset="pbmc", batch_size=100, cuda=False):
 
         return BatchDataLoader(X, Y, batch_size), num_genes, 2.0, 1.0, None
 
-    import scvi
     import scanpy as sc
+    import scvi
     adata = scvi.data.purified_pbmc_dataset(subset_datasets=["regulatory_t", "naive_t",
                                                              "memory_t", "naive_cytotoxic"])
 

--- a/examples/scanvi/scanvi.py
+++ b/examples/scanvi/scanvi.py
@@ -19,25 +19,22 @@ References:
 
 import argparse
 
+import matplotlib.pyplot as plt
 import numpy as np
-
 import torch
 import torch.nn as nn
+from data import get_data
+from matplotlib.patches import Patch
 from torch.distributions import constraints
-from torch.nn.functional import softplus, softmax
+from torch.nn.functional import softmax, softplus
 from torch.optim import Adam
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions.util import broadcast_shape
+from pyro.infer import SVI, TraceEnum_ELBO, config_enumerate
 from pyro.optim import MultiStepLR
-from pyro.infer import SVI, config_enumerate, TraceEnum_ELBO
-
-import matplotlib.pyplot as plt
-from matplotlib.patches import Patch
-
-from data import get_data
 
 
 # Helper for making fully-connected neural networks
@@ -300,6 +297,7 @@ def main(args):
     # Now that we're done training we'll inspect the latent representations we've learned
     if args.plot and args.dataset == 'pbmc':
         import scanpy as sc
+
         # Compute latent representation (z2_loc) for each cell in the dataset
         latent_rep = scanvi.z2l_encoder(dataloader.data_x)[0]
 

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -20,19 +20,16 @@ import os
 
 import numpy as np
 import torch
+import wget
 from torch.nn.functional import softplus
 
 import pyro
 import pyro.optim as optim
-import wget
-
-from pyro.contrib.examples.util import get_data_directory
-from pyro.distributions import Gamma, Poisson, Normal
-from pyro.infer import SVI, TraceMeanField_ELBO
-from pyro.infer.autoguide import AutoDiagonalNormal
-from pyro.infer.autoguide import init_to_feasible
 from pyro.contrib.easyguide import EasyGuide
-
+from pyro.contrib.examples.util import get_data_directory
+from pyro.distributions import Gamma, Normal, Poisson
+from pyro.infer import SVI, TraceMeanField_ELBO
+from pyro.infer.autoguide import AutoDiagonalNormal, init_to_feasible
 
 torch.set_default_tensor_type('torch.FloatTensor')
 pyro.util.set_rng_seed(0)

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -2,20 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import math
 
 import numpy as np
 import torch
-import math
+from torch.optim import Adam
 
 import pyro
 import pyro.distributions as dist
 from pyro import poutine
-from pyro.infer.autoguide import AutoDelta
 from pyro.infer import Trace_ELBO
-from pyro.infer.autoguide import init_to_median
-
-from torch.optim import Adam
-
+from pyro.infer.autoguide import AutoDelta, init_to_median
 
 """
 We demonstrate how to do sparse linear regression using a variant of the

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -5,16 +5,23 @@ import argparse
 
 import torch
 import torch.nn as nn
+from utils.custom_mlp import MLP, Exp
+from utils.mnist_cached import MNISTCached, mkdir_p, setup_data_loaders
+from utils.vae_plots import mnist_test_tsne_ssvae, plot_conditional_samples_ssvae
 from visdom import Visdom
 
 import pyro
 import pyro.distributions as dist
 from pyro.contrib.examples.util import print_and_log
-from pyro.infer import SVI, JitTrace_ELBO, JitTraceEnum_ELBO, Trace_ELBO, TraceEnum_ELBO, config_enumerate
+from pyro.infer import (
+    SVI,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    config_enumerate,
+)
 from pyro.optim import Adam
-from utils.custom_mlp import MLP, Exp
-from utils.mnist_cached import MNISTCached, mkdir_p, setup_data_loaders
-from utils.vae_plots import mnist_test_tsne_ssvae, plot_conditional_samples_ssvae
 
 
 class SSVAE(nn.Module):

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -7,14 +7,14 @@ import numpy as np
 import torch
 import torch.nn as nn
 import visdom
+from utils.mnist_cached import MNISTCached as MNIST
+from utils.mnist_cached import setup_data_loaders
+from utils.vae_plots import mnist_test_tsne, plot_llk, plot_vae_samples
 
 import pyro
 import pyro.distributions as dist
 from pyro.infer import SVI, JitTrace_ELBO, Trace_ELBO
 from pyro.optim import Adam
-from utils.mnist_cached import MNISTCached as MNIST
-from utils.mnist_cached import setup_data_loaders
-from utils.vae_plots import mnist_test_tsne, plot_llk, plot_vae_samples
 
 
 # define the PyTorch module that parameterizes the

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -10,13 +10,13 @@ import torch
 import torch.nn as nn
 from torch.nn import functional
 from torchvision.utils import save_image
+from utils.mnist_cached import DATA_DIR, RESULTS_DIR
 
 import pyro
 from pyro.contrib.examples import util
 from pyro.distributions import Bernoulli, Normal
 from pyro.infer import SVI, JitTrace_ELBO, Trace_ELBO
 from pyro.optim import Adam
-from utils.mnist_cached import DATA_DIR, RESULTS_DIR
 
 """
 Comparison of VAE implementation in PyTorch and Pyro. This example can be

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -7,8 +7,20 @@ import torch
 from torch.autograd import Variable
 
 from profiler.profiling_utils import Profile, profile_print
-from pyro.distributions import (Bernoulli, Beta, Categorical, Cauchy, Dirichlet, Exponential, Gamma, LogNormal, Normal,
-                                OneHotCategorical, Poisson, Uniform)
+from pyro.distributions import (
+    Bernoulli,
+    Beta,
+    Categorical,
+    Cauchy,
+    Dirichlet,
+    Exponential,
+    Gamma,
+    LogNormal,
+    Normal,
+    OneHotCategorical,
+    Poisson,
+    Uniform,
+)
 
 
 def T(arr):

--- a/profiler/hmm.py
+++ b/profiler/hmm.py
@@ -8,12 +8,11 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
-from os.path import join, abspath
+from os.path import abspath, join
 
 from numpy import median
 
 from pyro.util import timed
-
 
 EXAMPLES_DIR = join(abspath(__file__), os.pardir, os.pardir, "examples")
 

--- a/profiler/profiling_utils.py
+++ b/profiler/profiling_utils.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cProfile
-from io import StringIO
 import functools
 import os
 import pstats
 import timeit
 from contextlib import contextmanager
+from io import StringIO
 
 from prettytable import ALL, PrettyTable
 

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -4,9 +4,24 @@
 import pyro.poutine as poutine
 from pyro.logger import log
 from pyro.poutine import condition, do, markov
-from pyro.primitives import (barrier, clear_param_store, deterministic, enable_validation, factor, get_param_store,
-                             iarange, irange, module, param, plate, plate_stack, random_module, sample, subsample,
-                             validation_enabled)
+from pyro.primitives import (
+    barrier,
+    clear_param_store,
+    deterministic,
+    enable_validation,
+    factor,
+    get_param_store,
+    iarange,
+    irange,
+    module,
+    param,
+    plate,
+    plate_stack,
+    random_module,
+    sample,
+    subsample,
+    validation_enabled,
+)
 from pyro.util import set_rng_seed
 
 # After changing this, run scripts/update_version.py

--- a/pyro/contrib/__init__.py
+++ b/pyro/contrib/__init__.py
@@ -9,7 +9,16 @@ Contributed Code
     This code makes no guarantee about maintaining backwards compatibility.
 """
 
-from pyro.contrib import autoname, bnn, easyguide, epidemiology, forecast, gp, oed, tracking
+from pyro.contrib import (
+    autoname,
+    bnn,
+    easyguide,
+    epidemiology,
+    forecast,
+    gp,
+    oed,
+    tracking,
+)
 
 __all__ = [
     "autoname",
@@ -25,6 +34,7 @@ __all__ = [
 
 try:
     import funsor as funsor_  # noqa: F401
+
     from pyro.contrib import funsor
     __all__ += ["funsor"]
 except ImportError:

--- a/pyro/contrib/autoname/__init__.py
+++ b/pyro/contrib/autoname/__init__.py
@@ -6,9 +6,8 @@ The :mod:`pyro.contrib.autoname` module provides tools for automatically
 generating unique, semantically meaningful names for sample sites.
 """
 from pyro.contrib.autoname import named
-from pyro.contrib.autoname.scoping import scope, name_count
 from pyro.contrib.autoname.autoname import autoname, sample
-
+from pyro.contrib.autoname.scoping import name_count, scope
 
 __all__ = [
     "named",

--- a/pyro/contrib/bnn/hidden_layer.py
+++ b/pyro/contrib/bnn/hidden_layer.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from torch.distributions.utils import lazy_property
 import torch.nn.functional as F
+from torch.distributions.utils import lazy_property
 
 from pyro.contrib.bnn.utils import adjoin_ones_vector
 from pyro.distributions.torch_distribution import TorchDistribution

--- a/pyro/contrib/bnn/utils.py
+++ b/pyro/contrib/bnn/utils.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import math
+
+import torch
 
 
 def xavier_uniform(D_in, D_out):

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 import torch
 
 import pyro.distributions as dist
-from pyro.distributions.util import sum_leftmost
 from pyro import poutine
+from pyro.distributions.util import sum_leftmost
 from pyro.poutine.messenger import Messenger
 from pyro.poutine.util import site_is_subsample
 

--- a/pyro/contrib/easyguide/__init__.py
+++ b/pyro/contrib/easyguide/__init__.py
@@ -3,7 +3,6 @@
 
 from pyro.contrib.easyguide.easyguide import EasyGuide, easy_guide
 
-
 __all__ = [
     "EasyGuide",
     "easy_guide",

--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -14,8 +14,8 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 import pyro.poutine.runtime as runtime
 from pyro.distributions.util import broadcast_shape, sum_rightmost
-from pyro.infer.autoguide.initialization import InitMessenger
 from pyro.infer.autoguide.guides import prototype_hide_fn
+from pyro.infer.autoguide.initialization import InitMessenger
 from pyro.nn.module import PyroModule, PyroParam
 
 

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -20,9 +20,22 @@ import pyro.distributions as dist
 import pyro.distributions.hmm
 import pyro.poutine as poutine
 from pyro.distributions.transforms import HaarTransform
-from pyro.infer import MCMC, NUTS, SVI, JitTrace_ELBO, SMCFilter, Trace_ELBO, infer_discrete
-from pyro.infer.autoguide import (AutoLowRankMultivariateNormal, AutoMultivariateNormal, AutoNormal, init_to_generated,
-                                  init_to_value)
+from pyro.infer import (
+    MCMC,
+    NUTS,
+    SVI,
+    JitTrace_ELBO,
+    SMCFilter,
+    Trace_ELBO,
+    infer_discrete,
+)
+from pyro.infer.autoguide import (
+    AutoLowRankMultivariateNormal,
+    AutoMultivariateNormal,
+    AutoNormal,
+    init_to_generated,
+    init_to_value,
+)
 from pyro.infer.mcmc import ArrowheadMassMatrix
 from pyro.infer.reparam import HaarReparam, SplitReparam
 from pyro.infer.smcfilter import SMCFailed
@@ -31,7 +44,11 @@ from pyro.optim import ClippedAdam
 from pyro.poutine.util import site_is_factor, site_is_subsample
 from pyro.util import warn_if_nan
 
-from .distributions import set_approx_log_prob_tol, set_approx_sample_thresh, set_relaxed_distributions
+from .distributions import (
+    set_approx_log_prob_tol,
+    set_approx_sample_thresh,
+    set_relaxed_distributions,
+)
 from .util import align_samples, cat2, clamp, quantize, quantize_enumerate
 
 logger = logging.getLogger(__name__)

--- a/pyro/contrib/examples/bart.py
+++ b/pyro/contrib/examples/bart.py
@@ -14,7 +14,7 @@ import urllib
 
 import torch
 
-from pyro.contrib.examples.util import get_data_directory, _mkdir_p
+from pyro.contrib.examples.util import _mkdir_p, get_data_directory
 
 DATA = get_data_directory(__file__)
 

--- a/pyro/contrib/examples/finance.py
+++ b/pyro/contrib/examples/finance.py
@@ -6,7 +6,7 @@ import urllib
 
 import pandas as pd
 
-from pyro.contrib.examples.util import get_data_directory, _mkdir_p
+from pyro.contrib.examples.util import _mkdir_p, get_data_directory
 
 DATA = get_data_directory(__file__)
 

--- a/pyro/contrib/examples/polyphonic_data_loader.py
+++ b/pyro/contrib/examples/polyphonic_data_loader.py
@@ -17,16 +17,15 @@ und Kognitive Systeme at Universitaet Karlsruhe.
 """
 
 import os
+import pickle
 from collections import namedtuple
 from urllib.request import urlopen
-import pickle
 
 import torch
 import torch.nn as nn
 from torch.nn.utils.rnn import pad_sequence
 
 from pyro.contrib.examples.util import get_data_directory
-
 
 dset = namedtuple("dset", ["name", "url", "filename"])
 

--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -17,8 +17,15 @@ from pyro.infer.predictive import _guess_max_plate_nesting
 from pyro.nn.module import PyroModule
 from pyro.optim import DCTAdam
 
-from .util import (MarkDCTParamMessenger, PrefixConditionMessenger, PrefixReplayMessenger, PrefixWarmStartMessenger,
-                   reshape_batch, time_reparam_dct, time_reparam_haar)
+from .util import (
+    MarkDCTParamMessenger,
+    PrefixConditionMessenger,
+    PrefixReplayMessenger,
+    PrefixWarmStartMessenger,
+    reshape_batch,
+    time_reparam_dct,
+    time_reparam_haar,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/pyro/contrib/funsor/__init__.py
+++ b/pyro/contrib/funsor/__init__.py
@@ -3,14 +3,23 @@
 
 import pyroapi
 
-from pyro.primitives import (  # noqa: F401
-    clear_param_store, deterministic, enable_validation, factor, get_param_store,
-    module, param, random_module, sample, set_rng_seed, subsample,
-)
-
-from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor  # noqa: F401
-from pyro.contrib.funsor.handlers import condition, do, markov, vectorized_markov  # noqa: F401
+from pyro.contrib.funsor.handlers import condition, do, markov
 from pyro.contrib.funsor.handlers import plate as _plate
+from pyro.contrib.funsor.handlers import vectorized_markov
+from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
+from pyro.primitives import (
+    clear_param_store,
+    deterministic,
+    enable_validation,
+    factor,
+    get_param_store,
+    module,
+    param,
+    random_module,
+    sample,
+    set_rng_seed,
+    subsample,
+)
 
 
 def plate(*args, **kwargs):
@@ -25,3 +34,23 @@ pyroapi.register_backend('contrib.funsor', {
     'optim': 'pyro.optim',
     'pyro': 'pyro.contrib.funsor',
 })
+
+__all__ = [
+    "clear_param_store",
+    "condition",
+    "deterministic",
+    "do",
+    "enable_validation",
+    "factor",
+    "get_param_store",
+    "markov",
+    "module",
+    "param",
+    "random_module",
+    "sample",
+    "set_rng_seed",
+    "subsample",
+    "to_data",
+    "to_funsor",
+    "vectorized_markov",
+]

--- a/pyro/contrib/funsor/handlers/__init__.py
+++ b/pyro/contrib/funsor/handlers/__init__.py
@@ -1,19 +1,25 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyro.poutine.handlers import _make_handler
-
 from pyro.poutine import (  # noqa: F401
-    block, condition, do, escape, infer_config,
-    mask, reparam, scale, seed, uncondition,
+    block,
+    condition,
+    do,
+    escape,
+    infer_config,
+    mask,
+    reparam,
+    scale,
+    seed,
+    uncondition,
 )
+from pyro.poutine.handlers import _make_handler
 
 from .enum_messenger import EnumMessenger, queue  # noqa: F401
 from .named_messenger import MarkovMessenger, NamedMessenger
 from .plate_messenger import PlateMessenger, VectorizedMarkovMessenger
 from .replay_messenger import ReplayMessenger
 from .trace_messenger import TraceMessenger
-
 
 _msngrs = [
     EnumMessenger,

--- a/pyro/contrib/funsor/handlers/enum_messenger.py
+++ b/pyro/contrib/funsor/handlers/enum_messenger.py
@@ -9,18 +9,17 @@ import functools
 import math
 from collections import OrderedDict
 
-import torch
 import funsor
+import torch
 
 import pyro.poutine.runtime
 import pyro.poutine.util
-from pyro.poutine.escape_messenger import EscapeMessenger
-from pyro.poutine.subsample_messenger import _Subsample
-
-from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
 from pyro.contrib.funsor.handlers.named_messenger import NamedMessenger
+from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
 from pyro.contrib.funsor.handlers.replay_messenger import ReplayMessenger
 from pyro.contrib.funsor.handlers.trace_messenger import TraceMessenger
+from pyro.poutine.escape_messenger import EscapeMessenger
+from pyro.poutine.subsample_messenger import _Subsample
 
 funsor.set_backend("torch")
 

--- a/pyro/contrib/funsor/handlers/named_messenger.py
+++ b/pyro/contrib/funsor/handlers/named_messenger.py
@@ -4,9 +4,13 @@
 from collections import OrderedDict
 from contextlib import ExitStack
 
+from pyro.contrib.funsor.handlers.runtime import (
+    _DIM_STACK,
+    DimRequest,
+    DimType,
+    StackFrame,
+)
 from pyro.poutine.reentrant_messenger import ReentrantMessenger
-
-from pyro.contrib.funsor.handlers.runtime import _DIM_STACK, DimRequest, DimType, StackFrame
 
 
 class NamedMessenger(ReentrantMessenger):

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -6,14 +6,21 @@ from numbers import Number
 
 import funsor
 
-from pyro.contrib.funsor.handlers.named_messenger import DimRequest, DimType, GlobalNamedMessenger, NamedMessenger
+from pyro.contrib.funsor.handlers.named_messenger import (
+    DimRequest,
+    DimType,
+    GlobalNamedMessenger,
+    NamedMessenger,
+)
 from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
 from pyro.distributions.util import copy_docs_from
 from pyro.poutine.broadcast_messenger import BroadcastMessenger
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 from pyro.poutine.messenger import Messenger
 from pyro.poutine.runtime import effectful
-from pyro.poutine.subsample_messenger import SubsampleMessenger as OrigSubsampleMessenger
+from pyro.poutine.subsample_messenger import (
+    SubsampleMessenger as OrigSubsampleMessenger,
+)
 from pyro.util import ignore_jit_warnings
 
 funsor.set_backend("torch")

--- a/pyro/contrib/funsor/handlers/primitives.py
+++ b/pyro/contrib/funsor/handlers/primitives.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.poutine.runtime
-
 from pyro.contrib.funsor.handlers.runtime import _DIM_STACK, DimRequest, DimType
 
 

--- a/pyro/contrib/funsor/handlers/replay_messenger.py
+++ b/pyro/contrib/funsor/handlers/replay_messenger.py
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyro.poutine.replay_messenger import ReplayMessenger as OrigReplayMessenger
 from pyro.contrib.funsor.handlers.primitives import to_data
+from pyro.poutine.replay_messenger import ReplayMessenger as OrigReplayMessenger
 
 
 class ReplayMessenger(OrigReplayMessenger):

--- a/pyro/contrib/funsor/infer/__init__.py
+++ b/pyro/contrib/funsor/infer/__init__.py
@@ -5,5 +5,9 @@ from pyro.infer import SVI, config_enumerate  # noqa: F401
 
 from .elbo import ELBO  # noqa: F401
 from .trace_elbo import JitTrace_ELBO, Trace_ELBO  # noqa: F401
+from .traceenum_elbo import (  # noqa: F401
+    JitTraceEnum_ELBO,
+    TraceEnum_ELBO,
+    TraceMarkovEnum_ELBO,
+)
 from .tracetmc_elbo import JitTraceTMC_ELBO, TraceTMC_ELBO  # noqa: F401
-from .traceenum_elbo import JitTraceEnum_ELBO, TraceEnum_ELBO, TraceMarkovEnum_ELBO  # noqa: F401

--- a/pyro/contrib/funsor/infer/trace_elbo.py
+++ b/pyro/contrib/funsor/infer/trace_elbo.py
@@ -5,14 +5,13 @@ import contextlib
 
 import funsor
 
-from pyro.distributions.util import copy_docs_from
-from pyro.infer import Trace_ELBO as _OrigTrace_ELBO
-
 from pyro.contrib.funsor import to_data, to_funsor
 from pyro.contrib.funsor.handlers import enum, plate, replay, trace
 from pyro.contrib.funsor.infer import config_enumerate
+from pyro.distributions.util import copy_docs_from
+from pyro.infer import Trace_ELBO as _OrigTrace_ELBO
 
-from .elbo import Jit_ELBO, ELBO
+from .elbo import ELBO, Jit_ELBO
 from .traceenum_elbo import terms_from_trace
 
 

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -5,12 +5,11 @@ import contextlib
 
 import funsor
 
-from pyro.distributions.util import copy_docs_from
-from pyro.infer import TraceEnum_ELBO as _OrigTraceEnum_ELBO
-
 from pyro.contrib.funsor import to_data, to_funsor
 from pyro.contrib.funsor.handlers import enum, plate, replay, trace
 from pyro.contrib.funsor.infer.elbo import ELBO, Jit_ELBO
+from pyro.distributions.util import copy_docs_from
+from pyro.infer import TraceEnum_ELBO as _OrigTraceEnum_ELBO
 
 
 def terms_from_trace(tr):

--- a/pyro/contrib/funsor/infer/tracetmc_elbo.py
+++ b/pyro/contrib/funsor/infer/tracetmc_elbo.py
@@ -5,14 +5,12 @@ import contextlib
 
 import funsor
 
-from pyro.distributions.util import copy_docs_from
-from pyro.infer import TraceTMC_ELBO as _OrigTraceTMC_ELBO
-
 from pyro.contrib.funsor import to_data
 from pyro.contrib.funsor.handlers import enum, plate, replay, trace
-
 from pyro.contrib.funsor.infer.elbo import ELBO, Jit_ELBO
 from pyro.contrib.funsor.infer.traceenum_elbo import terms_from_trace
+from pyro.distributions.util import copy_docs_from
+from pyro.infer import TraceTMC_ELBO as _OrigTraceTMC_ELBO
 
 
 @copy_docs_from(_OrigTraceTMC_ELBO)

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -4,10 +4,24 @@
 from pyro.contrib.gp.kernels.brownian import Brownian
 from pyro.contrib.gp.kernels.coregionalize import Coregionalize
 from pyro.contrib.gp.kernels.dot_product import DotProduct, Linear, Polynomial
-from pyro.contrib.gp.kernels.isotropic import (RBF, Exponential, Isotropy, Matern32, Matern52,
-                                               RationalQuadratic)
-from pyro.contrib.gp.kernels.kernel import (Combination, Exponent, Kernel, Product, Sum,
-                                            Transforming, VerticalScaling, Warping)
+from pyro.contrib.gp.kernels.isotropic import (
+    RBF,
+    Exponential,
+    Isotropy,
+    Matern32,
+    Matern52,
+    RationalQuadratic,
+)
+from pyro.contrib.gp.kernels.kernel import (
+    Combination,
+    Exponent,
+    Kernel,
+    Product,
+    Sum,
+    Transforming,
+    VerticalScaling,
+    Warping,
+)
 from pyro.contrib.gp.kernels.periodic import Cosine, Periodic
 from pyro.contrib.gp.kernels.static import Constant, WhiteNoise
 

--- a/pyro/contrib/gp/likelihoods/binary.py
+++ b/pyro/contrib/gp/likelihoods/binary.py
@@ -5,7 +5,6 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-
 from pyro.contrib.gp.likelihoods.likelihood import Likelihood
 
 

--- a/pyro/contrib/gp/likelihoods/gaussian.py
+++ b/pyro/contrib/gp/likelihoods/gaussian.py
@@ -6,7 +6,6 @@ from torch.distributions import constraints
 
 import pyro
 import pyro.distributions as dist
-
 from pyro.contrib.gp.likelihoods.likelihood import Likelihood
 from pyro.nn.module import PyroParam
 

--- a/pyro/contrib/gp/likelihoods/multi_class.py
+++ b/pyro/contrib/gp/likelihoods/multi_class.py
@@ -5,7 +5,6 @@ import torch.nn.functional as F
 
 import pyro
 import pyro.distributions as dist
-
 from pyro.contrib.gp.likelihoods.likelihood import Likelihood
 
 

--- a/pyro/contrib/gp/likelihoods/poisson.py
+++ b/pyro/contrib/gp/likelihoods/poisson.py
@@ -5,7 +5,6 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-
 from pyro.contrib.gp.likelihoods.likelihood import Likelihood
 
 

--- a/pyro/contrib/oed/__init__.py
+++ b/pyro/contrib/oed/__init__.py
@@ -67,7 +67,7 @@ Statistical Science (1995): 273-304.
 
 """
 
-from pyro.contrib.oed import search, eig
+from pyro.contrib.oed import eig, search
 
 __all__ = [
     "search",

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1,17 +1,18 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import math
 import warnings
 
+import torch
+
 import pyro
 from pyro import poutine
-from pyro.infer.autoguide.utils import mean_field_entropy
 from pyro.contrib.oed.search import Search
-from pyro.infer import EmpiricalMarginal, Importance, SVI
-from pyro.util import torch_isnan, torch_isinf
 from pyro.contrib.util import lexpand
+from pyro.infer import SVI, EmpiricalMarginal, Importance
+from pyro.infer.autoguide.utils import mean_field_entropy
+from pyro.util import torch_isinf, torch_isnan
 
 __all__ = [
     "laplace_eig",

--- a/pyro/contrib/oed/glmm/__init__.py
+++ b/pyro/contrib/oed/glmm/__init__.py
@@ -36,5 +36,5 @@ Random effects may be incorporated as regular Bayesian regression coefficients.
 For random effects with a shared covariance matrix, see :meth:`pyro.contrib.oed.glmm.lmer_model`.
 """
 
-from pyro.contrib.oed.glmm.glmm import *  # noqa: F403,F401
 from pyro.contrib.oed.glmm import guides  # noqa: F401
+from pyro.contrib.oed.glmm.glmm import *  # noqa: F403,F401

--- a/pyro/contrib/oed/glmm/glmm.py
+++ b/pyro/contrib/oed/glmm/glmm.py
@@ -3,17 +3,17 @@
 
 import warnings
 from collections import OrderedDict
-from functools import partial
 from contextlib import ExitStack
+from functools import partial
 
 import torch
-from torch.nn.functional import softplus
 from torch.distributions import constraints
 from torch.distributions.transforms import AffineTransform, SigmoidTransform
+from torch.nn.functional import softplus
 
 import pyro
 import pyro.distributions as dist
-from pyro.contrib.util import rmv, iter_plates_to_shape
+from pyro.contrib.util import iter_plates_to_shape, rmv
 
 # TODO read from torch float spec
 epsilon = torch.tensor(2**-24)

--- a/pyro/contrib/oed/glmm/guides.py
+++ b/pyro/contrib/oed/glmm/guides.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import ExitStack
+
 import torch
 from torch import nn
-
-from contextlib import ExitStack
 
 import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.contrib.util import (
-    tensor_to_dict, rmv, rvv, rtril, lexpand, iter_plates_to_shape
+    iter_plates_to_shape,
+    lexpand,
+    rmv,
+    rtril,
+    rvv,
+    tensor_to_dict,
 )
 from pyro.ops.linalg import rinverse
 

--- a/pyro/contrib/oed/search.py
+++ b/pyro/contrib/oed/search.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import queue
-from pyro.infer.abstract_infer import TracePosterior
+
 import pyro.poutine as poutine
+from pyro.infer.abstract_infer import TracePosterior
 
 ###################################
 # Search borrowed from RSA example

--- a/pyro/contrib/oed/util.py
+++ b/pyro/contrib/oed/util.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+
 import torch
 
-from pyro.contrib.util import get_indices
 from pyro.contrib.oed.glmm import analytic_posterior_cov
+from pyro.contrib.util import get_indices
 from pyro.infer.autoguide.utils import mean_field_entropy
 
 

--- a/pyro/contrib/randomvariable/random_variable.py
+++ b/pyro/contrib/randomvariable/random_variable.py
@@ -4,16 +4,17 @@
 from typing import Union
 
 from torch import Tensor
+
 from pyro.distributions import TransformedDistribution
 from pyro.distributions.transforms import (
-    Transform,
-    AffineTransform,
     AbsTransform,
-    PowerTransform,
+    AffineTransform,
     ExpTransform,
-    TanhTransform,
+    PowerTransform,
+    SigmoidTransform,
     SoftmaxTransform,
-    SigmoidTransform
+    TanhTransform,
+    Transform,
 )
 
 

--- a/pyro/contrib/timeseries/__init__.py
+++ b/pyro/contrib/timeseries/__init__.py
@@ -6,7 +6,11 @@ The :mod:`pyro.contrib.timeseries` module provides a collection of Bayesian time
 models useful for forecasting applications.
 """
 from pyro.contrib.timeseries.base import TimeSeriesModel
-from pyro.contrib.timeseries.gp import IndependentMaternGP, LinearlyCoupledMaternGP, DependentMaternGP
+from pyro.contrib.timeseries.gp import (
+    DependentMaternGP,
+    IndependentMaternGP,
+    LinearlyCoupledMaternGP,
+)
 from pyro.contrib.timeseries.lgssm import GenericLGSSM
 from pyro.contrib.timeseries.lgssmgp import GenericLGSSMWithGPNoiseModel
 

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -5,9 +5,9 @@ import torch
 from torch.distributions import constraints
 
 import pyro.distributions as dist
-from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.contrib.tracking.extended_kalman_filter import EKFState
 from pyro.contrib.tracking.measurements import PositionMeasurement
+from pyro.distributions.torch_distribution import TorchDistribution
 
 
 class EKFDistribution(TorchDistribution):

--- a/pyro/contrib/tracking/dynamic_models.py
+++ b/pyro/contrib/tracking/dynamic_models.py
@@ -6,6 +6,7 @@ from abc import ABCMeta, abstractmethod
 import torch
 from torch import nn
 from torch.nn import Parameter
+
 import pyro.distributions as dist
 from pyro.distributions.util import eye_like
 

--- a/pyro/contrib/tracking/measurements.py
+++ b/pyro/contrib/tracking/measurements.py
@@ -4,6 +4,7 @@
 from abc import ABCMeta, abstractmethod
 
 import torch
+
 from pyro.distributions.util import eye_like
 
 

--- a/pyro/contrib/util.py
+++ b/pyro/contrib/util.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
+
 import torch
+
 import pyro
 
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions.torch_patch  # noqa F403
+from pyro.distributions.torch import *  # noqa F403
+
+# isort: split
+
 from pyro.distributions.affine_beta import AffineBeta
 from pyro.distributions.avf_mvn import AVFMultivariateNormal
 from pyro.distributions.coalescent import (
@@ -56,9 +60,12 @@ from pyro.distributions.relaxed_straight_through import (
 )
 from pyro.distributions.spanning_tree import SpanningTree
 from pyro.distributions.stable import Stable
-from pyro.distributions.torch import *  # noqa F403
 from pyro.distributions.torch import __all__ as torch_dists
-from pyro.distributions.torch_distribution import ExpandedDistribution, MaskedDistribution, TorchDistribution
+from pyro.distributions.torch_distribution import (
+    ExpandedDistribution,
+    MaskedDistribution,
+    TorchDistribution,
+)
 from pyro.distributions.torch_transform import ComposeTransformModule, TransformModule
 from pyro.distributions.unit import Unit
 from pyro.distributions.util import (

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 from torch.distributions.constraints import *  # noqa F403
+
+# isort: split
+
+import torch
 from torch.distributions.constraints import Constraint
 from torch.distributions.constraints import __all__ as torch_constraints
 from torch.distributions.constraints import independent, positive, positive_definite

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -3,9 +3,18 @@
 
 import torch
 
-from pyro.ops.gamma_gaussian import (GammaGaussian, gamma_and_mvn_to_gamma_gaussian, gamma_gaussian_tensordot,
-                                     matrix_and_mvn_to_gamma_gaussian)
-from pyro.ops.gaussian import Gaussian, gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
+from pyro.ops.gamma_gaussian import (
+    GammaGaussian,
+    gamma_and_mvn_to_gamma_gaussian,
+    gamma_gaussian_tensordot,
+    matrix_and_mvn_to_gamma_gaussian,
+)
+from pyro.ops.gaussian import (
+    Gaussian,
+    gaussian_tensordot,
+    matrix_and_mvn_to_gaussian,
+    mvn_to_gaussian,
+)
 from pyro.ops.special import safe_log
 from pyro.ops.tensor_utils import cholesky, cholesky_solve
 

--- a/pyro/distributions/kl.py
+++ b/pyro/distributions/kl.py
@@ -3,7 +3,13 @@
 
 import math
 
-from torch.distributions import Independent, MultivariateNormal, Normal, kl_divergence, register_kl
+from torch.distributions import (
+    Independent,
+    MultivariateNormal,
+    Normal,
+    kl_divergence,
+    register_kl,
+)
 
 from pyro.distributions.delta import Delta
 from pyro.distributions.distribution import Distribution

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -7,7 +7,10 @@ import torch
 
 from pyro.distributions.torch import Beta, TransformedDistribution
 from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.transforms.cholesky import CorrMatrixCholeskyTransform, _vector_to_l_cholesky
+from pyro.distributions.transforms.cholesky import (
+    CorrMatrixCholeskyTransform,
+    _vector_to_l_cholesky,
+)
 
 from . import constraints
 

--- a/pyro/distributions/ordered_logistic.py
+++ b/pyro/distributions/ordered_logistic.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+
 from pyro.distributions import constraints
 from pyro.distributions.torch import Categorical
 

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -5,9 +5,10 @@ import math
 
 import torch
 
+from pyro.ops.tensor_utils import safe_normalize
+
 from . import constraints
 from .torch_distribution import TorchDistribution
-from pyro.ops.tensor_utils import safe_normalize
 
 
 class ProjectedNormal(TorchDistribution):

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -218,6 +218,7 @@ def _get_cpp_module():
     global _cpp_module
     if _cpp_module is None:
         import os
+
         from torch.utils.cpp_extension import load
         path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "spanning_tree.cpp")
         _cpp_module = load(name="cpp_spanning_tree",

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -55,8 +55,8 @@ This module is a port of the
 `goftests <https://github.com/posterior/goftests>`_ library.
 """
 
-import warnings
 import math
+import warnings
 
 import torch
 

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -1,30 +1,67 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from torch.distributions import biject_to, transform_to
 from torch.distributions.transforms import *  # noqa F403
-from torch.distributions.transforms import ComposeTransform, ExpTransform, LowerCholeskyTransform
+
+# isort: split
+
+from torch.distributions import biject_to, transform_to
+from torch.distributions.transforms import (
+    ComposeTransform,
+    ExpTransform,
+    LowerCholeskyTransform,
+)
 from torch.distributions.transforms import __all__ as torch_transforms
 
 from .. import constraints
 from ..torch_transform import ComposeTransformModule
-from .affine_autoregressive import (AffineAutoregressive, ConditionalAffineAutoregressive, affine_autoregressive,
-                                    conditional_affine_autoregressive)
-from .affine_coupling import AffineCoupling, ConditionalAffineCoupling, affine_coupling, conditional_affine_coupling
+from .affine_autoregressive import (
+    AffineAutoregressive,
+    ConditionalAffineAutoregressive,
+    affine_autoregressive,
+    conditional_affine_autoregressive,
+)
+from .affine_coupling import (
+    AffineCoupling,
+    ConditionalAffineCoupling,
+    affine_coupling,
+    conditional_affine_coupling,
+)
 from .basic import ELUTransform, LeakyReLUTransform, elu, leaky_relu
 from .batchnorm import BatchNorm, batchnorm
 from .block_autoregressive import BlockAutoregressive, block_autoregressive
-from .cholesky import CholeskyTransform, CorrLCholeskyTransform, CorrMatrixCholeskyTransform
+from .cholesky import (
+    CholeskyTransform,
+    CorrLCholeskyTransform,
+    CorrMatrixCholeskyTransform,
+)
 from .discrete_cosine import DiscreteCosineTransform
-from .generalized_channel_permute import (ConditionalGeneralizedChannelPermute, GeneralizedChannelPermute,
-                                          conditional_generalized_channel_permute, generalized_channel_permute)
+from .generalized_channel_permute import (
+    ConditionalGeneralizedChannelPermute,
+    GeneralizedChannelPermute,
+    conditional_generalized_channel_permute,
+    generalized_channel_permute,
+)
 from .haar import HaarTransform
-from .householder import ConditionalHouseholder, Householder, conditional_householder, householder
+from .householder import (
+    ConditionalHouseholder,
+    Householder,
+    conditional_householder,
+    householder,
+)
 from .lower_cholesky_affine import LowerCholeskyAffine
-from .matrix_exponential import (ConditionalMatrixExponential, MatrixExponential, conditional_matrix_exponential,
-                                 matrix_exponential)
-from .neural_autoregressive import (ConditionalNeuralAutoregressive, NeuralAutoregressive,
-                                    conditional_neural_autoregressive, neural_autoregressive)
+from .matrix_exponential import (
+    ConditionalMatrixExponential,
+    MatrixExponential,
+    conditional_matrix_exponential,
+    matrix_exponential,
+)
+from .neural_autoregressive import (
+    ConditionalNeuralAutoregressive,
+    NeuralAutoregressive,
+    conditional_neural_autoregressive,
+    neural_autoregressive,
+)
 from .normalize import Normalize
 from .ordered import OrderedTransform
 from .permute import Permute, permute
@@ -32,8 +69,12 @@ from .planar import ConditionalPlanar, Planar, conditional_planar, planar
 from .polynomial import Polynomial, polynomial
 from .radial import ConditionalRadial, Radial, conditional_radial, radial
 from .spline import ConditionalSpline, Spline, conditional_spline, spline
-from .spline_autoregressive import (ConditionalSplineAutoregressive, SplineAutoregressive,
-                                    conditional_spline_autoregressive, spline_autoregressive)
+from .spline_autoregressive import (
+    ConditionalSplineAutoregressive,
+    SplineAutoregressive,
+    conditional_spline_autoregressive,
+    spline_autoregressive,
+)
 from .spline_coupling import SplineCoupling, spline_coupling
 from .sylvester import Sylvester, sylvester
 

--- a/pyro/distributions/zero_inflated.py
+++ b/pyro/distributions/zero_inflated.py
@@ -3,7 +3,12 @@
 
 import torch
 from torch.distributions import constraints
-from torch.distributions.utils import broadcast_all, lazy_property, logits_to_probs, probs_to_logits
+from torch.distributions.utils import (
+    broadcast_all,
+    lazy_property,
+    logits_to_probs,
+    probs_to_logits,
+)
 from torch.nn.functional import softplus
 
 from pyro.distributions import NegativeBinomial, Poisson, TorchDistribution

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -17,13 +17,13 @@ from pyro.infer.rws import ReweightedWakeSleep
 from pyro.infer.smcfilter import SMCFilter
 from pyro.infer.svgd import SVGD, IMQSteinKernel, RBFSteinKernel
 from pyro.infer.svi import SVI
-from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.trace_elbo import JitTrace_ELBO, Trace_ELBO
 from pyro.infer.trace_mean_field_elbo import JitTraceMeanField_ELBO, TraceMeanField_ELBO
 from pyro.infer.trace_mmd import Trace_MMD
 from pyro.infer.trace_tail_adaptive_elbo import TraceTailAdaptive_ELBO
 from pyro.infer.traceenum_elbo import JitTraceEnum_ELBO, TraceEnum_ELBO
 from pyro.infer.tracegraph_elbo import JitTraceGraph_ELBO, TraceGraph_ELBO
+from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.util import enable_validation, is_validation_enabled
 
 __all__ = [

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -10,8 +10,8 @@ import torch
 
 import pyro.poutine as poutine
 from pyro.distributions import Categorical, Empirical
-from pyro.poutine.util import site_is_subsample
 from pyro.ops.stats import waic
+from pyro.poutine.util import site_is_subsample
 
 
 class EmpiricalMarginal(Empirical):

--- a/pyro/infer/autoguide/__init__.py
+++ b/pyro/infer/autoguide/__init__.py
@@ -1,12 +1,30 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from pyro.infer.autoguide.guides import (AutoCallable, AutoContinuous, AutoDelta, AutoDiagonalNormal,
-                                         AutoDiscreteParallel, AutoGuide, AutoGuideList, AutoIAFNormal,
-                                         AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
-                                         AutoMultivariateNormal, AutoNormal, AutoNormalizingFlow)
-from pyro.infer.autoguide.initialization import (init_to_feasible, init_to_generated, init_to_mean, init_to_median,
-                                                 init_to_sample, init_to_uniform, init_to_value)
+from pyro.infer.autoguide.guides import (
+    AutoCallable,
+    AutoContinuous,
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoDiscreteParallel,
+    AutoGuide,
+    AutoGuideList,
+    AutoIAFNormal,
+    AutoLaplaceApproximation,
+    AutoLowRankMultivariateNormal,
+    AutoMultivariateNormal,
+    AutoNormal,
+    AutoNormalizingFlow,
+)
+from pyro.infer.autoguide.initialization import (
+    init_to_feasible,
+    init_to_generated,
+    init_to_mean,
+    init_to_median,
+    init_to_sample,
+    init_to_uniform,
+    init_to_value,
+)
 from pyro.infer.autoguide.utils import mean_field_entropy
 
 __all__ = [

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -30,7 +30,11 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions.transforms import affine_autoregressive, iterated
 from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
-from pyro.infer.autoguide.initialization import InitMessenger, init_to_feasible, init_to_median
+from pyro.infer.autoguide.initialization import (
+    InitMessenger,
+    init_to_feasible,
+    init_to_median,
+)
 from pyro.infer.enum import config_enumerate
 from pyro.nn import PyroModule, PyroParam
 from pyro.ops.hessian import hessian

--- a/pyro/infer/mcmc/__init__.py
+++ b/pyro/infer/mcmc/__init__.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.infer.mcmc.adaptation import ArrowheadMassMatrix, BlockMassMatrix
-from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.api import MCMC
+from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.nuts import NUTS
 
 __all__ = [

--- a/pyro/infer/mcmc/adaptation.py
+++ b/pyro/infer/mcmc/adaptation.py
@@ -7,9 +7,15 @@ from collections import namedtuple
 import torch
 
 import pyro
-from pyro.ops.arrowhead import SymmArrowhead, sqrt, triu_gram, triu_inverse, triu_matvecmul
+from pyro.ops.arrowhead import (
+    SymmArrowhead,
+    sqrt,
+    triu_gram,
+    triu_inverse,
+    triu_matvecmul,
+)
 from pyro.ops.dual_averaging import DualAveraging
-from pyro.ops.welford import WelfordCovariance, WelfordArrowheadCovariance
+from pyro.ops.welford import WelfordArrowheadCovariance, WelfordCovariance
 
 adapt_window = namedtuple("adapt_window", ["start", "end"])
 

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -24,7 +24,12 @@ import torch.multiprocessing as mp
 import pyro
 import pyro.poutine as poutine
 from pyro.infer.mcmc.hmc import HMC
-from pyro.infer.mcmc.logger import DIAGNOSTIC_MSG, ProgressBar, TqdmHandler, initialize_logger
+from pyro.infer.mcmc.logger import (
+    DIAGNOSTIC_MSG,
+    ProgressBar,
+    TqdmHandler,
+    initialize_logger,
+)
 from pyro.infer.mcmc.nuts import NUTS
 from pyro.infer.mcmc.util import diagnostics, print_summary
 from pyro.util import optional

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -8,9 +8,8 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.distributions.util import scalar_like
 from pyro.distributions.testing.fakes import NonreparameterizedNormal
-
+from pyro.distributions.util import scalar_like
 from pyro.infer.autoguide import init_to_uniform
 from pyro.infer.mcmc.adaptation import WarmupAdapter
 from pyro.infer.mcmc.mcmc_kernel import MCMCKernel

--- a/pyro/infer/mcmc/util.py
+++ b/pyro/infer/mcmc/util.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+import traceback as tb
 import warnings
 from collections import OrderedDict, defaultdict
 from functools import partial, reduce
 from itertools import product
-import traceback as tb
 
 import torch
-from torch.distributions import biject_to
 from opt_einsum import shared_intermediates
+from torch.distributions import biject_to
 
 import pyro
 import pyro.poutine as poutine

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from functools import reduce
 import warnings
+from functools import reduce
 
 import torch
 

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -8,6 +8,7 @@ import pyro.distributions as dist
 from pyro import poutine
 from pyro.distributions.util import sum_rightmost
 from pyro.infer.autoguide.guides import AutoContinuous
+
 from .reparam import Reparam
 
 

--- a/pyro/infer/reparam/unit_jacobian.py
+++ b/pyro/infer/reparam/unit_jacobian.py
@@ -44,7 +44,10 @@ class UnitJacobianReparam(Reparam):
                                      "setting experimental_allow_batch=True.")
 
                 # Reshape and mute plates using block_plate.
-                from pyro.contrib.forecast.util import reshape_batch, reshape_transform_batch
+                from pyro.contrib.forecast.util import (
+                    reshape_batch,
+                    reshape_transform_batch,
+                )
                 old_shape = fn.batch_shape
                 new_shape = old_shape[:-shift] + (1,) * shift + old_shape[-shift:]
                 fn = reshape_batch(fn, new_shape).to_event(shift)

--- a/pyro/infer/svgd.py
+++ b/pyro/infer/svgd.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import ABCMeta, abstractmethod
 import math
+from abc import ABCMeta, abstractmethod
 
 import torch
 from torch.distributions import biject_to
@@ -10,10 +10,10 @@ from torch.distributions import biject_to
 import pyro
 from pyro import poutine
 from pyro.distributions import Delta
-from pyro.infer.trace_elbo import Trace_ELBO
+from pyro.distributions.util import copy_docs_from
 from pyro.infer.autoguide.guides import AutoContinuous
 from pyro.infer.autoguide.initialization import init_to_sample
-from pyro.distributions.util import copy_docs_from
+from pyro.infer.trace_elbo import Trace_ELBO
 
 
 def vectorize(fn, num_particles, max_plate_nesting):

--- a/pyro/infer/trace_elbo.py
+++ b/pyro/infer/trace_elbo.py
@@ -8,7 +8,12 @@ import pyro.ops.jit
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
 from pyro.infer.enum import get_importance_trace
-from pyro.infer.util import MultiFrameTensor, get_plate_stacks, is_validation_enabled, torch_item
+from pyro.infer.util import (
+    MultiFrameTensor,
+    get_plate_stacks,
+    is_validation_enabled,
+    torch_item,
+)
 from pyro.util import check_if_enumerated, warn_if_nan
 
 

--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -10,7 +10,11 @@ from torch.distributions import kl_divergence
 import pyro.ops.jit
 from pyro.distributions.util import scale_and_mask
 from pyro.infer.trace_elbo import Trace_ELBO
-from pyro.infer.util import is_validation_enabled, torch_item, check_fully_reparametrized
+from pyro.infer.util import (
+    check_fully_reparametrized,
+    is_validation_enabled,
+    torch_item,
+)
 from pyro.util import warn_if_nan
 
 

--- a/pyro/infer/trace_mmd.py
+++ b/pyro/infer/trace_mmd.py
@@ -9,8 +9,8 @@ import pyro
 import pyro.ops.jit
 from pyro import poutine
 from pyro.infer.elbo import ELBO
-from pyro.infer.util import torch_item, is_validation_enabled
 from pyro.infer.enum import get_importance_trace
+from pyro.infer.util import is_validation_enabled, torch_item
 from pyro.util import check_if_enumerated, warn_if_nan
 
 

--- a/pyro/infer/trace_tail_adaptive_elbo.py
+++ b/pyro/infer/trace_tail_adaptive_elbo.py
@@ -6,7 +6,7 @@ import warnings
 import torch
 
 from pyro.infer.trace_elbo import Trace_ELBO
-from pyro.infer.util import is_validation_enabled, check_fully_reparametrized
+from pyro.infer.util import check_fully_reparametrized, is_validation_enabled
 
 
 class TraceTailAdaptive_ELBO(Trace_ELBO):

--- a/pyro/infer/traceenum_elbo.py
+++ b/pyro/infer/traceenum_elbo.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import queue
 import warnings
 import weakref
 from collections import OrderedDict
-import queue
 
 import torch
 from opt_einsum import shared_intermediates
@@ -15,7 +15,11 @@ import pyro.ops.jit
 import pyro.poutine as poutine
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
-from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_discrete_extend
+from pyro.infer.enum import (
+    get_importance_trace,
+    iter_discrete_escape,
+    iter_discrete_extend,
+)
 from pyro.infer.util import Dice, is_validation_enabled
 from pyro.ops import packed
 from pyro.ops.contract import contract_tensor_tree, contract_to_tensor

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -11,8 +11,13 @@ import pyro.ops.jit
 from pyro.distributions.util import detach, is_identically_zero
 from pyro.infer import ELBO
 from pyro.infer.enum import get_importance_trace
-from pyro.infer.util import (MultiFrameTensor, get_plate_stacks,
-                             is_validation_enabled, torch_backward, torch_item)
+from pyro.infer.util import (
+    MultiFrameTensor,
+    get_plate_stacks,
+    is_validation_enabled,
+    torch_backward,
+    torch_item,
+)
 from pyro.util import check_if_enumerated, warn_if_nan
 
 

--- a/pyro/infer/tracetmc_elbo.py
+++ b/pyro/infer/tracetmc_elbo.py
@@ -7,10 +7,13 @@ import warnings
 import torch
 
 import pyro.poutine as poutine
-
 from pyro.distributions.util import is_identically_zero
 from pyro.infer.elbo import ELBO
-from pyro.infer.enum import get_importance_trace, iter_discrete_escape, iter_discrete_extend
+from pyro.infer.enum import (
+    get_importance_trace,
+    iter_discrete_escape,
+    iter_discrete_extend,
+)
 from pyro.infer.util import compute_site_dice_factor, is_validation_enabled, torch_item
 from pyro.ops import packed
 from pyro.ops.contract import einsum

--- a/pyro/logger.py
+++ b/pyro/logger.py
@@ -3,7 +3,6 @@
 
 import logging
 
-
 default_format = '%(levelname)s \t %(message)s'
 log = logging.getLogger("pyro")
 log.setLevel(logging.INFO)

--- a/pyro/nn/__init__.py
+++ b/pyro/nn/__init__.py
@@ -3,7 +3,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-from pyro.nn.auto_reg_nn import AutoRegressiveNN, ConditionalAutoRegressiveNN, MaskedLinear
+from pyro.nn.auto_reg_nn import (
+    AutoRegressiveNN,
+    ConditionalAutoRegressiveNN,
+    MaskedLinear,
+)
 from pyro.nn.dense_nn import ConditionalDenseNN, DenseNN
 from pyro.nn.module import PyroModule, PyroParam, PyroSample, pyro_method
 

--- a/pyro/ops/arrowhead.py
+++ b/pyro/ops/arrowhead.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 
 import torch
 
-
 SymmArrowhead = namedtuple("SymmArrowhead", ["top", "bottom_diag"])
 TriuArrowhead = namedtuple("TriuArrowhead", ["top", "bottom_diag"])
 

--- a/pyro/ops/einsum/torch_map.py
+++ b/pyro/ops/einsum/torch_map.py
@@ -2,11 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import operator
-
 from functools import reduce
 
 from pyro.ops import packed
-from pyro.ops.einsum.adjoint import Backward, einsum_backward_sample, transpose, unflatten
+from pyro.ops.einsum.adjoint import (
+    Backward,
+    einsum_backward_sample,
+    transpose,
+    unflatten,
+)
 from pyro.ops.einsum.util import Tensordot
 
 

--- a/pyro/ops/einsum/torch_sample.py
+++ b/pyro/ops/einsum/torch_sample.py
@@ -2,13 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import operator
-
 from functools import reduce
 
 import pyro.distributions as dist
 import pyro.ops.einsum.torch_log
 from pyro.ops import packed
-from pyro.ops.einsum.adjoint import Backward, einsum_backward_sample, transpose, unflatten
+from pyro.ops.einsum.adjoint import (
+    Backward,
+    einsum_backward_sample,
+    transpose,
+    unflatten,
+)
 from pyro.ops.einsum.util import Tensordot
 from pyro.util import jit_iter
 

--- a/pyro/ops/newton.py
+++ b/pyro/ops/newton.py
@@ -4,8 +4,8 @@
 import torch
 from torch.autograd import grad
 
+from pyro.ops.linalg import eig_3d, rinverse
 from pyro.util import warn_if_nan
-from pyro.ops.linalg import rinverse, eig_3d
 
 
 def newton_step(loss, x, trust_radius=None):

--- a/pyro/ops/ssm_gp.py
+++ b/pyro/ops/ssm_gp.py
@@ -6,7 +6,7 @@ import math
 import torch
 from torch.distributions import constraints
 
-from pyro.nn import PyroModule, pyro_method, PyroParam
+from pyro.nn import PyroModule, PyroParam, pyro_method
 
 root_three = math.sqrt(3.0)
 root_five = math.sqrt(5.0)

--- a/pyro/params/__init__.py
+++ b/pyro/params/__init__.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from .param_store import module_from_param_with_module_name, param_with_module_name, user_param_name
+from .param_store import (
+    module_from_param_with_module_name,
+    param_with_module_name,
+    user_param_name,
+)
 
 __all__ = [
     "module_from_param_with_module_name",

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,8 +1,26 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from .handlers import (block, broadcast, collapse, condition, do, enum, escape, infer_config, lift, markov, mask, queue,
-                       reparam, replay, scale, seed, trace, uncondition)
+from .handlers import (
+    block,
+    broadcast,
+    collapse,
+    condition,
+    do,
+    enum,
+    escape,
+    infer_config,
+    lift,
+    markov,
+    mask,
+    queue,
+    reparam,
+    replay,
+    scale,
+    seed,
+    trace,
+    uncondition,
+)
 from .runtime import NonlocalExit, get_mask
 from .trace_struct import Trace
 from .util import enable_validation, is_validation_enabled

--- a/pyro/poutine/broadcast_messenger.py
+++ b/pyro/poutine/broadcast_messenger.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pyro.util import ignore_jit_warnings
+
 from .messenger import Messenger
 
 

--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 import torch
 
 from pyro.util import ignore_jit_warnings
+
 from .messenger import Messenger
 from .runtime import _DIM_ALLOCATOR
 

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -3,7 +3,10 @@
 
 import functools
 
-from pyro.params.param_store import _MODULE_NAMESPACE_DIVIDER, ParamStoreDict  # noqa: F401
+from pyro.params.param_store import (  # noqa: F401
+    _MODULE_NAMESPACE_DIVIDER,
+    ParamStoreDict,
+)
 
 # the global pyro stack
 _PYRO_STACK = []

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict
 import sys
+from collections import OrderedDict
 
 import opt_einsum
 

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -12,7 +12,13 @@ import pyro.infer as infer
 import pyro.poutine as poutine
 from pyro.params import param_with_module_name
 from pyro.poutine.plate_messenger import PlateMessenger
-from pyro.poutine.runtime import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, am_i_wrapped, apply_stack, effectful
+from pyro.poutine.runtime import (
+    _MODULE_NAMESPACE_DIVIDER,
+    _PYRO_PARAM_STORE,
+    am_i_wrapped,
+    apply_stack,
+    effectful,
+)
 from pyro.poutine.subsample_messenger import SubsampleMessenger
 from pyro.util import deep_getattr, set_rng_seed  # noqa: F401
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude = docs/src, build, dist, .ipynb_checkpoints
 extend-ignore = E721,E741
 
 [isort]
-line_length = 120
+profile = black
 skip_glob = .ipynb_checkpoints
 known_first_party = pyro, tests
 known_third_party = opt_einsum, six, torch, torchvision

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         'profile': ['prettytable', 'pytest-benchmark', 'snakeviz'],
         'dev': EXTRAS_REQUIRE + [
             'flake8',
-            'isort',
+            'isort>=5.0',
             'nbformat',
             'nbsphinx>=0.3.2',
             'nbstripout',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-
 import os
 
 # create log handler for tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ import torch
 
 import pyro
 
-
 torch.set_default_tensor_type(os.environ.get('PYRO_TENSOR_TYPE', 'torch.DoubleTensor'))
 
 

--- a/tests/contrib/autoguide/test_inference.py
+++ b/tests/contrib/autoguide/test_inference.py
@@ -12,10 +12,15 @@ from torch.distributions import biject_to, constraints
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
-from pyro.distributions.transforms import iterated, block_autoregressive
-from pyro.infer.autoguide import (AutoDiagonalNormal, AutoIAFNormal, AutoLaplaceApproximation,
-                                  AutoLowRankMultivariateNormal, AutoMultivariateNormal)
+from pyro.distributions.transforms import block_autoregressive, iterated
 from pyro.infer import SVI, Trace_ELBO, TraceMeanField_ELBO
+from pyro.infer.autoguide import (
+    AutoDiagonalNormal,
+    AutoIAFNormal,
+    AutoLaplaceApproximation,
+    AutoLowRankMultivariateNormal,
+    AutoMultivariateNormal,
+)
 from pyro.infer.autoguide.guides import AutoNormalizingFlow
 from tests.common import assert_equal
 from tests.integration_tests.test_conjugate_gaussian_models import GaussianChain

--- a/tests/contrib/autoguide/test_mean_field_entropy.py
+++ b/tests/contrib/autoguide/test_mean_field_entropy.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
-import scipy.special as sc
 import pytest
+import scipy.special as sc
+import torch
 
 import pyro
 import pyro.distributions as dist

--- a/tests/contrib/autoname/test_scoping.py
+++ b/tests/contrib/autoname/test_scoping.py
@@ -8,7 +8,7 @@ import torch
 import pyro
 import pyro.distributions.torch as dist
 import pyro.poutine as poutine
-from pyro.contrib.autoname import scope, name_count
+from pyro.contrib.autoname import name_count, scope
 
 logger = logging.getLogger(__name__)
 

--- a/tests/contrib/bnn/test_hidden_layer.py
+++ b/tests/contrib/bnn/test_hidden_layer.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 import torch.nn.functional as F
 from torch.distributions import Normal
 
-import pytest
 from pyro.contrib.bnn import HiddenLayer
 from tests.common import assert_equal
 

--- a/tests/contrib/epidemiology/test_distributions.py
+++ b/tests/contrib/epidemiology/test_distributions.py
@@ -9,7 +9,10 @@ from torch.distributions.transforms import SigmoidTransform
 
 import pyro.distributions as dist
 from pyro.contrib.epidemiology import beta_binomial_dist, binomial_dist, infection_dist
-from pyro.contrib.epidemiology.distributions import _RELAX_MIN_VARIANCE, set_relaxed_distributions
+from pyro.contrib.epidemiology.distributions import (
+    _RELAX_MIN_VARIANCE,
+    set_relaxed_distributions,
+)
 from tests.common import assert_close
 
 

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -9,10 +9,20 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.contrib.epidemiology.models import (HeterogeneousRegionalSIRModel, HeterogeneousSIRModel,
-                                              OverdispersedSEIRModel, OverdispersedSIRModel, RegionalSIRModel,
-                                              SimpleSEIRDModel, SimpleSEIRModel, SimpleSIRModel, SparseSIRModel,
-                                              SuperspreadingSEIRModel, SuperspreadingSIRModel, UnknownStartSIRModel)
+from pyro.contrib.epidemiology.models import (
+    HeterogeneousRegionalSIRModel,
+    HeterogeneousSIRModel,
+    OverdispersedSEIRModel,
+    OverdispersedSIRModel,
+    RegionalSIRModel,
+    SimpleSEIRDModel,
+    SimpleSEIRModel,
+    SimpleSIRModel,
+    SparseSIRModel,
+    SuperspreadingSEIRModel,
+    SuperspreadingSIRModel,
+    UnknownStartSIRModel,
+)
 from tests.common import xfail_param
 
 logger = logging.getLogger(__name__)

--- a/tests/contrib/epidemiology/test_quant.py
+++ b/tests/contrib/epidemiology/test_quant.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 import torch
 
 from pyro.contrib.epidemiology.util import compute_bin_probs

--- a/tests/contrib/forecast/test_util.py
+++ b/tests/contrib/forecast/test_util.py
@@ -6,7 +6,12 @@ import torch
 from torch.distributions import transform_to
 
 import pyro.distributions as dist
-from pyro.contrib.forecast.util import UNIVARIATE_DISTS, UNIVARIATE_TRANSFORMS, prefix_condition, reshape_batch
+from pyro.contrib.forecast.util import (
+    UNIVARIATE_DISTS,
+    UNIVARIATE_TRANSFORMS,
+    prefix_condition,
+    reshape_batch,
+)
 from tests.ops.gaussian import random_mvn
 
 DISTS = [

--- a/tests/contrib/funsor/test_enum_funsor.py
+++ b/tests/contrib/funsor/test_enum_funsor.py
@@ -7,7 +7,6 @@ import os
 import pyroapi
 import pytest
 import torch
-
 from torch.autograd import grad
 from torch.distributions import constraints
 
@@ -17,9 +16,10 @@ from tests.common import assert_equal, xfail_param
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
-    import pyro.contrib.funsor
     from pyroapi import distributions as dist
     from pyroapi import handlers, infer, pyro
+
+    import pyro.contrib.funsor
     funsor.set_backend("torch")
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")

--- a/tests/contrib/funsor/test_enum_funsor.py
+++ b/tests/contrib/funsor/test_enum_funsor.py
@@ -16,11 +16,11 @@ from tests.common import assert_equal, xfail_param
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
-    from pyroapi import distributions as dist
-    from pyroapi import handlers, infer, pyro
 
     import pyro.contrib.funsor
     funsor.set_backend("torch")
+    from pyroapi import distributions as dist
+    from pyroapi import handlers, infer, pyro
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_named_handlers.py
+++ b/tests/contrib/funsor/test_named_handlers.py
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 
 import pytest
 import torch
@@ -11,6 +11,7 @@ import torch
 try:
     import funsor
     from funsor.tensor import Tensor
+
     import pyro.contrib.funsor
     from pyro.contrib.funsor.handlers.named_messenger import NamedMessenger
     funsor.set_backend("torch")

--- a/tests/contrib/funsor/test_pyroapi_funsor.py
+++ b/tests/contrib/funsor/test_pyroapi_funsor.py
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
 
 try:
     # triggers backend registration
     import funsor
+
     import pyro.contrib.funsor  # noqa: F401
     funsor.set_backend("torch")
 except ImportError:

--- a/tests/contrib/funsor/test_pyroapi_funsor.py
+++ b/tests/contrib/funsor/test_pyroapi_funsor.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from pyroapi import pyro_backend
-from pyroapi.tests import *  # noqa F401
 
 try:
     # triggers backend registration
@@ -13,6 +11,9 @@ try:
     funsor.set_backend("torch")
 except ImportError:
     pytestmark = pytest.mark.skip()
+
+from pyroapi import pyro_backend
+from pyroapi.tests import *  # noqa F401
 
 
 @pytest.fixture(params=["contrib.funsor"])

--- a/tests/contrib/funsor/test_tmc.py
+++ b/tests/contrib/funsor/test_tmc.py
@@ -14,11 +14,11 @@ from tests.common import assert_equal
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
-    from pyroapi import distributions as dist
-    from pyroapi import infer, pyro, pyro_backend
 
     import pyro.contrib.funsor
     funsor.set_backend("torch")
+    from pyroapi import distributions as dist
+    from pyroapi import infer, pyro, pyro_backend
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_tmc.py
+++ b/tests/contrib/funsor/test_tmc.py
@@ -14,9 +14,10 @@ from tests.common import assert_equal
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
-    import pyro.contrib.funsor
     from pyroapi import distributions as dist
     from pyroapi import infer, pyro, pyro_backend
+
+    import pyro.contrib.funsor
     funsor.set_backend("torch")
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")

--- a/tests/contrib/funsor/test_valid_models_enum.py
+++ b/tests/contrib/funsor/test_valid_models_enum.py
@@ -1,10 +1,10 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-from collections import defaultdict
 import contextlib
 import logging
 import os
+from collections import defaultdict
 from queue import LifoQueue
 
 import pytest
@@ -19,11 +19,12 @@ from pyro.util import check_traceenum_requirements
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
+
     import pyro.contrib.funsor
     from pyro.contrib.funsor.handlers.runtime import _DIM_STACK
     funsor.set_backend("torch")
     from pyroapi import distributions as dist
-    from pyroapi import infer, handlers, pyro, pyro_backend
+    from pyroapi import handlers, infer, pyro, pyro_backend
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_valid_models_plate.py
+++ b/tests/contrib/funsor/test_valid_models_plate.py
@@ -12,9 +12,10 @@ from tests.common import xfail_param
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
-    import pyro.contrib.funsor
     from pyroapi import distributions as dist
     from pyroapi import infer, pyro
+
+    import pyro.contrib.funsor
     from tests.contrib.funsor.test_valid_models_enum import assert_ok
     funsor.set_backend("torch")
 except ImportError:

--- a/tests/contrib/funsor/test_valid_models_plate.py
+++ b/tests/contrib/funsor/test_valid_models_plate.py
@@ -12,12 +12,13 @@ from tests.common import xfail_param
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
+
+    import pyro.contrib.funsor
+    funsor.set_backend("torch")
     from pyroapi import distributions as dist
     from pyroapi import infer, pyro
 
-    import pyro.contrib.funsor
     from tests.contrib.funsor.test_valid_models_enum import assert_ok
-    funsor.set_backend("torch")
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_valid_models_sequential_plate.py
+++ b/tests/contrib/funsor/test_valid_models_sequential_plate.py
@@ -11,9 +11,10 @@ from pyro.ops.indexing import Vindex
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
-    import pyro.contrib.funsor
     from pyroapi import distributions as dist
     from pyroapi import infer, pyro
+
+    import pyro.contrib.funsor
     from tests.contrib.funsor.test_valid_models_enum import assert_ok
     funsor.set_backend("torch")
 except ImportError:

--- a/tests/contrib/funsor/test_valid_models_sequential_plate.py
+++ b/tests/contrib/funsor/test_valid_models_sequential_plate.py
@@ -11,12 +11,13 @@ from pyro.ops.indexing import Vindex
 # put all funsor-related imports here, so test collection works without funsor
 try:
     import funsor
+
+    import pyro.contrib.funsor
+    funsor.set_backend("torch")
     from pyroapi import distributions as dist
     from pyroapi import infer, pyro
 
-    import pyro.contrib.funsor
     from tests.contrib.funsor.test_valid_models_enum import assert_ok
-    funsor.set_backend("torch")
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -12,13 +12,12 @@ from pyro.ops.indexing import Vindex
 try:
     import funsor
     from funsor.testing import assert_close
-    from pyroapi import distributions as dist
 
     import pyro.contrib.funsor
-    funsor.set_backend("torch")
-    from pyroapi import handlers, infer, pyro
-
     from pyro.contrib.funsor.infer.traceenum_elbo import terms_from_trace
+    funsor.set_backend("torch")
+    from pyroapi import distributions as dist
+    from pyroapi import handlers, infer, pyro
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-
 from pyroapi import pyro_backend
 from torch.distributions import constraints
 
@@ -13,10 +12,12 @@ from pyro.ops.indexing import Vindex
 try:
     import funsor
     from funsor.testing import assert_close
-    import pyro.contrib.funsor
     from pyroapi import distributions as dist
+
+    import pyro.contrib.funsor
     funsor.set_backend("torch")
-    from pyroapi import handlers, pyro, infer
+    from pyroapi import handlers, infer, pyro
+
     from pyro.contrib.funsor.infer.traceenum_elbo import terms_from_trace
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")

--- a/tests/contrib/gp/test_kernels.py
+++ b/tests/contrib/gp/test_kernels.py
@@ -6,10 +6,26 @@ from collections import namedtuple
 import pytest
 import torch
 
-from pyro.contrib.gp.kernels import (RBF, Brownian, Constant, Coregionalize, Cosine, Exponent,
-                                     Exponential, Linear, Matern32, Matern52, Periodic,
-                                     Polynomial, Product, RationalQuadratic, Sum,
-                                     VerticalScaling, Warping, WhiteNoise)
+from pyro.contrib.gp.kernels import (
+    RBF,
+    Brownian,
+    Constant,
+    Coregionalize,
+    Cosine,
+    Exponent,
+    Exponential,
+    Linear,
+    Matern32,
+    Matern52,
+    Periodic,
+    Polynomial,
+    Product,
+    RationalQuadratic,
+    Sum,
+    VerticalScaling,
+    Warping,
+    WhiteNoise,
+)
 from tests.common import assert_equal
 
 T = namedtuple("TestGPKernel", ["kernel", "X", "Z", "K_sum"])

--- a/tests/contrib/gp/test_likelihoods.py
+++ b/tests/contrib/gp/test_likelihoods.py
@@ -11,7 +11,6 @@ from pyro.contrib.gp.likelihoods import Binary, MultiClass, Poisson
 from pyro.contrib.gp.models import VariationalGP, VariationalSparseGP
 from pyro.contrib.gp.util import train
 
-
 T = namedtuple("TestGPLikelihood", ["model_class", "X", "y", "kernel", "likelihood"])
 
 X = torch.tensor([[1.0, 5.0, 3.0], [4.0, 3.0, 7.0], [3.0, 4.0, 6.0]])

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -8,13 +8,18 @@ import pytest
 import torch
 
 import pyro.distributions as dist
-from pyro.contrib.gp.kernels import Cosine, Matern32, RBF, WhiteNoise
+from pyro.contrib.gp.kernels import RBF, Cosine, Matern32, WhiteNoise
 from pyro.contrib.gp.likelihoods import Gaussian
-from pyro.contrib.gp.models import (GPLVM, GPRegression, SparseGPRegression,
-                                    VariationalGP, VariationalSparseGP)
+from pyro.contrib.gp.models import (
+    GPLVM,
+    GPRegression,
+    SparseGPRegression,
+    VariationalGP,
+    VariationalSparseGP,
+)
 from pyro.contrib.gp.util import train
-from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.api import MCMC
+from pyro.infer.mcmc.hmc import HMC
 from pyro.nn.module import PyroSample
 from tests.common import assert_equal
 

--- a/tests/contrib/oed/test_ewma.py
+++ b/tests/contrib/oed/test_ewma.py
@@ -3,9 +3,9 @@
 
 import math
 
+import pytest
 import torch
 
-import pytest
 from pyro.contrib.oed.eig import EwmaLog
 from tests.common import assert_equal
 

--- a/tests/contrib/oed/test_finite_spaces_eig.py
+++ b/tests/contrib/oed/test_finite_spaces_eig.py
@@ -1,17 +1,22 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import pytest
+import torch
 
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
 from pyro.contrib.oed.eig import (
-    nmc_eig, posterior_eig, marginal_eig, marginal_likelihood_eig, vnmc_eig, lfire_eig,
-    donsker_varadhan_eig)
+    donsker_varadhan_eig,
+    lfire_eig,
+    marginal_eig,
+    marginal_likelihood_eig,
+    nmc_eig,
+    posterior_eig,
+    vnmc_eig,
+)
 from pyro.contrib.util import iter_plates_to_shape
-
 from tests.common import assert_equal
 
 try:

--- a/tests/contrib/oed/test_glmm.py
+++ b/tests/contrib/oed/test_glmm.py
@@ -9,8 +9,12 @@ import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.contrib.oed.glmm import (
-    known_covariance_linear_model, group_linear_model, zero_mean_unit_obs_sd_lm,
-    normal_inverse_gamma_linear_model, logistic_regression_model, sigmoid_model
+    group_linear_model,
+    known_covariance_linear_model,
+    logistic_regression_model,
+    normal_inverse_gamma_linear_model,
+    sigmoid_model,
+    zero_mean_unit_obs_sd_lm,
 )
 from tests.common import assert_equal
 

--- a/tests/contrib/oed/test_linear_models_eig.py
+++ b/tests/contrib/oed/test_linear_models_eig.py
@@ -1,20 +1,27 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import torch
 import pytest
+import torch
 
 import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
-from pyro.infer import Trace_ELBO
-from pyro.contrib.oed.glmm import known_covariance_linear_model
-from pyro.contrib.oed.util import linear_model_ground_truth
 from pyro.contrib.oed.eig import (
-    nmc_eig, posterior_eig, marginal_eig, marginal_likelihood_eig, vnmc_eig, laplace_eig, lfire_eig,
-    donsker_varadhan_eig)
-from pyro.contrib.util import rmv, rvv
+    donsker_varadhan_eig,
+    laplace_eig,
+    lfire_eig,
+    marginal_eig,
+    marginal_likelihood_eig,
+    nmc_eig,
+    posterior_eig,
+    vnmc_eig,
+)
+from pyro.contrib.oed.glmm import known_covariance_linear_model
 from pyro.contrib.oed.glmm.guides import LinearModelLaplaceGuide
+from pyro.contrib.oed.util import linear_model_ground_truth
+from pyro.contrib.util import rmv, rvv
+from pyro.infer import Trace_ELBO
 from tests.common import assert_equal
 
 

--- a/tests/contrib/randomvariable/test_random_variable.py
+++ b/tests/contrib/randomvariable/test_random_variable.py
@@ -4,6 +4,7 @@
 import math
 
 import torch.tensor as tt
+
 from pyro.distributions import Uniform
 
 N_SAMPLES = 100

--- a/tests/contrib/test_util.py
+++ b/tests/contrib/test_util.py
@@ -2,11 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
+
 import pytest
 import torch
 
 from pyro.contrib.util import (
-    get_indices, tensor_to_dict, rmv, rvv, lexpand, rexpand, rdiag, rtril
+    get_indices,
+    lexpand,
+    rdiag,
+    rexpand,
+    rmv,
+    rtril,
+    rvv,
+    tensor_to_dict,
 )
 from tests.common import assert_equal
 

--- a/tests/contrib/timeseries/test_gp.py
+++ b/tests/contrib/timeseries/test_gp.py
@@ -2,14 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+
+import pytest
 import torch
 
-from tests.common import assert_equal
 import pyro
-from pyro.contrib.timeseries import (IndependentMaternGP, LinearlyCoupledMaternGP, GenericLGSSM,
-                                     GenericLGSSMWithGPNoiseModel, DependentMaternGP)
+from pyro.contrib.timeseries import (
+    DependentMaternGP,
+    GenericLGSSM,
+    GenericLGSSMWithGPNoiseModel,
+    IndependentMaternGP,
+    LinearlyCoupledMaternGP,
+)
 from pyro.ops.tensor_utils import block_diag_embed
-import pytest
+from tests.common import assert_equal
 
 
 @pytest.mark.parametrize('model,obs_dim,nu_statedim', [('ssmgp', 3, 1.5), ('ssmgp', 2, 2.5),

--- a/tests/contrib/timeseries/test_lgssm.py
+++ b/tests/contrib/timeseries/test_lgssm.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 
-from tests.common import assert_equal
 from pyro.contrib.timeseries import GenericLGSSM, GenericLGSSMWithGPNoiseModel
-import pytest
+from tests.common import assert_equal
 
 
 @pytest.mark.parametrize('model_class', ['lgssm', 'lgssmgp'])

--- a/tests/contrib/tracking/test_assignment.py
+++ b/tests/contrib/tracking/test_assignment.py
@@ -1,15 +1,19 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 import pytest
 import torch
 from torch.autograd import grad
 
-import logging
-
 import pyro
 import pyro.distributions as dist
-from pyro.contrib.tracking.assignment import MarginalAssignment, MarginalAssignmentPersistent, MarginalAssignmentSparse
+from pyro.contrib.tracking.assignment import (
+    MarginalAssignment,
+    MarginalAssignmentPersistent,
+    MarginalAssignmentSparse,
+)
 from tests.common import assert_equal
 
 INF = float('inf')

--- a/tests/contrib/tracking/test_distributions.py
+++ b/tests/contrib/tracking/test_distributions.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 
 from pyro.contrib.tracking.distributions import EKFDistribution
 from pyro.contrib.tracking.dynamic_models import NcpContinuous, NcvContinuous
-
-import pytest
 
 
 @pytest.mark.parametrize('Model', [NcpContinuous, NcvContinuous])

--- a/tests/contrib/tracking/test_dynamic_models.py
+++ b/tests/contrib/tracking/test_dynamic_models.py
@@ -3,8 +3,12 @@
 
 import torch
 
-from pyro.contrib.tracking.dynamic_models import (NcpContinuous, NcvContinuous,
-                                                  NcvDiscrete, NcpDiscrete)
+from pyro.contrib.tracking.dynamic_models import (
+    NcpContinuous,
+    NcpDiscrete,
+    NcvContinuous,
+    NcvDiscrete,
+)
 from tests.common import assert_equal, assert_not_equal
 
 

--- a/tests/contrib/tracking/test_ekf.py
+++ b/tests/contrib/tracking/test_ekf.py
@@ -3,10 +3,9 @@
 
 import torch
 
-from pyro.contrib.tracking.extended_kalman_filter import EKFState
 from pyro.contrib.tracking.dynamic_models import NcpContinuous, NcvContinuous
+from pyro.contrib.tracking.extended_kalman_filter import EKFState
 from pyro.contrib.tracking.measurements import PositionMeasurement
-
 from tests.common import assert_equal, assert_not_equal
 
 

--- a/tests/contrib/tracking/test_em.py
+++ b/tests/contrib/tracking/test_em.py
@@ -16,7 +16,6 @@ from pyro.infer import SVI, TraceEnum_ELBO
 from pyro.optim import Adam
 from pyro.optim.multi import MixedMultiOptimizer, Newton
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/contrib/tracking/test_measurements.py
+++ b/tests/contrib/tracking/test_measurements.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+
 from pyro.contrib.tracking.measurements import PositionMeasurement
 
 

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -10,7 +10,11 @@ import scipy.stats as sp
 import pyro.distributions as dist
 from pyro.distributions.testing.naive_dirichlet import NaiveBeta, NaiveDirichlet
 from pyro.distributions.testing.rejection_exponential import RejectionExponential
-from pyro.distributions.testing.rejection_gamma import ShapeAugmentedBeta, ShapeAugmentedDirichlet, ShapeAugmentedGamma
+from pyro.distributions.testing.rejection_gamma import (
+    ShapeAugmentedBeta,
+    ShapeAugmentedDirichlet,
+    ShapeAugmentedGamma,
+)
 from tests.distributions.dist_fixture import Fixture
 
 

--- a/tests/distributions/test_binomial.py
+++ b/tests/distributions/test_binomial.py
@@ -5,7 +5,10 @@ import pytest
 import torch
 
 import pyro.distributions as dist
-from pyro.contrib.epidemiology.distributions import set_approx_log_prob_tol, set_approx_sample_thresh
+from pyro.contrib.epidemiology.distributions import (
+    set_approx_log_prob_tol,
+    set_approx_sample_thresh,
+)
 from tests.common import assert_close
 
 

--- a/tests/distributions/test_coalescent.py
+++ b/tests/distributions/test_coalescent.py
@@ -9,8 +9,12 @@ import torch
 
 import pyro
 from pyro.distributions import CoalescentTimes, CoalescentTimesWithRate
-from pyro.distributions.coalescent import (CoalescentRateLikelihood, CoalescentTimesConstraint,
-                                           _sample_coalescent_times, bio_phylo_to_times)
+from pyro.distributions.coalescent import (
+    CoalescentRateLikelihood,
+    CoalescentTimesConstraint,
+    _sample_coalescent_times,
+    bio_phylo_to_times,
+)
 from pyro.distributions.util import broadcast_shape
 from tests.common import assert_close
 

--- a/tests/distributions/test_cuda.py
+++ b/tests/distributions/test_cuda.py
@@ -5,7 +5,12 @@ import pytest
 import torch
 from torch.autograd import grad
 
-from tests.common import assert_equal, requires_cuda, tensors_default_to, xfail_if_not_implemented
+from tests.common import (
+    assert_equal,
+    requires_cuda,
+    tensors_default_to,
+    xfail_if_not_implemented,
+)
 
 
 @requires_cuda

--- a/tests/distributions/test_empirical.py
+++ b/tests/distributions/test_empirical.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from pyro.distributions.empirical import Empirical
-from tests.common import assert_equal, assert_close
+from tests.common import assert_close, assert_equal
 
 
 @pytest.mark.parametrize("size", [[], [1], [2, 3]])

--- a/tests/distributions/test_gaussian_mixtures.py
+++ b/tests/distributions/test_gaussian_mixtures.py
@@ -4,13 +4,15 @@
 import logging
 import math
 
+import pytest
 import torch
 
-import pytest
-from pyro.distributions import MixtureOfDiagNormalsSharedCovariance, GaussianScaleMixture
-from pyro.distributions import MixtureOfDiagNormals
+from pyro.distributions import (
+    GaussianScaleMixture,
+    MixtureOfDiagNormals,
+    MixtureOfDiagNormalsSharedCovariance,
+)
 from tests.common import assert_equal
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/distributions/test_haar.py
+++ b/tests/distributions/test_haar.py
@@ -1,9 +1,9 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 
-import pytest
 from pyro.distributions.transforms import HaarTransform
 from tests.common import assert_equal
 

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -11,16 +11,31 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.distributions.hmm import (_sequential_gamma_gaussian_tensordot, _sequential_gaussian_filter_sample,
-                                    _sequential_gaussian_tensordot, _sequential_logmatmulexp)
+from pyro.distributions.hmm import (
+    _sequential_gamma_gaussian_tensordot,
+    _sequential_gaussian_filter_sample,
+    _sequential_gaussian_tensordot,
+    _sequential_logmatmulexp,
+)
 from pyro.distributions.util import broadcast_shape
 from pyro.infer import TraceEnum_ELBO, config_enumerate
-from pyro.ops.gamma_gaussian import (gamma_and_mvn_to_gamma_gaussian, gamma_gaussian_tensordot,
-                                     matrix_and_mvn_to_gamma_gaussian)
-from pyro.ops.gaussian import gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
+from pyro.ops.gamma_gaussian import (
+    gamma_and_mvn_to_gamma_gaussian,
+    gamma_gaussian_tensordot,
+    matrix_and_mvn_to_gamma_gaussian,
+)
+from pyro.ops.gaussian import (
+    gaussian_tensordot,
+    matrix_and_mvn_to_gaussian,
+    mvn_to_gaussian,
+)
 from pyro.ops.indexing import Vindex
 from tests.common import assert_close
-from tests.ops.gamma_gaussian import assert_close_gamma_gaussian, random_gamma, random_gamma_gaussian
+from tests.ops.gamma_gaussian import (
+    assert_close_gamma_gaussian,
+    random_gamma,
+    random_gamma_gaussian,
+)
 from tests.ops.gaussian import assert_close_gaussian, random_gaussian, random_mvn
 
 logger = logging.getLogger(__name__)

--- a/tests/distributions/test_ig.py
+++ b/tests/distributions/test_ig.py
@@ -3,9 +3,9 @@
 
 import math
 
+import pytest
 import torch
 
-import pytest
 from pyro.distributions import Gamma, InverseGamma
 from tests.common import assert_equal
 

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -5,7 +5,13 @@ import math
 
 import pytest
 import torch
-from torch.distributions import AffineTransform, Beta, TransformedDistribution, biject_to, transform_to
+from torch.distributions import (
+    AffineTransform,
+    Beta,
+    TransformedDistribution,
+    biject_to,
+    transform_to,
+)
 
 from pyro.distributions import constraints, transforms
 from pyro.distributions.lkj import LKJCorrCholesky

--- a/tests/distributions/test_mask.py
+++ b/tests/distributions/test_mask.py
@@ -6,9 +6,8 @@ import torch
 from torch import tensor
 from torch.distributions import kl_divergence
 
-from pyro.distributions.util import broadcast_shape
 from pyro.distributions.torch import Bernoulli, Normal
-from pyro.distributions.util import scale_and_mask
+from pyro.distributions.util import broadcast_shape, scale_and_mask
 from tests.common import assert_equal
 
 

--- a/tests/distributions/test_mvt.py
+++ b/tests/distributions/test_mvt.py
@@ -4,7 +4,6 @@
 import math
 
 import pytest
-
 import torch
 from torch.distributions import Gamma, MultivariateNormal, StudentT
 

--- a/tests/distributions/test_omt_mvn.py
+++ b/tests/distributions/test_omt_mvn.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import pytest
 import torch
 
-import pytest
-from pyro.distributions import AVFMultivariateNormal, MultivariateNormal, OMTMultivariateNormal
+from pyro.distributions import (
+    AVFMultivariateNormal,
+    MultivariateNormal,
+    OMTMultivariateNormal,
+)
 from tests.common import assert_equal
 
 

--- a/tests/distributions/test_ordered_logistic.py
+++ b/tests/distributions/test_ordered_logistic.py
@@ -6,9 +6,8 @@ import torch
 import torch.tensor as tt
 from torch.autograd.functional import jacobian
 
-from pyro.distributions import OrderedLogistic, Normal
+from pyro.distributions import Normal, OrderedLogistic
 from pyro.distributions.transforms import OrderedTransform
-
 
 # Tests for the OrderedLogistic distribution
 

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -3,9 +3,9 @@
 
 import inspect
 import io
+import pickle
 
 import pytest
-import pickle
 import torch
 
 import pyro.distributions as dist

--- a/tests/distributions/test_rejector.py
+++ b/tests/distributions/test_rejector.py
@@ -7,8 +7,12 @@ from torch.autograd import grad
 
 from pyro.distributions import Exponential, Gamma
 from pyro.distributions.testing.rejection_exponential import RejectionExponential
-from pyro.distributions.testing.rejection_gamma import (RejectionGamma, RejectionStandardGamma, ShapeAugmentedBeta,
-                                                        ShapeAugmentedGamma)
+from pyro.distributions.testing.rejection_gamma import (
+    RejectionGamma,
+    RejectionStandardGamma,
+    ShapeAugmentedBeta,
+    ShapeAugmentedGamma,
+)
 from tests.common import assert_equal
 
 SIZES = list(map(torch.Size, [[], [1], [2], [3], [1, 1], [1, 2], [2, 3, 4]]))

--- a/tests/distributions/test_relaxed_straight_through.py
+++ b/tests/distributions/test_relaxed_straight_through.py
@@ -8,8 +8,13 @@ from torch.distributions import constraints
 
 import pyro
 import pyro.optim as optim
-from pyro.distributions import (OneHotCategorical, RelaxedBernoulli, RelaxedBernoulliStraightThrough,
-                                RelaxedOneHotCategorical, RelaxedOneHotCategoricalStraightThrough)
+from pyro.distributions import (
+    OneHotCategorical,
+    RelaxedBernoulli,
+    RelaxedBernoulliStraightThrough,
+    RelaxedOneHotCategorical,
+    RelaxedOneHotCategoricalStraightThrough,
+)
 from pyro.infer import SVI, Trace_ELBO
 from tests.common import assert_equal
 

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -5,11 +5,17 @@ import logging
 import os
 from collections import Counter
 
-import pyro
 import pytest
 import torch
-from pyro.distributions.spanning_tree import (NUM_SPANNING_TREES, SpanningTree, find_best_tree, make_complete_graph,
-                                              sample_tree)
+
+import pyro
+from pyro.distributions.spanning_tree import (
+    NUM_SPANNING_TREES,
+    SpanningTree,
+    find_best_tree,
+    make_complete_graph,
+    sample_tree,
+)
 from tests.common import assert_equal, xfail_if_not_implemented
 
 pytestmark = pytest.mark.skipif("CUDA_TEST" in os.environ, reason="spanning_tree unsupported on CUDA.")

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -8,7 +8,13 @@ import pytest
 import torch
 
 import pyro.distributions as dist
-from pyro.distributions.util import broadcast_shape, detach, sum_leftmost, sum_rightmost, weakmethod
+from pyro.distributions.util import (
+    broadcast_shape,
+    detach,
+    sum_leftmost,
+    sum_rightmost,
+    weakmethod,
+)
 from tests.common import assert_equal
 
 INF = float('inf')

--- a/tests/distributions/test_zero_inflated.py
+++ b/tests/distributions/test_zero_inflated.py
@@ -6,8 +6,15 @@ import math
 import pytest
 import torch
 
-from pyro.distributions import (Delta, NegativeBinomial, Normal, Poisson, ZeroInflatedDistribution,
-                                ZeroInflatedNegativeBinomial, ZeroInflatedPoisson)
+from pyro.distributions import (
+    Delta,
+    NegativeBinomial,
+    Normal,
+    Poisson,
+    ZeroInflatedDistribution,
+    ZeroInflatedNegativeBinomial,
+    ZeroInflatedPoisson,
+)
 from pyro.distributions.util import broadcast_shape
 from tests.common import assert_close
 

--- a/tests/doctest_fixtures.py
+++ b/tests/doctest_fixtures.py
@@ -6,15 +6,14 @@ import pytest
 import torch
 
 import pyro
-import pyro.contrib.gp as gp
 import pyro.contrib.autoname.named as named
+import pyro.contrib.gp as gp
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer import EmpiricalMarginal
-from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc import HMC, NUTS
+from pyro.infer.mcmc.api import MCMC
 from pyro.params import param_with_module_name
-
 
 # Fix seed for all doctest runs.
 pyro.set_rng_seed(0)

--- a/tests/infer/mcmc/test_hmc.py
+++ b/tests/infer/mcmc/test_hmc.py
@@ -11,9 +11,9 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro.infer.mcmc import NUTS
-from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.api import MCMC
-from tests.common import assert_equal, assert_close
+from pyro.infer.mcmc.hmc import HMC
+from tests.common import assert_close, assert_equal
 
 logger = logging.getLogger(__name__)
 

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -11,7 +11,7 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.infer.mcmc import HMC, NUTS
-from pyro.infer.mcmc.api import MCMC, _UnarySampler, _MultiSampler
+from pyro.infer.mcmc.api import MCMC, _MultiSampler, _UnarySampler
 from pyro.infer.mcmc.mcmc_kernel import MCMCKernel
 from pyro.infer.mcmc.util import initialize_model
 from pyro.util import optional

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -9,8 +9,15 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro.infer import Predictive
-from pyro.infer.autoguide import (init_to_feasible, init_to_generated, init_to_mean, init_to_median, init_to_sample,
-                                  init_to_uniform, init_to_value)
+from pyro.infer.autoguide import (
+    init_to_feasible,
+    init_to_generated,
+    init_to_mean,
+    init_to_median,
+    init_to_sample,
+    init_to_uniform,
+    init_to_value,
+)
 from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.util import initialize_model

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -10,12 +10,17 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.infer.autoguide import AutoDelta
-from pyro.contrib.conjugate.infer import BetaBinomialPair, collapse_conjugate, GammaPoissonPair, posterior_replay
-from pyro.infer import TraceEnum_ELBO, SVI
-from pyro.infer.mcmc import ArrowheadMassMatrix, MCMC, NUTS
 import pyro.optim as optim
 import pyro.poutine as poutine
+from pyro.contrib.conjugate.infer import (
+    BetaBinomialPair,
+    GammaPoissonPair,
+    collapse_conjugate,
+    posterior_replay,
+)
+from pyro.infer import SVI, TraceEnum_ELBO
+from pyro.infer.autoguide import AutoDelta
+from pyro.infer.mcmc import MCMC, NUTS, ArrowheadMassMatrix
 from pyro.util import ignore_jit_warnings
 from tests.common import assert_close, assert_equal
 

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -13,7 +13,11 @@ import pyro.poutine as poutine
 from pyro.infer import config_enumerate
 from pyro.infer.mcmc import HMC, NUTS
 from pyro.infer.mcmc.api import MCMC
-from pyro.infer.mcmc.util import TraceEinsumEvaluator, TraceTreeEvaluator, initialize_model
+from pyro.infer.mcmc.util import (
+    TraceEinsumEvaluator,
+    TraceTreeEvaluator,
+    initialize_model,
+)
 from pyro.infer.reparam import LatentStableReparam
 from pyro.poutine.subsample_messenger import _Subsample
 from tests.common import assert_close, assert_equal, xfail_param

--- a/tests/infer/reparam/test_hmm.py
+++ b/tests/infer/reparam/test_hmm.py
@@ -7,7 +7,12 @@ import torch
 import pyro
 import pyro.distributions as dist
 from pyro import poutine
-from pyro.infer.reparam import LinearHMMReparam, StableReparam, StudentTReparam, SymmetricStableReparam
+from pyro.infer.reparam import (
+    LinearHMMReparam,
+    StableReparam,
+    StudentTReparam,
+    SymmetricStableReparam,
+)
 from tests.common import assert_close
 from tests.ops.gaussian import random_mvn
 

--- a/tests/infer/reparam/test_stable.py
+++ b/tests/infer/reparam/test_stable.py
@@ -12,7 +12,11 @@ from pyro import poutine
 from pyro.distributions.torch_distribution import MaskedDistribution
 from pyro.infer import Trace_ELBO
 from pyro.infer.autoguide import AutoNormal
-from pyro.infer.reparam import LatentStableReparam, StableReparam, SymmetricStableReparam
+from pyro.infer.reparam import (
+    LatentStableReparam,
+    StableReparam,
+    SymmetricStableReparam,
+)
 from tests.common import assert_close
 
 

--- a/tests/infer/test_abstract_infer.py
+++ b/tests/infer/test_abstract_infer.py
@@ -8,11 +8,10 @@ import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
 import pyro.poutine as poutine
-from pyro.infer.autoguide import AutoLaplaceApproximation
 from pyro.infer import SVI, Trace_ELBO
+from pyro.infer.autoguide import AutoLaplaceApproximation
 from pyro.infer.mcmc import MCMC, NUTS
 from tests.common import assert_equal
-
 
 pytestmark = pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -16,10 +16,23 @@ import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.infer import SVI, Predictive, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO
-from pyro.infer.autoguide import (AutoCallable, AutoDelta, AutoDiagonalNormal, AutoDiscreteParallel, AutoGuide,
-                                  AutoGuideList, AutoIAFNormal, AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
-                                  AutoMultivariateNormal, AutoNormal, init_to_feasible, init_to_mean, init_to_median,
-                                  init_to_sample)
+from pyro.infer.autoguide import (
+    AutoCallable,
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoDiscreteParallel,
+    AutoGuide,
+    AutoGuideList,
+    AutoIAFNormal,
+    AutoLaplaceApproximation,
+    AutoLowRankMultivariateNormal,
+    AutoMultivariateNormal,
+    AutoNormal,
+    init_to_feasible,
+    init_to_mean,
+    init_to_median,
+    init_to_sample,
+)
 from pyro.infer.reparam import ProjectedNormalReparam
 from pyro.nn.module import PyroModule, PyroParam, PyroSample
 from pyro.optim import Adam

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -13,8 +13,18 @@ import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions.testing import fakes
-from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, JitTraceMeanField_ELBO, Trace_ELBO,
-                        TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO, config_enumerate)
+from pyro.infer import (
+    SVI,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+    TraceMeanField_ELBO,
+    config_enumerate,
+)
 from pyro.optim import Adam
 from tests.common import assert_equal, xfail_if_not_implemented, xfail_param
 

--- a/tests/infer/test_inference.py
+++ b/tests/infer/test_inference.py
@@ -16,13 +16,30 @@ import pyro.optim as optim
 from pyro import poutine
 from pyro.distributions.testing import fakes
 from pyro.distributions.testing.rejection_gamma import ShapeAugmentedGamma
-from pyro.infer import (SVI, EnergyDistance, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, RenyiELBO,
-                        ReweightedWakeSleep, Trace_ELBO, Trace_MMD, TraceEnum_ELBO, TraceGraph_ELBO,
-                        TraceMeanField_ELBO, TraceTailAdaptive_ELBO)
+from pyro.infer import (
+    SVI,
+    EnergyDistance,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    RenyiELBO,
+    ReweightedWakeSleep,
+    Trace_ELBO,
+    Trace_MMD,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+    TraceMeanField_ELBO,
+    TraceTailAdaptive_ELBO,
+)
 from pyro.infer.autoguide import AutoDelta
 from pyro.infer.reparam import LatentStableReparam
 from pyro.infer.util import torch_item
-from tests.common import assert_close, assert_equal, xfail_if_not_implemented, xfail_param
+from tests.common import (
+    assert_close,
+    assert_equal,
+    xfail_if_not_implemented,
+    xfail_param,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/infer/test_initialization.py
+++ b/tests/infer/test_initialization.py
@@ -5,7 +5,11 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.infer.autoguide.initialization import InitMessenger, init_to_generated, init_to_value
+from pyro.infer.autoguide.initialization import (
+    InitMessenger,
+    init_to_generated,
+    init_to_value,
+)
 
 
 def test_init_to_generated():

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -14,8 +14,18 @@ import pyro.distributions as dist
 import pyro.ops.jit
 import pyro.poutine as poutine
 from pyro.distributions.util import scale_and_mask
-from pyro.infer import (SVI, JitTrace_ELBO, JitTraceEnum_ELBO, JitTraceGraph_ELBO, JitTraceMeanField_ELBO, Trace_ELBO,
-                        TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO, infer_discrete)
+from pyro.infer import (
+    SVI,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+    TraceMeanField_ELBO,
+    infer_discrete,
+)
 from pyro.optim import Adam
 from pyro.poutine.indep_messenger import CondIndepStackFrame
 from pyro.util import ignore_jit_warnings

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -8,8 +8,8 @@ import pyro
 import pyro.distributions as dist
 import pyro.optim as optim
 import pyro.poutine as poutine
+from pyro.infer import SVI, Predictive, Trace_ELBO
 from pyro.infer.autoguide import AutoDelta, AutoDiagonalNormal
-from pyro.infer import Predictive, SVI, Trace_ELBO
 from tests.common import assert_close
 
 

--- a/tests/infer/test_svgd.py
+++ b/tests/infer/test_svgd.py
@@ -6,11 +6,9 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-
-from pyro.infer import SVGD, RBFSteinKernel, IMQSteinKernel
-from pyro.optim import Adam
+from pyro.infer import SVGD, IMQSteinKernel, RBFSteinKernel
 from pyro.infer.autoguide.utils import _product
-
+from pyro.optim import Adam
 from tests.common import assert_equal
 
 

--- a/tests/infer/test_tmc.py
+++ b/tests/infer/test_tmc.py
@@ -15,10 +15,9 @@ import pyro.poutine as poutine
 from pyro.distributions.testing import fakes
 from pyro.infer import config_enumerate
 from pyro.infer.importance import vectorized_importance_weights
-from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.traceenum_elbo import TraceEnum_ELBO
+from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from tests.common import assert_equal
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -3,12 +3,12 @@
 
 import math
 
+import pytest
 import torch
 
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-import pytest
 from pyro.infer.importance import psis_diagnostic
 from pyro.infer.util import MultiFrameTensor
 from tests.common import assert_equal

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -13,8 +13,16 @@ import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions.testing import fakes
-from pyro.infer import (SVI, EnergyDistance, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO, TraceMeanField_ELBO,
-                        TraceTailAdaptive_ELBO, config_enumerate)
+from pyro.infer import (
+    SVI,
+    EnergyDistance,
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+    TraceMeanField_ELBO,
+    TraceTailAdaptive_ELBO,
+    config_enumerate,
+)
 from pyro.infer.reparam import LatentStableReparam
 from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.util import torch_item

--- a/tests/ops/test_arrowhead.py
+++ b/tests/ops/test_arrowhead.py
@@ -4,8 +4,13 @@
 import pytest
 import torch
 
-from pyro.ops.arrowhead import SymmArrowhead, sqrt, triu_gram, triu_inverse, triu_matvecmul
-
+from pyro.ops.arrowhead import (
+    SymmArrowhead,
+    sqrt,
+    triu_gram,
+    triu_inverse,
+    triu_matvecmul,
+)
 from tests.common import assert_close
 
 

--- a/tests/ops/test_contract.py
+++ b/tests/ops/test_contract.py
@@ -11,7 +11,14 @@ import torch
 
 import pyro.ops.jit
 from pyro.distributions.util import logsumexp
-from pyro.ops.contract import _partition_terms, contract_tensor_tree, contract_to_tensor, einsum, naive_ubersum, ubersum
+from pyro.ops.contract import (
+    _partition_terms,
+    contract_tensor_tree,
+    contract_to_tensor,
+    einsum,
+    naive_ubersum,
+    ubersum,
+)
 from pyro.ops.einsum.adjoint import require_backward
 from pyro.ops.rings import LogRing
 from pyro.poutine.indep_messenger import CondIndepStackFrame

--- a/tests/ops/test_gamma_gaussian.py
+++ b/tests/ops/test_gamma_gaussian.py
@@ -11,12 +11,16 @@ import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.gamma_gaussian import (
     GammaGaussian,
+    gamma_and_mvn_to_gamma_gaussian,
     gamma_gaussian_tensordot,
     matrix_and_mvn_to_gamma_gaussian,
-    gamma_and_mvn_to_gamma_gaussian,
 )
 from tests.common import assert_close
-from tests.ops.gamma_gaussian import assert_close_gamma_gaussian, random_gamma, random_gamma_gaussian
+from tests.ops.gamma_gaussian import (
+    assert_close_gamma_gaussian,
+    random_gamma,
+    random_gamma_gaussian,
+)
 from tests.ops.gaussian import random_mvn
 
 

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -9,7 +9,13 @@ from torch.nn.functional import pad
 
 import pyro.distributions as dist
 from pyro.distributions.util import broadcast_shape
-from pyro.ops.gaussian import AffineNormal, Gaussian, gaussian_tensordot, matrix_and_mvn_to_gaussian, mvn_to_gaussian
+from pyro.ops.gaussian import (
+    AffineNormal,
+    Gaussian,
+    gaussian_tensordot,
+    matrix_and_mvn_to_gaussian,
+    mvn_to_gaussian,
+)
 from tests.common import assert_close
 from tests.ops.gaussian import assert_close_gaussian, random_gaussian, random_mvn
 

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -11,7 +11,6 @@ from torch.autograd import grad
 from pyro.ops.newton import newton_step
 from tests.common import assert_equal
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -6,9 +6,21 @@ import warnings
 import pytest
 import torch
 
-from pyro.ops.stats import (_cummin, autocorrelation, autocovariance, crps_empirical, effective_sample_size,
-                            fit_generalized_pareto, gelman_rubin, hpdi, pi, quantile, resample, split_gelman_rubin,
-                            waic)
+from pyro.ops.stats import (
+    _cummin,
+    autocorrelation,
+    autocovariance,
+    crps_empirical,
+    effective_sample_size,
+    fit_generalized_pareto,
+    gelman_rubin,
+    hpdi,
+    pi,
+    quantile,
+    resample,
+    split_gelman_rubin,
+    waic,
+)
 from tests.common import assert_close, assert_equal, xfail_if_not_implemented
 
 

--- a/tests/ops/test_tensor_utils.py
+++ b/tests/ops/test_tensor_utils.py
@@ -9,9 +9,19 @@ import scipy.fftpack as fftpack
 import torch
 
 import pyro
-from pyro.ops.tensor_utils import (block_diag_embed, block_diagonal, convolve, dct, idct, next_fast_len,
-                                   periodic_cumsum, periodic_features, periodic_repeat, precision_to_scale_tril,
-                                   repeated_matmul)
+from pyro.ops.tensor_utils import (
+    block_diag_embed,
+    block_diagonal,
+    convolve,
+    dct,
+    idct,
+    next_fast_len,
+    periodic_cumsum,
+    periodic_features,
+    periodic_repeat,
+    precision_to_scale_tril,
+    repeated_matmul,
+)
 from tests.common import assert_close, assert_equal
 
 pytestmark = pytest.mark.stage('unit')

--- a/tests/optim/test_multi.py
+++ b/tests/optim/test_multi.py
@@ -9,7 +9,12 @@ import pyro
 import pyro.distributions as dist
 import pyro.optim
 import pyro.poutine as poutine
-from pyro.optim.multi import MixedMultiOptimizer, Newton, PyroMultiOptimizer, TorchMultiOptimizer
+from pyro.optim.multi import (
+    MixedMultiOptimizer,
+    Newton,
+    PyroMultiOptimizer,
+    TorchMultiOptimizer,
+)
 from tests.common import assert_equal
 
 FACTORIES = [

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -16,8 +16,8 @@ import pyro.distributions as dist
 import pyro.optim as optim
 from pyro.distributions.testing import fakes
 from pyro.infer import SVI, Trace_ELBO, TraceGraph_ELBO
-from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.api import MCMC
+from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.nuts import NUTS
 
 Model = namedtuple('TestModel', ['model', 'model_args', 'model_id'])

--- a/tests/poutine/test_nesting.py
+++ b/tests/poutine/test_nesting.py
@@ -4,10 +4,9 @@
 import logging
 
 import pyro
-import pyro.poutine as poutine
 import pyro.distributions as dist
+import pyro.poutine as poutine
 import pyro.poutine.runtime
-
 
 logger = logging.getLogger(__name__)
 

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -6,12 +6,12 @@ import io
 import logging
 import pickle
 import warnings
+from queue import Queue
 from unittest import TestCase
 
 import pytest
 import torch
 import torch.nn as nn
-from queue import Queue
 
 import pyro
 import pyro.distributions as dist
@@ -19,7 +19,7 @@ import pyro.poutine as poutine
 from pyro.distributions import Bernoulli, Categorical, Normal
 from pyro.poutine.runtime import _DIM_ALLOCATOR, NonlocalExit
 from pyro.poutine.util import all_escape, discrete_escape
-from tests.common import assert_equal, assert_not_equal, assert_close
+from tests.common import assert_close, assert_equal, assert_not_equal
 
 logger = logging.getLogger(__name__)
 

--- a/tests/poutine/test_trace_struct.py
+++ b/tests/poutine/test_trace_struct.py
@@ -8,7 +8,6 @@ import pytest
 from pyro.poutine import Trace
 from tests.common import assert_equal
 
-
 EDGE_SETS = [
     #   1
     #  / \

--- a/tests/pyroapi/test_pyroapi.py
+++ b/tests/pyroapi/test_pyroapi.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 from pyroapi import pyro_backend
 from pyroapi.tests import *  # noqa F401
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,13 @@ from subprocess import check_call
 import pytest
 import torch
 
-from tests.common import EXAMPLES_DIR, requires_cuda, requires_funsor, requires_horovod, xfail_param
+from tests.common import (
+    EXAMPLES_DIR,
+    requires_cuda,
+    requires_funsor,
+    requires_horovod,
+    xfail_param,
+)
 
 logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.stage('test_examples')

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
-from pyro.generic import handlers, infer, pyro, pyro_backend, ops
 from pyroapi.testing import MODELS
+
+from pyro.generic import handlers, infer, ops, pyro, pyro_backend
 from tests.common import xfail_if_not_implemented
 
 pytestmark = pytest.mark.stage('unit')

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
+
 import pyro
 import pyro.distributions as dist
-import torch
 
 pytestmark = pytest.mark.stage('unit')
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
-import pytest
 
+import pytest
 import torch
+
 from pyro import util
 
 pytestmark = pytest.mark.stage('unit')

--- a/tutorial/source/conf.py
+++ b/tutorial/source/conf.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sphinx_rtd_theme
+
 from pyro import __version__
 
 # -*- coding: utf-8 -*-

--- a/tutorial/source/search_inference.py
+++ b/tutorial/source/search_inference.py
@@ -7,18 +7,17 @@ Inference algorithms and utilities used in the RSA example models.
 Adapted from: http://dippl.org/chapters/03-enumeration.html
 """
 
+import collections
+import functools
+import queue
+
 import torch
 
 import pyro.distributions as dist
 import pyro.poutine as poutine
-
 from pyro.distributions.util import logsumexp
 from pyro.infer.abstract_infer import TracePosterior
 from pyro.poutine.runtime import NonlocalExit
-
-import queue
-import collections
-import functools
 
 
 def memoize(fn=None, **kwargs):


### PR DESCRIPTION
Resolves #2601 

This is much easier now that isort 5.0 has been released: there is a new `isort: section` annotation.

After this PR it should be safe to run `make format`.  I've used `--profile black` in anticipation of #2602 

## Nontrivial changes
- `Makefile`: added `isort --check .` to lint target; updated `format` target
- `setup.cfg`: configure `isort` to use black profile
- `setup.py`: require `isort>=5.0`
- `.travis.yml`: require `isort>=5.0`