### PR TITLE
Add docs for constraints

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -709,3 +709,8 @@ spline_coupling
 sylvester
 ---------
 .. autofunction:: pyro.distributions.transforms.sylvester
+
+
+Constraints
+~~~~~~~~~~~
+.. automodule:: pyro.distributions.constraints

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -64,4 +64,25 @@ __all__ = [
 ]
 
 __all__.extend(torch_constraints)
+__all__ = sorted(set(__all__))
 del torch_constraints
+
+
+# Create sphinx documentation.
+__doc__ = """
+    Pyro's constraints library extends
+    :mod:`torch.distributions.constraints`.
+"""
+__doc__ += "\n".join([
+    """
+    {}
+    ----------------------------------------------------------------
+    {}
+    """.format(
+        _name,
+        "alias of :class:`torch.distributions.constraints.{}`".format(_name)
+        if globals()[_name].__module__.startswith("torch") else
+        ".. autoclass:: {}".format(_name)
+    )
+    for _name in sorted(__all__)
+])


### PR DESCRIPTION
I noticed none of Pyro's constraints are on docs.pyro.ai. This is a fix.

![image](https://user-images.githubusercontent.com/648532/95094587-104bef00-06f8-11eb-8c4a-d1a93ce58d8e.png)
