### PR TITLE
Add rate parameter to CoalescentTimes distribution

### DIFF
--- a/tests/distributions/test_coalescent.py
+++ b/tests/distributions/test_coalescent.py
@@ -104,7 +104,7 @@ def test_log_prob_scale(num_leaves, num_steps, batch_shape, sample_shape):
 @pytest.mark.parametrize("sample_shape", [(), (5,)], ids=str)
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("num_leaves", [2, 7, 11])
-def test_log_prob_constant_rate(num_leaves, num_steps, batch_shape, sample_shape):
+def test_log_prob_constant_rate_1(num_leaves, num_steps, batch_shape, sample_shape):
     rate = torch.randn(batch_shape).exp()
     rate_grid = rate.unsqueeze(-1).expand(batch_shape + (num_steps,))
     leaf_times_2 = torch.rand(batch_shape + (num_leaves,)).pow(0.5) * num_steps
@@ -126,7 +126,7 @@ def test_log_prob_constant_rate(num_leaves, num_steps, batch_shape, sample_shape
 @pytest.mark.parametrize("sample_shape", [(), (5,)], ids=str)
 @pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("num_leaves", [2, 7, 11])
-def test_log_prob_constant_rate(num_leaves, num_steps, batch_shape, sample_shape):
+def test_log_prob_constant_rate_2(num_leaves, num_steps, batch_shape, sample_shape):
     rate = torch.randn(batch_shape).exp()
     rate_grid = rate.unsqueeze(-1).expand(batch_shape + (num_steps,))
     leaf_times = torch.rand(batch_shape + (num_leaves,)).pow(0.5) * num_steps

--- a/tests/distributions/test_coalescent.py
+++ b/tests/distributions/test_coalescent.py
@@ -85,15 +85,15 @@ def test_log_prob_unit_rate(num_leaves, num_steps, batch_shape, sample_shape):
 @pytest.mark.parametrize("num_leaves", [2, 7, 11])
 def test_log_prob_scale(num_leaves, num_steps, batch_shape, sample_shape):
     rate = torch.randn(batch_shape).exp()
-    leaf_times_2 = torch.rand(batch_shape + (num_leaves,)).pow(0.5) * num_steps
-    leaf_times_1 = leaf_times_2 * rate.unsqueeze(-1)
 
+    leaf_times_1 = torch.rand(batch_shape + (num_leaves,)).pow(0.5) * num_steps
     d1 = CoalescentTimes(leaf_times_1)
     coal_times_1 = d1.sample(sample_shape)
     log_prob_1 = d1.log_prob(coal_times_1)
 
-    d2 = CoalescentTimes(leaf_times_2, rate)
+    leaf_times_2 = leaf_times_1 / rate.unsqueeze(-1)
     coal_times_2 = coal_times_1 / rate.unsqueeze(-1)
+    d2 = CoalescentTimes(leaf_times_2, rate)
     log_prob_2 = d2.log_prob(coal_times_2)
 
     log_abs_det_jacobian = -coal_times_2.size(-1) * rate.log()


### PR DESCRIPTION
This PR does two things.

1. Adds a `rate` parameter to the simple `CoalescentTimes` distribution so that models can learn a (time-homogeneous) effective population size. I'm using this to match behavior of Beast2 which can learn the coalescent rate while fixing substitution rate (i.e. mutation rate).

2. Adds support for gradients through `CoalescentTimes.log_prob()`. Previously this was difficult because `._weak_memoize()` relied on caching by id, which would have broken for mutable tensors. I've updated to check the `Tensor._version` counter to avoid cache hits if tensors have been mutated. @eb8680 I wonder if we could use this trick anywhere in Funsor.

## Tested
- [x] added test for the new rate parameter
- [x] tested in a phylogenetic inference problem