### PR TITLE
create OrderedTransform

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -692,10 +692,6 @@ neural_autoregressive
 ---------------------
 .. autofunction:: pyro.distributions.transforms.neural_autoregressive
 
-ordered
--------
-.. autofunction:: pyro.distributions.transforms.ordered
-
 permute
 -------
 .. autofunction:: pyro.distributions.transforms.permute

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -382,6 +382,13 @@ LowerCholeskyAffine
     :undoc-members:
     :show-inheritance:
 
+OrderedTransform
+----------------
+.. autoclass:: pyro.distributions.transforms.OrderedTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Permute
 -------
 .. autoclass:: pyro.distributions.transforms.Permute
@@ -684,6 +691,10 @@ matrix_exponential
 neural_autoregressive
 ---------------------
 .. autofunction:: pyro.distributions.transforms.neural_autoregressive
+
+ordered
+-------
+.. autofunction:: pyro.distributions.transforms.ordered
 
 permute
 -------

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -30,6 +30,7 @@ from pyro.distributions.transforms.matrix_exponential import (ConditionalMatrixE
 from pyro.distributions.transforms.neural_autoregressive import (ConditionalNeuralAutoregressive, NeuralAutoregressive,
                                                                  conditional_neural_autoregressive,
                                                                  neural_autoregressive)
+from pyro.distributions.transforms.ordered import OrderedTransform, ordered
 from pyro.distributions.transforms.permute import Permute, permute
 from pyro.distributions.transforms.planar import ConditionalPlanar, Planar, conditional_planar, planar
 from pyro.distributions.transforms.polynomial import Polynomial, polynomial
@@ -96,6 +97,7 @@ __all__ = [
     'LowerCholeskyAffine',
     'MatrixExponential',
     'NeuralAutoregressive',
+    'OrderedTransform',
     'Permute',
     'Planar',
     'Polynomial',
@@ -124,6 +126,7 @@ __all__ = [
     'leaky_relu',
     'matrix_exponential',
     'neural_autoregressive',
+    'ordered',
     'permute',
     'planar',
     'polynomial',

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -5,7 +5,10 @@ from torch.distributions import biject_to, transform_to
 from torch.distributions.transforms import *  # noqa F403
 from torch.distributions.transforms import __all__ as torch_transforms
 
-from pyro.distributions.constraints import IndependentConstraint, corr_cholesky_constraint
+from pyro.distributions.constraints import (
+                                            IndependentConstraint,
+                                            corr_cholesky_constraint,
+                                            ordered_vector)
 from pyro.distributions.torch_transform import ComposeTransformModule
 from pyro.distributions.transforms.affine_autoregressive import (AffineAutoregressive, ConditionalAffineAutoregressive,
                                                                  affine_autoregressive,
@@ -30,7 +33,7 @@ from pyro.distributions.transforms.matrix_exponential import (ConditionalMatrixE
 from pyro.distributions.transforms.neural_autoregressive import (ConditionalNeuralAutoregressive, NeuralAutoregressive,
                                                                  conditional_neural_autoregressive,
                                                                  neural_autoregressive)
-from pyro.distributions.transforms.ordered import OrderedTransform, ordered
+from pyro.distributions.transforms.ordered import OrderedTransform
 from pyro.distributions.transforms.permute import Permute, permute
 from pyro.distributions.transforms.planar import ConditionalPlanar, Planar, conditional_planar, planar
 from pyro.distributions.transforms.polynomial import Polynomial, polynomial
@@ -53,6 +56,12 @@ transform_to.register(IndependentConstraint, lambda c: transform_to(c.base_const
 @transform_to.register(corr_cholesky_constraint)
 def _transform_to_corr_cholesky(constraint):
     return CorrLCholeskyTransform()
+
+
+@biject_to.register(ordered_vector)
+@transform_to.register(ordered_vector)
+def _transform_to_ordered_vector(constraint):
+    return OrderedTransform()
 
 
 def iterated(repeats, base_fn, *args, **kwargs):
@@ -126,7 +135,6 @@ __all__ = [
     'leaky_relu',
     'matrix_exponential',
     'neural_autoregressive',
-    'ordered',
     'permute',
     'planar',
     'polynomial',

--- a/pyro/distributions/transforms/ordered.py
+++ b/pyro/distributions/transforms/ordered.py
@@ -6,10 +6,10 @@ from pyro.distributions import constraints
 class OrderedTransform(Transform):
     """
     Transforms a real vector into an ordered vector.
-    
+
     Specifically, enforces monotonically increasing order on the last dimension
     of a given tensor via the transformation :math:`y_0 = x_0`,
-    :math:`y_i = \sum_{1 \le j \le i} \exp(x_i)`
+    :math:`y_i = \\sum_{1 \\le j \\le i} \\exp(x_i)`
     """
     domain = constraints.real_vector
     codomain = constraints.ordered_vector

--- a/pyro/distributions/transforms/ordered.py
+++ b/pyro/distributions/transforms/ordered.py
@@ -8,8 +8,8 @@ class OrderedTransform(Transform):
     Transforms a real vector into an ordered vector.
     
     Specifically, enforces monotonically increasing order on the last dimension
-    of a given tensor via the transformation $y_0 = x_0$,
-    $y_i = \sum_{1 \le j \le i} \exp(x_i)$
+    of a given tensor via the transformation :math:`y_0 = x_0`,
+    :math:`y_i = \sum_{1 \le j \le i} \exp(x_i)`
     """
     domain = constraints.real_vector
     codomain = constraints.ordered_vector

--- a/pyro/distributions/transforms/ordered.py
+++ b/pyro/distributions/transforms/ordered.py
@@ -15,6 +15,7 @@ class OrderedTransform(Transform):
     codomain = constraints.ordered_vector
     bijective = True
     sign = +1
+    event_dim = 1
 
     def _call(self, x):
         z = torch.cat([x[..., :1], x[..., 1:].exp()], dim=-1)
@@ -26,10 +27,3 @@ class OrderedTransform(Transform):
 
     def log_abs_det_jacobian(self, x, y):
         return torch.sum(x[..., 1:], dim=-1)
-
-
-def ordered():
-    """ A helper function to create an
-    :class: `~pyro.distributions.transform.OrderedTransform` object
-    """
-    return OrderedTransform()

--- a/pyro/distributions/transforms/ordered.py
+++ b/pyro/distributions/transforms/ordered.py
@@ -1,0 +1,35 @@
+import torch
+from pyro.distributions.transforms import Transform
+from pyro.distributions import constraints
+
+
+class OrderedTransform(Transform):
+    """
+    Transforms a real vector into an ordered vector.
+    
+    Specifically, enforces monotonically increasing order on the last dimension
+    of a given tensor via the transformation $y_0 = x_0$,
+    $y_i = \sum_{1 \le j \le i} \exp(x_i)$
+    """
+    domain = constraints.real_vector
+    codomain = constraints.ordered_vector
+    bijective = True
+    sign = +1
+
+    def _call(self, x):
+        z = torch.cat([x[..., :1], x[..., 1:].exp()], dim=-1)
+        return torch.cumsum(z, dim=-1)
+
+    def _inverse(self, y):
+        x = (y[..., 1:] - y[..., :-1]).log()
+        return torch.cat([y[..., :1], x], dim=-1)
+
+    def log_abs_det_jacobian(self, x, y):
+        return torch.sum(x[..., 1:], dim=-1)
+
+
+def ordered():
+    """ A helper function to create an
+    :class: `~pyro.distributions.transform.OrderedTransform` object
+    """
+    return OrderedTransform()

--- a/tests/distributions/test_ordered_logistic.py
+++ b/tests/distributions/test_ordered_logistic.py
@@ -69,8 +69,9 @@ def test_expand():
 
 def test_autograd():
     predictor = torch.randn(5, requires_grad=True)
-    cutpoints = torch.sort(torch.randn(3)).values
-    cutpoints.requires_grad = True
+    order = OrderedTransform()
+    pre_cutpoints = torch.randn(3, requires_grad=True)
+    cutpoints = order(pre_cutpoints)
     data = torch.tensor([0, 1, 2, 3, 0], dtype=float)
 
     dist = OrderedLogistic(predictor, cutpoints, validate_args=True)
@@ -78,8 +79,8 @@ def test_autograd():
 
     assert predictor.grad is not None
     assert torch.all(predictor.grad != 0).item()
-    assert cutpoints.grad is not None
-    assert torch.all(cutpoints.grad != 0).item()
+    assert pre_cutpoints.grad is not None
+    assert torch.all(pre_cutpoints.grad != 0).item()
 
 
 # Tests for the OrderedTransform

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -288,6 +288,10 @@ class TransformTests(TestCase):
         for activation in ['ELU', 'LeakyReLU', 'sigmoid', 'tanh']:
             self._test(partial(T.neural_autoregressive, activation=activation), inverse=False)
 
+    def test_ordered_transform(self):
+        # NOTE: Need following since transform takes no input parameters
+        self._test(lambda event_shape: T.OrderedTransform(), autodiff=False)
+
     def test_permute(self):
         for dim in [-1, -2]:
             self._test(partial(T.permute, dim=dim), event_dim=-dim, autodiff=False)


### PR DESCRIPTION
Basically just copied the `OrderedTransform` implementation [in numpyro](http://num.pyro.ai/en/stable/_modules/numpyro/distributions/transforms.html#OrderedTransform) exactly. Was surprised the jacobian was so simple, I had to re-derive it myself just to make sure!