### PR TITLE
Add a "getting started" page to tutorials and rearrange the table of contents

### DIFF
--- a/tutorial/source/capture_recapture.rst
+++ b/tutorial/source/capture_recapture.rst
@@ -1,5 +1,5 @@
-Capture-Recapture Models (CJS Models)
-=====================================
+Example: Capture-Recapture Models (CJS Models)
+==============================================
 
 `View cjs.py on github`__
 

--- a/tutorial/source/cevae.rst
+++ b/tutorial/source/cevae.rst
@@ -1,5 +1,5 @@
-Causal Effect VAE
-=================
+Example: Causal Effect VAE
+==========================
 
 `View cevae.py on github`__
 

--- a/tutorial/source/dkl.rst
+++ b/tutorial/source/dkl.rst
@@ -1,5 +1,5 @@
-Deep Kernel Learning
-====================
+Example: Deep Kernel Learning
+=============================
 
 `View sv-dkl.py on github`__
 

--- a/tutorial/source/einsum.rst
+++ b/tutorial/source/einsum.rst
@@ -1,5 +1,5 @@
-Plated Einsum
-=============
+Example: Discrete Factor Graph Inference with Plated Einsum
+===========================================================
 
 `View einsum.py on github`__
 

--- a/tutorial/source/epi_regional.rst
+++ b/tutorial/source/epi_regional.rst
@@ -1,4 +1,4 @@
-Example: Epidemiological models: Regional
+Example: Regional epidemiological models
 =========================================
 
 `View regional.py on github`__

--- a/tutorial/source/epi_regional.rst
+++ b/tutorial/source/epi_regional.rst
@@ -1,5 +1,5 @@
-Epidemiological models: Regional
-================================
+Example: Epidemiological models: Regional
+=========================================
 
 `View regional.py on github`__
 

--- a/tutorial/source/epi_sir.rst
+++ b/tutorial/source/epi_sir.rst
@@ -1,4 +1,4 @@
-Example: Epidemiological models: Univariate
+Example: Univariate epidemiological models
 ===========================================
 
 `View sir.py on github`__

--- a/tutorial/source/epi_sir.rst
+++ b/tutorial/source/epi_sir.rst
@@ -1,5 +1,5 @@
-Epidemiological models: Univariate
-==================================
+Example: Epidemiological models: Univariate
+===========================================
 
 `View sir.py on github`__
 

--- a/tutorial/source/hmm.rst
+++ b/tutorial/source/hmm.rst
@@ -1,5 +1,5 @@
-Hidden Markov Model
-===================
+Example: Hidden Markov Models
+=============================
 
 `View hmm.py on github`__
 

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -14,11 +14,13 @@ New users: getting from zero to one
 ------------------------------------
 If you're new to probabilistic programming or variational inference,
 you might want to start by reading the series :ref:`introductory-tutorials`.
+If you're new to PyTorch, you may also benefit from reading the official introduction `"Deep Learning with PyTorch." <https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html>`_
 
 After that, you're ready to get started using Pyro! (Yes, really!)
-Look carefully through the series :ref:`practical-pyro-and-pytorch`,
-especially the :doc:`first Bayesian regression tutorial <bayesian_regression>`,
-which goes step-by-step through solving a simple Bayesian machine learning problem with Pyro,
+Follow `the instructions on the front page to install Pyro <http://pyro.ai/#install>`_
+and look carefully through the series :ref:`practical-pyro-and-pytorch`,
+especially the :doc:`first Bayesian regression tutorial <bayesian_regression>`.
+This tutorial goes step-by-step through solving a simple Bayesian machine learning problem with Pyro,
 grounding the concepts from the introductory tutorials in runnable code.
 Industry users interested in serving predictions from a trained model in C++ should also read :doc:`the PyroModule tutorial <modules>`.
 

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -3,21 +3,71 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Pyro Examples and Tutorials!
-==========================================
+Getting Started With Pyro: Tutorials, How-to Guides and Examples
+================================================================
 
-This page collects how-to guides and examples written by the Pyro community.
+Welcome! This page collects tutorials written by the Pyro community.
+If you're having trouble finding or understanding anything here,
+please don't hesitate to ask a question on our `forum <https://forum.pyro.ai/>`_!
+
+New users: getting from zero to one
+------------------------------------
 If you're new to probabilistic programming or variational inference,
-you might want to start by reading our :ref:`introductory-tutorials`.
+you might want to start by reading the series :ref:`introductory-tutorials`.
 
-After that, you're ready to get your hands dirty!
+After that, you're ready to get your hands dirty! (Yes, really!)
+Look carefully through the series :ref:`hands-on-with-pyro-and-pytorch`,
+especially the :doc:`first Bayesian regression tutorial <bayesian_regression>`,
+which goes step-by-step through solving a simple Bayesian machine learning problem with Pyro,
+grounding the concepts from the introductory tutorials in runnable code.
+Industry users interested in serving predictions from a trained model in C++ should also read :doc:`the PyroModule tutorial <modules>`.
 
-A basic familiarity with this introductory material is all you will need
-to dive right into using Pyro's two superpowers:
-:ref:`deep-generative-models` and :ref:`inference-with-discrete-latent-variables`.
+Most users who reach this point will also find our :doc:`guide to tensor shapes in Pyro <tensor_shapes>` essential reading.
+Pyro makes extensive use of the behavior of `"array broadcasting" <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
+baked into PyTorch and other array libraries to parallelize models and inference algorithms,
+and while it can be difficult to understand this behavior initially, applying the intuition and rules of thumb there
+will go a long way toward making your experience smooth and reducing the prevalence of nasty shape errors.
+
+Core functionality: Deep learning, discrete variables and customizable inference
+---------------------------------------------------------------------------------
+A basic familiarity with this introductory material is all you will need to dive right into using Pyro's two superpowers:
+integration with deep learning and automated exact inference for discrete latent variables.
+The former is described with numerous examples in the series :ref:`deep-generative-models`.
+All are elaborations on the basic idea of the variational autoencoder, introduced in great detail in :doc:`the first tutorial of this series <vae>`.
+
+Pyro's facility with discrete latent variable models like the hidden Markov model is surveyed in the series :ref:`discrete-latent-variables`.
+Making use of this in your own work will require careful reading of :doc:`our overview and programming guide <enumeration>` that opens this series.
 
 Another feature of Pyro is its programmability, the subject of a series of tutorials in :ref:`customizing-inference`.
-Particularly advanced or enthusiastic users may even be interested in :ref:`understanding-pyros-internals`.
+Users working with large models where only part of the model needs special attention
+may be interested in `pyro.contrib.easyguide <http://docs.pyro.ai/en/dev/contrib.easyguide.html>`_, introduced in :doc:`the first tutorial of the series <easyguide>`.
+Meanwhile, machine learning researchers interested in developing variational inference algorithms may wish to peruse
+:doc:`the guide to implementing custom variational objectives <custom_objectives>`,
+and a companion example that walks through :doc:`implementing "Boosting BBVI" <boosting_bbvi>`.
+
+Particularly enthusiastic users and potential contributors, especially those interested in contributing to Pyro's core components,
+may even be interested in how Pyro itself works under the hood, partially described in the series :ref:`understanding-pyros-internals`.
+The :doc:`mini-pyro example <minipyro>` contains a complete and heavily commented implementation of a small version of the Pyro language in just a few hundred lines of code,
+and should serve as a more digestable introduction to the real thing.
+
+Tools for specific problems
+-----------------------------
+Pyro is a mature piece of open-source software, not a just science project,
+and in addition to the core machinery for modelling and inference,
+it includes quite a bit of dedicated domain- or problem-specific modelling functionality.
+
+One particular area of strength is time-series modelling via `pyro.contrib.forecasting <http://docs.pyro.ai/en/dev/contrib.forecast.html>`_,
+a library for scaling hierarchical, fully Bayesian models of multivariate time series to thousands or millions of series and datapoints.
+This is described in the series :ref:`time-series`.
+
+Another area of strength is probabilistic machine learning with Gaussian processes.
+`pyro.contrib.gp <http://docs.pyro.ai/en/dev/contrib.gp.html>`_, described in the series :ref:`gaussian-processes`,
+is a library within Pyro implementing a variety of exact or approximate Gaussian process models compatible with Pyro's inference engines.
+Pyro is also fully compatible with `GPyTorch <https://gpytorch.ai/>`_, a dedicated library for scalable GPs,
+as described in `their Pyro example series <https://github.com/cornellius-gp/gpytorch/tree/master/examples/07_Pyro_Integration>`_.
+
+List of Tutorials
+==================
 
 .. toctree::
    :maxdepth: 1
@@ -32,18 +82,11 @@ Particularly advanced or enthusiastic users may even be interested in :ref:`unde
 
 .. toctree::
    :maxdepth: 1
-   :caption: Hands-On Bayesian Modelling
-   :name: hands-on-bayesian-modelling
+   :caption: Hands On with Pyro and PyTorch
+   :name: hands-on-with-pyro-and-pytorch
 
    bayesian_regression
    bayesian_regression_ii
-   mle_map
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Understanding Pyro and PyTorch
-   :name: understanding-pyro-and-pytorch
-
    tensor_shapes
    modules
    jit
@@ -65,8 +108,8 @@ Particularly advanced or enthusiastic users may even be interested in :ref:`unde
 
 .. toctree::
    :maxdepth: 1
-   :caption: Inference With Discrete Variables
-   :name: inference-with-discrete-variables
+   :caption: Discrete Latent Variables
+   :name: discrete-latent-variables
 
    enumeration
    gmm
@@ -82,6 +125,7 @@ Particularly advanced or enthusiastic users may even be interested in :ref:`unde
    :caption: Customizing Inference
    :name: customizing-inference
 
+   mle_map
    easyguide
    custom_objectives
    boosting_bbvi
@@ -96,8 +140,8 @@ Particularly advanced or enthusiastic users may even be interested in :ref:`unde
    forecasting_ii
    forecasting_iii
    forecasting_dlm
-   forecast_simple
    stable
+   forecast_simple
    timeseries
 
 .. toctree::

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -17,6 +17,9 @@ This page collects how-to guides and tutorials written by the Pyro community.
    svi_part_i
    svi_part_ii
    svi_part_iii
+   bayesian_regression
+   bayesian_regression_ii
+   mle_map
 
 .. toctree::
    :maxdepth: 2
@@ -26,16 +29,6 @@ This page collects how-to guides and tutorials written by the Pyro community.
    modules
    jit
    svi_horovod
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Bayesian data science
-
-   bayesian_regression
-   bayesian_regression_ii
-   mle_map
-   stable
-   mcmc
 
 .. toctree::
    :maxdepth: 2
@@ -81,16 +74,8 @@ This page collects how-to guides and tutorials written by the Pyro community.
    forecasting_iii
    forecasting_dlm
    forecast_simple
+   stable
    timeseries
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Bayesian phylodynamics
-
-   epi_intro
-   epi_sir
-   epi_regional
-   sir_hmc
 
 .. toctree::
    :maxdepth: 2
@@ -100,6 +85,15 @@ This page collects how-to guides and tutorials written by the Pyro community.
    gplvm
    bo
    dkl
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Bayesian epidemiological models
+
+   epi_intro
+   epi_sir
+   epi_regional
+   sir_hmc
 
 .. toctree::
    :maxdepth: 2
@@ -119,6 +113,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
    :maxdepth: 2
    :caption: Other examples:
 
+   mcmc
    RSA-implicature
    RSA-hyperbole
    csis

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -6,31 +6,67 @@
 Welcome to Pyro Examples and Tutorials!
 ==========================================
 
+This page collects how-to guides and examples written by the Pyro community.
+If you're new to probabilistic programming or variational inference,
+you might want to start by reading our :ref:`introductory-tutorials`.
+
+After that, you're ready to get your hands dirty!
+
+A basic familiarity with this introductory material is all you will need
+to dive right into using Pyro's two superpowers:
+:ref:`deep-generative-models` and :ref:`inference-with-discrete-latent-variables`.
+
+Another feature of Pyro is its programmability, the subject of a series of tutorials in :ref:`customizing-inference`.
+Particularly advanced or enthusiastic users may even be interested in :ref:`understanding-pyros-internals`.
+
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Introductory Tutorials
+   :name: introductory-tutorials
 
    intro_part_i
    intro_part_ii
    svi_part_i
    svi_part_ii
    svi_part_iii
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Hands-On Bayesian Modelling
+   :name: hands-on-bayesian-modelling
+
    bayesian_regression
    bayesian_regression_ii
    mle_map
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Understanding Pyro and PyTorch
+   :name: understanding-pyro-and-pytorch
 
    tensor_shapes
    modules
    jit
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Deep Generative Models
+   :name: deep-generative-models
+
+   vae
+   ss-vae
+   cvae
+   normalizing_flows_i
+   dmm
+   air
+   cevae
+   sparse_gamma
    svi_horovod
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Inference With Discrete Variables
+   :name: inference-with-discrete-variables
 
    enumeration
    gmm
@@ -42,21 +78,9 @@ Welcome to Pyro Examples and Tutorials!
    lda
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Deep Probabilistic Programming
-
-   vae
-   ss-vae
-   cvae
-   normalizing_flows_i
-   dmm
-   air
-   cevae
-   sparse_gamma
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Advanced: Customizing Inference
+   :maxdepth: 1
+   :caption: Customizing Inference
+   :name: customizing-inference
 
    easyguide
    custom_objectives
@@ -64,8 +88,9 @@ Welcome to Pyro Examples and Tutorials!
    neutra
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Application: Time Series
+   :name: time-series
 
    forecasting_i
    forecasting_ii
@@ -76,8 +101,9 @@ Welcome to Pyro Examples and Tutorials!
    timeseries
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Application: Gaussian Processes
+   :name: gaussian-processes
 
    gp
    gplvm
@@ -85,8 +111,9 @@ Welcome to Pyro Examples and Tutorials!
    dkl
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Application: Epidemiology
+   :name: epidemiology
 
    epi_intro
    epi_sir
@@ -94,21 +121,23 @@ Welcome to Pyro Examples and Tutorials!
    sir_hmc
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Application: Optimal Experiment Design
+   :name: optimal-experiment-design
 
    working_memory
    elections
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Application: Object Tracking
+   :name: object-tracking
 
    tracking_1d
    ekf
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Other Examples:
 
    RSA-implicature
@@ -118,8 +147,9 @@ Welcome to Pyro Examples and Tutorials!
    smcfilter
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Developers: Understanding Pyro's Internals
+   :name: understanding-pyros-internals
 
    minipyro
    effect_handlers

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -15,8 +15,8 @@ New users: getting from zero to one
 If you're new to probabilistic programming or variational inference,
 you might want to start by reading the series :ref:`introductory-tutorials`.
 
-After that, you're ready to get your hands dirty! (Yes, really!)
-Look carefully through the series :ref:`hands-on-with-pyro-and-pytorch`,
+After that, you're ready to get started using Pyro! (Yes, really!)
+Look carefully through the series :ref:`practical-pyro-and-pytorch`,
 especially the :doc:`first Bayesian regression tutorial <bayesian_regression>`,
 which goes step-by-step through solving a simple Bayesian machine learning problem with Pyro,
 grounding the concepts from the introductory tutorials in runnable code.
@@ -26,7 +26,7 @@ Most users who reach this point will also find our :doc:`guide to tensor shapes 
 Pyro makes extensive use of the behavior of `"array broadcasting" <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
 baked into PyTorch and other array libraries to parallelize models and inference algorithms,
 and while it can be difficult to understand this behavior initially, applying the intuition and rules of thumb there
-will go a long way toward making your experience smooth and reducing the prevalence of nasty shape errors.
+will go a long way toward making your experience smooth and avoiding nasty shape errors.
 
 Core functionality: Deep learning, discrete variables and customizable inference
 ---------------------------------------------------------------------------------
@@ -52,9 +52,9 @@ and should serve as a more digestable introduction to the real thing.
 
 Tools for specific problems
 -----------------------------
-Pyro is a mature piece of open-source software, not a just science project,
-and in addition to the core machinery for modelling and inference,
-it includes quite a bit of dedicated domain- or problem-specific modelling functionality.
+Pyro is a mature piece of open-source software with "batteries included."
+In addition to the core machinery for modelling and inference,
+it includes a large toolkit of dedicated domain- or problem-specific modelling functionality.
 
 One particular area of strength is time-series modelling via `pyro.contrib.forecasting <http://docs.pyro.ai/en/dev/contrib.forecast.html>`_,
 a library for scaling hierarchical, fully Bayesian models of multivariate time series to thousands or millions of series and datapoints.
@@ -82,14 +82,15 @@ List of Tutorials
 
 .. toctree::
    :maxdepth: 1
-   :caption: Hands On with Pyro and PyTorch
-   :name: hands-on-with-pyro-and-pytorch
+   :caption: Practical Pyro and PyTorch
+   :name: practical-pyro-and-pytorch
 
    bayesian_regression
    bayesian_regression_ii
    tensor_shapes
    modules
    jit
+   svi_horovod
 
 .. toctree::
    :maxdepth: 1
@@ -104,7 +105,6 @@ List of Tutorials
    air
    cevae
    sparse_gamma
-   svi_horovod
 
 .. toctree::
    :maxdepth: 1
@@ -166,7 +166,7 @@ List of Tutorials
 
 .. toctree::
    :maxdepth: 1
-   :caption: Application: Optimal Experiment Design
+   :caption: Application: Experimental Design
    :name: optimal-experiment-design
 
    working_memory
@@ -182,17 +182,17 @@ List of Tutorials
 
 .. toctree::
    :maxdepth: 1
-   :caption: Other Examples:
+   :caption: Other Inference Algorithms
 
-   RSA-implicature
-   RSA-hyperbole
    mcmc
    csis
    smcfilter
+   RSA-implicature
+   RSA-hyperbole
 
 .. toctree::
    :maxdepth: 1
-   :caption: Developers: Understanding Pyro's Internals
+   :caption: Understanding Pyro's Internals
    :name: understanding-pyros-internals
 
    minipyro

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -32,7 +32,7 @@ will go a long way toward making your experience smooth and avoiding nasty shape
 
 Core functionality: Deep learning, discrete variables and customizable inference
 ---------------------------------------------------------------------------------
-A basic familiarity with this introductory material is all you will need to dive right into using Pyro's two superpowers:
+A basic familiarity with this introductory material is all you will need to dive right into exploiting Pyro's two biggest strengths:
 integration with deep learning and automated exact inference for discrete latent variables.
 The former is described with numerous examples in the series :ref:`deep-generative-models`.
 All are elaborations on the basic idea of the variational autoencoder, introduced in great detail in :doc:`the first tutorial of this series <vae>`.

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -6,11 +6,9 @@
 Welcome to Pyro Examples and Tutorials!
 ==========================================
 
-This page collects how-to guides and tutorials written by the Pyro community.
-
 .. toctree::
    :maxdepth: 2
-   :caption: Probabilistic programming and variational inference
+   :caption: Introductory Tutorials
 
    intro_part_i
    intro_part_ii
@@ -23,7 +21,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Pyro and PyTorch:
+   :caption: Understanding Pyro and PyTorch
 
    tensor_shapes
    modules
@@ -32,7 +30,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Discrete latent variables
+   :caption: Inference With Discrete Variables
 
    enumeration
    gmm
@@ -45,7 +43,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Deep generative models
+   :caption: Deep Probabilistic Programming
 
    vae
    ss-vae
@@ -58,7 +56,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Advanced custom inference
+   :caption: Advanced: Customizing Inference
 
    easyguide
    custom_objectives
@@ -67,7 +65,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Time-series forecasting
+   :caption: Application: Time Series
 
    forecasting_i
    forecasting_ii
@@ -79,7 +77,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Gaussian Processes
+   :caption: Application: Gaussian Processes
 
    gp
    gplvm
@@ -88,7 +86,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Bayesian epidemiological models
+   :caption: Application: Epidemiology
 
    epi_intro
    epi_sir
@@ -97,21 +95,21 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Bayesian optimal experimental design:
+   :caption: Application: Optimal Experiment Design
 
    working_memory
    elections
 
 .. toctree::
    :maxdepth: 2
-   :caption: Probabilistic object tracking:
+   :caption: Application: Object Tracking
 
    tracking_1d
    ekf
 
 .. toctree::
    :maxdepth: 2
-   :caption: Other examples:
+   :caption: Other Examples:
 
    RSA-implicature
    RSA-hyperbole
@@ -121,7 +119,7 @@ This page collects how-to guides and tutorials written by the Pyro community.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Understanding Pyro's internals
+   :caption: Developers: Understanding Pyro's Internals
 
    minipyro
    effect_handlers

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -113,9 +113,9 @@ This page collects how-to guides and tutorials written by the Pyro community.
    :maxdepth: 2
    :caption: Other examples:
 
-   mcmc
    RSA-implicature
    RSA-hyperbole
+   mcmc
    csis
    smcfilter
 

--- a/tutorial/source/index.rst
+++ b/tutorial/source/index.rst
@@ -6,89 +6,132 @@
 Welcome to Pyro Examples and Tutorials!
 ==========================================
 
+This page collects how-to guides and tutorials written by the Pyro community.
+
 .. toctree::
    :maxdepth: 2
-   :caption: Introduction:
+   :caption: Probabilistic programming and variational inference
 
    intro_part_i
    intro_part_ii
    svi_part_i
    svi_part_ii
    svi_part_iii
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Pyro and PyTorch:
+
    tensor_shapes
-   mle_map
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Advanced:
-
-   enumeration
-   custom_objectives
-   jit
-   minipyro
-   effect_handlers
    modules
-   normalizing_flows_i
-   contrib_funsor_intro_i
-   contrib_funsor_intro_ii
+   jit
+   svi_horovod
 
 .. toctree::
    :maxdepth: 2
-   :caption: Examples:
+   :caption: Bayesian data science
 
-   vae
    bayesian_regression
    bayesian_regression_ii
-   dmm
-   air
-   ss-vae
+   mle_map
    stable
-   cvae
+   mcmc
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contributed:
+   :caption: Discrete latent variables
 
+   enumeration
    gmm
-   gp
-   gplvm
-   bo
+   dirichlet_process_mixture
+   toy_mixture_model_discrete_enumeration
+   hmm
+   capture_recapture
+   einsum
+   lda
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Deep generative models
+
+   vae
+   ss-vae
+   cvae
+   normalizing_flows_i
+   dmm
+   air
+   cevae
+   sparse_gamma
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Advanced custom inference
+
    easyguide
+   custom_objectives
+   boosting_bbvi
+   neutra
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Time-series forecasting
+
    forecasting_i
    forecasting_ii
    forecasting_iii
-   tracking_1d
-   csis
-   RSA-implicature
-   RSA-hyperbole
-   ekf
-   working_memory
-   elections
-   dirichlet_process_mixture
-   boosting_bbvi
-   epi_intro
+   forecasting_dlm
+   forecast_simple
+   timeseries
 
 .. toctree::
    :maxdepth: 2
-   :caption: Code Examples:
+   :caption: Bayesian phylodynamics
 
-   capture_recapture
-   cevae
-   hmm
-   lda
-   mcmc
-   neutra
-   sparse_gamma
-   dkl
-   einsum
-   forecast_simple
-   timeseries
-   smcfilter
+   epi_intro
    epi_sir
    epi_regional
    sir_hmc
-   toy_mixture_model_discrete_enumeration
-   svi_horovod
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Gaussian Processes
+
+   gp
+   gplvm
+   bo
+   dkl
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Bayesian optimal experimental design:
+
+   working_memory
+   elections
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Probabilistic object tracking:
+
+   tracking_1d
+   ekf
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Other examples:
+
+   RSA-implicature
+   RSA-hyperbole
+   csis
+   smcfilter
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Understanding Pyro's internals
+
+   minipyro
+   effect_handlers
+   contrib_funsor_intro_i
+   contrib_funsor_intro_ii
 
 Indices and tables
 ==================

--- a/tutorial/source/lda.rst
+++ b/tutorial/source/lda.rst
@@ -1,5 +1,5 @@
-Latent Dirichlet Allocation
-===========================
+Example: Amortized Latent Dirichlet Allocation
+==============================================
 
 `View lda.py on github`__
 

--- a/tutorial/source/mcmc.rst
+++ b/tutorial/source/mcmc.rst
@@ -1,5 +1,5 @@
-Markov Chain Monte Carlo
-========================
+Example: Inference with Markov Chain Monte Carlo
+================================================
 
 `View hmm.py on github`__
 

--- a/tutorial/source/neutra.rst
+++ b/tutorial/source/neutra.rst
@@ -1,5 +1,5 @@
-NeuTraReparam
-=============
+Example: Neural MCMC with NeuTraReparam
+=======================================
 
 `View neutra.py on github`__
 

--- a/tutorial/source/sir_hmc.rst
+++ b/tutorial/source/sir_hmc.rst
@@ -1,5 +1,5 @@
-Epidemiological inference via HMC
-=================================
+Example: Epidemiological inference via HMC
+==========================================
 
 This tutorial is in the form of a script (see below).
 

--- a/tutorial/source/sparse_gamma.rst
+++ b/tutorial/source/sparse_gamma.rst
@@ -1,5 +1,5 @@
-Sparse Gamma Deep Exponential Family
-====================================
+Example: Sparse Gamma Deep Exponential Family
+=============================================
 
 `View sparse_gamma_def.py on github`__
 

--- a/tutorial/source/svi_horovod.rst
+++ b/tutorial/source/svi_horovod.rst
@@ -1,5 +1,5 @@
-Distributed training via Horovod
-================================
+Example: distributed training via Horovod
+=========================================
 
 Unlike other examples, this example must be run under horovodrun_, for example
 

--- a/tutorial/source/timeseries.rst
+++ b/tutorial/source/timeseries.rst
@@ -1,5 +1,5 @@
-Gaussian Process Time Series Models
-===================================
+Example: Gaussian Process Time Series Models
+============================================
 
 `View gp_models.py on github`__
 

--- a/tutorial/source/toy_mixture_model_discrete_enumeration.rst
+++ b/tutorial/source/toy_mixture_model_discrete_enumeration.rst
@@ -1,5 +1,5 @@
-Toy Mixture Model With Discrete Enumeration
-===========================================
+Example: Toy Mixture Model With Discrete Enumeration
+====================================================
 
 `View toy_mixture_model_discrete_enumeration.py on github`__
 


### PR DESCRIPTION
In the interest of making Pyro easier to pick up, this PR attempts to reorder and group the tutorials more coherently with respect to their contents.

I have also added a substantial "getting started" opening section that aims to help users orient themselves according to their goals and knowledge.