### PR TITLE
AutoGuideList documentation refers to deprecated method

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -182,8 +182,8 @@ class AutoGuideList(AutoGuide, nn.ModuleList):
     Example usage::
 
         guide = AutoGuideList(my_model)
-        guide.add(AutoDiagonalNormal(poutine.block(model, hide=["assignment"])))
-        guide.add(AutoDiscreteParallel(poutine.block(model, expose=["assignment"])))
+        guide.append(AutoDiagonalNormal(poutine.block(model, hide=["assignment"])))
+        guide.append(AutoDiscreteParallel(poutine.block(model, expose=["assignment"])))
         svi = SVI(model, guide, optim, Trace_ELBO())
 
     :param callable model: a Pyro model


### PR DESCRIPTION
AutoGuideList documentation refers to deprecated method `add`