### PR TITLE
Add a OneOneMatching distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -253,6 +253,13 @@ OMTMultivariateNormal
     :undoc-members:
     :show-inheritance:
 
+OneOneMatching
+--------------
+.. autoclass:: pyro.distributions.OneOneMatching
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 OneTwoMatching
 --------------
 .. autoclass:: pyro.distributions.OneTwoMatching

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -43,6 +43,7 @@ from pyro.distributions.lkj import LKJCorrCholesky
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.multivariate_studentt import MultivariateStudentT
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
+from pyro.distributions.one_one_matching import OneOneMatching
 from pyro.distributions.one_two_matching import OneTwoMatching
 from pyro.distributions.ordered_logistic import OrderedLogistic
 from pyro.distributions.polya_gamma import TruncatedPolyaGamma
@@ -107,6 +108,7 @@ __all__ = [
     "MixtureOfDiagNormalsSharedCovariance",
     "MultivariateStudentT",
     "OMTMultivariateNormal",
+    "OneOneMatching",
     "OneTwoMatching",
     "OrderedLogistic",
     "Rejector",

--- a/pyro/distributions/one_one_matching.py
+++ b/pyro/distributions/one_one_matching.py
@@ -42,7 +42,7 @@ class OneOneMatching(TorchDistribution):
     r"""
     Random perfect matching from ``N`` sources to ``N`` destinations where each
     source matches exactly **one** destination and each destination matches
-    exactly **one** sources.
+    exactly **one** source.
 
     Samples are represented as long tensors of shape ``(N,)`` taking values in
     ``{0,...,N-1}`` and satisfying the above one-one constraint. The log

--- a/pyro/distributions/one_one_matching.py
+++ b/pyro/distributions/one_one_matching.py
@@ -1,0 +1,171 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import logging
+import warnings
+
+import torch
+from torch.distributions import constraints
+from torch.distributions.utils import lazy_property
+
+from .torch import Categorical
+from .torch_distribution import TorchDistribution
+
+logger = logging.getLogger(__name__)
+
+
+class OneOneMatchingConstraint(constraints.Constraint):
+    def __init__(self, num_nodes):
+        self.num_nodes = num_nodes
+
+    def check(self, value):
+        if value.dim() == 0:
+            warnings.warn("Invalid event_shape: ()")
+            return torch.tensor(False)
+        batch_shape, event_shape = value.shape[:-1], value.shape[-1:]
+        if event_shape != (self.num_nodes,):
+            warnings.warn("Invalid event_shape: {}".format(event_shape))
+            return torch.tensor(False)
+        if value.min() < 0 or value.max() >= self.num_nodes:
+            warnings.warn("Value out of bounds")
+            return torch.tensor(False)
+        counts = torch.zeros(batch_shape + (self.num_nodes,))
+        counts.scatter_add_(-1, value, torch.ones(value.shape))
+        if (counts != 1).any():
+            warnings.warn("Matching is not binary")
+            return torch.tensor(False)
+        return torch.tensor(True)
+
+
+class OneOneMatching(TorchDistribution):
+    r"""
+    Random perfect matching from ``N`` sources to ``N`` destinations where each
+    source matches exactly **one** destination and each destination matches
+    exactly **one** sources.
+
+    Samples are represented as long tensors of shape ``(N,)`` taking values in
+    ``{0,...,N-1}`` and satisfying the above one-one constraint. The log
+    probability of a sample ``v`` is the sum of edge logits, up to the log
+    partition function ``log Z``:
+
+    .. math::
+
+        \log p(v) = \sum_s \text{logits}[s, v[s]] - \log Z
+
+    Exact computations are expensive. To enable tractable approximations, set a
+    number of belief propagation iterations via the ``bp_iters`` argument.  The
+    :meth:`log_partition_function` and :meth:`log_prob` methods use a Bethe
+    approximation [1,2,3,4].
+
+    **References:**
+
+    [1] Michael Chertkov, Lukas Kroc, Massimo Vergassola (2008)
+        "Belief propagation and beyond for particle tracking"
+        https://arxiv.org/pdf/0806.1199.pdf
+    [2] Bert Huang, Tony Jebara (2009)
+        "Approximating the Permanent with Belief Propagation"
+        https://arxiv.org/pdf/0908.1769.pdf
+    [3] Pascal O. Vontobel (2012)
+        "The Bethe Permanent of a Non-Negative Matrix"
+        https://arxiv.org/pdf/1107.4196.pdf
+    [4] M Chertkov, AB Yedidia (2013)
+        "Approximating the permanent with fractional belief propagation"
+        http://www.jmlr.org/papers/volume14/chertkov13a/chertkov13a.pdf
+
+    :param Tensor logits: An ``(N, N)``-shaped tensor of edge logits.
+    :param int bp_iters: Optional number of belief propagation iterations. If
+        unspecified or ``None`` expensive exact algorithms will be used.
+    """
+    arg_constraints = {"logits": constraints.real}
+    has_enumerate_support = True
+
+    def __init__(self, logits, *, bp_iters=None, validate_args=None):
+        if logits.dim() != 2:
+            raise NotImplementedError("OneOneMatching does not support batching")
+        assert bp_iters is None or isinstance(bp_iters, int) and bp_iters > 0
+        self.num_nodes, num_nodes = logits.shape
+        assert num_nodes == self.num_nodes
+        self.logits = logits
+        batch_shape = ()
+        event_shape = (self.num_nodes,)
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
+        self.bp_iters = bp_iters
+
+    @constraints.dependent_property
+    def support(self):
+        return OneOneMatchingConstraint(self.num_nodes)
+
+    @lazy_property
+    def log_partition_function(self):
+        if self.bp_iters is None:
+            # Brute force.
+            d = self.enumerate_support()
+            s = torch.arange(d.size(-1), dtype=d.dtype, device=d.device)
+            return self.logits[s, d].sum(-1).logsumexp(-1)
+
+        # Approximate mean field beliefs b via Sinkhorn iteration.
+        # We find that Sinkhorn iteration is more robust and faster than the
+        # optimal belief propagation updates suggested in [1-4].
+        finfo = torch.finfo(self.logits.dtype)
+        shift = self.logits.data.max(1, True).values
+        shift.clamp_(min=finfo.min, max=finfo.max)
+        p = (self.logits - shift).exp().clamp(min=finfo.tiny ** 0.5)
+        d = 1 / p.sum(0)
+        for _ in range(self.bp_iters):
+            s = 1 / (p @ d)
+            d = 1 / (s @ p)
+        b = s[:, None] * d * p
+
+        # Evaluate the Bethe free energy.
+        b = b.clamp(min=finfo.tiny ** 0.5)
+        b_ = (1 - b).clamp(min=finfo.tiny ** 0.5)
+        free_energy = (b * (b.log() - p.log())).sum() - (b_ * b_.log()).sum()
+        return shift.sum() - free_energy
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        d = value
+        s = torch.arange(d.size(-1), dtype=d.dtype, device=d.device)
+        return self.logits[s, d].sum(-1) - self.log_partition_function
+
+    def enumerate_support(self, expand=True):
+        return torch.tensor(list(itertools.permutations(range(self.num_nodes))))
+
+    def sample(self, sample_shape=torch.Size()):
+        if self.bp_iters is None:
+            # Brute force.
+            d = self.enumerate_support()
+            s = torch.arange(d.size(-1), dtype=d.dtype, device=d.device)
+            logits = self.logits[s, d].sum(-1)
+            sample = Categorical(logits=logits).sample(sample_shape)
+            return d[sample]
+
+        if sample_shape:
+            return torch.stack([self.sample(sample_shape[1:])
+                                for _ in range(sample_shape[0])])
+        # TODO initialize via .mode(), then perform a small number of MCMC steps
+        # https://www.cc.gatech.edu/~vigoda/Permanent.pdf
+        # https://papers.nips.cc/paper/2012/file/4c27cea8526af8cfee3be5e183ac9605-Paper.pdf
+        raise NotImplementedError
+
+    def mode(self):
+        """
+        Computes a maximum probability matching.
+
+        .. note:: This requires the `lap <https://pypi.org/project/lap/>`_
+            package and runs on CPU.
+        """
+        return maximum_weight_matching(self.logits)
+
+
+@torch.no_grad()
+def maximum_weight_matching(logits):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=ImportWarning)
+        import lap
+    cost = -logits.cpu()
+    value = lap.lapjv(cost.numpy())[1]
+    value = torch.tensor(value, dtype=torch.long, device=logits.device)
+    return value

--- a/tests/distributions/test_one_one_matching.py
+++ b/tests/distributions/test_one_one_matching.py
@@ -1,0 +1,116 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import math
+
+import pytest
+import torch
+
+import pyro.distributions as dist
+from tests.common import assert_close, assert_equal, xfail_if_not_implemented
+
+BP_ITERS = 30
+
+
+def _hash(value):
+    return tuple(value.tolist())
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("num_nodes", [1, 2, 3, 4, 5, 6])
+def test_enumerate(num_nodes, dtype):
+    logits = torch.randn(num_nodes, num_nodes, dtype=dtype)
+    d = dist.OneOneMatching(logits)
+    values = d.enumerate_support()
+    logging.info("destins = {}, suport size = {}".format(num_nodes, len(values)))
+    assert d.support.check(values), "invalid"
+    assert len(set(map(_hash, values))) == len(values), "not unique"
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("num_nodes", [1, 2, 3, 4, 5, 6])
+@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
+def test_sample_shape_smoke(num_nodes, sample_shape, dtype, bp_iters):
+    logits = torch.randn(num_nodes, num_nodes, dtype=dtype)
+    d = dist.OneOneMatching(logits, bp_iters=bp_iters)
+    with xfail_if_not_implemented():
+        values = d.sample(sample_shape)
+    assert values.shape == sample_shape + (num_nodes,)
+    assert d.support.check(values).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("num_nodes", [1, 2, 3, 4, 5, 6, 7, 8])
+@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
+def test_log_prob_full(num_nodes, dtype, bp_iters):
+    logits = torch.randn(num_nodes, num_nodes, dtype=dtype) * 10
+    d = dist.OneOneMatching(logits, bp_iters=bp_iters)
+    values = d.enumerate_support()
+    log_total = d.log_prob(values).logsumexp(0).item()
+    logging.info(f"log_total = {log_total:0.3g}, " +
+                 f"log_Z = {d.log_partition_function:0.3g}")
+    assert_close(log_total, 0., atol=2.0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
+def test_log_prob_hard(dtype, bp_iters):
+    logits = [[0., 0.], [0., -math.inf]]
+    logits = torch.tensor(logits, dtype=dtype)
+    d = dist.OneOneMatching(logits, bp_iters=bp_iters)
+    values = d.enumerate_support()
+    log_total = d.log_prob(values).logsumexp(0).item()
+    logging.info(f"log_total = {log_total:0.3g}, " +
+                 f"log_Z = {d.log_partition_function:0.3g}")
+    assert_close(log_total, 0., atol=0.5)
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("num_nodes", [1, 2, 3, 4, 5, 6, 7, 8])
+def test_mode_full(num_nodes, dtype):
+    pytest.importorskip("lap")
+    logits = torch.randn(num_nodes, num_nodes, dtype=dtype) * 10
+    d = dist.OneOneMatching(logits)
+    values = d.enumerate_support()
+    i = d.log_prob(values).max(0).indices.item()
+    expected = values[i]
+    actual = d.mode()
+    assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("num_nodes", [3, 5, 8, 13, 100, 1000])
+def test_mode_full_smoke(num_nodes, dtype):
+    pytest.importorskip("lap")
+    logits = torch.randn(num_nodes, num_nodes, dtype=dtype) * 10
+    d = dist.OneOneMatching(logits)
+    value = d.mode()
+    assert d.support.check(value)
+
+
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+@pytest.mark.parametrize("num_nodes", [2, 3, 4, 5, 6])
+@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
+def test_sample_full(num_nodes, dtype, bp_iters):
+    pytest.importorskip("lap")
+    logits = torch.randn(num_nodes, num_nodes, dtype=dtype) * 10
+    d = dist.OneOneMatching(logits, bp_iters=bp_iters)
+
+    # Compute an empirical mean.
+    num_samples = 1000
+    s = torch.arange(num_nodes)
+    actual = torch.zeros_like(logits)
+    with xfail_if_not_implemented():
+        for v in d.sample([num_samples]):
+            actual[s, v] += 1 / num_samples
+
+    # Compute truth via enumeration.
+    values = d.enumerate_support()
+    probs = d.log_prob(values).exp()
+    probs /= probs.sum()
+    expected = torch.zeros(num_nodes, num_nodes)
+    for v, p in zip(values, probs):
+        expected[s, v] += p
+    assert_close(actual, expected, atol=0.1)


### PR DESCRIPTION
This follows #2697 by introducing a `OneOneMatching` distribution that is nearly identical to, but slightly simpler than, the earlier `OneTwoMatching`. (Indeed this PR took only around 15 minutes to create. @martinjankowiak I hope it will be similarly easy to review 😬 )

My motivation is (1) completeness, (2) to have a simpler set of tests where I can experiment with better BP algorithms, and (3) to verify the relationship between 1-1-matchings and 1-2-matchings.

## Tested
- [x] added tests as in the original PR
- [x] added gradcheck tests for `OneOneMatching`
- [x] added gradcheck tests for `OneTwoMatching`