### PR TITLE
Replacing sample delta by deterministic in lda.py and smcfilter.py

### DIFF
--- a/examples/lda.py
+++ b/examples/lda.py
@@ -107,7 +107,7 @@ def parametrized_guide(predictor, data, args, batch_size=None):
         counts = (torch.zeros(args.num_words, ind.size(0))
                        .scatter_add(0, data, torch.ones(data.shape)))
         doc_topics = predictor(counts.transpose(0, 1))
-        pyro.sample("doc_topics", dist.Delta(doc_topics, event_dim=1))
+        pyro.deterministic("doc_topics", doc_topics, event_dim=1)
 
 
 def main(args):

--- a/examples/smcfilter.py
+++ b/examples/smcfilter.py
@@ -33,7 +33,7 @@ class SimpleHarmonicModel:
 
     def init(self, state, initial):
         self.t = 0
-        state["z"] = pyro.sample("z_init", dist.Delta(initial, event_dim=1))
+        state["z"] = pyro.deterministic("z_init", initial, event_dim=1)
 
     def step(self, state, y=None):
         self.t += 1
@@ -53,7 +53,7 @@ class SimpleHarmonicModel_Guide:
 
     def init(self, state, initial):
         self.t = 0
-        pyro.sample("z_init", dist.Delta(initial, event_dim=1))
+        pyro.deterministic("z_init", initial, event_dim=1)
 
     def step(self, state, y=None):
         self.t += 1


### PR DESCRIPTION
Hey guys,
Following [this forum discussion](https://forum.pyro.ai/t/sample-delta-vs-deterministic/2222), I'm submitting 2 changes. Replacing sample delta by deterministic in lda.py and smcfilter.py. 

There are only 2 other places where Delta distribution is still used in examples folder: in mixed_hmm/model.py lines [162](https://github.com/pyro-ppl/pyro/blob/dev/examples/mixed_hmm/model.py#L162) and [191](https://github.com/pyro-ppl/pyro/blob/dev/examples/mixed_hmm/model.py#L191), but as it is used as inputs to a MaskedMixture distribution, I don't know how to refactor it out.

Finally, there are several places where it is used in the codebase, which could be replaced by deterministic:
- in contrib/easyguide/easyguide.py
- in contrib/epidemiology/models.py
- in contrib/gp/parametrized.py
- in contrib/oed/glmm/guides.py
- in infer/autoguide/guides.py
- and in several files in infer/reparam

I left those unchanged...

Cheers!