### PR TITLE
Warn if infer_discrete finds no enumerated sites

### DIFF
--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+import warnings
 from collections import OrderedDict
 
 from opt_einsum import shared_intermediates
@@ -37,7 +38,8 @@ class SamplePosteriorMessenger(ReplayMessenger):
             msg["cond_indep_stack"] = self.trace.nodes[msg["name"]]["cond_indep_stack"]
 
 
-def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
+def _sample_posterior(model, first_available_dim, temperature, strict_enumeration_warning,
+                      *args, **kwargs):
     # For internal use by infer_discrete.
 
     # Create an enumerated trace.
@@ -47,10 +49,12 @@ def _sample_posterior(model, first_available_dim, temperature, *args, **kwargs):
     enum_trace.compute_log_prob()
     enum_trace.pack_tensors()
 
-    return _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs)
+    return _sample_posterior_from_trace(model, enum_trace, temperature,
+                                        strict_enumeration_warning, *args, **kwargs)
 
 
-def _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs):
+def _sample_posterior_from_trace(model, enum_trace, temperature, strict_enumeration_warning,
+                                 *args, **kwargs):
     plate_to_symbol = enum_trace.plate_to_symbol
 
     # Collect a set of query sample sites to which the backward algorithm will propagate.
@@ -83,6 +87,11 @@ def _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs
             if not node["is_observed"]:
                 queries.append(log_prob)
                 require_backward(log_prob)
+
+    if strict_enumeration_warning and not enum_terms:
+        warnings.warn('infer_discrete found no sample sites configured for enumeration. '
+                      'If you want to enumerate sites, you need to @config_enumerate or set '
+                      'infer={"enumerate": "sequential"} or infer={"enumerate": "parallel"}.')
 
     # We take special care to match the term ordering in
     # pyro.infer.traceenum_elbo._compute_model_factors() to allow
@@ -149,7 +158,8 @@ def _sample_posterior_from_trace(model, enum_trace, temperature, *args, **kwargs
         return model(*args, **kwargs)
 
 
-def infer_discrete(fn=None, first_available_dim=None, temperature=1):
+def infer_discrete(fn=None, first_available_dim=None, temperature=1, *,
+                   strict_enumeration_warning=True):
     """
     A poutine that samples discrete sites marked with
     ``site["infer"]["enumerate"] = "parallel"`` from the posterior,
@@ -181,13 +191,16 @@ def infer_discrete(fn=None, first_available_dim=None, temperature=1):
         This should be a negative integer.
     :param int temperature: Either 1 (sample via forward-filter backward-sample)
         or 0 (optimize via Viterbi-like MAP inference). Defaults to 1 (sample).
+    :param bool strict_enumeration_warning: Whether to warn in case no
+        enumerated sample sites are found. Defalts to True.
     """
     assert first_available_dim < 0, first_available_dim
     if fn is None:  # support use as a decorator
         return functools.partial(infer_discrete,
                                  first_available_dim=first_available_dim,
                                  temperature=temperature)
-    return functools.partial(_sample_posterior, fn, first_available_dim, temperature)
+    return functools.partial(_sample_posterior, fn, first_available_dim, temperature,
+                             strict_enumeration_warning)
 
 
 class TraceEnumSample_ELBO(TraceEnum_ELBO):
@@ -232,4 +245,6 @@ class TraceEnumSample_ELBO(TraceEnum_ELBO):
         model, model_trace, guide_trace, args, kwargs = self._saved_state
         model = poutine.replay(model, guide_trace)
         temperature = 1
-        return _sample_posterior_from_trace(model, model_trace, temperature, *args, **kwargs)
+        return _sample_posterior_from_trace(model, model_trace, temperature,
+                                            self.strict_enumeration_warning,
+                                            *args, **kwargs)


### PR DESCRIPTION
Addresses https://forum.pyro.ai/t/map-prediction/2275/3

This adds a `strict_enumeration_warning` kwarg to `infer_discrete`, similar to the same kwarg in `ELBO` implementations. When True (default), `infer_discrete()` will warn users if no enumerated sites are found, suggesting they should use `@config_enumerate` following the warning in `ELBO`.

## Tested
- [x] added a warning test