### PR TITLE
Fix model-directed subsampling in AutoGuide

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -144,7 +144,9 @@ class AutoGuide(PyroModule):
                 self.plates = {p.name: p for p in plates}
             for name, frame in sorted(self._prototype_frames.items()):
                 if name not in self.plates:
-                    self.plates[name] = pyro.plate(name, frame.size, dim=frame.dim)
+                    full_size = getattr(frame, "full_size", frame.size)
+                    self.plates[name] = pyro.plate(name, full_size, dim=frame.dim,
+                                                   subsample_size=frame.size)
         else:
             assert self.create_plates is None, "Cannot pass create_plates() to non-master guide"
             self.plates = self.master().plates


### PR DESCRIPTION
This implements @fehiepsi's fix to `AutoGuide` from https://github.com/pyro-ppl/numpyro/pull/747

## Tested
- [x] added a regression test adapted from @fehiepsi's example