### PR TITLE
Stabilize Bethe approximation in matching distributions

### DIFF
--- a/pyro/distributions/one_two_matching.py
+++ b/pyro/distributions/one_two_matching.py
@@ -135,9 +135,9 @@ class OneTwoMatching(TorchDistribution):
         # coefficient: perplexity * (perplexity - 1) / 2.
         h2 = h + log(h.expm1()) - math.log(2)
         free_energy = internal_energy - h2.sum() - (b_ * log(b_)).sum()
-        result = shift.sum() - free_energy
-        assert torch.isfinite(result)
-        return result
+        log_Z = shift.sum() - free_energy
+        assert torch.isfinite(log_Z)
+        return log_Z
 
     def log_prob(self, value):
         if self._validate_args:

--- a/pyro/distributions/one_two_matching.py
+++ b/pyro/distributions/one_two_matching.py
@@ -92,7 +92,6 @@ class OneTwoMatching(TorchDistribution):
         event_shape = (self.num_sources,)
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
         self.bp_iters = bp_iters
-        # print(f"DEBUG {logits.data.numpy()}")
 
     @constraints.dependent_property
     def support(self):

--- a/tests/distributions/test_one_two_matching.py
+++ b/tests/distributions/test_one_two_matching.py
@@ -127,7 +127,7 @@ def test_grad_full(num_destins, bp_iters):
         d = dist.OneTwoMatching(logits, bp_iters=bp_iters)
         return d.log_partition_function
 
-    torch.autograd.gradcheck(fn, logits, atol=0.01, rtol=0.01)
+    torch.autograd.gradcheck(fn, logits, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.parametrize("num_destins", [2, 3, 4])
@@ -144,7 +144,7 @@ def test_grad_hard(num_destins, bp_iters):
         d = dist.OneTwoMatching(logits, bp_iters=bp_iters)
         return d.log_partition_function
 
-    torch.autograd.gradcheck(fn, logits, atol=0.01, rtol=0.01)
+    torch.autograd.gradcheck(fn, logits, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.parametrize("num_leaves", [2, 3, 4, 5])
@@ -157,7 +157,7 @@ def test_grad_phylo(num_leaves, bp_iters):
         d = dist.OneTwoMatching(logits, bp_iters=bp_iters)
         return d.log_partition_function
 
-    torch.autograd.gradcheck(fn, logits, atol=0.01, rtol=0.01)
+    torch.autograd.gradcheck(fn, logits, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)

--- a/tests/distributions/test_one_two_matching.py
+++ b/tests/distributions/test_one_two_matching.py
@@ -116,12 +116,7 @@ def test_log_prob_phylo_smoke(num_leaves, dtype):
     assert not torch.isnan(dt).any()
 
 
-@pytest.mark.parametrize("num_destins", [2, 3, 4, 5])
-@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
-def test_grad_full(num_destins, bp_iters):
-    num_sources = 2 * num_destins
-    logits = torch.randn(num_sources, num_destins) * 10
-    logits.requires_grad_()
+def assert_grads_ok(logits, bp_iters=None):
 
     def fn(logits):
         d = dist.OneTwoMatching(logits, bp_iters=bp_iters)
@@ -130,9 +125,28 @@ def test_grad_full(num_destins, bp_iters):
     torch.autograd.gradcheck(fn, logits, atol=1e-3, rtol=1e-3)
 
 
+def assert_grads_agree(logits):
+    d1 = dist.OneTwoMatching(logits)
+    d2 = dist.OneTwoMatching(logits, bp_iters=BP_ITERS)
+    expected = torch.autograd.grad(d1.log_partition_function, [logits])[0]
+    actual = torch.autograd.grad(d2.log_partition_function, [logits])[0]
+    assert torch.allclose(actual, expected, atol=0.2, rtol=1e-3), \
+        f"Expected:\n{expected.numpy()}\nActual:\n{actual.numpy()}"
+
+
+@pytest.mark.parametrize("num_destins", [2, 3, 4, 5])
+def test_grad_full(num_destins):
+    num_sources = 2 * num_destins
+    logits = torch.randn(num_sources, num_destins) * 10
+    logits.requires_grad_()
+
+    assert_grads_ok(logits)
+    assert_grads_ok(logits, bp_iters=BP_ITERS)
+    assert_grads_agree(logits)
+
+
 @pytest.mark.parametrize("num_destins", [2, 3, 4])
-@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
-def test_grad_hard(num_destins, bp_iters):
+def test_grad_hard(num_destins):
     num_sources = 2 * num_destins
     i = torch.arange(num_sources)[:, None]
     j = torch.arange(num_destins)
@@ -140,24 +154,19 @@ def test_grad_hard(num_destins, bp_iters):
     logits[i < j] = -100
     logits.requires_grad_()
 
-    def fn(logits):
-        d = dist.OneTwoMatching(logits, bp_iters=bp_iters)
-        return d.log_partition_function
-
-    torch.autograd.gradcheck(fn, logits, atol=1e-3, rtol=1e-3)
+    assert_grads_ok(logits)
+    assert_grads_ok(logits, bp_iters=BP_ITERS)
+    assert_grads_agree(logits)
 
 
 @pytest.mark.parametrize("num_leaves", [2, 3, 4, 5])
-@pytest.mark.parametrize("bp_iters", [None, BP_ITERS], ids=["exact", "bp"])
-def test_grad_phylo(num_leaves, bp_iters):
+def test_grad_phylo(num_leaves):
     logits, times = random_phylo_logits(num_leaves, torch.double)
     logits = logits.detach().requires_grad_()
 
-    def fn(logits):
-        d = dist.OneTwoMatching(logits, bp_iters=bp_iters)
-        return d.log_partition_function
-
-    torch.autograd.gradcheck(fn, logits, atol=1e-3, rtol=1e-3)
+    assert_grads_ok(logits)
+    assert_grads_ok(logits, bp_iters=BP_ITERS)
+    assert_grads_agree(logits)
 
 
 @pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)


### PR DESCRIPTION
This improves numerical stability of gradient computations in `OneOneMatching` and `OneTwoMatching` by switching their Sinkhorn computations from linear coords to log coords (using `logsumexp`). This reduces the amount of clamping and empirically improves the gradients in large phylogenetic models.

## Tested
All matching tests still run in about ~15sec in a single process.
- [x] Narrowed tolerance of existing gradient tests
- [x] Added new gradient tests comparing BP gradients to exact gradients (this test can catch weird errors where BP gets lucky in computing a correct value but has arbitrarily bad gradients)
- [x] Tested new gradient computation in a bigger model, which resulted in: better loss, more plausible solutions, more plausible gradient trajectories (e.g. with many more zero crossings)