### PR TITLE
Add an optional .finalize() method to CompartmentalModel

### DIFF
--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -8,7 +8,7 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from functools import reduce
 from timeit import default_timer
 
@@ -42,6 +42,20 @@ def _require_double_precision():
         warnings.warn("CompartmentalModel is unstable for dtypes less than torch.float64; "
                       "try torch.set_default_dtype(torch.float64)",
                       RuntimeWarning)
+
+
+@contextmanager
+def _disallow_latent_variables(section_name):
+    if not is_validation_enabled():
+        yield
+        return
+
+    with poutine.trace() as tr:
+        yield
+    for name, site in tr.trace.nodes.items():
+        if site["type"] == "sample" and not site["is_observed"]:
+            raise NotImplementedError("{} contained latent variable {}"
+                                      .format(section_name, name))
 
 
 class CompartmentalModel(ABC):
@@ -252,6 +266,20 @@ class CompartmentalModel(ABC):
         :type t: int or slice
         """
         raise NotImplementedError
+
+    def finalize(self, params, state):
+        """
+        Optional method for likelihoods that depend on the entire time series.
+
+        .. warning:: This currently does not support latent variables.
+
+        :param params: The global params returned by :meth:`global_model`.
+        :param dict state: A dictionary mapping compartment name to tensor of
+            entire time series. For quantized models, this uses the approximate
+            point estimates, so users must request any needed time series via
+            ``super().__init__(approximate=...)``.
+        """
+        pass
 
     def compute_flows(self, prev, curr, t):
         """
@@ -660,6 +688,7 @@ class CompartmentalModel(ABC):
                 continue
 
         # Select the most probable hypothesis.
+        # Note this ignores the .finalize() likelihood.
         i = int(smc.state._log_weights.max(0).indices)
         init = {key: value[i, 0] for key, value in smc.state.items()}
 
@@ -825,6 +854,7 @@ class CompartmentalModel(ABC):
         Sequential model used to sample latents in the interval [0:duration].
         This is compatible with both quantized and relaxed inference.
         This method is called only inside particle_plate.
+        This method is used only for prediction.
         """
         C = len(self.compartments)
         T = self.duration
@@ -946,6 +976,11 @@ class CompartmentalModel(ABC):
         warn_if_nan(logp)
         pyro.factor("transition", logp)
 
+        # Apply final likelihood.
+        state = {name: curr[name + "_approx"] for name in self.approximate}
+        with _disallow_latent_variables(".finalize()"):
+            self.finalize(params, state)
+
         self._clear_plates()
 
     @set_relaxed_distributions()
@@ -982,6 +1017,10 @@ class CompartmentalModel(ABC):
         with self.time_plate:
             t = slice(0, T, 1)  # Used to slice data tensors.
             self._transition_bwd(params, prev, curr, t)
+
+        # Apply final likelihood.
+        with _disallow_latent_variables(".finalize()"):
+            self.finalize(params, curr)
 
         self._clear_plates()
 

--- a/pyro/contrib/epidemiology/compartmental.py
+++ b/pyro/contrib/epidemiology/compartmental.py
@@ -271,13 +271,22 @@ class CompartmentalModel(ABC):
         """
         Optional method for likelihoods that depend on the entire time series.
 
+        This should be used only for non-factorizable likelihoods that couple
+        states across time. Factorizable likelihoods should instead be added to
+        the :meth:`transition` method, thereby enabling their use in
+        :meth:`heuristic` initialization. Since this method is called only
+        after the last time step, it is not used in :meth:`heuristic`
+        initialization.
+
         .. warning:: This currently does not support latent variables.
 
         :param params: The global params returned by :meth:`global_model`.
         :param dict state: A dictionary mapping compartment name to tensor of
-            entire time series. For quantized models, this uses the approximate
-            point estimates, so users must request any needed time series via
-            ``super().__init__(approximate=...)``.
+            entire time series. For quantized inference, this uses the
+            approximate point estimates, so users must request any needed time
+            series in :meth:`__init__`, e.g. by calling
+            ``super().__init__(..., approximate=("I", "E"))`` if likelihood
+            depends on the ``I`` and ``E`` time series.
         """
         pass
 

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -499,7 +499,6 @@ def test_regional_smoke(duration, forecast, options, algo):
 class RegionalSIRModelWithFinalize(RegionalSIRModel):
     def finalize(self, params, state):
         I = state["I"]
-        print(f"DEBUG I.shape = {tuple(I.shape)}")
         I_mean = I.mean(dim=[-1, -2], keepdim=True).expand_as(I)
         with self.region_plate, self.time_plate:
             pyro.sample("likelihood", dist.Normal(I_mean, 1.),

--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -7,6 +7,7 @@ import math
 import pytest
 import torch
 
+import pyro
 import pyro.distributions as dist
 from pyro.contrib.epidemiology.models import (HeterogeneousRegionalSIRModel, HeterogeneousSIRModel,
                                               OverdispersedSEIRModel, OverdispersedSIRModel, RegionalSIRModel,
@@ -483,6 +484,57 @@ def test_regional_smoke(duration, forecast, options, algo):
 
     # Infer.
     model = RegionalSIRModel(population, coupling, recovery_time, data)
+    num_samples = 5
+    if algo == "mcmc":
+        model.fit_mcmc(warmup_steps=1, num_samples=num_samples, max_tree_depth=2, **options)
+    else:
+        model.fit_svi(num_steps=2, num_samples=num_samples, **options)
+
+    # Predict and forecast.
+    samples = model.predict(forecast=forecast)
+    assert samples["S"].shape == (num_samples, duration + forecast, num_regions)
+    assert samples["I"].shape == (num_samples, duration + forecast, num_regions)
+
+
+class RegionalSIRModelWithFinalize(RegionalSIRModel):
+    def finalize(self, params, state):
+        I = state["I"]
+        print(f"DEBUG I.shape = {tuple(I.shape)}")
+        I_mean = I.mean(dim=[-1, -2], keepdim=True).expand_as(I)
+        with self.region_plate, self.time_plate:
+            pyro.sample("likelihood", dist.Normal(I_mean, 1.),
+                        obs=I)
+
+
+@pytest.mark.parametrize("duration", [3, 7])
+@pytest.mark.parametrize("forecast", [0, 7])
+@pytest.mark.parametrize("algo,options", [
+    ("svi", {}),
+    ("svi", {"haar": False}),
+    ("mcmc", {}),
+    ("mcmc", {"haar": False}),
+    ("mcmc", {"haar_full_mass": 0}),
+    ("mcmc", {"num_quant_bins": 2}),
+], ids=str)
+def test_regional_finalize_smoke(duration, forecast, options, algo):
+    num_regions = 6
+    coupling = torch.eye(num_regions).clamp(min=0.1)
+    population = torch.tensor([2., 3., 4., 10., 100., 1000.])
+    recovery_time = 7.0
+
+    # Generate data.
+    model = RegionalSIRModelWithFinalize(population, coupling, recovery_time,
+                                         data=[None] * duration)
+    assert model.full_mass == [("R0", "rho_c1", "rho_c0", "rho")]
+    for attempt in range(100):
+        data = model.generate({"R0": 1.5, "rho": 0.5})["obs"]
+        assert data.shape == (duration, num_regions)
+        if data.sum():
+            break
+    assert data.sum() > 0, "failed to generate positive data"
+
+    # Infer.
+    model = RegionalSIRModelWithFinalize(population, coupling, recovery_time, data)
     num_samples = 5
     if algo == "mcmc":
         model.fit_mcmc(warmup_steps=1, num_samples=num_samples, max_tree_depth=2, **options)


### PR DESCRIPTION
This adds a `CompartmentalModel.finalize()` method that can declare likelihoods that depend on the entire model time series. The motivation is a phylogeographic likelihood ([private repo](https://github.com/broadinstitute/pyro-cov/blob/09c661f5588a864847e33660a915b69ed7ae1401/pyrophylo/models.py#L85)) that depends on the entire `I` time series in a way that does not factorize.

## Tested
- [x] added a smoke test