### PR TITLE
Fix enumeration notebook tiny problem

### DIFF
--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -362,7 +362,7 @@
     "@config_enumerate\n",
     "def model(data, num_components=3):\n",
     "    print('Running model with {} data points'.format(len(data)))\n",
-    "    p = pyro.sample(\"p\", dist.Dirichlet(0.5 * torch.ones(3)))\n",
+    "    p = pyro.sample(\"p\", dist.Dirichlet(0.5 * torch.ones(num_components)))\n",
     "    scale = pyro.sample(\"scale\", dist.LogNormal(0, num_components))\n",
     "    with pyro.plate(\"components\", num_components):\n",
     "        loc = pyro.sample(\"loc\", dist.Normal(0, 10))\n",

--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -643,4 +643,3 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
-

--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -643,3 +643,4 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
+


### PR DESCRIPTION
The Dirhchlet prior should have length identical to the number of components instead of 3. 