### PR TITLE
Optimize logmatmulexp() and friends

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -39,8 +39,8 @@ def _logmatmulexp(x, y):
     Numerically stable version of ``(x.log() @ y.log()).exp()``.
     """
     finfo = torch.finfo(x.dtype)  # avoid nan due to -inf - -inf
-    x_shift = x.detach().max(-1, keepdim=True).values.clamp(min=finfo.min)
-    y_shift = y.detach().max(-2, keepdim=True).values.clamp(min=finfo.min)
+    x_shift = x.detach().max(-1, keepdim=True).values.clamp_(min=finfo.min)
+    y_shift = y.detach().max(-2, keepdim=True).values.clamp_(min=finfo.min)
     xy = safe_log(torch.matmul((x - x_shift).exp(), (y - y_shift).exp()))
     return xy + x_shift + y_shift
 

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -39,8 +39,8 @@ def _logmatmulexp(x, y):
     Numerically stable version of ``(x.log() @ y.log()).exp()``.
     """
     finfo = torch.finfo(x.dtype)  # avoid nan due to -inf - -inf
-    x_shift = x.max(-1, keepdim=True).values.clamp(min=finfo.min)
-    y_shift = y.max(-2, keepdim=True).values.clamp(min=finfo.min)
+    x_shift = x.detach().max(-1, keepdim=True).values.clamp(min=finfo.min)
+    y_shift = y.detach().max(-2, keepdim=True).values.clamp(min=finfo.min)
     xy = safe_log(torch.matmul((x - x_shift).exp(), (y - y_shift).exp()))
     return xy + x_shift + y_shift
 

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -113,7 +113,7 @@ class SpanningTree(TorchDistribution):
         # See https://en.wikipedia.org/wiki/Kirchhoff%27s_theorem
         V = self.num_vertices
         grid = make_complete_graph(V)
-        shift = self.edge_logits.max()
+        shift = self.edge_logits.detach().max()
         edge_probs = (self.edge_logits - shift).exp()
         adjacency = torch.zeros(V, V, dtype=edge_probs.dtype)
         adjacency[grid[0], grid[1]] = edge_probs

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -34,7 +34,7 @@ def einsum(equation, *operands):
             if dim not in output:
                 shift = shift.max(i, keepdim=True)[0]
         # avoid nan due to -inf - -inf
-        shift.clamp_(min=torch.finfo(shift.dtype).min)
+        shift = shift.clamp(min=torch.finfo(shift.dtype).min)
         exp_operands.append((operand - shift).exp())
 
         # permute shift to match output

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -34,7 +34,7 @@ def einsum(equation, *operands):
             if dim not in output:
                 shift = shift.max(i, keepdim=True)[0]
         # avoid nan due to -inf - -inf
-        shift = shift.clamp(min=torch.finfo(shift.dtype).min)
+        shift.clamp_(min=torch.finfo(shift.dtype).min)
         exp_operands.append((operand - shift).exp())
 
         # permute shift to match output

--- a/pyro/ops/einsum/torch_log.py
+++ b/pyro/ops/einsum/torch_log.py
@@ -29,7 +29,7 @@ def einsum(equation, *operands):
     shifts = []
     exp_operands = []
     for dims, operand in zip(inputs, operands):
-        shift = operand
+        shift = operand.detach()
         for i, dim in enumerate(dims):
             if dim not in output:
                 shift = shift.max(i, keepdim=True)[0]


### PR DESCRIPTION
This adds a tiny optimization to the numerical stabilizing logic in `logmatmulexp()` used in `DiscreteHMM` and enumeration.

The observation is that the numerical stabilizing `shift` does not need gradients, since we simply add and subtract it. Detaching `shift` leads to a small speedup, for example `python -O examples/hmm.py -m 7 -n 500 --jit` sees a ~15% speedup:

| | time |
|---|---|
| before | 16.9 sec | 
| after | 14.2 sec |

## Tested
- [x] refactoring is exercised by existing tests