### PR TITLE
Return funsor.Variable from pyro.sample inside collapse

### DIFF
--- a/pyro/poutine/collapse_messenger.py
+++ b/pyro/poutine/collapse_messenger.py
@@ -86,7 +86,7 @@ class CollapseMessenger(TraceMessenger):
     .. warning:: This is not compatible with automatic guessing of
         ``max_plate_nesting``. If any plates appear within the collapsed
         context, you should manually declare ``max_plate_nesting`` to your
-        inference algorithm (e.g. ``Trace_ELBO(max_plate_nesting=1)``.
+        inference algorithm (e.g. ``Trace_ELBO(max_plate_nesting=1)``).
     """
     _coerce = None
 


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/funsor/issues/367#issuecomment-711450825

This changes `poutine.collapse` to more eagerly convert `msg["fn"]` and `msg["value"]` to Funsors, and thereby allows `pyro.sample` statements to return `funsor.Variable`s rather than strings. This is important e.g. in @fehiepsi's use case where he transforms one of those returned variables.

@fehiepsi I tried to get this working with NumPyro but NumPyro is a little behind the Pyro version. I think you might need the `._block` logic to avoid converting the final `pyro.factor` statement to a funsor expression, but I'm not sure why I couldn't get it working.

## Tested
- [x] refactoring covered by existing tests
- [x] added a type assertion
- [x] added smoke tests with an enclosing particle plate