### PR TITLE
Implement a GumbelSoftmaxReparam

### DIFF
--- a/docs/source/infer.reparam.rst
+++ b/docs/source/infer.reparam.rst
@@ -32,6 +32,15 @@ Loc-Scale Decentering
     :special-members: __call__
     :show-inheritance:
 
+Gumbel-Softmax
+--------------
+.. automodule:: pyro.infer.reparam.softmax
+    :members:
+    :undoc-members:
+    :member-order: bysource
+    :special-members: __call__
+    :show-inheritance:
+
 Transformed Distributions
 -------------------------
 .. automodule:: pyro.infer.reparam.transform

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -8,6 +8,7 @@ from .haar import HaarReparam
 from .hmm import LinearHMMReparam
 from .loc_scale import LocScaleReparam
 from .neutra import NeuTraReparam
+from .softmax import GumbelSoftmaxReparam
 from .split import SplitReparam
 from .stable import LatentStableReparam, StableReparam, SymmetricStableReparam
 from .studentt import StudentTReparam
@@ -17,6 +18,7 @@ from .unit_jacobian import UnitJacobianReparam
 __all__ = [
     "ConjugateReparam",
     "DiscreteCosineReparam",
+    "GumbelSoftmaxReparam",
     "HaarReparam",
     "LatentStableReparam",
     "LinearHMMReparam",

--- a/pyro/infer/reparam/softmax.py
+++ b/pyro/infer/reparam/softmax.py
@@ -1,0 +1,38 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import pyro
+import pyro.distributions as dist
+
+from .reparam import Reparam
+
+
+class GumbelSoftmaxReparam(Reparam):
+    """
+    Reparametrizer for :class:`~pyro.distributions.RelaxedOneHotCategorical`
+    latent variables.
+
+    This is useful for transforming multimodal posteriors to unimodal
+    posteriors. Note this increases the latent dimension by 1 per event.
+
+    This reparameterization works only for latent variables, not likelihoods.
+    """
+    def __call__(self, name, fn, obs):
+        fn, event_dim = self._unwrap(fn)
+        assert isinstance(fn, dist.RelaxedOneHotCategorical)
+        assert obs is None, "SoftmaxReparam does not support observe statements"
+
+        # Draw parameter-free noise.
+        proto = fn.logits
+        new_fn = dist.Uniform(torch.zeros_like(proto), torch.ones_like(proto))
+        u = pyro.sample("{}_uniform".format(name), self._wrap(new_fn, event_dim))
+
+        # Differentiably transform.
+        logits = fn.logits - u.log().neg().log()
+        value = (logits / fn.temperature).softmax(dim=-1)
+
+        # Simulate a pyro.deterministic() site.
+        new_fn = dist.Delta(value, event_dim=event_dim).mask(False)
+        return new_fn, value

--- a/tests/infer/reparam/test_softmax.py
+++ b/tests/infer/reparam/test_softmax.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2017-2019 Uber Technologies, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from torch.autograd import grad
+
+import pyro
+import pyro.distributions as dist
+from pyro import poutine
+from pyro.infer.reparam import GumbelSoftmaxReparam
+from tests.common import assert_close
+
+
+# Test helper to extract a few central moments from samples.
+def get_moments(x):
+    m1 = x.mean(0)
+    x = x - m1
+    xx = x[..., None] * x[..., None, :]
+    m2 = xx.mean(0)
+    return torch.cat([m1.reshape(-1), m2.reshape(-1)])
+
+
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("temperature", [0.01, 0.1, 1.0])
+@pytest.mark.parametrize("dim", [2, 3])
+def test_gumbel_softmax(temperature, shape, dim):
+    temperature = torch.tensor(temperature)
+    logits = torch.randn(shape + (dim,)).requires_grad_()
+
+    def model():
+        with pyro.plate_stack("plates", shape):
+            with pyro.plate("particles", 10000):
+                pyro.sample("x", dist.RelaxedOneHotCategorical(temperature,
+                                                               logits=logits))
+
+    value = poutine.trace(model).get_trace().nodes["x"]["value"]
+    expected_probe = get_moments(value)
+
+    reparam_model = poutine.reparam(model, {"x": GumbelSoftmaxReparam()})
+    value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
+    actual_probe = get_moments(value)
+    assert_close(actual_probe, expected_probe, atol=0.05)
+
+    for actual_m, expected_m in zip(actual_probe, expected_probe):
+        expected_grad = grad(expected_m, [logits], retain_graph=True)
+        actual_grad = grad(actual_m, [logits], retain_graph=True)
+        assert_close(actual_grad, expected_grad, atol=0.05)


### PR DESCRIPTION
This adds a reparametrizer for the Gumbel-Softmax trick.

The reparametrizer replaces a d-dimensional `RelaxedOneHotCategorical` with a d-dimensional `Uniform(0,1)` distribution whose samples are first transformed to be Gumbel distributed and then passed through the softmax trick.

The motivation is that, when unimodal autoguides try to learn the posterior of a R.O.H.C. distribution they are only able to capture a single mode, i.e. a single category. By instead learning the posterior in pre-softmax space, a single mode can then be softmax-transformed to a multimodal posterior, with one mode per category. Thus this reparametrizer allows naive autoguides like `AutoNormal` to capture multimodal posteriors.

## Tested
- [x] added moment tests
- [x] smoke tested in [a practical model](https://github.com/broadinstitute/pyro-cov/blob/816b8eba116bcc77a367aad7fdf736b09e87167e/pyrophylo/kirchhoff.py#L93)