### PR TITLE
Fix exception chaining all over the codebase

### DIFF
--- a/pyro/contrib/autoname/named.py
+++ b/pyro/contrib/autoname/named.py
@@ -213,9 +213,9 @@ class Dict(dict):
     def __getitem__(self, key):
         try:
             return super().__getitem__(key)
-        except KeyError:
+        except KeyError as e:
             if self._name is None:
-                raise RuntimeError("Cannot access an unnamed named.Dict")
+                raise RuntimeError("Cannot access an unnamed named.Dict") from e
             value = Object("{}[{!r}]".format(self._name, key))
             super(Object, value).__setattr__(
                 "_set_value", lambda value: self.__setitem__(key, value))

--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -211,8 +211,8 @@ def prefix_condition(d, data):
     """
     try:
         return d.prefix_condition(data)
-    except AttributeError:
-        raise NotImplementedError("prefix_condition() does not suport {}".format(type(d)))
+    except AttributeError as e:
+        raise NotImplementedError("prefix_condition() does not suport {}".format(type(d))) from e
 
 
 @prefix_condition.register(dist.Independent)

--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -23,8 +23,8 @@ _RINGS = {0: MapRing, 1: SampleRing}
 def _make_ring(temperature, cache, dim_to_size):
     try:
         return _RINGS[temperature](cache=cache, dim_to_size=dim_to_size)
-    except KeyError:
-        raise ValueError("temperature must be 0 (map) or 1 (sample) for now")
+    except KeyError as e:
+        raise ValueError("temperature must be 0 (map) or 1 (sample) for now") from e
 
 
 class SamplePosteriorMessenger(ReplayMessenger):

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -174,8 +174,8 @@ class TqdmHandler(logging.StreamHandler):
             msg = self.format(record)
             self.flush()
             tqdm.write(msg, file=sys.stderr)
-        except (KeyboardInterrupt, SystemExit) as e:
-            raise e
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception:
             self.handleError(record)
 
@@ -205,8 +205,8 @@ class MCMCLoggingHandler(logging.Handler):
                 self.progress_bar.update()
             else:
                 self.log_handler.handle(record)
-        except (KeyboardInterrupt, SystemExit) as e:
-            raise e
+        except (KeyboardInterrupt, SystemExit):
+            raise
         except Exception:
             self.handleError(record)
 

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -64,10 +64,10 @@ class NeuTraReparam(Reparam):
             # Sample a shared latent.
             try:
                 self.transform = self.guide.get_transform()
-            except (NotImplementedError, TypeError):
+            except (NotImplementedError, TypeError) as e:
                 raise ValueError("NeuTraReparam only supports guides that implement "
                                  "`get_transform` method that does not depend on the "
-                                 "model's `*args, **kwargs`")
+                                 "model's `*args, **kwargs`") from e
 
             z_unconstrained = pyro.sample("{}_shared_latent".format(name),
                                           self.guide.get_base_dist().mask(False))

--- a/pyro/ops/contract.py
+++ b/pyro/ops/contract.py
@@ -348,10 +348,10 @@ def einsum(equation, *operands, **kwargs):
     modulo_total = kwargs.pop('modulo_total', False)
     try:
         Ring = BACKEND_TO_RING[backend]
-    except KeyError:
+    except KeyError as e:
         raise NotImplementedError('\n'.join(
             ['Only the following pyro backends are currently implemented:'] +
-            list(BACKEND_TO_RING)))
+            list(BACKEND_TO_RING))) from e
 
     # Parse generalized einsum equation.
     if '.' in equation:

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -25,12 +25,12 @@ def pack(value, dim_to_symbol):
                 dims = ''.join(dim_to_symbol[dim - shift]
                                for dim, size in enumerate(shape)
                                if size > 1)
-        except KeyError:
+        except KeyError as e:
             raise ValueError('\n  '.join([
                 'Invalid tensor shape.',
                 'Allowed dims: {}'.format(', '.join(map(str, sorted(dim_to_symbol)))),
                 'Actual shape: {}'.format(tuple(value.shape)),
-                "Try adding shape assertions for your model's sample values and distribution parameters."]))
+                "Try adding shape assertions for your model's sample values and distribution parameters."])) from e
         value = value.squeeze()
         value._pyro_dims = dims
         assert value.dim() == len(value._pyro_dims)

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
-
 from .messenger import Messenger
 from .trace_struct import Trace
 from .util import site_is_subsample

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+
 from .messenger import Messenger
 from .trace_struct import Trace
 from .util import site_is_subsample
@@ -162,8 +164,11 @@ class TraceHandler:
             try:
                 ret = self.fn(*args, **kwargs)
             except (ValueError, RuntimeError) as e:
+                exc_type, exc_value, traceback = sys.exc_info()
                 shapes = self.msngr.trace.format_shapes()
-                raise type(e)(u"\n{}".format(shapes)) from e
+                exc = exc_type(u"{}\n{}".format(exc_value, shapes))
+                exc = exc.with_traceback(traceback)
+                raise exc from e
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -164,11 +164,8 @@ class TraceHandler:
             try:
                 ret = self.fn(*args, **kwargs)
             except (ValueError, RuntimeError) as e:
-                exc_type, exc_value, traceback = sys.exc_info()
                 shapes = self.msngr.trace.format_shapes()
-                exc = exc_type(u"{}\n{}".format(exc_value, shapes))
-                exc = exc.with_traceback(traceback)
-                raise exc from e
+                raise type(e)(u"{}".format(shapes)) from e
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -163,12 +163,12 @@ class TraceHandler:
                                       args=args, kwargs=kwargs)
             try:
                 ret = self.fn(*args, **kwargs)
-            except (ValueError, RuntimeError):
+            except (ValueError, RuntimeError) as e:
                 exc_type, exc_value, traceback = sys.exc_info()
                 shapes = self.msngr.trace.format_shapes()
                 exc = exc_type(u"{}\n{}".format(exc_value, shapes))
                 exc = exc.with_traceback(traceback)
-                raise exc from None
+                raise exc from e
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/pyro/poutine/trace_messenger.py
+++ b/pyro/poutine/trace_messenger.py
@@ -165,7 +165,7 @@ class TraceHandler:
                 ret = self.fn(*args, **kwargs)
             except (ValueError, RuntimeError) as e:
                 shapes = self.msngr.trace.format_shapes()
-                raise type(e)(u"{}".format(shapes)) from e
+                raise type(e)(u"\n{}".format(shapes)) from e
             self.msngr.trace.add_node("_RETURN", name="_RETURN", type="return", value=ret)
         return ret
 

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -190,10 +190,9 @@ class Trace:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                     except ValueError as e:
-                        _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
-                        raise ValueError("Error while computing log_prob_sum at site '{}':\n{}\n{}\n"
-                                         .format(name, exc_value, shapes)).with_traceback(traceback) from e
+                        raise ValueError("Error while computing log_prob_sum at site '{}':\n{}"
+                                         .format(name, shapes)) from e
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"]).sum()
                     site["log_prob_sum"] = log_p
                     if is_validation_enabled():
@@ -215,10 +214,9 @@ class Trace:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                     except ValueError as e:
-                        _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
-                        raise ValueError("Error while computing log_prob at site '{}':\n{}\n{}"
-                                         .format(name, exc_value, shapes)).with_traceback(traceback) from e
+                        raise ValueError("Error while computing log_prob at site '{}':\n{}"
+                                         .format(name, shapes)) from e
                     site["unscaled_log_prob"] = log_p
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"])
                     site["log_prob"] = log_p
@@ -242,10 +240,9 @@ class Trace:
                 try:
                     value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"])
                 except ValueError as e:
-                    _, exc_value, traceback = sys.exc_info()
                     shapes = self.format_shapes(last_site=site["name"])
-                    raise ValueError("Error while computing score_parts at site '{}':\n{}\n{}"
-                                     .format(name, exc_value, shapes)).with_traceback(traceback) from e
+                    raise ValueError("Error while computing score_parts at site '{}':\n{}"
+                                     .format(name, shapes)) from e
                 site["unscaled_log_prob"] = value.log_prob
                 value = value.scale_and_mask(site["scale"], site["mask"])
                 site["score_parts"] = value
@@ -376,10 +373,9 @@ class Trace:
                     packed["log_prob"] = pack(site["log_prob"], dim_to_symbol)
                     packed["unscaled_log_prob"] = pack(site["unscaled_log_prob"], dim_to_symbol)
             except ValueError as e:
-                _, exc_value, traceback = sys.exc_info()
                 shapes = self.format_shapes(last_site=site["name"])
-                raise ValueError("Error while packing tensors at site '{}':\n  {}\n{}"
-                                 .format(site["name"], exc_value, shapes)).with_traceback(traceback) from e
+                raise ValueError("Error while packing tensors at site '{}':\n{}"
+                                 .format(site["name"], shapes)) from e
 
     def format_shapes(self, title='Trace Shapes:', last_site=None):
         """

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -189,11 +189,11 @@ class Trace:
                 else:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
-                    except ValueError:
+                    except ValueError as e:
                         _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
                         raise ValueError("Error while computing log_prob_sum at site '{}':\n{}\n{}\n"
-                                         .format(name, exc_value, shapes)).with_traceback(traceback)
+                                         .format(name, exc_value, shapes)).with_traceback(traceback) from e
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"]).sum()
                     site["log_prob_sum"] = log_p
                     if is_validation_enabled():
@@ -214,11 +214,11 @@ class Trace:
                 if "log_prob" not in site:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
-                    except ValueError:
+                    except ValueError as e:
                         _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
                         raise ValueError("Error while computing log_prob at site '{}':\n{}\n{}"
-                                         .format(name, exc_value, shapes)).with_traceback(traceback)
+                                         .format(name, exc_value, shapes)).with_traceback(traceback) from e
                     site["unscaled_log_prob"] = log_p
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"])
                     site["log_prob"] = log_p
@@ -241,11 +241,11 @@ class Trace:
                 # to correctly scale each of its three parts.
                 try:
                     value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"])
-                except ValueError:
+                except ValueError as e:
                     _, exc_value, traceback = sys.exc_info()
                     shapes = self.format_shapes(last_site=site["name"])
                     raise ValueError("Error while computing score_parts at site '{}':\n{}\n{}"
-                                     .format(name, exc_value, shapes)).with_traceback(traceback)
+                                     .format(name, exc_value, shapes)).with_traceback(traceback) from e
                 site["unscaled_log_prob"] = value.log_prob
                 value = value.scale_and_mask(site["scale"], site["mask"])
                 site["score_parts"] = value
@@ -375,11 +375,11 @@ class Trace:
                 elif "log_prob" in site:
                     packed["log_prob"] = pack(site["log_prob"], dim_to_symbol)
                     packed["unscaled_log_prob"] = pack(site["unscaled_log_prob"], dim_to_symbol)
-            except ValueError:
+            except ValueError as e:
                 _, exc_value, traceback = sys.exc_info()
                 shapes = self.format_shapes(last_site=site["name"])
                 raise ValueError("Error while packing tensors at site '{}':\n  {}\n{}"
-                                 .format(site["name"], exc_value, shapes)).with_traceback(traceback)
+                                 .format(site["name"], exc_value, shapes)).with_traceback(traceback) from e
 
     def format_shapes(self, title='Trace Shapes:', last_site=None):
         """

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
+import sys
 
 import opt_einsum
 
@@ -189,9 +190,10 @@ class Trace:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                     except ValueError as e:
+                        _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
-                        raise ValueError("Error while computing log_prob_sum at site '{}':\n{}"
-                                         .format(name, shapes)) from e
+                        raise ValueError("Error while computing log_prob_sum at site '{}':\n{}\n{}\n"
+                                         .format(name, exc_value, shapes)).with_traceback(traceback) from e
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"]).sum()
                     site["log_prob_sum"] = log_p
                     if is_validation_enabled():
@@ -213,9 +215,10 @@ class Trace:
                     try:
                         log_p = site["fn"].log_prob(site["value"], *site["args"], **site["kwargs"])
                     except ValueError as e:
+                        _, exc_value, traceback = sys.exc_info()
                         shapes = self.format_shapes(last_site=site["name"])
-                        raise ValueError("Error while computing log_prob at site '{}':\n{}"
-                                         .format(name, shapes)) from e
+                        raise ValueError("Error while computing log_prob at site '{}':\n{}\n{}"
+                                         .format(name, exc_value, shapes)).with_traceback(traceback) from e
                     site["unscaled_log_prob"] = log_p
                     log_p = scale_and_mask(log_p, site["scale"], site["mask"])
                     site["log_prob"] = log_p
@@ -239,9 +242,10 @@ class Trace:
                 try:
                     value = site["fn"].score_parts(site["value"], *site["args"], **site["kwargs"])
                 except ValueError as e:
+                    _, exc_value, traceback = sys.exc_info()
                     shapes = self.format_shapes(last_site=site["name"])
-                    raise ValueError("Error while computing score_parts at site '{}':\n{}"
-                                     .format(name, shapes)) from e
+                    raise ValueError("Error while computing score_parts at site '{}':\n{}\n{}"
+                                     .format(name, exc_value, shapes)).with_traceback(traceback) from e
                 site["unscaled_log_prob"] = value.log_prob
                 value = value.scale_and_mask(site["scale"], site["mask"])
                 site["score_parts"] = value
@@ -372,9 +376,10 @@ class Trace:
                     packed["log_prob"] = pack(site["log_prob"], dim_to_symbol)
                     packed["unscaled_log_prob"] = pack(site["unscaled_log_prob"], dim_to_symbol)
             except ValueError as e:
+                _, exc_value, traceback = sys.exc_info()
                 shapes = self.format_shapes(last_site=site["name"])
-                raise ValueError("Error while packing tensors at site '{}':\n{}"
-                                 .format(site["name"], shapes)) from e
+                raise ValueError("Error while packing tensors at site '{}':\n  {}\n{}"
+                                 .format(site["name"], exc_value, shapes)).with_traceback(traceback) from e
 
     def format_shapes(self, title='Trace Shapes:', last_site=None):
         """

--- a/pyro/poutine/trace_struct.py
+++ b/pyro/poutine/trace_struct.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections import OrderedDict
-import sys
 
 import opt_einsum
 


### PR DESCRIPTION
I would like to suggest an enhancement in the way that Python 3's exception chaining is used.

## Motivation
As described in detail in [this article](https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with), exception chaining ([PEP 3134](https://www.python.org/dev/peps/pep-3134/)) can be used to make exceptions more user-friendly, and in that case, the syntax `raise .. from ..` needs to be used.

When `raise .. from ..` is used, there is a line saying `The above exception was the direct cause of the following exception` between tracebacks. However, when implicitly chaining exceptions (meaning when `raise .. from ..` is not used), the message will be `During handling of the above exception, another exception occurred`, which can confuse users.

## Description of the change
Below is the before/after the change using the following code block:
```python
from pyro.infer.discrete import _make_ring
_make_ring(temperature=123, cache={}, dim_to_size={})
```
Before the change:
```sh
Traceback (most recent call last):
  File "/home/nitta/Dropbox/home/src/projects/pyro/pyro/infer/discrete.py", line 25, in _make_ring
    return _RINGS[temperature](cache=cache, dim_to_size=dim_to_size)
KeyError: 123

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nitta/Dropbox/home/src/projects/pyro/pyro/infer/discrete.py", line 27, in _make_ring
    raise ValueError("temperature must be 0 (map) or 1 (sample) for now")
ValueError: temperature must be 0 (map) or 1 (sample) for now
```
After the change:
```sh
Traceback (most recent call last):
  File "/home/nitta/Dropbox/home/src/projects/pyro/pyro/infer/discrete.py", line 25, in _make_ring
    return _RINGS[temperature](cache=cache, dim_to_size=dim_to_size)
KeyError: 123

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nitta/Dropbox/home/src/projects/pyro/pyro/infer/discrete.py", line 27, in _make_ring
    raise ValueError("temperature must be 0 (map) or 1 (sample) for now") from e
ValueError: temperature must be 0 (map) or 1 (sample) for now
```

If this PR seems reasonable, I'd be happy to submit another PR for fixing exception chaining all over the codebase. Let me know your thoughts!