### PR TITLE
Attempt to fix help(MyDistribution)

### DIFF
--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
 from abc import ABCMeta, abstractmethod
 
 from pyro.distributions.score_parts import ScoreParts
@@ -15,6 +16,10 @@ class DistributionMeta(ABCMeta):
             if result is not None:
                 return result
         return super().__call__(*args, **kwargs)
+
+    @property
+    def __wrapped__(cls):
+        return functools.partial(cls.__init__, None)
 
 
 class Distribution(metaclass=DistributionMeta):


### PR DESCRIPTION
Fixes #2681 

@fehiepsi this seems like a hack, but I believe this is an intended use of the [`.__wrapped__` attribute](https://docs.python.org/3.6/library/inspect.html#inspect.signature). WDYT?

This attempts to fix e.g. `help(dist.Normal)`. Before this PR:
```
$ python -c 'import pyro.distributions as d; help(d.Normal)' | head -n 4
Help on class Normal in module pyro.distributions.torch:

class Normal(torch.distributions.normal.Normal, pyro.distributions.torch_distribution.TorchDistributionMixin)
 |  Normal(*args, **kwargs)
```
After this PR:
```
$ python -c 'import pyro.distributions as d; help(d.Normal)' | head -n 4
Help on class Normal in module pyro.distributions.torch:

class Normal(torch.distributions.normal.Normal, pyro.distributions.torch_distribution.TorchDistributionMixin)
 |  Normal(loc, scale, validate_args=None)
```