### PR TITLE
Implement a funsor-based poutine.collapse

### DIFF
--- a/docs/source/pyro.poutine.txt
+++ b/docs/source/pyro.poutine.txt
@@ -22,6 +22,14 @@ __________________
     :undoc-members:
     :show-inheritance:
 
+CollapseMessenger
+_________________
+
+.. automodule:: pyro.poutine.collapse_messenger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ConditionMessenger
 ___________________
 

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -10,7 +10,7 @@ from pyro.distributions.conjugate import BetaBinomial, DirichletMultinomial, Gam
 from pyro.distributions.delta import Delta
 from pyro.distributions.diag_normal_mixture import MixtureOfDiagNormals
 from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNormalsSharedCovariance
-from pyro.distributions.distribution import Distribution
+from pyro.distributions.distribution import Distribution, interpretation
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.extended import ExtendedBetaBinomial, ExtendedBinomial
 from pyro.distributions.folded import FoldedDistribution
@@ -89,6 +89,7 @@ __all__ = [
     "ZeroInflatedDistribution",
     "constraints",
     "enable_validation",
+    "interpretation",
     "is_validation_enabled",
     "kl",
     "transforms",

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -10,7 +10,7 @@ from pyro.distributions.conjugate import BetaBinomial, DirichletMultinomial, Gam
 from pyro.distributions.delta import Delta
 from pyro.distributions.diag_normal_mixture import MixtureOfDiagNormals
 from pyro.distributions.diag_normal_mixture_shared_cov import MixtureOfDiagNormalsSharedCovariance
-from pyro.distributions.distribution import Distribution, interpretation
+from pyro.distributions.distribution import Distribution
 from pyro.distributions.empirical import Empirical
 from pyro.distributions.extended import ExtendedBetaBinomial, ExtendedBinomial
 from pyro.distributions.folded import FoldedDistribution
@@ -89,7 +89,6 @@ __all__ = [
     "ZeroInflatedDistribution",
     "constraints",
     "enable_validation",
-    "interpretation",
     "is_validation_enabled",
     "kl",
     "transforms",

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -7,15 +7,20 @@ from contextlib import contextmanager
 from pyro.distributions.score_parts import ScoreParts
 
 
-class DistributionMeta(ABCMeta):
-    _interpretation = None
+# TODO Remove import guard once funsor is a required dependency.
+try:
+    from funsor.distribution import CoerceToFunsor
+except ImportError:
+    DistributionMeta = ABCMeta
+else:
+    class DistributionMeta(ABCMeta):
+        _coerce_to_funsor = CoerceToFunsor("torch")
 
-    def __call__(cls, *args, **kwargs):
-        if _interpretation is not None:
-            result = _interpretation(cls, args, kwargs)
+        def __call__(cls, *args, **kwargs):
+            result = _coerce_to_funsor(cls, args, kwargs)
             if result is not None:
                 return result
-        return super().__call__(*args, **kwargs)
+            return super().__call__(*args, **kwargs)
 
 
 class Distribution(metaclass=DistributionMeta):

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -2,11 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
 
 from pyro.distributions.score_parts import ScoreParts
 
 
-class Distribution(object, metaclass=ABCMeta):
+class DistributionMeta(ABCMeta):
+    _interpretation = None
+
+    def __call__(cls, *args, **kwargs):
+        if _interpretation is not None:
+            result = _interpretation(cls, args, kwargs)
+            if result is not None:
+                return result
+        return super().__call__(*args, **kwargs)
+
+
+class Distribution(metaclass=DistributionMeta):
     """
     Base class for parameterized probability distributions.
 

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -8,11 +8,11 @@ from pyro.distributions.score_parts import ScoreParts
 
 # TODO Remove import guard once funsor is a required dependency.
 try:
-    from funsor.distribution import CoerceToFunsor
+    from funsor.distribution import CoerceDistributionToFunsor
 except ImportError:
     DistributionMeta = ABCMeta
 else:
-    _coerce_to_funsor = CoerceToFunsor("torch")
+    _coerce_to_funsor = CoerceDistributionToFunsor("torch")
 
     class DistributionMeta(ABCMeta):
         def __call__(cls, *args, **kwargs):

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABCMeta, abstractmethod
-from contextlib import contextmanager
 
 from pyro.distributions.score_parts import ScoreParts
 
@@ -13,9 +12,9 @@ try:
 except ImportError:
     DistributionMeta = ABCMeta
 else:
-    class DistributionMeta(ABCMeta):
-        _coerce_to_funsor = CoerceToFunsor("torch")
+    _coerce_to_funsor = CoerceToFunsor("torch")
 
+    class DistributionMeta(ABCMeta):
         def __call__(cls, *args, **kwargs):
             result = _coerce_to_funsor(cls, args, kwargs)
             if result is not None:

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -10,7 +10,7 @@ import torch
 
 import pyro.poutine as poutine
 from pyro.distributions import Categorical, Empirical
-from pyro.infer.util import site_is_subsample
+from pyro.poutine.util import site_is_subsample
 from pyro.ops.stats import waic
 
 

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from .handlers import (block, broadcast, condition, do, enum, escape, infer_config, lift, markov, mask, queue, reparam,
-                       replay, scale, seed, trace, uncondition)
+from .handlers import (block, broadcast, collapse, condition, do, enum, escape, infer_config, lift, markov, mask, queue,
+                       reparam, replay, scale, seed, trace, uncondition)
 from .runtime import NonlocalExit
 from .trace_struct import Trace
 from .util import enable_validation, is_validation_enabled
@@ -10,6 +10,7 @@ from .util import enable_validation, is_validation_enabled
 __all__ = [
     "block",
     "broadcast",
+    "collapse",
     "condition",
     "do",
     "enable_validation",

--- a/pyro/poutine/collapse_messenger.py
+++ b/pyro/poutine/collapse_messenger.py
@@ -16,6 +16,12 @@ except ImportError:
 
 
 class CollapseMessenger(TraceMessenger):
+    """
+    EXPERIMENTAL Collapses all sites in the context by lazily sampling and
+    attempting to use conjugacy relations. If no conjugacy is known this will
+    fail. Code using the results of sample sites must be written to accept
+    Funsors rather than Tensors. This requires ``funsor`` to be installed.
+    """
     def __init__(self, *args, **kwargs):
         import funsor
         funsor.set_backend("torch")

--- a/pyro/poutine/collapse_messenger.py
+++ b/pyro/poutine/collapse_messenger.py
@@ -1,0 +1,61 @@
+import pyro.distributions as dist
+
+from .runtime import _PYRO_STACK
+
+# TODO Remove import guard once funsor is a required dependency.
+try:
+    import funsor
+    from funsor.terms import Funsor
+    from funsor.distribution import CoerceToFunsor
+except ImportError:
+    _interpreter = None
+else:
+    _interpreter = CoerceToFunsor("torch")
+
+
+class CollapseMessenger(TraceMessenger):
+
+    def _process_message(self, msg):
+        super()._process_message(msg)
+        if msg["type"] == "sample":
+            if isinstance(msg["fn"], Funsor) or isinstance(msg["value"], Funsor):
+                msg["stop"] = True
+
+    def _pyro_sample(self, msg):
+        if msg["value"] is not None:
+            msg["value"] = funsor.Variable(msg["name"], msg["fn"].value_domain)
+        msg["done"] = True
+
+    def __enter__(self):
+        self.preserved_plates = frozenset(h.name for h in _PYRO_STACK
+                                          if isinstance(h, pyro.plate))
+
+        meta = type(dist.Distribution)
+        self._old_interpretation = meta._interpretation
+        meta._interpretation = _interpreter
+        return super().__enter__()
+
+    def __exit__(self, *args):
+        meta = type(dist.Distribution)
+        meta._interpretation = self._old_interpretation
+        super().__exit__(*args)
+
+        # Convert delayed statements to pyro.factor()
+        log_prob_terms, reduced_vars = [], []
+        for name, site in self.trace.items():
+            if not site["is_observed"]:
+                reduced_vars.append(name)
+            log_prob = to_funsor(site["fn"])(value=site["value"])
+            plates |= frozenset(f.name for f in site["cond_indep_stack"]
+                                if f.vectorized)
+        if log_prob_terms:
+            reduced_plates = plates - self.preserved_plates
+            log_prob = funsor.sum_product.sum_product(
+                funsor.ops.logaddexp,
+                funsor.ops.add,
+                log_prob_terms,
+                eliminate=frozenset(reduced_vars) | reduced_plates,
+                plates=plates,
+            )
+            name = reduced_vars[0]
+            pyro.factor(name, log_prob)

--- a/pyro/poutine/collapse_messenger.py
+++ b/pyro/poutine/collapse_messenger.py
@@ -56,7 +56,12 @@ class CollapseMessenger(TraceMessenger):
         for name, site in self.trace.nodes.items():
             if not site["is_observed"]:
                 reduced_vars.append(name)
-            log_prob_terms.append(funsor.to_funsor(site["fn"])(value=site["value"]))
+            dim_to_name = {f.dim: f.name for f in site["cond_indep_stack"]}
+            fn = funsor.to_funsor(site["fn"], funsor.Real, dim_to_name)
+            value = site["value"]
+            if not isinstance(value, str):
+                value = funsor.to_funsor(site["value"], fn.inputs["value"], dim_to_name)
+            log_prob_terms.append(fn(value=value))
             plates |= frozenset(f.name for f in site["cond_indep_stack"]
                                 if f.vectorized)
         assert log_prob_terms, "nothing to collapse"

--- a/pyro/poutine/collapse_messenger.py
+++ b/pyro/poutine/collapse_messenger.py
@@ -6,11 +6,8 @@ from .runtime import _PYRO_STACK
 try:
     import funsor
     from funsor.terms import Funsor
-    from funsor.distribution import CoerceToFunsor
 except ImportError:
-    _interpreter = None
-else:
-    _interpreter = CoerceToFunsor("torch")
+    pass
 
 
 class CollapseMessenger(TraceMessenger):
@@ -29,15 +26,9 @@ class CollapseMessenger(TraceMessenger):
     def __enter__(self):
         self.preserved_plates = frozenset(h.name for h in _PYRO_STACK
                                           if isinstance(h, pyro.plate))
-
-        meta = type(dist.Distribution)
-        self._old_interpretation = meta._interpretation
-        meta._interpretation = _interpreter
         return super().__enter__()
 
     def __exit__(self, *args):
-        meta = type(dist.Distribution)
-        meta._interpretation = self._old_interpretation
         super().__exit__(*args)
 
         # Convert delayed statements to pyro.factor()

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -82,6 +82,7 @@ from .uncondition_messenger import UnconditionMessenger
 _msngrs = [
     BlockMessenger,
     BroadcastMessenger,
+    CollapseMessenger,
     ConditionMessenger,
     DoMessenger,
     EnumMessenger,

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -57,6 +57,7 @@ from pyro.poutine import util
 
 from .block_messenger import BlockMessenger
 from .broadcast_messenger import BroadcastMessenger
+from .collapse_messenger import CollapseMessenger
 from .condition_messenger import ConditionMessenger
 from .do_messenger import DoMessenger
 from .enum_messenger import EnumMessenger

--- a/tests/infer/test_gradient.py
+++ b/tests/infer/test_gradient.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import torch
 import torch.optim
+from torch.distributions import constraints
 
 import pyro
 import pyro.distributions as dist
@@ -238,3 +239,42 @@ def test_subsample_gradient_sequential(Elbo, reparameterized, subsample):
         logger.info('expected {} = {}'.format(name, expected_grads[name]))
         logger.info('actual   {} = {}'.format(name, actual_grads[name]))
     assert_equal(actual_grads, expected_grads, prec=precision)
+
+
+def test_collapse_beta_binomial():
+    pytest.importorskip("funsor")
+
+    total_count = 10
+    data = torch.tensor(3.)
+
+    def model1():
+        c1 = pyro.param("c1", torch.tensor(0.5), constraint=constraints.positive)
+        c0 = pyro.param("c0", torch.tensor(1.5), constraint=constraints.positive)
+        with poutine.collapse():
+            probs = pyro.sample("probs", dist.Beta(c1, c0))
+            pyro.sample("obs", dist.Binomial(total_count, probs), obs=data)
+
+    def model2():
+        c1 = pyro.param("c1", torch.tensor(0.5), constraint=constraints.positive)
+        c0 = pyro.param("c0", torch.tensor(1.5), constraint=constraints.positive)
+        pyro.sample("obs", dist.BetaBinomial(c1, c0, total_count),
+                    obs=data)
+
+    trace1 = poutine.trace(model1).get_trace()
+    trace2 = poutine.trace(model2).get_trace()
+    assert "probs" in trace1.nodes
+    assert "obs" not in trace1.nodes
+    assert "probs" not in trace2.nodes
+    assert "obs" in trace2.nodes
+
+    logp1 = trace1.log_prob_sum()
+    logp2 = trace2.log_prob_sum()
+    assert_equal(logp1.detach().item(), logp2.detach().item())
+
+    log_c1 = pyro.param("c1").unconstrained()
+    log_c0 = pyro.param("c0").unconstrained()
+    grads1 = torch.autograd.grad(logp1, [log_c1, log_c0], retain_graph=True)
+    grads2 = torch.autograd.grad(logp2, [log_c1, log_c0], retain_graph=True)
+    for g1, g2, name in zip(grads1, grads2, ["log(c1)", "log(c0)"]):
+        print(g1, g2)
+        assert_equal(g1, g2, msg=name)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2172,3 +2172,22 @@ def test_reparam_stable():
         pyro.sample("z_exponential", dist.Delta(torch.tensor(1.)))
 
     assert_ok(model, guide, Trace_ELBO())
+
+
+def test_collapse_beta_bernoulli():
+    pytest.importorskip("funsor").set_backend("torch")
+    ops = pytest.importorskip("funsor.ops")
+    data = torch.tensor(0.)
+
+    def model():
+        c = pyro.sample("c", dist.Gamma(1, 1))
+        with poutine.collapse():
+            probs = pyro.sample("probs", dist.Beta(c, 2))
+            pyro.sample(dist.Bernoulli(probs), obs=data)
+
+    def guide():
+        a = pyro.param("a", torch.tensor(1.), constraint=constraints.positive)
+        b = pyro.param("b", torch.tensor(1.), constraint=constraints.positive)
+        pyro.sample("c", dist.Gamma(a, b))
+
+    assert_ok(model, guide, Trace_ELBO())

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2175,15 +2175,52 @@ def test_reparam_stable():
 
 
 def test_collapse_beta_bernoulli():
-    pytest.importorskip("funsor").set_backend("torch")
-    ops = pytest.importorskip("funsor.ops")
+    pytest.importorskip("funsor")
     data = torch.tensor(0.)
 
     def model():
         c = pyro.sample("c", dist.Gamma(1, 1))
         with poutine.collapse():
             probs = pyro.sample("probs", dist.Beta(c, 2))
-            pyro.sample(dist.Bernoulli(probs), obs=data)
+            pyro.sample("obs", dist.Bernoulli(probs), obs=data)
+
+    def guide():
+        a = pyro.param("a", torch.tensor(1.), constraint=constraints.positive)
+        b = pyro.param("b", torch.tensor(1.), constraint=constraints.positive)
+        pyro.sample("c", dist.Gamma(a, b))
+
+    assert_ok(model, guide, Trace_ELBO())
+
+
+def test_collapse_beta_binomial():
+    pytest.importorskip("funsor")
+    data = torch.tensor(5.)
+
+    def model():
+        c = pyro.sample("c", dist.Gamma(1, 1))
+        with poutine.collapse():
+            probs = pyro.sample("probs", dist.Beta(c, 2))
+            pyro.sample("obs", dist.Binomial(10, probs), obs=data)
+
+    def guide():
+        a = pyro.param("a", torch.tensor(1.), constraint=constraints.positive)
+        b = pyro.param("b", torch.tensor(1.), constraint=constraints.positive)
+        pyro.sample("c", dist.Gamma(a, b))
+
+    assert_ok(model, guide, Trace_ELBO())
+
+
+def test_collapse_beta_binomial_plate():
+    pytest.importorskip("funsor")
+    data = torch.tensor([0., 1., 5., 5.])
+
+    def model():
+        c = pyro.sample("c", dist.Gamma(1, 1))
+        with poutine.collapse():
+            probs = pyro.sample("probs", dist.Beta(c, 2))
+            with pyro.plate("plate", len(data)):
+                pyro.sample("obs", dist.Binomial(10, probs),
+                            obs=data)
 
     def guide():
         a = pyro.param("a", torch.tensor(1.), constraint=constraints.positive)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2211,6 +2211,7 @@ def test_collapse_beta_binomial():
     assert_ok(model, guide, Trace_ELBO())
 
 
+@pytest.mark.xfail(reason="missing pattern in Funsor")
 def test_collapse_beta_binomial_plate():
     pytest.importorskip("funsor")
     data = torch.tensor([0., 1., 5., 5.])

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2174,6 +2174,7 @@ def test_reparam_stable():
     assert_ok(model, guide, Trace_ELBO())
 
 
+@pytest.mark.xfail(reason="missing Beta-Bernoulli pattern in Funsor")
 def test_collapse_beta_bernoulli():
     pytest.importorskip("funsor")
     data = torch.tensor(0.)


### PR DESCRIPTION
Addresses #2618 
~~Blocked by https://github.com/pyro-ppl/funsor/pull/361~~
pair coded with @eb8680

This attempts to implement a `poutine.collapse()` using Funsors, in a way that is compatible with Pyro 1.0-style inference algorithms. This is a possible intermediate step towards Pyro 2.0-style inference algorithms as in `contrib.funsor` and #2580.