### PR TITLE
Expand interface of CompartmentalModel.finalize()

### DIFF
--- a/tests/contrib/epidemiology/test_models.py
+++ b/tests/contrib/epidemiology/test_models.py
@@ -497,8 +497,11 @@ def test_regional_smoke(duration, forecast, options, algo):
 
 
 class RegionalSIRModelWithFinalize(RegionalSIRModel):
-    def finalize(self, params, state):
-        I = state["I"]
+    def finalize(self, params, prev, curr):
+        assert set(prev.keys()) == set(curr.keys())
+        for key in prev:
+            assert prev[key].shape == curr[key].shape
+        I = curr["I"]
         I_mean = I.mean(dim=[-1, -2], keepdim=True).expand_as(I)
         with self.region_plate, self.time_plate:
             pyro.sample("likelihood", dist.Normal(I_mean, 1.),


### PR DESCRIPTION
This expands the argument list of `.finalize` from `(params, state)` to `(params, prev, curr)`.

The motivation is a model where I'd like to use the flow time series `S2I`, and this can be computed as
```
S2I = prev["S"] - curr["S"]
```
or in general by a user provided `.compute_flows()`. And indeed the `prev` time series is available at no cost wherever `.finalize()` is called. So I've added `prev` access to the `.finalize()` method.

## Tested
- [x] updated smoke test and added a shape assertion