### PR TITLE
Fix parallel pytest test collection

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -4,6 +4,7 @@
 import contextlib
 import numbers
 import os
+import re
 import shutil
 import tempfile
 import warnings
@@ -31,6 +32,16 @@ EXAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), 'examples')
 def xfail_param(*args, **kwargs):
     kwargs.setdefault("reason", "unknown")
     return pytest.param(*args, marks=[pytest.mark.xfail(**kwargs)])
+
+
+def str_erase_pointers(x):
+    """
+    Print a string representation of ``x`` but remove pointers from function
+    names, since the pointers have different values on different pytest xdist
+    workers and break test collection. This is useful as the ``ids`` arg to
+    ``@pytest.mark.parametrize``.
+    """
+    return re.sub(" at 0x[a-f0-9]+", "", str(x))
 
 
 def skipif_param(*args, **kwargs):

--- a/tests/infer/mcmc/test_mcmc_util.py
+++ b/tests/infer/mcmc/test_mcmc_util.py
@@ -15,7 +15,7 @@ from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.util import initialize_model
 from pyro.util import optional
-from tests.common import assert_close
+from tests.common import assert_close, str_erase_pointers
 
 
 def beta_bernoulli():
@@ -116,7 +116,7 @@ def test_init_to_value():
     init_to_value(values={"x": torch.tensor(3.)}),
     init_to_generated(
         generate=lambda: init_to_value(values={"x": torch.rand(())})),
-], ids=str)
+], ids=str_erase_pointers)
 def test_init_strategy_smoke(init_strategy):
     def model():
         pyro.sample("x", dist.LogNormal(0, 1))


### PR DESCRIPTION
This fixes `make test` which is currently failing due to (I believe) a change in Pytest xdist test collection.

## Tested
- [x] successfully ran `make test` locally