### PR TITLE
TraceMarkovEnum_ELBO - a trace implementation of ELBO-based SVI that supports model side enumeration of Markov variables

### DIFF
--- a/pyro/contrib/funsor/infer/__init__.py
+++ b/pyro/contrib/funsor/infer/__init__.py
@@ -6,4 +6,4 @@ from pyro.infer import SVI, config_enumerate  # noqa: F401
 from .elbo import ELBO  # noqa: F401
 from .trace_elbo import JitTrace_ELBO, Trace_ELBO  # noqa: F401
 from .tracetmc_elbo import JitTraceTMC_ELBO, TraceTMC_ELBO  # noqa: F401
-from .traceenum_elbo import JitTraceEnum_ELBO, TraceEnum_ELBO  # noqa: F401
+from .traceenum_elbo import JitTraceEnum_ELBO, TraceEnum_ELBO, TraceMarkovEnum_ELBO  # noqa: F401

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -18,8 +18,10 @@ def terms_from_trace(tr):
     # data structure containing densities, measures, scales, and identification
     # of free variables as either product (plate) variables or sum (measure) variables
     terms = {"log_factors": [], "log_measures": [], "scale": to_funsor(1.),
-             "plate_vars": frozenset(), "measure_vars": frozenset()}
+             "plate_vars": frozenset(), "measure_vars": frozenset(), "plate_to_step": dict()}
     for name, node in tr.nodes.items():
+        if node["type"] == "markov_chain":
+            terms["plate_to_step"][node["name"]] = node["value"]
         if node["type"] != "sample" or type(node["fn"]).__name__ == "_Subsample":
             continue
         # grab plate dimensions from the cond_indep_stack
@@ -39,7 +41,67 @@ def terms_from_trace(tr):
         # grab the log-density, found at all sites except those that are not replayed
         if node["is_observed"] or not node.get("replay_skipped", False):
             terms["log_factors"].append(node["funsor"]["log_prob"])
+    for p in terms["plate_vars"]:
+        terms["plate_to_step"][p] = terms["plate_to_step"].get(p, {})
     return terms
+
+
+@copy_docs_from(_OrigTraceEnum_ELBO)
+class TraceMarkovEnum_ELBO(ELBO):
+
+    def differentiable_loss(self, model, guide, *args, **kwargs):
+
+        # get batched, enumerated, to_funsor-ed traces from the guide and model
+        with plate(size=self.num_particles) if self.num_particles > 1 else contextlib.ExitStack(), \
+                enum(first_available_dim=(-self.max_plate_nesting-1) if self.max_plate_nesting else None):
+            guide_tr = trace(guide).get_trace(*args, **kwargs)
+            model_tr = trace(replay(model, trace=guide_tr)).get_trace(*args, **kwargs)
+
+        # extract from traces all metadata that we will need to compute the elbo
+        guide_terms = terms_from_trace(guide_tr)
+        model_terms = terms_from_trace(model_tr)
+
+        # build up a lazy expression for the elbo
+        with funsor.interpreter.interpretation(funsor.terms.lazy):
+            # identify and contract out auxiliary variables in the model with partial_sum_product
+            contracted_factors, uncontracted_factors = [], []
+            for f in model_terms["log_factors"]:
+                if model_terms["measure_vars"].intersection(f.inputs):
+                    contracted_factors.append(f)
+                else:
+                    uncontracted_factors.append(f)
+            # incorporate the effects of subsampling and handlers.scale through a common scale factor
+            contracted_costs = [model_terms["scale"] * f for f in funsor.sum_product.modified_partial_sum_product(
+                funsor.ops.logaddexp, funsor.ops.add,
+                model_terms["log_measures"] + contracted_factors,
+                plate_to_step=model_terms["plate_to_step"],
+                eliminate=model_terms["measure_vars"] | frozenset({
+                    p for p, s in model_terms["plate_to_step"].items() if s})
+            )]
+
+            costs = contracted_costs + uncontracted_factors  # model costs: logp
+            costs += [-f for f in guide_terms["log_factors"]]  # guide costs: -logq
+
+            # finally, integrate out guide variables in the elbo and all plates
+            # dict1 | dict2 in python 3.9
+            plate_to_step = {**guide_terms["plate_to_step"], **model_terms["plate_to_step"]}
+            plate_vars = frozenset(plate_to_step.keys())
+            elbo = to_funsor(0, output=funsor.Real)
+            for cost in costs:
+                # compute the marginal logq in the guide corresponding to this cost term
+                log_prob = funsor.sum_product.modified_sum_product(
+                    funsor.ops.logaddexp, funsor.ops.add,
+                    guide_terms["log_measures"],
+                    plate_to_step=plate_to_step,
+                    eliminate=(plate_vars | guide_terms["measure_vars"]) - frozenset(cost.inputs)
+                )
+                # compute the expected cost term E_q[logp] or E_q[-logq] using the marginal logq for q
+                elbo_term = funsor.Integrate(log_prob, cost, guide_terms["measure_vars"] & frozenset(cost.inputs))
+                elbo += elbo_term.reduce(funsor.ops.add, plate_vars & frozenset(cost.inputs))
+
+        # evaluate the elbo, using memoize to share tensor computation where possible
+        with funsor.memoize.memoize():
+            return -to_data(funsor.optimizer.apply_optimizer(elbo))
 
 
 @copy_docs_from(_OrigTraceEnum_ELBO)

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
-from functools import reduce
 
 import funsor
 
@@ -22,6 +21,7 @@ def terms_from_trace(tr):
              "plate_vars": frozenset(), "measure_vars": frozenset(), "plate_to_step": dict()}
     for name, node in tr.nodes.items():
         if node["type"] == "markov_chain":
+            # add markov dimensions to the plate_to_step dictionary
             terms["plate_to_step"][node["name"]] = node["value"]
         if node["type"] != "sample" or type(node["fn"]).__name__ == "_Subsample":
             continue
@@ -31,7 +31,8 @@ def terms_from_trace(tr):
         if node["funsor"].get("log_measure", None) is not None:
             terms["log_measures"].append(node["funsor"]["log_measure"])
             # sum (measure) variables: the fresh non-plate variables at a site
-            terms["measure_vars"] |= (frozenset(node["funsor"]["value"].inputs) | {name}) - terms["plate_vars"]
+            # terms["measure_vars"] |= (frozenset(node["funsor"]["value"].inputs) | {name}) - terms["plate_vars"]
+            terms["measure_vars"] |= (frozenset(node["funsor"]["log_prob"].inputs) | {name}) - terms["plate_vars"]
         # grab the scale, assuming a common subsampling scale
         if node.get("replay_active", False) and set(node["funsor"]["log_prob"].inputs) & terms["measure_vars"] and \
                 float(to_data(node["funsor"]["scale"])) != 1.:
@@ -42,8 +43,8 @@ def terms_from_trace(tr):
         # grab the log-density, found at all sites except those that are not replayed
         if node["is_observed"] or not node.get("replay_skipped", False):
             terms["log_factors"].append(node["funsor"]["log_prob"])
-    for p in terms["plate_vars"]:
-        terms["plate_to_step"][p] = terms["plate_to_step"].get(p, {})
+    # add plate dimenstions to the plate_to_step dictionary
+    terms["plate_to_step"].update({plate: terms["plate_to_step"].get(plate, {}) for plate in terms["plate_vars"]})
     return terms
 
 
@@ -61,6 +62,9 @@ class TraceMarkovEnum_ELBO(ELBO):
         # extract from traces all metadata that we will need to compute the elbo
         guide_terms = terms_from_trace(guide_tr)
         model_terms = terms_from_trace(model_tr)
+
+        if any(guide_terms["plate_to_step"].values()):
+            raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side enumeration")
 
         # build up a lazy expression for the elbo
         with funsor.interpreter.interpretation(funsor.terms.lazy):
@@ -84,19 +88,16 @@ class TraceMarkovEnum_ELBO(ELBO):
             costs += [-f for f in guide_terms["log_factors"]]  # guide costs: -logq
 
             # finally, integrate out guide variables in the elbo and all plates
-            # dict1 | dict2 in python 3.9
-            plate_to_step = {**guide_terms["plate_to_step"], **model_terms["plate_to_step"]}
-            plate_vars = frozenset(plate_to_step.keys())
+            plate_vars = guide_terms["plate_vars"] | model_terms["plate_vars"]
             elbo = to_funsor(0, output=funsor.Real)
             for cost in costs:
                 # compute the marginal logq in the guide corresponding to this cost term
-                factors = funsor.sum_product.modified_partial_sum_product(
+                log_prob = funsor.sum_product.sum_product(
                     funsor.ops.logaddexp, funsor.ops.add,
                     guide_terms["log_measures"],
-                    plate_to_step=plate_to_step,
+                    plates=plate_vars,
                     eliminate=(plate_vars | guide_terms["measure_vars"]) - frozenset(cost.inputs)
                 )
-                log_prob = reduce(funsor.ops.add, factors, funsor.Number(funsor.ops.UNITS[funsor.ops.add]))
                 # compute the expected cost term E_q[logp] or E_q[-logq] using the marginal logq for q
                 elbo_term = funsor.Integrate(log_prob, cost, guide_terms["measure_vars"] & frozenset(cost.inputs))
                 elbo += elbo_term.reduce(funsor.ops.add, plate_vars & frozenset(cost.inputs))

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -64,7 +64,7 @@ class TraceMarkovEnum_ELBO(ELBO):
 
         # guide side enumeration is not supported
         if any(guide_terms["plate_to_step"].values()):
-            raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side enumeration")
+            raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side Markov enumeration")
 
         # build up a lazy expression for the elbo
         with funsor.interpreter.interpretation(funsor.terms.lazy):

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -16,7 +16,6 @@ try:
     from pyroapi import distributions as dist
     funsor.set_backend("torch")
     from pyroapi import handlers, pyro, pyro_backend, infer
-    from pyro.contrib.funsor.infer.traceenum_elbo import terms_from_trace
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 
@@ -46,10 +45,6 @@ def model_0(data, history, vectorized):
                 pyro.sample("y_{}".format(i), dist.Normal(Vindex(locs)[..., x_curr], 1.),
                             obs=Vindex(data)[sequences, i])
             x_prev = x_curr
-
-
-def guide(data, history, vectorized):
-    pass
 
 
 #     x[t-1] --> x[t] --> x[t+1]
@@ -273,7 +268,6 @@ def model_7(data, history, vectorized):
         x_prev, w_prev = x_curr, w_curr
 
 
-
 @pytest.mark.parametrize("use_replay", [True, False])
 @pytest.mark.parametrize("model,data,var,history", [
     (model_0, torch.rand(3, 5, 4), "xy", 1),
@@ -287,7 +281,7 @@ def model_7(data, history, vectorized):
     (model_7, torch.ones((5, 4), dtype=torch.long), "wxy", 1),
     (model_7, torch.ones((50, 4), dtype=torch.long), "wxy", 1),
 ])
-def test_vectorized_markov(model, data, var, history, use_replay):
+def test_enumeration(model, data, var, history, use_replay):
 
     with pyro_backend("contrib.funsor"):
         with handlers.enum():
@@ -299,35 +293,39 @@ def test_vectorized_markov(model, data, var, history, use_replay):
                 vectorized_trace = handlers.trace(
                         handlers.replay(model, trace=vectorized_trace)).get_trace(data, history, True)
 
-        terms = terms_from_trace(trace)
-        vectorized_terms = terms_from_trace(vectorized_trace)
+        # sequential factors
+        factors = list()
+        for i in range(data.shape[-2]):
+            for v in var:
+                factors.append(trace.nodes["{}_{}".format(v, i)]["funsor"]["log_prob"])
 
-        factors = terms["log_factors"]
-        vectorized_factors = vectorized_terms["log_factors"]
-        time_vars = frozenset({key for key, value in vectorized_terms["plate_to_step"].items() if value})
-        markov_vars = set.union(*(set(chain) for time in time_vars
-                                for chain in vectorized_terms["plate_to_step"][time]))
-        vectorized_factors, _, _ = funsor.sum_product.partial_unroll(
-                vectorized_factors,
-                eliminate=time_vars | markov_vars,
-                plate_to_step=vectorized_terms["plate_to_step"])
+        # vectorized factors
+        vectorized_factors = list()
+        for i in range(history):
+            for v in var:
+                vectorized_factors.append(vectorized_trace.nodes["{}_{}".format(v, i)]["funsor"]["log_prob"])
+        for i in range(history, data.shape[-2]):
+            for v in var:
+                vectorized_factors.append(
+                    vectorized_trace.nodes["{}_{}".format(v, slice(history, data.shape[-2]))]["funsor"]["log_prob"]
+                    (**{"time": i-history},
+                     **{"{}_{}".format(k, slice(history-j, data.shape[-2]-j)): "{}_{}".format(k, i-j)
+                        for j in range(history+1) for k in var})
+                    )
 
-        factor_names = [set(f.inputs) for f in factors]
-        vectorized_factors.sort(key=lambda x: factor_names.index(set(x.inputs)))
         # assert correct factors
         for f1, f2 in zip(factors, vectorized_factors):
             assert_close(f2, f1.align(tuple(f2.inputs)))
 
-        if history > 1:
-            pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
-
-        elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)
-        expected_loss = elbo.differentiable_loss(model, guide, data, history, False)
-
-        vectorized_elbo = infer.TraceMarkovEnum_ELBO(max_plate_nesting=4)
-        actual_loss = vectorized_elbo.differentiable_loss(model, guide, data, history, True)
-
-        assert_close(actual_loss, expected_loss)
+        # assert correct step
+        actual_step = vectorized_trace.nodes["time"]["value"]
+        # expected step: assume that all but the last var is markov
+        expected_step = frozenset()
+        for v in var[:-1]:
+            v_step = tuple("{}_{}".format(v, i) for i in range(history)) \
+                     + tuple("{}_{}".format(v, slice(j, data.shape[-2]-history+j)) for j in range(history+1))
+            expected_step |= frozenset({v_step})
+        assert actual_step == expected_step
 
 
 #     x[i-1] --> x[i] --> x[i+1]
@@ -384,12 +382,18 @@ def model_8(weeks_data, days_data, history, vectorized):
     (model_8, torch.ones(3), torch.zeros(9), "xy", "wz", 1),
     (model_8, torch.ones(30), torch.zeros(50), "xy", "wz", 1),
 ])
-def test_vectorized_markov_multi(model, weeks_data, days_data, vars1, vars2, history, use_replay):
+def test_enumeration_multi(model, weeks_data, days_data, vars1, vars2, history, use_replay):
 
-    with pyro_backend("contrib.funsor"), \
-            handlers.enum():
-        # sequential factors
-        trace = handlers.trace(model).get_trace(weeks_data, days_data, history, False)
+    with pyro_backend("contrib.funsor"):
+        with handlers.enum():
+            # sequential factors
+            trace = handlers.trace(model).get_trace(weeks_data, days_data, history, False)
+
+            # vectorized trace
+            vectorized_trace = handlers.trace(model).get_trace(weeks_data, days_data, history, True)
+            if use_replay:
+                vectorized_trace = handlers.trace(
+                    handlers.replay(model, trace=vectorized_trace)).get_trace(weeks_data, days_data, history, True)
 
         factors = list()
         # sequential weeks factors
@@ -400,12 +404,6 @@ def test_vectorized_markov_multi(model, weeks_data, days_data, vars1, vars2, his
         for j in range(len(days_data)):
             for v in vars2:
                 factors.append(trace.nodes["{}_{}".format(v, j)]["funsor"]["log_prob"])
-
-        # vectorized trace
-        vectorized_trace = handlers.trace(model).get_trace(weeks_data, days_data, history, True)
-        if use_replay:
-            vectorized_trace = handlers.trace(
-                    handlers.replay(model, trace=vectorized_trace)).get_trace(weeks_data, days_data, history, True)
 
         vectorized_factors = list()
         # vectorized weeks factors
@@ -459,3 +457,107 @@ def test_vectorized_markov_multi(model, weeks_data, days_data, vars1, vars2, his
 
         assert actual_weeks_step == expected_weeks_step
         assert actual_days_step == expected_days_step
+
+
+def guide_empty(data, history, vectorized):
+    pass
+
+
+@pytest.mark.parametrize("model,guide,data,history", [
+    (model_0, guide_empty, torch.rand(3, 5, 4), 1),
+    (model_1, guide_empty, torch.rand(5, 4), 1),
+    (model_2, guide_empty, torch.ones((5, 4), dtype=torch.long), 1),
+    (model_3, guide_empty, torch.ones((5, 4), dtype=torch.long), 1),
+    (model_4, guide_empty, torch.ones((5, 4), dtype=torch.long), 1),
+    (model_5, guide_empty, torch.ones((5, 4), dtype=torch.long), 2),
+    (model_6, guide_empty, torch.rand(5, 4), 1),
+    (model_6, guide_empty, torch.rand(100, 4), 1),
+    (model_7, guide_empty, torch.ones((5, 4), dtype=torch.long), 1),
+    (model_7, guide_empty, torch.ones((50, 4), dtype=torch.long), 1),
+])
+def test_model_enumerated_elbo(model, guide, data, history):
+
+    with pyro_backend("contrib.funsor"):
+        if history > 1:
+            pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
+
+        elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)
+        expected_loss = elbo.differentiable_loss(model, guide, data, history, False)
+
+        vectorized_elbo = infer.TraceMarkovEnum_ELBO(max_plate_nesting=4)
+        actual_loss = vectorized_elbo.differentiable_loss(model, guide, data, history, True)
+
+        assert_close(actual_loss, expected_loss)
+
+
+def guide_empyt_multi(weeks_data, days_data, history, vectorized):
+    pass
+
+
+@pytest.mark.parametrize("model,guide,weeks_data,days_data,history", [
+    (model_8, guide_empyt_multi, torch.ones(3), torch.zeros(9), 1),
+    (model_8, guide_empyt_multi, torch.ones(30), torch.zeros(50), 1),
+])
+def test_model_enumerated_elbo_multi(model, guide, weeks_data, days_data, history):
+
+    with pyro_backend("contrib.funsor"):
+
+        elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)
+        expected_loss = elbo.differentiable_loss(model, guide, weeks_data, days_data, history, False)
+
+        vectorized_elbo = infer.TraceMarkovEnum_ELBO(max_plate_nesting=4)
+        actual_loss = vectorized_elbo.differentiable_loss(model, guide, weeks_data, days_data, history, True)
+
+        assert_close(actual_loss, expected_loss)
+
+
+def model_10(data, vectorized):
+    init_probs = torch.tensor([0.5, 0.5])
+    transition_probs = pyro.param("transition_probs",
+                                  torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
+                                  constraint=constraints.simplex)
+    emission_probs = pyro.param("emission_probs",
+                                torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
+                                constraint=constraints.simplex)
+    x = None
+    markov_loop = \
+        pyro.vectorized_markov(name="time", size=len(data)) if vectorized \
+        else pyro.markov(range(len(data)))
+    for i in markov_loop:
+        probs = init_probs if x is None else transition_probs[x]
+        x = pyro.sample("x_{}".format(i), dist.Categorical(probs))
+        pyro.sample("y_{}".format(i), dist.Categorical(emission_probs[x]), obs=data[i])
+
+
+def guide_10(data, vectorized):
+    init_probs = torch.tensor([0.5, 0.5])
+    transition_probs = pyro.param("transition_probs",
+                                  torch.tensor([[0.75, 0.25], [0.25, 0.75]]),
+                                  constraint=constraints.simplex)
+    x = None
+    markov_loop = \
+        pyro.vectorized_markov(name="time", size=len(data)) if vectorized \
+        else pyro.markov(range(len(data)))
+    for i in markov_loop:
+        probs = init_probs if x is None else transition_probs[x]
+        x = pyro.sample("x_{}".format(i), dist.Categorical(probs),
+                        infer={"enumerate": "parallel"})
+
+
+@pytest.mark.parametrize("model,guide,data,", [
+    (model_10, guide_10, torch.ones(5)),
+])
+def test_guide_enumerated_elbo_guide(model, guide, data):
+
+    with pyro_backend("contrib.funsor"):
+        with pytest.raises(
+                NotImplementedError,
+                match="TraceMarkovEnum_ELBO does not yet support guide side enumeration"):
+
+            elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)
+            expected_loss = elbo.differentiable_loss(model, guide, data, False)
+
+            vectorized_elbo = infer.TraceMarkovEnum_ELBO(max_plate_nesting=4)
+            actual_loss = vectorized_elbo.differentiable_loss(model, guide, data, True)
+
+            assert_close(actual_loss, expected_loss)

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -476,6 +476,7 @@ def guide_empty(data, history, vectorized):
     (model_7, guide_empty, torch.ones((50, 4), dtype=torch.long), 1),
 ])
 def test_model_enumerated_elbo(model, guide, data, history):
+    pyro.clear_param_store()
 
     with pyro_backend("contrib.funsor"):
         if history > 1:
@@ -503,6 +504,7 @@ def guide_empty_multi(weeks_data, days_data, history, vectorized):
     (model_8, guide_empty_multi, torch.ones(30), torch.zeros(50), 1),
 ])
 def test_model_enumerated_elbo_multi(model, guide, weeks_data, days_data, history):
+    pyro.clear_param_store()
 
     with pyro_backend("contrib.funsor"):
 
@@ -556,6 +558,7 @@ def guide_10(data, vectorized):
     (model_10, guide_10, torch.ones(5)),
 ])
 def test_guide_enumerated_elbo(model, guide, data):
+    pyro.clear_param_store()
 
     with pyro_backend("contrib.funsor"):
         with pytest.raises(

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -320,7 +320,7 @@ def test_vectorized_markov(model, data, var, history, use_replay):
 
         # assert correct factors
         for f1, f2 in zip(factors, vectorized_factors):
-            funsor.testing.assert_close(f2, f1.align(tuple(f2.inputs)))
+            assert_close(f2, f1.align(tuple(f2.inputs)))
 
         # assert correct step
         actual_step = vectorized_trace.nodes["time"]["value"]
@@ -333,12 +333,14 @@ def test_vectorized_markov(model, data, var, history, use_replay):
         assert actual_step == expected_step
 
     with pyro_backend("contrib.funsor"):
-        if model != model_5:
-            elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)
-            expected_loss = elbo.differentiable_loss(model, guide, data, history, False)
-            vectorized_elbo = infer.TraceMarkovEnum_ELBO(max_plate_nesting=4)
-            actual_loss = vectorized_elbo.differentiable_loss(model, guide, data, history, True)
-            assert_close(actual_loss, expected_loss)
+        if history > 1:
+            pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
+
+        elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)
+        expected_loss = elbo.differentiable_loss(model, guide, data, history, False)
+        vectorized_elbo = infer.TraceMarkovEnum_ELBO(max_plate_nesting=4)
+        actual_loss = vectorized_elbo.differentiable_loss(model, guide, data, history, True)
+        assert_close(actual_loss, expected_loss)
 
 
 #     x[i-1] --> x[i] --> x[i+1]

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -490,13 +490,13 @@ def test_model_enumerated_elbo(model, guide, data, history):
         assert_close(actual_loss, expected_loss)
 
 
-def guide_empyt_multi(weeks_data, days_data, history, vectorized):
+def guide_empty_multi(weeks_data, days_data, history, vectorized):
     pass
 
 
 @pytest.mark.parametrize("model,guide,weeks_data,days_data,history", [
-    (model_8, guide_empyt_multi, torch.ones(3), torch.zeros(9), 1),
-    (model_8, guide_empyt_multi, torch.ones(30), torch.zeros(50), 1),
+    (model_8, guide_empty_multi, torch.ones(3), torch.zeros(9), 1),
+    (model_8, guide_empty_multi, torch.ones(30), torch.zeros(50), 1),
 ])
 def test_model_enumerated_elbo_multi(model, guide, weeks_data, days_data, history):
 
@@ -547,7 +547,7 @@ def guide_10(data, vectorized):
 @pytest.mark.parametrize("model,guide,data,", [
     (model_10, guide_10, torch.ones(5)),
 ])
-def test_guide_enumerated_elbo_guide(model, guide, data):
+def test_guide_enumerated_elbo(model, guide, data):
 
     with pyro_backend("contrib.funsor"):
         with pytest.raises(


### PR DESCRIPTION
WIP. This first commit has a draft implementation of the `TraceMarkovEnum_ELBO` with `modified_partial_sum_product`. Tests compare elbos for `pyro.markov` models computed using `TraceEnum_ELBO` and `pyro.vectorized_markov` models computed using `TraceMarkovEnum_ELBO`. Note: all models have an empty guide.

**Note**

`TraceMarkovEnum_ELBO` only supports model side Markov enumeration. All discrete variable with the same&higher ordinal must also be enumerated in the model.