### PR TITLE
Stabilize math in SpanningTree.log_partition_function

### DIFF
--- a/pyro/distributions/spanning_tree.cpp
+++ b/pyro/distributions/spanning_tree.cpp
@@ -142,7 +142,7 @@ at::Tensor sample_tree_approx(at::Tensor edge_logits) {
   // the complete graph. The id of an edge (v1,v2) is k = v1+v2*(v2-1)/2.
   auto edge_ids = torch::empty({E}, at::kLong);
   // This maps each vertex to whether it is a member of the cumulative tree.
-  auto components = torch::zeros({V}, at::kByte);
+  auto components = torch::zeros({V}, at::kBool);
 
   // Sample the first edge at random.
   auto probs = (edge_logits - edge_logits.max()).exp();


### PR DESCRIPTION
This makes the numerical stabilization math more fine-grained in `SpanningTree.log_partition_function`.

Previously we shifted by a max over all edges. After this PR we shift by column sums. This is advantageous because the resulting Laplacian matrix has constant 1's on the diagonal and is safer for the Cholesky factorization in `.logdet()`.

Could a reviewer please go over the math in detail to ensure gradients are correct? Thanks in advance!

## Tested
- [x] refactoring covered by existing tests
- [x] fixes nan issues in a gradient-based inference that uses `.log_partition_function`