### PR TITLE
Add SpanningTree properties .mode, .edge_mean

### DIFF
--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -170,6 +170,7 @@ class SpanningTree(TorchDistribution):
         trees = enumerate_spanning_trees(self.num_vertices)
         return torch.tensor(trees, dtype=torch.long)
 
+    @property
     def mode(self):
         """
         :returns: The maximum weight spanning tree.
@@ -178,6 +179,7 @@ class SpanningTree(TorchDistribution):
         backend = self.sampler_options.get("backend", "python")
         return find_best_tree(self.edge_logits, backend=backend)
 
+    @property
     def edge_mean(self):
         """
         Computes marginal probabilities of each edge being active.

--- a/pyro/distributions/spanning_tree.py
+++ b/pyro/distributions/spanning_tree.py
@@ -184,9 +184,9 @@ class SpanningTree(TorchDistribution):
         """
         Computes marginal probabilities of each edge being active.
 
-        ..note:: This is similar to other distributions' ``.mean()``
+        .. note:: This is similar to other distributions' ``.mean()``
             method, but with a different shape because this distribution's
-            values are note encoded as binary matrices.
+            values are not encoded as binary matrices.
 
         :returns: A symmetric square ``(V,V)``-shaped matrix with values
             in ``[0,1]`` denoting the marginal probability of each edge

--- a/tests/distributions/test_spanning_tree.py
+++ b/tests/distributions/test_spanning_tree.py
@@ -137,7 +137,7 @@ def test_edge_mean_function(num_edges):
     probs = d.log_prob(support).exp()[:, None].expand_as(k)
     expected = torch.zeros(K).scatter_add_(0, k.reshape(-1), probs.reshape(-1))
 
-    actual = d.edge_mean()
+    actual = d.edge_mean
     assert actual.shape == (V, V)
     v1, v2 = make_complete_graph(V)
     assert (actual[v1, v2] - expected).abs().max() < 1e-5, (actual, expected)
@@ -158,7 +158,7 @@ def test_mode(num_edges, backend):
     v2 = support[..., 1]
     k = v1 + v2 * (v2 - 1) // 2
     expected = support[edge_logits[k].sum(-1).argmax(0)]
-    actual = d.mode()
+    actual = d.mode
     assert (actual == expected).all()
 
 


### PR DESCRIPTION
This adds:
- An `.edge_mean` property that computes edge marginals. This has a different return shape than the usual `.mean` properties because `SpanningTree` returns a packed tensor rather than a binary array. Hence I've named it slightly differently.
- A `.mode` property to compute a maximum-weight spanning tree. This has nearly identical implementation to the greedy `sample_tree_approx()` method (here using argmax rather than sampling), hence I've simply forked that code for implementation.

## Tested
- [x] unit tests for `.edge_mean`
- [x] unit tests for `.mode`
- [x] larger smoke tests for `.mode`