### PR TITLE
Add a block_plate() helper

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -6,7 +6,7 @@ from pyro.logger import log
 from pyro.poutine import condition, do, markov
 from pyro.primitives import (clear_param_store, deterministic, enable_validation, factor, get_param_store, iarange,
                              irange, module, param, plate, plate_stack, random_module, sample, subsample,
-                             unplate, validation_enabled)
+                             validation_enabled)
 from pyro.util import set_rng_seed
 
 version_prefix = '1.4.0'
@@ -40,6 +40,5 @@ __all__ = [
     "sample",
     "set_rng_seed",
     "subsample",
-    "unplate",
     "validation_enabled",
 ]

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -6,7 +6,7 @@ from pyro.logger import log
 from pyro.poutine import condition, do, markov
 from pyro.primitives import (clear_param_store, deterministic, enable_validation, factor, get_param_store, iarange,
                              irange, module, param, plate, plate_stack, random_module, sample, subsample,
-                             validation_enabled)
+                             unplate, validation_enabled)
 from pyro.util import set_rng_seed
 
 version_prefix = '1.4.0'
@@ -40,5 +40,6 @@ __all__ = [
     "sample",
     "set_rng_seed",
     "subsample",
+    "unplate",
     "validation_enabled",
 ]

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -204,7 +204,7 @@ class Messenger:
 
 
 @contextmanager
-def mute_messengers(predicate):
+def block_messengers(predicate):
     """
     Context manager to temporarily remove matching messengers from the _PYRO_STACK.
     Note this does not call the ``.__exit__()`` and ``.__enter__()`` methods.
@@ -213,15 +213,15 @@ def mute_messengers(predicate):
 
     :param callable predicate: A predicate mapping messenger instance to boolean.
         This mutes all messengers ``m`` for which ``bool(predicate(m)) is True``.
-    :yields: A list of matched messengers that are muted.
+    :yields: A list of matched messengers that are blocked.
     """
-    muted = {}
+    blocked = {}
     try:
         for i, messenger in enumerate(_PYRO_STACK):
             if predicate(messenger):
-                muted[i] = messenger
+                blocked[i] = messenger
                 _PYRO_STACK[i] = Messenger()  # trivial messenger
-        yield list(muted.values())
+        yield list(blocked.values())
     finally:
-        for i, messenger in muted.items():
+        for i, messenger in blocked.items():
             _PYRO_STACK[i] = messenger

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -206,8 +206,9 @@ class Messenger:
 @contextmanager
 def block_messengers(predicate):
     """
-    Context manager to temporarily remove matching messengers from the _PYRO_STACK.
-    Note this does not call the ``.__exit__()`` and ``.__enter__()`` methods.
+    EXPERIMENTAL Context manager to temporarily remove matching messengers from
+    the _PYRO_STACK. Note this does not call the ``.__exit__()`` and
+    ``.__enter__()`` methods.
 
     This is useful to selectively block enclosing handlers.
 

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -27,7 +27,7 @@ class PlateMessenger(SubsampleMessenger):
 @contextmanager
 def block_plate(name=None, dim=None):
     """
-    Context manager to temporarily block a single enclosing plate.
+    EXPERIMENTAL Context manager to temporarily block a single enclosing plate.
 
     This is useful for sampling auxiliary variables or lazily sampling global
     variables that are needed in a plated context. For example the following

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import contextmanager
+
 from .broadcast_messenger import BroadcastMessenger
+from .messenger import mute_messengers
 from .subsample_messenger import SubsampleMessenger
 
 
@@ -19,3 +22,53 @@ class PlateMessenger(SubsampleMessenger):
         if self._vectorized and self._indices is not None:
             return self.indices
         return None
+
+
+@contextmanager
+def unplate(name=None, dim=None):
+    """
+    EXPERIMENTAL Context manager to temporarily exit a single enclosing plate.
+
+    This is useful for sampling auxiliary variables or lazily sampling global
+    variables that are needed in a plated context. For example the following
+    models are equivalent:
+
+    Example::
+
+        def model_1(data):
+            loc = pyro.sample("loc", dist.Normal(0, 1))
+            with pyro.plate("data", len(data)):
+                with unplate("data"):
+                    scale = pyro.sample("scale", dist.LogNormal(0, 1))
+                pyro.sample("x", dist.Normal(loc, scale))
+
+        def model_2(data):
+            loc = pyro.sample("loc", dist.Normal(0, 1))
+            scale = pyro.sample("scale", dist.LogNormal(0, 1))
+            with pyro.plate("data", len(data)):
+                pyro.sample("x", dist.Normal(loc, scale))
+
+    :param str name: Optional name of plate to match.
+    :param int dim: Optional dim of plate to match. Must be negative.
+    :raises: ValueError if no enclosing plate was found.
+    """
+    if (name is not None) == (dim is not None):
+        raise ValueError("Exactly one of name,dim must be specified")
+    if name is not None:
+        assert isinstance(name, str)
+    if dim is not None:
+        assert isinstance(dim, int)
+        assert dim < 0
+
+    def predicate(messenger):
+        if not isinstance(messenger, PlateMessenger):
+            return False
+        if name is not None:
+            return messenger.name == name
+        if dim is not None:
+            return messenger.dim == dim
+
+    with mute_messengers(predicate) as matches:
+        if len(matches) != 1:
+            raise ValueError("unplate matched {} messengers".format(len(matches)))
+        yield

--- a/pyro/poutine/plate_messenger.py
+++ b/pyro/poutine/plate_messenger.py
@@ -4,7 +4,7 @@
 from contextlib import contextmanager
 
 from .broadcast_messenger import BroadcastMessenger
-from .messenger import mute_messengers
+from .messenger import block_messengers
 from .subsample_messenger import SubsampleMessenger
 
 
@@ -25,9 +25,9 @@ class PlateMessenger(SubsampleMessenger):
 
 
 @contextmanager
-def unplate(name=None, dim=None):
+def block_plate(name=None, dim=None):
     """
-    EXPERIMENTAL Context manager to temporarily exit a single enclosing plate.
+    Context manager to temporarily block a single enclosing plate.
 
     This is useful for sampling auxiliary variables or lazily sampling global
     variables that are needed in a plated context. For example the following
@@ -38,7 +38,7 @@ def unplate(name=None, dim=None):
         def model_1(data):
             loc = pyro.sample("loc", dist.Normal(0, 1))
             with pyro.plate("data", len(data)):
-                with unplate("data"):
+                with block_plate("data"):
                     scale = pyro.sample("scale", dist.LogNormal(0, 1))
                 pyro.sample("x", dist.Normal(loc, scale))
 
@@ -68,7 +68,7 @@ def unplate(name=None, dim=None):
         if dim is not None:
             return messenger.dim == dim
 
-    with mute_messengers(predicate) as matches:
+    with block_messengers(predicate) as matches:
         if len(matches) != 1:
-            raise ValueError("unplate matched {} messengers".format(len(matches)))
+            raise ValueError("block_plate matched {} messengers".format(len(matches)))
         yield

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -4,13 +4,14 @@
 import copy
 import warnings
 from collections import OrderedDict
-from contextlib import contextmanager, ExitStack
+from contextlib import ExitStack, contextmanager
 from inspect import isclass
 
 import pyro.distributions as dist
 import pyro.infer as infer
 import pyro.poutine as poutine
 from pyro.params import param_with_module_name
+from pyro.poutine.messenger import mute_messengers
 from pyro.poutine.plate_messenger import PlateMessenger
 from pyro.poutine.runtime import _MODULE_NAMESPACE_DIVIDER, _PYRO_PARAM_STORE, am_i_wrapped, apply_stack, effectful
 from pyro.poutine.subsample_messenger import SubsampleMessenger
@@ -318,6 +319,56 @@ def plate_stack(prefix, sizes, rightmost_dim=-1):
         for i, size in enumerate(reversed(sizes)):
             plate_i = plate("{}_{}".format(prefix, i), size, dim=rightmost_dim - i)
             stack.enter_context(plate_i)
+        yield
+
+
+@contextmanager
+def unplate(name=None, dim=None):
+    """
+    Context manager to temporarily exit a single enclosing plate.
+
+    This is useful for sampling auxiliary variables or lazily sampling global
+    variables that are needed in a plated context. For example the following
+    models are equivalent:
+
+    Example::
+
+        def model_1(data):
+            loc = pyro.sample("loc", dist.Normal(0, 1))
+            with pyro.plate("data", len(data)):
+                with pyro.unplate("data"):
+                    scale = pyro.sample("scale", dist.LogNormal(0, 1))
+                pyro.sample("x", dist.Normal(loc, scale))
+
+        def model_2(data):
+            loc = pyro.sample("loc", dist.Normal(0, 1))
+            scale = pyro.sample("scale", dist.LogNormal(0, 1))
+            with pyro.plate("data", len(data)):
+                pyro.sample("x", dist.Normal(loc, scale))
+
+    :param str name: Optional name of plate to match.
+    :param int dim: Optional dim of plate to match. Must be negative.
+    :raises: ValueError if no enclosing plate was found.
+    """
+    if (name is not None) == (dim is not None):
+        raise ValueError("Exactly one of name,dim must be specified")
+    if name is not None:
+        assert isinstance(name, str)
+    if dim is not None:
+        assert isinstance(dim, int)
+        assert dim < 0
+
+    def predicate(messenger):
+        if not isinstance(messenger, PlateMessenger):
+            return False
+        if name is not None:
+            return messenger.name == name
+        if dim is not None:
+            return messenger.dim == dim
+
+    with mute_messengers(predicate) as matches:
+        if len(matches) != 1:
+            raise ValueError("unplate matched {} messengers".format(len(matches)))
         yield
 
 

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -20,6 +20,7 @@ from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.util import torch_item
 from pyro.ops.indexing import Vindex
 from pyro.optim import Adam
+from pyro.poutine.plate_messenger import unplate
 from tests.common import assert_close
 
 logger = logging.getLogger(__name__)
@@ -867,7 +868,7 @@ def test_unplate_name_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with pyro.unplate("plate"):
+            with unplate("plate"):
                 c = pyro.sample("c", dist.Normal(0, 1))
                 assert c.shape == ()
 
@@ -877,7 +878,7 @@ def test_unplate_name_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with pyro.unplate("plate"):
+            with unplate("plate"):
                 a = pyro.sample("a", dist.Normal(0, 1))
                 assert a.shape == ()
 
@@ -892,7 +893,7 @@ def test_unplate_dim_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with pyro.unplate(dim=-1):
+            with unplate(dim=-1):
                 c = pyro.sample("c", dist.Normal(0, 1))
                 assert c.shape == ()
 
@@ -902,7 +903,7 @@ def test_unplate_dim_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with pyro.unplate(dim=-1):
+            with unplate(dim=-1):
                 a = pyro.sample("a", dist.Normal(0, 1))
                 assert a.shape == ()
 
@@ -912,7 +913,7 @@ def test_unplate_dim_ok():
 def test_unplate_missing_error():
 
     def model():
-        with pyro.unplate("plate"):
+        with unplate("plate"):
             pyro.sample("a", dist.Normal(0, 1))
 
     def guide():

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -20,7 +20,7 @@ from pyro.infer.tracetmc_elbo import TraceTMC_ELBO
 from pyro.infer.util import torch_item
 from pyro.ops.indexing import Vindex
 from pyro.optim import Adam
-from pyro.poutine.plate_messenger import unplate
+from pyro.poutine.plate_messenger import block_plate
 from tests.common import assert_close
 
 logger = logging.getLogger(__name__)
@@ -860,7 +860,7 @@ def test_plate_wrong_size_error():
     assert_error(model, guide, TraceGraph_ELBO(), match='Shape mismatch inside plate')
 
 
-def test_unplate_name_ok():
+def test_block_plate_name_ok():
 
     def model():
         a = pyro.sample("a", dist.Normal(0, 1))
@@ -868,7 +868,7 @@ def test_unplate_name_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with unplate("plate"):
+            with block_plate("plate"):
                 c = pyro.sample("c", dist.Normal(0, 1))
                 assert c.shape == ()
 
@@ -878,14 +878,14 @@ def test_unplate_name_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with unplate("plate"):
+            with block_plate("plate"):
                 a = pyro.sample("a", dist.Normal(0, 1))
                 assert a.shape == ()
 
     assert_ok(model, guide, Trace_ELBO())
 
 
-def test_unplate_dim_ok():
+def test_block_plate_dim_ok():
 
     def model():
         a = pyro.sample("a", dist.Normal(0, 1))
@@ -893,7 +893,7 @@ def test_unplate_dim_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with unplate(dim=-1):
+            with block_plate(dim=-1):
                 c = pyro.sample("c", dist.Normal(0, 1))
                 assert c.shape == ()
 
@@ -903,24 +903,24 @@ def test_unplate_dim_ok():
         with pyro.plate("plate", 2):
             b = pyro.sample("b", dist.Normal(0, 1))
             assert b.shape == (2,)
-            with unplate(dim=-1):
+            with block_plate(dim=-1):
                 a = pyro.sample("a", dist.Normal(0, 1))
                 assert a.shape == ()
 
     assert_ok(model, guide, Trace_ELBO())
 
 
-def test_unplate_missing_error():
+def test_block_plate_missing_error():
 
     def model():
-        with unplate("plate"):
+        with block_plate("plate"):
             pyro.sample("a", dist.Normal(0, 1))
 
     def guide():
         pyro.sample("a", dist.Normal(0, 1))
 
     assert_error(model, guide, Trace_ELBO(),
-                 match="unplate matched 0 messengers")
+                 match="block_plate matched 0 messengers")
 
 
 @pytest.mark.parametrize("enumerate_", [None, "sequential", "parallel"])


### PR DESCRIPTION
Blocking #2636

This PR adds a primitive `pyro.block_plate()` that temporarily blocks a specified enclosing `pyro.plate()` so that plate-global variables can be sampled. The primitive is implemented via a more general `block_messenger()` helper that temporarily swaps out a messenger with a no-op `Messenger()` in the `_PYRO_STACK`.

The motivating use case is to support reparametrization over plated dimensions in `pyro.reparam()`, where the auxiliary variable needs to be outside of the plate context. See #2636 for demonstration.

## Tested
- [x] added to test_valid_models.py