### PR TITLE
Make replay work correctly with vectorized_markov

### DIFF
--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -315,7 +315,8 @@ class VectorizedMarkovMessenger(NamedMessenger):
             assert msg["name"].endswith(str(self._indices))
             msg["name"] = msg["name"][:-len(str(self._indices))] + str(self._suffix)
         if str(self._suffix) != str(self._suffixes[-1]):
-            # do not trace auxiliary vars
+            # _do_not_score: record these sites when tracing for use with replay,
+            # but do not include them in ELBO computation.
             msg["infer"]["_do_not_score"] = True
             msg["infer"]["is_auxiliary"] = True
             # map auxiliary var to markov var name prefix

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -316,7 +316,7 @@ class VectorizedMarkovMessenger(NamedMessenger):
             msg["name"] = msg["name"][:-len(str(self._indices))] + str(self._suffix)
         if str(self._suffix) != str(self._suffixes[-1]):
             # do not trace auxiliary vars
-            msg["infer"]["_do_not_trace"] = True
+            msg["infer"]["_do_not_score"] = True
             msg["infer"]["is_auxiliary"] = True
             msg["is_observed"] = False
             # map auxiliary var to markov var name prefix

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -333,7 +333,7 @@ class VectorizedMarkovMessenger(NamedMessenger):
             return
         # if last step in the for loop
         if str(self._suffix) == str(self._suffixes[-1]):
-            funsor_log_prob = msg["funsor"]["log_prob"] if "log_prob" in msg["funsor"] else \
+            funsor_log_prob = msg["funsor"]["log_prob"] if "log_prob" in msg.get("funsor", {}) else \
                 to_funsor(msg["fn"].log_prob(msg["value"]), output=funsor.Real)
             # for auxiliary sites in the log_prob
             for name in set(funsor_log_prob.inputs) & set(self._auxiliary_to_markov):

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -318,7 +318,6 @@ class VectorizedMarkovMessenger(NamedMessenger):
             # do not trace auxiliary vars
             msg["infer"]["_do_not_score"] = True
             msg["infer"]["is_auxiliary"] = True
-            msg["is_observed"] = False
             # map auxiliary var to markov var name prefix
             # assuming that site name has a format: "markov_var{}".format(_suffix)
             # is there a better way?

--- a/pyro/contrib/funsor/handlers/plate_messenger.py
+++ b/pyro/contrib/funsor/handlers/plate_messenger.py
@@ -318,7 +318,6 @@ class VectorizedMarkovMessenger(NamedMessenger):
             # _do_not_score: record these sites when tracing for use with replay,
             # but do not include them in ELBO computation.
             msg["infer"]["_do_not_score"] = True
-            msg["infer"]["is_auxiliary"] = True
             # map auxiliary var to markov var name prefix
             # assuming that site name has a format: "markov_var{}".format(_suffix)
             # is there a better way?

--- a/pyro/contrib/funsor/handlers/trace_messenger.py
+++ b/pyro/contrib/funsor/handlers/trace_messenger.py
@@ -37,7 +37,10 @@ class TraceMessenger(OrigTraceMessenger):
             if "value" not in msg["funsor"]:
                 # value_output = funsor.Reals[getattr(msg["fn"], "event_shape", ())]
                 msg["funsor"]["value"] = to_funsor(msg["value"], msg["funsor"]["fn"].inputs[msg["name"]])
-            if "log_prob" not in msg["funsor"] and not msg["infer"].get("_do_not_trace"):
+            if "log_prob" not in msg["funsor"] and \
+                    not msg["infer"].get("_do_not_trace") and \
+                    not msg["infer"].get("_do_not_score", False):
+                # optimization: don't perform this tensor op unless we have to
                 fn_masked = msg["fn"].mask(msg["mask"]) if msg["mask"] is not None else msg["fn"]
                 msg["funsor"]["log_prob"] = to_funsor(fn_masked.log_prob(msg["value"]), output=funsor.Real)
                 # TODO support this pattern which uses funsor directly - blocked by casting issues

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -94,7 +94,7 @@ class TraceMarkovEnum_ELBO(ELBO):
             target = funsor.Tensor(funsor.ops.new_zeros(funsor.tensor.get_default_prototype(), ()).expand(
                 tuple(v.size for v in cost.inputs.values())), cost.inputs, cost.dtype)
             # this normalization step should guarantee that the resulting elbo
-            # is not off by an arbitrary constant
+            # is not off by an arbitrary scalar constant relative to sequential case
             # TODO use fill_like instead to avoid allocating tensor memory
             target -= sum([funsor.ops.log(v.size) for k, v in target.inputs.items() if k in guide_terms["measure_vars"]], 0)
             targets.append(target)

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -23,6 +23,9 @@ def terms_from_trace(tr):
         # add markov dimensions to the plate_to_step dictionary
         if node["type"] == "markov_chain":
             terms["plate_to_step"][node["name"]] = node["value"]
+            # ensure previous step variables are added to measure_vars
+            for step in node["value"]:
+                terms["measure_vars"] |= frozenset(step[1:-1])
         if node["type"] != "sample" or type(node["fn"]).__name__ == "_Subsample" or \
                 node["infer"].get("_do_not_score", False):
             continue

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -62,9 +62,9 @@ class TraceMarkovEnum_ELBO(ELBO):
         guide_terms = terms_from_trace(guide_tr)
         model_terms = terms_from_trace(model_tr)
 
-        # guide side enumeration is not supported
-        if any(guide_terms["plate_to_step"].values()):
-            raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side Markov enumeration")
+        # # guide side enumeration is not supported
+        # if any(guide_terms["plate_to_step"].values()):
+        #     raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side Markov enumeration")
 
         # build up a lazy expression for the elbo
         with funsor.interpreter.interpretation(funsor.terms.lazy):
@@ -88,20 +88,35 @@ class TraceMarkovEnum_ELBO(ELBO):
             costs = contracted_costs + uncontracted_factors  # model costs: logp
             costs += [-f for f in guide_terms["log_factors"]]  # guide costs: -logq
 
-            # finally, integrate out guide variables in the elbo and all plates
-            plate_vars = guide_terms["plate_vars"] | model_terms["plate_vars"]
+        # finally, integrate out guide variables in the elbo and all plates
+        guide_markov_dims = frozenset(plate for plate, step in guide_terms["plate_to_step"].items() if step)
+        # first compute all marginal logqs eagerly in a single forward-backward pass
+        # we create dummy tensors for each model cost to ensure all requisite marginals are computed
+        targets = [funsor.Tensor(funsor.ops.new_zeros(funsor.tensor.get_default_prototype(), ()).expand(
+            tuple(v.size for v in cost.inputs.values()) + cost.output.shape), cost.inputs, cost.dtype)
+            for cost in contracted_costs + uncontracted_factors] + guide_terms["log_measures"]
+        assert all(target.output.shape == () for target in targets)
+        with funsor.interpreter.interpretation(funsor.terms.lazy):
+            logzq = sum(funsor.sum_product.modified_partial_sum_product(
+                funsor.ops.logaddexp, funsor.ops.add,
+                targets,
+                plate_to_step=guide_terms["plate_to_step"],
+                eliminate=guide_terms["measure_vars"] | guide_markov_dims
+            ))
+
+        with funsor.adjoint.AdjointTape() as tape:
+            logzq = funsor.optimizer.apply_optimizer(logzq)
+        log_qs = tape.adjoint(funsor.ops.logaddexp, funsor.ops.add, logzq, tuple(targets))
+
+        with funsor.interpreter.interpretation(funsor.terms.lazy):
             elbo = to_funsor(0, output=funsor.Real)
             for cost in costs:
-                # compute the marginal logq in the guide corresponding to this cost term
-                log_prob = funsor.sum_product.sum_product(
-                    funsor.ops.logaddexp, funsor.ops.add,
-                    guide_terms["log_measures"],
-                    plates=plate_vars,
-                    eliminate=(plate_vars | guide_terms["measure_vars"]) - frozenset(cost.inputs)
-                )
+                # look up the marginal logq in the guide corresponding to this cost term
+                log_prob = next(iter(log_q for log_q in log_qs if dict(log_q.inputs) == dict(cost.inputs)))
                 # compute the expected cost term E_q[logp] or E_q[-logq] using the marginal logq for q
-                elbo_term = funsor.Integrate(log_prob, cost, guide_terms["measure_vars"] & frozenset(cost.inputs))
-                elbo += elbo_term.reduce(funsor.ops.add, plate_vars & frozenset(cost.inputs))
+                elbo_term = funsor.Integrate(
+                    log_prob, cost, frozenset(cost.inputs) - frozenset(guide_terms["plate_to_step"]))
+                elbo += elbo_term.reduce(funsor.ops.add)
 
         # evaluate the elbo, using memoize to share tensor computation where possible
         with funsor.memoize.memoize():

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -63,10 +63,6 @@ class TraceMarkovEnum_ELBO(ELBO):
         guide_terms = terms_from_trace(guide_tr)
         model_terms = terms_from_trace(model_tr)
 
-        # # guide side enumeration is not supported
-        # if any(guide_terms["plate_to_step"].values()):
-        #     raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side Markov enumeration")
-
         # build up a lazy expression for the elbo
         with funsor.interpreter.interpretation(funsor.terms.lazy):
             # identify and contract out auxiliary variables in the model with partial_sum_product

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -115,7 +115,7 @@ class TraceMarkovEnum_ELBO(ELBO):
             elbo = to_funsor(0, output=funsor.Real)
             for cost in costs:
                 # look up the marginal logq in the guide corresponding to this cost term
-                log_prob = next(iter(log_q for log_q in log_qs if dict(log_q.inputs) == dict(cost.inputs)))
+                log_prob = next(iter(log_q for log_q in log_qs.values() if dict(log_q.inputs) == dict(cost.inputs)))
                 # compute the expected cost term E_q[logp] or E_q[-logq] using the marginal logq for q
                 elbo_term = funsor.Integrate(
                     log_prob, cost, frozenset(cost.inputs) - frozenset(guide_terms["plate_to_step"]))

--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -63,6 +63,10 @@ class TraceMarkovEnum_ELBO(ELBO):
         guide_terms = terms_from_trace(guide_tr)
         model_terms = terms_from_trace(model_tr)
 
+        # guide side enumeration is not supported
+        if any(guide_terms["plate_to_step"].values()):
+            raise NotImplementedError("TraceMarkovEnum_ELBO does not yet support guide side Markov enumeration")
+
         # build up a lazy expression for the elbo
         with funsor.interpreter.interpretation(funsor.terms.lazy):
             # identify and contract out auxiliary variables in the model with partial_sum_product
@@ -85,37 +89,20 @@ class TraceMarkovEnum_ELBO(ELBO):
             costs = contracted_costs + uncontracted_factors  # model costs: logp
             costs += [-f for f in guide_terms["log_factors"]]  # guide costs: -logq
 
-        # finally, integrate out guide variables in the elbo and all plates
-        guide_markov_dims = frozenset(plate for plate, step in guide_terms["plate_to_step"].items() if step)
-        # first compute all marginal logqs eagerly in a single forward-backward pass
-        # we create dummy factors for each model cost to ensure all required marginals are computed
-        targets = []
-        for cost in contracted_costs + uncontracted_factors:
-            target = funsor.Tensor(funsor.ops.new_zeros(funsor.tensor.get_default_prototype(), ()).expand(
-                tuple(v.size for v in cost.inputs.values())), cost.inputs, cost.dtype)
-            targets.append(target)
-        targets += guide_terms["log_measures"]
-        with funsor.interpreter.interpretation(funsor.terms.lazy):
-            logzq = sum(funsor.sum_product.modified_partial_sum_product(
-                funsor.ops.logaddexp, funsor.ops.add,
-                targets,
-                plate_to_step=guide_terms["plate_to_step"],
-                eliminate=guide_terms["measure_vars"] | guide_markov_dims
-            ))
-
-        with funsor.adjoint.AdjointTape() as tape:
-            logzq = funsor.optimizer.apply_optimizer(logzq)
-        log_qs = tuple(tape.adjoint(funsor.ops.logaddexp, funsor.ops.add, logzq, tuple(targets)).values())
-
-        with funsor.interpreter.interpretation(funsor.terms.lazy):
+            # finally, integrate out guide variables in the elbo and all plates
+            plate_vars = guide_terms["plate_vars"] | model_terms["plate_vars"]
             elbo = to_funsor(0, output=funsor.Real)
             for cost in costs:
-                # look up the marginal logq in the guide corresponding to this cost term
-                log_prob = next(iter(log_q for log_q in log_qs if dict(log_q.inputs) == dict(cost.inputs)))
+                # compute the marginal logq in the guide corresponding to this cost term
+                log_prob = funsor.sum_product.sum_product(
+                    funsor.ops.logaddexp, funsor.ops.add,
+                    guide_terms["log_measures"],
+                    plates=plate_vars,
+                    eliminate=(plate_vars | guide_terms["measure_vars"]) - frozenset(cost.inputs)
+                )
                 # compute the expected cost term E_q[logp] or E_q[-logq] using the marginal logq for q
-                elbo_term = funsor.Integrate(
-                    log_prob, cost, frozenset(cost.inputs) - frozenset(guide_terms["plate_to_step"]))
-                elbo += elbo_term.reduce(funsor.ops.add)
+                elbo_term = funsor.Integrate(log_prob, cost, guide_terms["measure_vars"] & frozenset(cost.inputs))
+                elbo += elbo_term.reduce(funsor.ops.add, plate_vars & frozenset(cost.inputs))
 
         # evaluate the elbo, using memoize to share tensor computation where possible
         with funsor.memoize.memoize():

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -534,10 +534,9 @@ def model_10(data, vectorized):
         pyro.vectorized_markov(name="time", size=len(data)) if vectorized \
         else pyro.markov(range(len(data)))
     for i in markov_loop:
-        probs = init_probs if x is None else Vindex(transition_probs)[x]
-        x = pyro.sample("x_{}".format(i), dist.Categorical(probs),
-                        infer={"enumerate": "parallel"})  # XXX hack - fix and remove
-        pyro.sample("y_{}".format(i), dist.Categorical(Vindex(emission_probs)[x]), obs=data[i])
+        probs = init_probs if x is None else transition_probs[x]
+        x = pyro.sample("x_{}".format(i), dist.Categorical(probs))
+        pyro.sample("y_{}".format(i), dist.Categorical(emission_probs[x]), obs=data[i])
 
 
 def guide_10(data, vectorized):
@@ -550,7 +549,7 @@ def guide_10(data, vectorized):
         pyro.vectorized_markov(name="time", size=len(data)) if vectorized \
         else pyro.markov(range(len(data)))
     for i in markov_loop:
-        probs = init_probs if x is None else Vindex(transition_probs)[x]
+        probs = init_probs if x is None else transition_probs[x]
         x = pyro.sample("x_{}".format(i), dist.Categorical(probs),
                         infer={"enumerate": "parallel"})
 

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -4,7 +4,6 @@
 import pytest
 import torch
 
-from pyroapi import pyro_backend
 from torch.distributions import constraints
 
 from pyro.ops.indexing import Vindex
@@ -16,7 +15,7 @@ try:
     import pyro.contrib.funsor
     from pyroapi import distributions as dist
     funsor.set_backend("torch")
-    from pyroapi import handlers, pyro, infer
+    from pyroapi import handlers, pyro, pyro_backend, infer
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 
@@ -259,10 +258,10 @@ def model_7(data, history, vectorized):
         x_prev, w_prev = x_curr, w_curr
 
 
-@pyro_backend("contrib.funsor")
 def _guide_from_model(model):
-    return handlers.block(infer.config_enumerate(model, default="parallel"),
-                          lambda msg: msg.get("is_observed", False))
+    with pyro_backend("contrib.funsor"):
+        return handlers.block(infer.config_enumerate(model, default="parallel"),
+                              lambda msg: msg.get("is_observed", False))
 
 
 @pytest.mark.parametrize("use_replay", [True, False])

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from pyroapi import pyro_backend
 from torch.distributions import constraints
 
 from pyro.ops.indexing import Vindex
@@ -15,7 +16,7 @@ try:
     import pyro.contrib.funsor
     from pyroapi import distributions as dist
     funsor.set_backend("torch")
-    from pyroapi import handlers, pyro, pyro_backend, infer
+    from pyroapi import handlers, pyro, infer
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -379,6 +379,7 @@ def model_8(weeks_data, days_data, history, vectorized):
     (model_8, torch.ones(30), torch.zeros(50), "xy", "wz", 1),
 ])
 def test_enumeration_multi(model, weeks_data, days_data, vars1, vars2, history, use_replay):
+    pyro.clear_param_store()
 
     with pyro_backend("contrib.funsor"):
         with handlers.enum():

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from pyroapi import pyro_backend
 from torch.distributions import constraints
 
 from pyro.ops.indexing import Vindex
@@ -15,7 +16,7 @@ try:
     import pyro.contrib.funsor
     from pyroapi import distributions as dist
     funsor.set_backend("torch")
-    from pyroapi import handlers, pyro, pyro_backend, infer
+    from pyroapi import handlers, pyro, infer
 except ImportError:
     pytestmark = pytest.mark.skip(reason="funsor is not installed")
 
@@ -259,9 +260,12 @@ def model_7(data, history, vectorized):
 
 
 def _guide_from_model(model):
-    with pyro_backend("contrib.funsor"):
-        return handlers.block(infer.config_enumerate(model, default="parallel"),
-                              lambda msg: msg.get("is_observed", False))
+    try:
+        with pyro_backend("contrib.funsor"):
+            return handlers.block(infer.config_enumerate(model, default="parallel"),
+                                  lambda msg: msg.get("is_observed", False))
+    except KeyError:
+        return model
 
 
 @pytest.mark.parametrize("use_replay", [True, False])

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -572,15 +572,17 @@ def _guide_from_model(model):
     (model_4, _guide_from_model(model_4), torch.ones((5, 4), dtype=torch.long), 1),
     (model_5, _guide_from_model(model_5), torch.ones((5, 4), dtype=torch.long), 2),
     (model_6, _guide_from_model(model_6), torch.rand(5, 4), 1),
-    # (model_6, _guide_from_model(model_6), torch.rand(100, 4), 1),
     (model_7, _guide_from_model(model_7), torch.ones((5, 4), dtype=torch.long), 1),
-    # (model_7, _guide_from_model(model_7), torch.ones((50, 4), dtype=torch.long), 1),
     (model_10, guide_10, torch.ones(5), 1),
 ])
 def test_guide_enumerated_elbo(model, guide, data, history):
     pyro.clear_param_store()
 
-    with pyro_backend("contrib.funsor"):
+    with pyro_backend("contrib.funsor"), \
+        pytest.raises(
+            NotImplementedError,
+            match="TraceMarkovEnum_ELBO does not yet support guide side Markov enumeration"):
+
         if history > 1:
             pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
 


### PR DESCRIPTION
This PR fixes a bug in the interaction between `VectorizedMarkovMessenger`, enumeration and `replay` and strengthens the tests in `tests/contrib/funsor/test_vectorized_markov.py` so that they would have caught it.

Specifically, by setting `msg["infer"]["_do_not_trace"] = True` for all but the final parallel-enumerated site, `vectorized_markov` was guaranteeing that those sites would not have their values recorded in or replayed from a guide trace.  I have replaced `_do_not_trace` here with a different flag, `_do_not_score`, which ensures that these values are replayed correctly but still excluded from ELBO term computation.  There should be no change in the number of tensor ops used in `TraceMarkovEnum_ELBO`.

This was not being caught in the `vectorized_markov` test cases with `use_replay=True` because the test case models had hard-coded `infer={"enumerate": "parallel"}`, meaning that model sites that should have been replayed were enumerated in the model. Removing these hard-coded `infer` dicts causes those sites to be sampled from the prior, leading to incorrect factors and ELBOs.