### PR TITLE
AffineBeta distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -50,6 +50,13 @@ TorchDistribution
     :show-inheritance:
     :member-order: bysource
 
+AffineBeta
+---------------------
+.. autoclass:: pyro.distributions.AffineBeta
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 AVFMultivariateNormal
 ---------------------
 .. autoclass:: pyro.distributions.AVFMultivariateNormal

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyro.distributions.torch_patch  # noqa F403
+from pyro.distributions.affine_beta import AffineBeta
 from pyro.distributions.avf_mvn import AVFMultivariateNormal
 from pyro.distributions.coalescent import (
     CoalescentRateLikelihood,
@@ -74,6 +75,7 @@ from pyro.distributions.zero_inflated import (
 from . import constraints, kl, transforms
 
 __all__ = [
+    "AffineBeta",
     "AVFMultivariateNormal",
     "BetaBinomial",
     "CoalescentRateLikelihood",

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -69,6 +69,10 @@ class AffineBeta(TransformedDistribution):
         x = torch.max(torch.min(x, self.loc + eps), self.loc + self.scale - eps)
         return x
 
+    @constraints.dependent_property
+    def support(self):
+        return constraints.interval(self.low, self.high)
+
     @property
     def concentration1(self):
         return self.base_dist.concentration1

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -52,7 +52,7 @@ class AffineBeta(TransformedDistribution):
                 x = transform(x)
             # eps = torch.finfo(x.dtype).eps
             eps = 1e-5
-            x = torch.max(torch.min(x, self.low + eps), self.high - eps)
+            x = torch.min(torch.max(x, self.low + eps), self.high - eps)
             return x
 
     def rsample(self, sample_shape=torch.Size()):
@@ -66,7 +66,7 @@ class AffineBeta(TransformedDistribution):
             x = transform(x)
         # eps = torch.finfo(x.dtype).eps
         eps = 1e-5
-        x = torch.max(torch.min(x, self.low + eps), self.high - eps)
+        x = torch.min(torch.max(x, self.low + eps), self.high - eps)
         return x
 
     @constraints.dependent_property

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -1,6 +1,6 @@
 import torch
-from pyro.distributions.torch import TransformedDistribution
-from torch.distributions import Beta, constraints
+from pyro.distributions.torch import Beta, TransformedDistribution
+from torch.distributions import constraints
 from torch.distributions.transforms import AffineTransform
 
 
@@ -52,7 +52,7 @@ class AffineBeta(TransformedDistribution):
                 x = transform(x)
             # eps = torch.finfo(x.dtype).eps
             eps = 1e-5
-            x = torch.max(torch.min(x, self.loc + eps), self.loc + self.scale - eps)
+            x = torch.max(torch.min(x, self.low + eps), self.high - eps)
             return x
 
     def rsample(self, sample_shape=torch.Size()):
@@ -66,7 +66,7 @@ class AffineBeta(TransformedDistribution):
             x = transform(x)
         # eps = torch.finfo(x.dtype).eps
         eps = 1e-5
-        x = torch.max(torch.min(x, self.loc + eps), self.loc + self.scale - eps)
+        x = torch.max(torch.min(x, self.low + eps), self.high - eps)
         return x
 
     @constraints.dependent_property

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -1,0 +1,93 @@
+import torch
+from pyro.distributions.torch import TransformedDistribution
+from torch.distributions import Beta, constraints
+from torch.distributions.transforms import AffineTransform
+
+
+class AffineBeta(TransformedDistribution):
+    r"""
+    Beta distribution scaled by :attr:`scale` and shifted by :attr:`loc`::
+
+        X ~ Beta(concentration1, concentration0)
+        f(X) = loc + scale * X
+        Y = f(X) ~ AffineBeta(concentration1, concentration0, loc, scale)
+
+    :param float or torch.Tensor concentration1: alpha parameter.
+    :param float or torch.Tensor concentration0: beta parameter.
+    :param float or torch.Tensor loc: location parameter.
+    :param float or torch.Tensor scale: scale parameter.
+    """
+
+    arg_constraints = {
+        "concentration1": constraints.positive,
+        "concentration0": constraints.positive,
+        "loc": constraints.real,
+        "scale": constraints.positive,
+    }
+    has_rsample = True
+
+    def __init__(self, concentration1, concentration0, loc, scale, validate_args=None):
+        base_dist = Beta(concentration1, concentration0)
+        super(AffineBeta, self).__init__(
+            base_dist,
+            AffineTransform(loc=loc, scale=scale),
+            validate_args=validate_args,
+        )
+
+    def expand(self, batch_shape, _instance=None):
+        """"""
+        new = self._get_checked_instance(AffineBeta, _instance)
+        return super(AffineBeta, self).expand(batch_shape, _instance=new)
+
+    def sample(self, sample_shape=torch.Size()):
+        """
+        Generates a sample from `Beta` distribution and applies `AffineTransform`.
+        Additionally clamps the output in order to avoid `NaN` and `Inf` values
+        in the gradients.
+        """
+        with torch.no_grad():
+            x = self.base_dist.sample(sample_shape)
+            for transform in self.transforms:
+                x = transform(x)
+            # eps = torch.finfo(x.dtype).eps
+            eps = 1e-5
+            x = x.clamp(min=self.loc + eps, max=self.loc + self.scale - eps)
+            return x
+
+    def rsample(self, sample_shape=torch.Size()):
+        """
+        Generates a sample from `Beta` distribution and applies `AffineTransform`.
+        Additionally clamps the output in order to avoid `NaN` and `Inf` values
+        in the gradients.
+        """
+        x = self.base_dist.rsample(sample_shape)
+        for transform in self.transforms:
+            x = transform(x)
+        # eps = torch.finfo(x.dtype).eps
+        eps = 1e-5
+        x = x.clamp(min=self.loc + eps, max=self.loc + self.scale - eps)
+        return x
+
+    @property
+    def concentration1(self):
+        return self.base_dist.concentration1
+
+    @property
+    def concentration0(self):
+        return self.base_dist.concentration0
+
+    @property
+    def loc(self):
+        return torch.as_tensor(self.transforms[0].loc)
+
+    @property
+    def scale(self):
+        return torch.as_tensor(self.transforms[0].scale)
+
+    @property
+    def mean(self):
+        return self.loc + self.scale * self.base_dist.mean
+
+    @property
+    def variance(self):
+        return self.scale.pow(2) * self.base_dist.variance

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -26,7 +26,6 @@ class AffineBeta(TransformedDistribution):
         "loc": constraints.real,
         "scale": constraints.positive,
     }
-    has_rsample = True
 
     def __init__(self, concentration1, concentration0, loc, scale, validate_args=None):
         base_dist = Beta(concentration1, concentration0)
@@ -50,8 +49,7 @@ class AffineBeta(TransformedDistribution):
             x = self.base_dist.sample(sample_shape)
             for transform in self.transforms:
                 x = transform(x)
-            # eps = torch.finfo(x.dtype).eps
-            eps = 1e-5
+            eps = torch.finfo(x.dtype).eps * self.scale
             x = torch.min(torch.max(x, self.low + eps), self.high - eps)
             return x
 
@@ -64,8 +62,7 @@ class AffineBeta(TransformedDistribution):
         x = self.base_dist.rsample(sample_shape)
         for transform in self.transforms:
             x = transform(x)
-        # eps = torch.finfo(x.dtype).eps
-        eps = 1e-5
+        eps = torch.finfo(x.dtype).eps * self.scale
         x = torch.min(torch.max(x, self.low + eps), self.high - eps)
         return x
 

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -12,8 +12,10 @@ class AffineBeta(TransformedDistribution):
         f(X) = loc + scale * X
         Y = f(X) ~ AffineBeta(concentration1, concentration0, loc, scale)
 
-    :param float or torch.Tensor concentration1: alpha parameter.
-    :param float or torch.Tensor concentration0: beta parameter.
+    :param float or torch.Tensor concentration1: 1st concentration parameter
+        (alpha) for the Beta distribution.
+    :param float or torch.Tensor concentration0: 2nd concentration parameter
+        (beta) for the Beta distribution.
     :param float or torch.Tensor loc: location parameter.
     :param float or torch.Tensor scale: scale parameter.
     """
@@ -35,7 +37,6 @@ class AffineBeta(TransformedDistribution):
         )
 
     def expand(self, batch_shape, _instance=None):
-        """"""
         new = self._get_checked_instance(AffineBeta, _instance)
         return super(AffineBeta, self).expand(batch_shape, _instance=new)
 
@@ -51,7 +52,7 @@ class AffineBeta(TransformedDistribution):
                 x = transform(x)
             # eps = torch.finfo(x.dtype).eps
             eps = 1e-5
-            x = x.clamp(min=self.loc + eps, max=self.loc + self.scale - eps)
+            x = torch.max(torch.min(x, self.loc + eps), self.loc + self.scale - eps)
             return x
 
     def rsample(self, sample_shape=torch.Size()):
@@ -65,7 +66,7 @@ class AffineBeta(TransformedDistribution):
             x = transform(x)
         # eps = torch.finfo(x.dtype).eps
         eps = 1e-5
-        x = x.clamp(min=self.loc + eps, max=self.loc + self.scale - eps)
+        x = torch.max(torch.min(x, self.loc + eps), self.loc + self.scale - eps)
         return x
 
     @property

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -39,6 +39,20 @@ class AffineBeta(TransformedDistribution):
         new = self._get_checked_instance(AffineBeta, _instance)
         return super(AffineBeta, self).expand(batch_shape, _instance=new)
 
+    def sample(self, sample_shape=torch.Size()):
+        """
+        Generates a sample from `Beta` distribution and applies `AffineTransform`.
+        Additionally clamps the output in order to avoid `NaN` and `Inf` values
+        in the gradients.
+        """
+        with torch.no_grad():
+            x = self.base_dist.sample(sample_shape)
+            for transform in self.transforms:
+                x = transform(x)
+            eps = torch.finfo(x.dtype).eps * self.scale
+            x = torch.min(torch.max(x, self.low + eps), self.high - eps)
+            return x
+
     def rsample(self, sample_shape=torch.Size()):
         """
         Generates a sample from `Beta` distribution and applies `AffineTransform`.

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -78,12 +78,24 @@ class AffineBeta(TransformedDistribution):
         return self.base_dist.concentration0
 
     @property
+    def size(self):
+        return self.concentration1 + self.concentration0
+
+    @property
     def loc(self):
         return torch.as_tensor(self.transforms[0].loc)
 
     @property
     def scale(self):
         return torch.as_tensor(self.transforms[0].scale)
+
+    @property
+    def low(self):
+        return self.loc
+
+    @property
+    def high(self):
+        return self.loc + self.scale
 
     @property
     def mean(self):

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -131,6 +131,20 @@ continuous_dists = [
                  'test_data': [[5.5], [6.4]]}
             ],
             scipy_arg_fn=lambda loc, scale: ((np.array(scale),), {"scale": np.exp(np.array(loc))})),
+    Fixture(pyro_dist=dist.AffineBeta,
+            scipy_dist=sp.beta,
+            examples=[
+                {'concentration1': [2.4], 'concentration0': [3.6], 'loc': [-1.0], 'scale': [2.0],
+                 'test_data': [-0.4]},
+                {'concentration1': [[2.4, 2.4], [3.6, 3.6]], 'concentration0': [[2.5, 2.5], [2.5, 2.5]],
+                 'loc': [[-1.0, -1.0], [2.0, 2.0]], 'scale': [[2.0, 2.0], [1.0, 1.0]],
+                 'test_data': [[[-0.4, 0.4], [2.5, 2.6]]]},
+                {'concentration1': [[2.4], [3.7]], 'concentration0': [[3.6], [2.5]],
+                 'loc': [[-1.0], [2.0]], 'scale': [[2.0], [2.0]],
+                 'test_data': [[0.0], [3.0]]}
+            ],
+            scipy_arg_fn=lambda concentration1, concentration0, loc, scale:
+            ((np.array(concentration1), np.array(concentration0), np.array(loc), np.array(scale)), {})),
     Fixture(pyro_dist=dist.Normal,
             scipy_dist=sp.norm,
             examples=[


### PR DESCRIPTION
An implementation of the `AffineBeta` distribution.

**Distribution parameters**
There are other possible ways to parameterize `AffineBeta`, e.g. `low,high` instead of `loc,scale` or `mean,size` instead of `concentration1,concentration0`. Which approach is more preferred?

One way to achieve alternative parameterization is by subclassing `AffineBeta`:

<details>

```py
class NewAffineBeta(AffineBeta):
    """
    :param mean: mean of the distribution.
    :param size: size parameter of the Beta distribution.
    :param low: min parameter.
    :param high: max parameter.
    """

    arg_constraints = {
        "mean": constraints.dependent,
        "size": constraints.real,
        "low": constraints.real,
        "high": constraints.dependent,
    }

    def __init__(self, mean, size, low, high, validate_args=None):
        try:
            concentration1 = size * (mean - low) / (high - low)
            concentration0 = size * (high - mean) / (high - low)
        except ZeroDivisionError:
            # this is needed to work with funsor make_dist
            low = torch.tensor(0.0)
            high = torch.tensor(1.0)
            concentration1 = torch.tensor(1.0)
            concentration0 = torch.tensor(1.0)
        super(AffineBeta, self).__init__(
            concentration1,
            concentration0,
            low,
            high - low,
            validate_args=validate_args,
        )

    def expand(self, batch_shape, _instance=None):
        new = self._get_checked_instance(NewAffineBeta, _instance)
        return super(NewAffineBeta, self).expand(batch_shape, _instance=new)
```

</details>

**Clamping sample values**

To avoid  `NaN` and `Inf` values in the gradient sample values are clamped by  `torch.finfo(x.dtype).eps * self.scale`.