### PR TITLE
Support MaskedDistribution in contrib.forecast

### DIFF
--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -215,6 +215,13 @@ def prefix_condition(d, data):
         raise NotImplementedError("prefix_condition() does not suport {}".format(type(d))) from e
 
 
+@prefix_condition.register(dist.MaskedDistribution)
+def _(d, data):
+    base_dist = prefix_condition(d.base_dist, data)
+    mask = d._mask[tuple(map(slice, base_dist.batch_shape))]
+    return base_dist.mask(mask)
+
+
 @prefix_condition.register(dist.Independent)
 def _(d, data):
     base_dist = prefix_condition(d.base_dist, data)
@@ -270,6 +277,13 @@ def reshape_batch(d, batch_shape):
     :rtype: ~pyro.distributions.Distribution
     """
     raise NotImplementedError("reshape_batch() does not suport {}".format(type(d)))
+
+
+@reshape_batch.register(dist.MaskedDistribution)
+def _(d, batch_shape):
+    mask = d._mask.reshape(batch_shape)
+    base_dist = reshape_batch(d.base_dist, batch_shape)
+    return base_dist.mask(mask)
 
 
 @reshape_batch.register(dist.Independent)

--- a/pyro/contrib/forecast/util.py
+++ b/pyro/contrib/forecast/util.py
@@ -218,7 +218,7 @@ def prefix_condition(d, data):
 @prefix_condition.register(dist.MaskedDistribution)
 def _(d, data):
     base_dist = prefix_condition(d.base_dist, data)
-    mask = d._mask[tuple(map(slice, base_dist.batch_shape))]
+    mask = d._mask[tuple(slice(-size, None) for size in base_dist.batch_shape)]
     return base_dist.mask(mask)
 
 

--- a/tests/contrib/forecast/test_util.py
+++ b/tests/contrib/forecast/test_util.py
@@ -27,6 +27,7 @@ DISTS = [
     dist.Laplace,
     dist.LinearHMM,
     dist.LogNormal,
+    dist.MaskedDistribution,
     dist.MultivariateNormal,
     dist.NegativeBinomial,
     dist.Normal,
@@ -39,6 +40,10 @@ DISTS = [
 def random_dist(Dist, shape, transform=None):
     if Dist is dist.FoldedDistribution:
         return Dist(random_dist(dist.Normal, shape))
+    if Dist is dist.MaskedDistribution:
+        base_dist = random_dist(dist.Normal, shape)
+        mask = torch.empty(shape, dtype=torch.bool).bernoulli_(0.5)
+        return base_dist.mask(mask)
     elif Dist in (dist.GaussianHMM, dist.LinearHMM):
         batch_shape, duration, obs_dim = shape[:-2], shape[-2], shape[-1]
         hidden_dim = obs_dim + 1


### PR DESCRIPTION
Addresses #2708 

This adds support for `MaskedDistribution` in `contrib.forecast` by implementing `prefix_condition()` and `reshape_batch()` for `MaskedDistribution`.

## Tested
- [x] added unit tests