### PR TITLE
docs: fix simple typo, precison -> precision

### DIFF
--- a/pyro/ops/gamma_gaussian.py
+++ b/pyro/ops/gamma_gaussian.py
@@ -313,7 +313,7 @@ def gamma_and_mvn_to_gamma_gaussian(gamma, mvn):
 
         p(x | s) ~ Gaussian(s * info_vec, s * precision)
         p(s) ~ Gamma(alpha, beta)
-        p(x, s) ~ GammaGaussian(info_vec, precison, alpha, beta)
+        p(x, s) ~ GammaGaussian(info_vec, precision, alpha, beta)
 
     :param ~pyro.distributions.Gamma gamma: the mixing distribution
     :param ~pyro.distributions.MultivariateNormal mvn: the conditional distribution


### PR DESCRIPTION
There is a small typo in pyro/ops/gamma_gaussian.py.

Should read `precision` rather than `precison`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md