### PR TITLE
Silence pyro.param warning if .training is False

### DIFF
--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -356,9 +356,10 @@ def module(name, nn_module, update_module_params=False):
 
             if param_value._cdata != returned_param._cdata:
                 target_state_dict[param_name] = returned_param
-        else:
-            warnings.warn("{} was not registered in the param store because".format(param_name) +
-                          " requires_grad=False")
+        elif nn_module.training:
+            warnings.warn(f"{param_name} was not registered in the param store "
+                          "because requires_grad=False. You can silence this "
+                          "warning by calling my_module.train(False)")
 
     if target_state_dict and update_module_params:
         # WARNING: this is very dangerous. better method?


### PR DESCRIPTION
Fixes #2705 

This provides a mechanism to silence `pyro.param` warnings when running a detached `PyroModule` during training. It is a coarse-grained solution; this silences the warning for the module as a whole. To silence individual param warnings, users could convert from `PyroParam` to `Tensor`:
```py
value = my_module.my_param.detach()
del my_module.my_param  # deletes the PyroParam
my_module.my_param = value  # creates a new Tensor
```