### PR TITLE
Fix some typos in the contrib.funsor docs

### DIFF
--- a/pyro/contrib/funsor/handlers/enum_messenger.py
+++ b/pyro/contrib/funsor/handlers/enum_messenger.py
@@ -140,7 +140,7 @@ def enumerate_site(dist, msg):
 
 class EnumMessenger(NamedMessenger):
     """
-    This version of EnumMessenger uses :func:`~pyro.contrib.funsor.to_data`
+    This version of :class:`~EnumMessenger` uses :func:`~pyro.contrib.funsor.to_data`
     to allocate a fresh enumeration dim for each discrete sample site.
     """
     def _pyro_sample(self, msg):

--- a/pyro/contrib/funsor/handlers/enum_messenger.py
+++ b/pyro/contrib/funsor/handlers/enum_messenger.py
@@ -140,8 +140,8 @@ def enumerate_site(dist, msg):
 
 class EnumMessenger(NamedMessenger):
     """
-    This version of EnumMessenger uses to_data to allocate a fresh enumeration dim
-    for each discrete sample site.
+    This version of EnumMessenger uses :func:`~pyro.contrib.funsor.to_data`
+    to allocate a fresh enumeration dim for each discrete sample site.
     """
     def _pyro_sample(self, msg):
         if msg["done"] or msg["is_observed"] or \

--- a/pyro/contrib/funsor/handlers/named_messenger.py
+++ b/pyro/contrib/funsor/handlers/named_messenger.py
@@ -158,11 +158,11 @@ class MarkovMessenger(NamedMessenger):
 class GlobalNamedMessenger(NamedMessenger):
     """
     Base class for any new effect handlers that use the
-    :func:~`pyro.contrib.funsor.to_funsor` and :func:~`pyro.contrib.funsor.to_data` primitives
-    to allocate `DimType.GLOBAL` or `DimType.VISIBLE` dimensions.
+    :func:`~pyro.contrib.funsor.to_funsor` and :func:`~pyro.contrib.funsor.to_data` primitives
+    to allocate ``DimType.GLOBAL`` or ``DimType.VISIBLE`` dimensions.
 
-    Serves as a manual "scope" for dimensions that should not be recycled by :class:~`MarkovMessenger`:
-    global dimensions will be considered active until the innermost ``GlobalNamedMessenger``
+    Serves as a manual "scope" for dimensions that should not be recycled by :class:`~MarkovMessenger`:
+    global dimensions will be considered active until the innermost :class:`~GlobalNamedMessenger`
     under which they were initially allocated exits.
     """
     def __init__(self, first_available_dim=None):

--- a/pyro/contrib/funsor/handlers/named_messenger.py
+++ b/pyro/contrib/funsor/handlers/named_messenger.py
@@ -11,10 +11,10 @@ from pyro.contrib.funsor.handlers.runtime import _DIM_STACK, DimRequest, DimType
 
 class NamedMessenger(ReentrantMessenger):
     """
-    Base effect handler class for the :func:~`pyro.contrib.funsor.to_funsor`
-    and :func:~`pyro.contrib.funsor.to_data` primitives.
+    Base effect handler class for the :func:`~pyro.contrib.funsor.to_funsor`
+    and :func:`~pyro.contrib.funsor.to_data` primitives.
     Any effect handlers that invoke these primitives internally or wrap
-    code that does should inherit from ``NamedMessenger``.
+    code that does should inherit from :class:`~NamedMessenger`.
 
     This design ensures that the global name-dim mapping is reset upon handler exit
     rather than potentially persisting until the entire program terminates.

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -23,7 +23,8 @@ funsor.set_backend("torch")
 
 class IndepMessenger(GlobalNamedMessenger):
     """
-    Vectorized plate implementation using to_data instead of _DIM_ALLOCATOR.
+    Vectorized plate implementation using :func:`~pyro.contrib.funsor.to_data` instead of
+    :class:`~pyro.poutine.runtime._DimAllocator`.
     """
     def __init__(self, name=None, size=None, dim=None, indices=None):
         assert size > 1
@@ -114,7 +115,7 @@ class SubsampleMessenger(IndepMessenger):
 class PlateMessenger(SubsampleMessenger):
     """
     Combines new :class:`~IndepMessenger` implementation with existing
-    :class:`~pyro.poutine.BroadcastMessenger`. Should eventually be a drop-in
+    :class:`pyro.poutine.BroadcastMessenger`. Should eventually be a drop-in
     replacement for :class:`pyro.plate`.
     """
     def __enter__(self):

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -115,7 +115,7 @@ class PlateMessenger(SubsampleMessenger):
     """
     Combines new :class:`~IndepMessenger` implementation with existing
     :class:`~pyro.poutine.BroadcastMessenger`. Should eventually be a drop-in
-    replacement for :class:`~pyro.plate`.
+    replacement for :class:`pyro.plate`.
     """
     def __enter__(self):
         super().__enter__()

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -115,7 +115,7 @@ class PlateMessenger(SubsampleMessenger):
     """
     Combines new :class:`~IndepMessenger` implementation with existing
     :class:`~pyro.poutine.BroadcastMessenger`. Should eventually be a drop-in
-    replacement for pyro.plate.
+    replacement for :class:`~pyro.plate`.
     """
     def __enter__(self):
         super().__enter__()
@@ -202,7 +202,7 @@ class VectorizedMarkovMessenger(NamedMessenger):
                 x_prev = x_curr
 
         #  trace.nodes["time"]["value"]
-        #  frozenset({('x_0', 'x_slice(0, 1, None)', 'x_slice(1, 2, None)')})
+        #  frozenset({('x_0', 'x_slice(0, 2, None)', 'x_slice(1, 3, None)')})
         #
         #  pyro.vectorized_markov trace
         #  ...
@@ -216,10 +216,10 @@ class VectorizedMarkovMessenger(NamedMessenger):
         #       y_0 dist     3 1 1 1 1 |
         #          value               |
         #       log_prob     3 1 1 1 1 |
-        #  x_slice(1, 2, None) dist   3 1 1 1 1 2 |
+        #  x_slice(1, 3, None) dist   3 1 1 1 1 2 |
         #          value 3 1 1 1 1 1 1 |
         #       log_prob 3 3 1 1 1 1 2 |
-        #  y_slice(1, 2, None) dist 3 1 1 1 1 1 2 |
+        #  y_slice(1, 3, None) dist 3 1 1 1 1 1 2 |
         #          value             2 |
         #       log_prob 3 1 1 1 1 1 2 |
         #

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -113,8 +113,9 @@ class SubsampleMessenger(IndepMessenger):
 
 class PlateMessenger(SubsampleMessenger):
     """
-    Combines new IndepMessenger implementation with existing BroadcastMessenger.
-    Should eventually be a drop-in replacement for pyro.plate.
+    Combines new :class:`~IndepMessenger` implementation with existing
+    :class:`~pyro.poutine.BroadcastMessenger`. Should eventually be a drop-in
+    replacement for pyro.plate.
     """
     def __enter__(self):
         super().__enter__()

--- a/pyro/contrib/funsor/handlers/replay_messenger.py
+++ b/pyro/contrib/funsor/handlers/replay_messenger.py
@@ -8,7 +8,7 @@ from pyro.contrib.funsor.handlers.primitives import to_data
 class ReplayMessenger(OrigReplayMessenger):
     """
     This version of :class:`~ReplayMessenger` is almost identical to the original version,
-    except that it calls to_data on the replayed funsor values.
+    except that it calls :func:`~pyro.contrib.funsor.to_data` on the replayed funsor values.
     This may result in different unpacked shapes, but should produce correct allocations.
     """
     def _pyro_sample(self, msg):

--- a/pyro/contrib/funsor/handlers/replay_messenger.py
+++ b/pyro/contrib/funsor/handlers/replay_messenger.py
@@ -7,7 +7,7 @@ from pyro.contrib.funsor.handlers.primitives import to_data
 
 class ReplayMessenger(OrigReplayMessenger):
     """
-    This version of ReplayMessenger is almost identical to the original version,
+    This version of :class:`~ReplayMessenger` is almost identical to the original version,
     except that it calls to_data on the replayed funsor values.
     This may result in different unpacked shapes, but should produce correct allocations.
     """

--- a/pyro/contrib/funsor/handlers/runtime.py
+++ b/pyro/contrib/funsor/handlers/runtime.py
@@ -56,7 +56,8 @@ class DimStack:
     """
     Single piece of global state to keep track of the mapping between names and dimensions.
 
-    Replaces the plate DimAllocator, the enum EnumAllocator, the ``stack`` in :class:`~MarkovMessenger`,
+    Replaces the plate :class:`~pyro.poutine.runtime._DimAllocator`,
+    the enum :class:`~pyro.poutine.runtime._EnumAllocator`, the ``stack`` in :class:`~MarkovMessenger`,
     ``_param_dims`` and ``_value_dims`` in :class:`~EnumMessenger`, and ``dim_to_symbol`` in ``msg['infer']``
     """
     def __init__(self):

--- a/pyro/contrib/funsor/handlers/runtime.py
+++ b/pyro/contrib/funsor/handlers/runtime.py
@@ -8,7 +8,7 @@ from enum import Enum
 class StackFrame:
     """
     Consistent bidirectional mapping between integer positional dimensions and names.
-    Can be queried like a dictionary (value = frame[key], frame[key] = value).
+    Can be queried like a dictionary (``value = frame[key]``, ``frame[key] = value``).
     """
     def __init__(self, name_to_dim, dim_to_name, history=1, keep=False):
         assert isinstance(name_to_dim, OrderedDict) and \
@@ -56,8 +56,8 @@ class DimStack:
     """
     Single piece of global state to keep track of the mapping between names and dimensions.
 
-    Replaces the plate DimAllocator, the enum EnumAllocator, the stack in MarkovMessenger,
-    _param_dims and _value_dims in EnumMessenger, and dim_to_symbol in msg['infer']
+    Replaces the plate DimAllocator, the enum EnumAllocator, the ``stack`` in :class:`~MarkovMessenger`,
+    ``_param_dims`` and ``_value_dims`` in :class:`~EnumMessenger`, and ``dim_to_symbol`` in ``msg['infer']``
     """
     def __init__(self):
         global_frame = StackFrame(

--- a/pyro/contrib/funsor/handlers/trace_messenger.py
+++ b/pyro/contrib/funsor/handlers/trace_messenger.py
@@ -17,7 +17,7 @@ class TraceMessenger(OrigTraceMessenger):
 
     Setting ``pack_online=False`` computes information necessary to do packing after execution.
     Each sample site is annotated with a "dim_to_name" dictionary,
-    which can be passed directly to funsor.to_funsor.
+    which can be passed directly to :func:`~funsor.to_funsor`.
     """
     def __init__(self, graph_type=None, param_only=None, pack_online=True):
         super().__init__(graph_type=graph_type, param_only=param_only)

--- a/pyro/contrib/funsor/handlers/trace_messenger.py
+++ b/pyro/contrib/funsor/handlers/trace_messenger.py
@@ -16,8 +16,8 @@ class TraceMessenger(OrigTraceMessenger):
     converting all distributions and values to Funsors as soon as they are available.
 
     Setting ``pack_online=False`` computes information necessary to do packing after execution.
-    Each sample site is annotated with a "dim_to_name" dictionary,
-    which can be passed directly to :func:`~funsor.to_funsor`.
+    Each sample site is annotated with a ``dim_to_name`` dictionary,
+    which can be passed directly to :func:`~pyro.contrib.funsor.to_funsor`.
     """
     def __init__(self, graph_type=None, param_only=None, pack_online=True):
         super().__init__(graph_type=graph_type, param_only=param_only)


### PR DESCRIPTION
- It is mostly sphinx cross-references.
- Fix the range of slices in `VectorizedMarkovMessenger` docstring example

Html files looked alright after compiling them with `make docs`. 