### PR TITLE
Clarify some .forward() docstrings

### DIFF
--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -90,6 +90,9 @@ class EasyGuide(PyroModule, metaclass=_EasyGuideMeta):
     def forward(self, *args, **kwargs):
         """
         Runs the guide. This is typically used by inference algorithms.
+
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__`.
         """
         if self.prototype_trace is None:
             self._setup_prototype(*args, **kwargs)

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -229,6 +229,9 @@ class AutoGuideList(AutoGuide, nn.ModuleList):
         """
         A composite guide with the same ``*args, **kwargs`` as the base ``model``.
 
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__`.
+
         :return: A dict mapping sample site name to sampled value.
         :rtype: dict
         """
@@ -358,6 +361,9 @@ class AutoDelta(AutoGuide):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
 
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__`.
+
         :return: A dict mapping sample site name to sampled value.
         :rtype: dict
         """
@@ -467,6 +473,9 @@ class AutoNormal(AutoGuide):
     def forward(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
+
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__`.
 
         :return: A dict mapping sample site name to sampled value.
         :rtype: dict
@@ -672,6 +681,9 @@ class AutoContinuous(AutoGuide):
     def forward(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
+
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__`.
 
         :return: A dict mapping sample site name to sampled value.
         :rtype: dict
@@ -1090,6 +1102,9 @@ class AutoDiscreteParallel(AutoGuide):
     def forward(self, *args, **kwargs):
         """
         An automatic guide with the same ``*args, **kwargs`` as the base ``model``.
+
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__`.
 
         :return: A dict mapping sample site name to sampled value.
         :rtype: dict

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -187,6 +187,10 @@ class Predictive(torch.nn.Module):
         contained in `posterior_samples` are returned. This can be modified by changing the
         `return_sites` keyword argument of this :class:`Predictive` instance.
 
+        .. note:: This method is used internally by :class:`~torch.nn.Module`.
+            Users should instead use :meth:`~torch.nn.Module.__call__` as in
+            ``Predictive(model)(*args, **kwargs)``.
+
         :param args: model arguments.
         :param kwargs: model keyword arguments.
         """

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -96,9 +96,6 @@ class MaskedLinear(nn.Linear):
         self.register_buffer('mask', mask.data)
 
     def forward(self, _input):
-        """
-        the forward method that does the masked linear computation and returns the result
-        """
         masked_weight = self.weight * self.mask
         return F.linear(_input, masked_weight, self.bias)
 
@@ -221,9 +218,6 @@ class ConditionalAutoRegressiveNN(nn.Module):
         return self.permutation
 
     def forward(self, x, context=None):
-        """
-        The forward method
-        """
         # We must be able to broadcast the size of the context over the input
         if context is None:
             context = self.context
@@ -318,7 +312,4 @@ class AutoRegressiveNN(ConditionalAutoRegressiveNN):
             nonlinearity=nonlinearity)
 
     def forward(self, x):
-        """
-        The forward method
-        """
         return self._forward(x)

--- a/pyro/nn/dense_nn.py
+++ b/pyro/nn/dense_nn.py
@@ -65,9 +65,6 @@ class ConditionalDenseNN(torch.nn.Module):
         self.f = nonlinearity
 
     def forward(self, x, context):
-        """
-        The forward method
-        """
         # We must be able to broadcast the size of the context over the input
         context = context.expand(x.size()[:-1]+(context.size(-1),))
 
@@ -138,7 +135,4 @@ class DenseNN(ConditionalDenseNN):
         )
 
     def forward(self, x):
-        """
-        The forward method
-        """
         return self._forward(x)


### PR DESCRIPTION
Addresses confusion in https://forum.pyro.ai/t/why-samples-from-categorical-and-bernoulli-dist-are-missing-after-mcmc/2315/3

This clarifies some `.forward()` docstrings and removes a few trivial docstrings.