### PR TITLE
Support tracing of latents in contrib.forecast

### DIFF
--- a/tests/contrib/forecast/test_forecaster.py
+++ b/tests/contrib/forecast/test_forecaster.py
@@ -131,6 +131,43 @@ def test_smoke(Model, batch_shape, t_obs, t_forecast, obs_dim, cov_dim, dct_grad
     assert samples.shape == (num_samples,) + batch_shape + (t_forecast, obs_dim,)
 
 
+@pytest.mark.parametrize("t_obs", [1, 7])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("cov_dim", [0, 1, 6])
+@pytest.mark.parametrize("obs_dim", [1, 2])
+@pytest.mark.parametrize("Model", [Model0, Model1, Model2, Model3, Model4])
+def test_trace_smoke(Model, batch_shape, t_obs, obs_dim, cov_dim):
+    model = Model()
+    data = torch.randn(batch_shape + (t_obs, obs_dim))
+    covariates = torch.randn(batch_shape + (t_obs, cov_dim))
+    forecaster = Forecaster(model, data, covariates, num_steps=2, log_every=1)
+    hmc_forecaster = HMCForecaster(model, data, covariates, max_tree_depth=1,
+                               num_warmup=1, num_samples=1, jit_compile=False)
+
+    # This is the desired syntax for recording posterior latent samples.
+    num_samples = 5
+    with poutine.trace() as svi:
+        forecaster(data, covariates, num_samples)
+    with poutine.trace() as hmc:
+        hmc_forecaster(data, covariates, num_samples)
+
+    # Check they match the equivalent poutine version.
+    dim = -1 - forecaster.max_plate_nesting
+    with torch.no_grad():
+        with poutine.trace() as tr:
+            with pyro.plate("particles", num_samples, dim=dim):
+                forecaster.guide(data, covariates)
+        with poutine.trace() as expected:
+            with pyro.plate("particles", num_samples, dim=dim):
+                return model(data, covariates)
+    for actual, engine in zip([svi, hmc], ["svi", "hmc"]):
+        for name, site in expected.trace.nodes.items():
+            expected_fn = site["fn"].event_shape
+            actual_fn = actual.trace.nodes[name]["fn"]
+            assert name in actual.trace.nodes, engine
+            assert actual_fn.event_shape == expected_fn.event_shape, engine
+
+
 @pytest.mark.parametrize("subsample_aware", [False, True])
 def test_svi_custom_smoke(subsample_aware):
     t_obs = 5


### PR DESCRIPTION
Addresses #2619 

@edwinnglabs requested the ability to sample and forecast latent variables from the posterior. Previously this could only be accomplished by complex `poutine` logic. After this PR the same can be accomplished in one line:
```py
posterior = poutine.trace(forecaster).get_trace(data, covariates, num_samples)
```
The crux was to add a `poutine.block()` around the guide invocation so that an enclosing `poutine.trace()` sees only the replayed model.

## Tested
- [x] added a new test
- [x] refactoring is covered by existing tests