### PR TITLE
Fix cyclic import in DistributionMeta

### DIFF
--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -5,21 +5,16 @@ from abc import ABCMeta, abstractmethod
 
 from pyro.distributions.score_parts import ScoreParts
 
+COERCIONS = []
 
-# TODO Remove import guard once funsor is a required dependency.
-try:
-    from funsor.distribution import CoerceDistributionToFunsor
-except ImportError:
-    DistributionMeta = ABCMeta
-else:
-    _coerce_to_funsor = CoerceDistributionToFunsor("torch")
 
-    class DistributionMeta(ABCMeta):
-        def __call__(cls, *args, **kwargs):
-            result = _coerce_to_funsor(cls, args, kwargs)
+class DistributionMeta(ABCMeta):
+    def __call__(cls, *args, **kwargs):
+        for coerce_ in COERCIONS:
+            result = coerce_(cls, args, kwargs)
             if result is not None:
                 return result
-            return super().__call__(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 class Distribution(metaclass=DistributionMeta):


### PR DESCRIPTION
Blocking https://github.com/pyro-ppl/funsor/pull/366

This fixes a cyclic import bug introduced in #2620 that is blocking Funsor development.

@fehiepsi @eb8680 maybe a better long-term solution is to remove [the line](https://github.com/pyro-ppl/funsor/blob/e3eba15e2ad7d9db5dd5622c247e0aaa7e81e7dd/funsor/__init__.py#L47)
```py
set_backend(get_backend())
```
from funsor entirely and remove the `FUNSOR_BACKEND` environment variable. Let's discuss at the next Pyro dev meeting.

## Tested
- [x] locally verified this fixes funsor tests