### PR TITLE
Fix forecaster replay logic

### DIFF
--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -355,6 +355,8 @@ class Forecaster(nn.Module):
                     stack.enter_context(PrefixReplayMessenger(tr.trace))
                     stack.enter_context(
                         PrefixConditionMessenger(self.model._prefix_condition_data))
+                else:
+                    stack.enter_context(poutine.replay(trace=tr.trace))
                 with pyro.plate("particles", num_samples, dim=dim):
                     return self.model(data, covariates)
 


### PR DESCRIPTION
This fixes the new trace logic introduced in #2632.

The but was that, in case `PrefixReplayMessenger` is not installed, I had forgotten to install the vanilla `poutine.replay()`.

Before #2632, `forecaster(data, covariates)` would error unless `len(covariates) > len(data)`.
After #2632, `forecaster(data, covariates)` would give incorrect result when `len(covariates) == len(data)`.
After this PR, `forecaster(data, covariates)` should be correct for `len(covariates) >= len(data)`.

## Tested
- [x] covered by existing smoke tests
- [x] manually inspected results in #2619 