### PR TITLE
Implement ProjectedNormal distribution and reparametrizer

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -283,7 +283,7 @@ OrderedLogistic
 
 ProjectedNormal
 ---------------
-.. autoclass:: pyro.distributions.projected_normal
+.. autoclass:: pyro.distributions.ProjectedNormal
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -274,6 +274,13 @@ OrderedLogistic
     :undoc-members:
     :show-inheritance:
 
+ProjectedNormal
+---------------
+.. autoclass:: pyro.distributions.projected_normal
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 RelaxedBernoulliStraightThrough
 -------------------------------
 .. autoclass:: pyro.distributions.RelaxedBernoulliStraightThrough

--- a/docs/source/infer.reparam.rst
+++ b/docs/source/infer.reparam.rst
@@ -95,6 +95,15 @@ Stable Distributions
     :special-members: __call__
     :show-inheritance:
 
+Projected Normal Distributions
+------------------------------
+.. automodule:: pyro.infer.reparam.projected_normal
+    :members:
+    :undoc-members:
+    :member-order: bysource
+    :special-members: __call__
+    :show-inheritance:
+
 Hidden Markov Models
 --------------------
 .. automodule:: pyro.infer.reparam.hmm

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -47,6 +47,7 @@ from pyro.distributions.one_one_matching import OneOneMatching
 from pyro.distributions.one_two_matching import OneTwoMatching
 from pyro.distributions.ordered_logistic import OrderedLogistic
 from pyro.distributions.polya_gamma import TruncatedPolyaGamma
+from pyro.distributions.projected_normal import ProjectedNormal
 from pyro.distributions.rejector import Rejector
 from pyro.distributions.relaxed_straight_through import (
     RelaxedBernoulliStraightThrough,
@@ -111,6 +112,7 @@ __all__ = [
     "OneOneMatching",
     "OneTwoMatching",
     "OrderedLogistic",
+    "ProjectedNormal",
     "Rejector",
     "RelaxedBernoulliStraightThrough",
     "RelaxedOneHotCategoricalStraightThrough",

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -43,6 +43,21 @@ class _Integer(Constraint):
         return self.__class__.__name__[1:]
 
 
+class _Sphere(Constraint):
+    """
+    Constrain to the Euclidean n-sphere.
+    """
+    reltol = 10.
+
+    def check(self, value):
+        eps = torch.finfo(value.dtype).eps
+        error = torch.linalg.norm(value, dim=-1).sub(1).abs()
+        return error < self.reltol * eps * value.size(-1) ** 0.5
+
+    def __repr__(self):
+        return self.__class__.__name__[1:]
+
+
 class _CorrCholesky(Constraint):
     """
     Constrains to lower-triangular square matrices with positive diagonals and
@@ -73,12 +88,14 @@ class _OrderedVector(Constraint):
 corr_cholesky_constraint = _CorrCholesky()
 integer = _Integer()
 ordered_vector = _OrderedVector()
+sphere = _Sphere()
 
 __all__ = [
     'IndependentConstraint',
     'corr_cholesky_constraint',
     'integer',
     'ordered_vector',
+    'sphere',
 ]
 
 __all__.extend(torch_constraints)

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -47,7 +47,7 @@ class _Sphere(Constraint):
     """
     Constrain to the Euclidean n-sphere.
     """
-    reltol = 10.
+    reltol = 10.  # Relative to finfo.eps.
 
     def check(self, value):
         eps = torch.finfo(value.dtype).eps

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -51,7 +51,11 @@ class _Sphere(Constraint):
 
     def check(self, value):
         eps = torch.finfo(value.dtype).eps
-        error = torch.linalg.norm(value, dim=-1).sub(1).abs()
+        try:
+            norm = torch.linalg.norm(value, dim=-1)  # torch 1.7+
+        except AttributeError:
+            norm = value.norm(dim=-1)  # torch 1.6
+        error = (norm - 1).abs()
         return error < self.reltol * eps * value.size(-1) ** 0.5
 
     def __repr__(self):

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -45,7 +45,7 @@ class _Integer(Constraint):
 
 class _Sphere(Constraint):
     """
-    Constrain to the Euclidean n-sphere.
+    Constrain to the Euclidean sphere of any dimension.
     """
     reltol = 10.  # Relative to finfo.eps.
 
@@ -117,7 +117,8 @@ __doc__ += "\n".join([
         _name,
         "alias of :class:`torch.distributions.constraints.{}`".format(_name)
         if globals()[_name].__module__.startswith("torch") else
-        ".. autoclass:: {}".format(_name)
+        ".. autoclass:: {}".format(_name if type(globals()[_name]) is type else
+                                   type(globals()[_name]).__name__)
     )
     for _name in sorted(__all__)
 ])

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -3,9 +3,9 @@
 
 import torch
 
-import pyro.distributions.constraints as constraints
-from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.util import broadcast_shape
+from . import constraints
+from .torch_distribution import TorchDistribution
+from .util import broadcast_shape
 
 
 def safe_project(x):

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -36,7 +36,7 @@ class ProjectedNormal(TorchDistribution):
     inference via reparametrized gradients.
 
     To use this distribution with autoguides, use ``poutine.reparam`` with a
-    :class:`~pyro.infer.reparam.projectednormal.ProjectedNormalReparam`
+    :class:`~pyro.infer.reparam.projected_normal.ProjectedNormalReparam`
     reparametrizer in the model, e.g.::
 
         @poutine.reparam(config={"direction": ProjectedNormalReparam()})

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -18,7 +18,10 @@ def safe_project(x):
     :returns: A normalized version ``x / ||x||_2``.
     :rtype: Tensor
     """
-    norm = torch.linalg.norm(x, dim=-1, keepdim=True)
+    try:
+        norm = torch.linalg.norm(x, dim=-1, keepdim=True)  # torch 1.7+
+    except AttributeError:
+        norm = x.norm(dim=-1, keepdim=True)  # torch 1.6
     x = x / norm.clamp(min=torch.finfo(x.dtype).tiny)
     x.data[..., 0][x.data.eq(0).all(dim=-1)] = 1  # Avoid the singularity.
     return x

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -51,6 +51,7 @@ class ProjectedNormal(TorchDistribution):
     """
     arg_constraints = {"concentration": constraints.real_vector}
     support = constraints.sphere
+    has_rsample = True
     _log_prob_impls = {}  # maps dim -> function(concentration, value)
 
     def __init__(self, concentration, *, validate_args=None):

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -1,0 +1,78 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import pyro.distributions.constraints as constraints
+from pyro.distributions.torch_distribution import TorchDistribution
+from pyro.distributions.util import broadcast_shape
+
+
+def safe_project(x):
+    """
+    Safely project a vector onto the sphere. This avoid the singularity at zero
+    by mapping to the vector ``[1, 0, 0, ..., 0]``.
+
+    :param Tensor x: A vector
+    :returns: A normalized version ``x / ||x||_2``.
+    :rtype: Tensor
+    """
+    x = x / torch.linalg.norm(x, dim=-1).clamp(min=torch.finfo(x.dtype).tiny)
+    x.data[..., 0][x.data.eq(0).all(dim=-1)] = 1  # Avoid the singularity.
+    return x
+
+
+class ProjectedNormal(TorchDistribution):
+    """
+    Projected isotropic normal distribution of arbitrary dimension.
+
+    This distribution over directional data is qualitatively similar to the von
+    Mises and von Mises-Fisher distributions, but permits tractable variational
+    inference via reparametrized gradients.
+
+    To use this distribution with autoguides, use ``poutine.reparam`` with a
+    :class:`~pyro.infer.reparam.projectednormal.ProjectedNormalReparam`
+    reparametrizer in the model, e.g.::
+
+        @poutine.reparam(config={"direction": ProjectedNormalReparam()})
+        def model():
+            direction = pyro.sample("direction", ProjectedNormal(torch.zeros(3)))
+            ...
+
+    [1] D. Hernandez-Stumpfhauser, F.J. Breidt, M.J. van der Woerd (2017)
+        "The General Projected Normal Distribution of Arbitrary Dimension:
+        Modeling and Bayesian Inference"
+        https://projecteuclid.org/euclid.ba/1453211962
+    """
+    arg_constraints = {"concentration": constraints.real_vector}
+    support = constraints.sphere
+
+    def __init__(self, concentration, *, validate_args=None):
+        self.concentration = concentration
+        batch_shape = concentration.shape[:-1]
+        event_shape = concentration.shape[-1:]
+        super().__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(ProjectedNormal, _instance)
+        batch_shape = torch.Size(broadcast_shape(self.batch_shape, batch_shape))
+        new.concentration = self.concentration.expand(batch_shape + (-1,))
+        super(ProjectedNormal, new).__init__(batch_shape, self.event_shape, validate_args=False)
+        new._validate_args = self.__dict__.get('_validate_args')
+        return new
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = self._extended_shape(sample_shape)
+        x = self.concentration.new_empty(shape).normal_()
+        x = x + self.concentration
+        x = safe_project(x)
+        return x
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        raise NotImplementedError("Use poutine.reparam with ProjectedNormalReparam")
+
+    @property
+    def mode(self):
+        return safe_project(self.concentration)

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -129,8 +129,8 @@ def _log_prob_2(concentration, value):
     # This is the log of a definite integral, computed by mathematica:
     # Integrate[x/(E^((x-t)^2/2) Sqrt[2 Pi]), {x, 0, Infinity}]
     # = (t + Sqrt[2/Pi]/E^(t^2/2) + t Erf[t/Sqrt[2]])/2
-    para_part = (t + t2.mul(-0.5).exp().mul((2 / math.pi) ** 0.5)
-                 + t * (t * 0.5 ** 0.5).erf()).mul(0.5).log()
+    para_part = (t2.mul(-0.5).exp().mul((2 / math.pi) ** 0.5)
+                 + t * (1 + (t * 0.5 ** 0.5).erf())).mul(0.5).log()
 
     return para_part + perp_part
 

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -5,8 +5,8 @@ import math
 
 import torch
 
-import pyro.distributions.constraints as constraints
-from pyro.distributions import TorchDistribution
+from . import constraints
+from .torch_distribution import TorchDistribution
 
 
 class VonMises3D(TorchDistribution):

--- a/pyro/distributions/von_mises_3d.py
+++ b/pyro/distributions/von_mises_3d.py
@@ -4,8 +4,8 @@
 import math
 
 import torch
-from torch.distributions import constraints
 
+import pyro.distributions.constraints as constraints
 from pyro.distributions import TorchDistribution
 
 
@@ -19,7 +19,8 @@ class VonMises3D(TorchDistribution):
     must be a normalized 3-vector that lies on the 2-sphere.
 
     See :class:`~pyro.distributions.VonMises` for a 2D polar coordinate cousin
-    of this distribution.
+    of this distribution. See :class:`~pyro.distributions.projected_normal` for
+    a qualitatively similar distribution but implementing more functionality.
 
     Currently only :meth:`log_prob` is implemented.
 
@@ -28,7 +29,7 @@ class VonMises3D(TorchDistribution):
         magnitude is the concentration.
     """
     arg_constraints = {'concentration': constraints.real}
-    support = constraints.real  # TODO implement constraints.sphere or similar
+    support = constraints.sphere
 
     def __init__(self, concentration, validate_args=None):
         if concentration.dim() < 1 or concentration.shape[-1] != 3:

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -31,12 +31,13 @@ import pyro.poutine as poutine
 from pyro.distributions.transforms import affine_autoregressive, iterated
 from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
 from pyro.infer.autoguide.initialization import InitMessenger, init_to_feasible, init_to_median
-from pyro.infer.autoguide.utils import _product
 from pyro.infer.enum import config_enumerate
 from pyro.nn import PyroModule, PyroParam
 from pyro.ops.hessian import hessian
 from pyro.ops.tensor_utils import periodic_repeat
 from pyro.poutine.util import site_is_subsample
+
+from .utils import _product, helpful_support_errors
 
 
 def _deep_setattr(obj, key, val):
@@ -355,7 +356,8 @@ class AutoDelta(AutoGuide):
                     value = periodic_repeat(value, full_size, dim).contiguous()
 
             value = PyroParam(value, site["fn"].support, event_dim)
-            _deep_setattr(self, name, value)
+            with helpful_support_errors(site):
+                _deep_setattr(self, name, value)
 
     def forward(self, *args, **kwargs):
         """
@@ -447,7 +449,8 @@ class AutoNormal(AutoGuide):
         # Initialize guide params
         for name, site in self.prototype_trace.iter_stochastic_nodes():
             # Collect unconstrained event_dims, which may differ from constrained event_dims.
-            init_loc = biject_to(site["fn"].support).inv(site["value"].detach()).detach()
+            with helpful_support_errors(site):
+                init_loc = biject_to(site["fn"].support).inv(site["value"].detach()).detach()
             event_dim = site["fn"].event_dim + init_loc.dim() - site["value"].dim()
             self._event_dims[name] = event_dim
 
@@ -591,7 +594,8 @@ class AutoContinuous(AutoGuide):
         for name, site in self.prototype_trace.iter_stochastic_nodes():
             # Collect the shapes of unconstrained values.
             # These may differ from the shapes of constrained values.
-            self._unconstrained_shapes[name] = biject_to(site["fn"].support).inv(site["value"]).shape
+            with helpful_support_errors(site):
+                self._unconstrained_shapes[name] = biject_to(site["fn"].support).inv(site["value"]).shape
 
             # Collect independence contexts.
             self._cond_indep_stacks[name] = site["cond_indep_stack"]

--- a/pyro/infer/autoguide/initialization.py
+++ b/pyro/infer/autoguide/initialization.py
@@ -20,8 +20,10 @@ from pyro.infer.util import is_validation_enabled
 from pyro.poutine.messenger import Messenger
 from pyro.util import torch_isnan
 
+from .utils import helpful_support_errors
 
 # TODO: move this file out of `autoguide` in a minor release
+
 
 def _is_multivariate(d):
     while isinstance(d, (Independent, MaskedDistribution)):
@@ -180,7 +182,7 @@ class InitMessenger(Messenger):
     def _pyro_sample(self, msg):
         if msg["done"] or msg["is_observed"] or type(msg["fn"]).__name__ == "_Subsample":
             return
-        with torch.no_grad():
+        with torch.no_grad(), helpful_support_errors(msg):
             value = self.init_fn(msg)
         if is_validation_enabled() and msg["value"] is not None:
             if not isinstance(value, type(msg["value"])):

--- a/pyro/infer/autoguide/utils.py
+++ b/pyro/infer/autoguide/utils.py
@@ -57,5 +57,6 @@ def helpful_support_errors(site):
             raise ValueError(
                 f"Continuous inference cannot handle spherical sample site '{name}'. "
                 "Consider using ProjectedNormal distribution together with "
-                "poutine.reparam and a ProjectedNormalReparam reparametrizer.")
+                "a reparameterizer, e.g. "
+                f"poutine.reparam(config={{'{name}': ProjectedNormalReparam()}}).")
         raise e from None

--- a/pyro/infer/autoguide/utils.py
+++ b/pyro/infer/autoguide/utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import contextmanager
+
 from pyro import poutine
 
 
@@ -33,3 +35,27 @@ def mean_field_entropy(model, args, whitelist=None):
                 if whitelist is None or name in whitelist:
                     entropy += site["fn"].entropy()
     return entropy
+
+
+@contextmanager
+def helpful_support_errors(site):
+    try:
+        yield
+    except NotImplementedError as e:
+        support_name = repr(site["fn"].support).lower()
+        if "integer" in support_name or "boolean" in support_name:
+            name = site["name"]
+            raise ValueError(
+                f"Continuous inference cannot handle discrete sample site '{name}'. "
+                "Consider enumerating that variable as documented in "
+                "https://pyro.ai/examples/enumeration.html . "
+                "If you are already enumerating, take care to hide this site when "
+                "constructing an autoguide, e.g. "
+                f"guide = AutoNormal(poutine.block(model, hide=['{name}'])).")
+        if "sphere" in support_name:
+            name = site["name"]
+            raise ValueError(
+                f"Continuous inference cannot handle spherical sample site '{name}'. "
+                "Consider using ProjectedNormal distribution together with "
+                "poutine.reparam and a ProjectedNormalReparam reparametrizer.")
+        raise e from None

--- a/pyro/infer/reparam/__init__.py
+++ b/pyro/infer/reparam/__init__.py
@@ -8,6 +8,7 @@ from .haar import HaarReparam
 from .hmm import LinearHMMReparam
 from .loc_scale import LocScaleReparam
 from .neutra import NeuTraReparam
+from .projected_normal import ProjectedNormalReparam
 from .softmax import GumbelSoftmaxReparam
 from .split import SplitReparam
 from .stable import LatentStableReparam, StableReparam, SymmetricStableReparam
@@ -24,6 +25,7 @@ __all__ = [
     "LinearHMMReparam",
     "LocScaleReparam",
     "NeuTraReparam",
+    "ProjectedNormalReparam",
     "SplitReparam",
     "StableReparam",
     "StudentTReparam",

--- a/pyro/infer/reparam/projected_normal.py
+++ b/pyro/infer/reparam/projected_normal.py
@@ -1,0 +1,32 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pyro
+import pyro.distributions as dist
+from pyro.distributions.projected_normal import safe_project
+
+from .reparam import Reparam
+
+
+class ProjectedNormalReparam(Reparam):
+    """
+    Reparametrizer for :class:`~pyro.distributions.ProjectedNormal` latent
+    variables.
+
+    This reparameterization works only for latent variables, not likelihoods.
+    """
+    def __call__(self, name, fn, obs):
+        fn, event_dim = self._unwrap(fn)
+        assert isinstance(fn, dist.ProjectedNormal)
+        assert obs is None, "ProjectedNormalReparam does not support observe statements"
+
+        # Draw parameter-free noise.
+        new_fn = dist.Normal(fn.concentration, 1).to_event(1)
+        x = pyro.sample("{}_normal".format(name), self._wrap(new_fn, event_dim))
+
+        # Differentiably transform.
+        value = safe_project(x)
+
+        # Simulate a pyro.deterministic() site.
+        new_fn = dist.Delta(value, event_dim=event_dim).mask(False)
+        return new_fn, value

--- a/tests/common.py
+++ b/tests/common.py
@@ -27,7 +27,7 @@ Source: https://github.com/pytorch/pytorch/blob/master/test/common.py
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 RESOURCE_DIR = os.path.join(TESTS_DIR, 'resources')
 EXAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), 'examples')
-TEST_FAILURE_RATE = 1 / 1000  # For all goodness-of-fit tests.
+TEST_FAILURE_RATE = 2e-5  # For all goodness-of-fit tests.
 
 
 def xfail_param(*args, **kwargs):

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -263,6 +263,13 @@ continuous_dists = [
                 {'df': 1.5, 'loc': [0.2, 0.3], 'scale_tril': [[0.8, 0.0], [1.3, 0.4]],
                  'test_data': [-3., 2]},
                 ]),
+    Fixture(pyro_dist=dist.ProjectedNormal,
+            examples=[
+                {'concentration': [0., 0.], 'test_data': [1., 0.]},
+                {'concentration': [5., 9.], 'test_data': [0., 1.]},
+                {'concentration': [0., 0., 0.], 'test_data': [1., 0., 0.]},
+                {'concentration': [-1., 5., 9.], 'test_data': [0., 0., 1.]},
+                ]),
 ]
 
 discrete_dists = [

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -280,9 +280,9 @@ continuous_dists = [
     Fixture(pyro_dist=dist.ProjectedNormal,
             examples=[
                 {'concentration': [0., 0.], 'test_data': [1., 0.]},
-                {'concentration': [5., 9.], 'test_data': [0., 1.]},
-                # {'concentration': [0., 0., 0.], 'test_data': [1., 0., 0.]},
-                # {'concentration': [-1., 5., 9.], 'test_data': [0., 0., 1.]},
+                {'concentration': [2., 3.], 'test_data': [0., 1.]},
+                {'concentration': [0., 0., 0.], 'test_data': [1., 0., 0.]},
+                {'concentration': [-1., 2., 3.], 'test_data': [0., 0., 1.]},
                 ]),
 ]
 

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -281,8 +281,8 @@ continuous_dists = [
             examples=[
                 {'concentration': [0., 0.], 'test_data': [1., 0.]},
                 {'concentration': [5., 9.], 'test_data': [0., 1.]},
-                {'concentration': [0., 0., 0.], 'test_data': [1., 0., 0.]},
-                {'concentration': [-1., 5., 9.], 'test_data': [0., 0., 1.]},
+                # {'concentration': [0., 0., 0.], 'test_data': [1., 0., 0.]},
+                # {'concentration': [-1., 5., 9.], 'test_data': [0., 0., 1.]},
                 ]),
 ]
 

--- a/tests/distributions/test_constraints.py
+++ b/tests/distributions/test_constraints.py
@@ -1,0 +1,19 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pyro.distributions import constraints
+from pyro.distributions.projected_normal import safe_project
+
+
+@pytest.mark.parametrize("dim", [2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000, 10000, 100000])
+def test_shpere_check(dim):
+    data = torch.randn(100, dim)
+    assert not constraints.sphere.check(data).any()
+
+    data = safe_project(data)
+    actual = constraints.sphere.check(data)
+    assert actual.all()
+    assert actual.shape == data.shape[:-1]

--- a/tests/distributions/test_constraints.py
+++ b/tests/distributions/test_constraints.py
@@ -9,7 +9,7 @@ from pyro.distributions.projected_normal import safe_project
 
 
 @pytest.mark.parametrize("dim", [2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000, 10000, 100000])
-def test_shpere_check(dim):
+def test_sphere_check(dim):
     data = torch.randn(100, dim)
     assert not constraints.sphere.check(data).any()
 

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -97,14 +97,18 @@ def test_gof(continuous_dist):
         with xfail_if_not_implemented():
             probs = d.log_prob(samples).exp()
 
-        # Test each batch independently.
-        probs = probs.reshape(num_samples, -1)
-        samples = samples.reshape(probs.shape + d.event_shape)
+        dim = None
         if "Dirichlet" in Dist.__name__:
             # The Dirichlet density is over all but one of the probs.
             samples = samples[..., :-1]
+        if "ProjectedNormal" in Dist.__name__:
+            dim = samples.size(-1) - 1
+
+        # Test each batch independently.
+        probs = probs.reshape(num_samples, -1)
+        samples = samples.reshape(probs.shape + d.event_shape)
         for b in range(probs.size(-1)):
-            gof = auto_goodness_of_fit(samples[:, b], probs[:, b])
+            gof = auto_goodness_of_fit(samples[:, b], probs[:, b], dim=dim)
             assert gof > TEST_FAILURE_RATE
 
 

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -98,15 +98,15 @@ def test_gof(continuous_dist):
             probs = d.log_prob(samples).exp()
 
         dim = None
-        if "Dirichlet" in Dist.__name__:
-            # The Dirichlet density is over all but one of the probs.
-            samples = samples[..., :-1]
         if "ProjectedNormal" in Dist.__name__:
             dim = samples.size(-1) - 1
 
         # Test each batch independently.
         probs = probs.reshape(num_samples, -1)
         samples = samples.reshape(probs.shape + d.event_shape)
+        if "Dirichlet" in Dist.__name__:
+            # The Dirichlet density is over all but one of the probs.
+            samples = samples[..., :-1]
         for b in range(probs.size(-1)):
             gof = auto_goodness_of_fit(samples[:, b], probs[:, b], dim=dim)
             assert gof > TEST_FAILURE_RATE

--- a/tests/infer/reparam/test_projected_normal.py
+++ b/tests/infer/reparam/test_projected_normal.py
@@ -1,0 +1,47 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from torch.autograd import grad
+
+import pyro
+import pyro.distributions as dist
+from pyro import poutine
+from pyro.infer.reparam import ProjectedNormalReparam
+from tests.common import assert_close
+
+
+# Test helper to extract a few central moments from samples.
+def get_moments(x):
+    m1 = x.mean(0)
+    x = x - m1
+    xx = x[..., None] * x[..., None, :]
+    m2 = xx.mean(0)
+    return torch.cat([m1.reshape(-1), m2.reshape(-1)])
+
+
+@pytest.mark.parametrize("shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("dim", [2, 3, 4])
+def test_projected_normal(shape, dim):
+    concentration = torch.randn(shape + (dim,)).requires_grad_()
+
+    def model():
+        with pyro.plate_stack("plates", shape):
+            with pyro.plate("particles", 10000):
+                pyro.sample("x", dist.ProjectedNormal(concentration))
+
+    value = poutine.trace(model).get_trace().nodes["x"]["value"]
+    assert dist.ProjectedNormal.support.check(value).all()
+    expected_probe = get_moments(value)
+
+    reparam_model = poutine.reparam(model, {"x": ProjectedNormalReparam()})
+    value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
+    assert dist.ProjectedNormal.support.check(value).all()
+    actual_probe = get_moments(value)
+    assert_close(actual_probe, expected_probe, atol=0.05)
+
+    for actual_m, expected_m in zip(actual_probe, expected_probe):
+        expected_grad = grad(expected_m, [concentration], retain_graph=True)
+        actual_grad = grad(actual_m, [concentration], retain_graph=True)
+        assert_close(actual_grad, expected_grad, atol=0.1)


### PR DESCRIPTION
This implements an isotropic `ProjectedNormal` distribution for inference of latent **directional** data of arbitrary dimension.

Currently the `VonMises` and `VonMises3d` distributions implement `.sample()` but not `.rsample()`, and use a bogus `real` constraint. This PR attempts to support `.rsample()`, implements a reparametrizer making this distribution compatible with autoguides, and adds a `sphere` constraint.

## Density computation

I have implemented `.log_prob()` only for dim=2 and dim=3. Note `.log_prob()` is required for use of this distribution as a likelihood or as a latent variable without `poutine.reparam` (in either model or guide). Many papers such as [(Hernandez-Stumpfhauser et al. 2017)]() try to generalize to arbitrary covariance matrices. However I'm choosing to standardize to a unit covariance, thus guaranteeing unimodality ("let the guide handle multiple modes, and the distribution focus on a single mode"). The density integral reduces to a definite integral of the gaussian density times a simple polynomial. We can evaluate this integral using [Wolfram alpha](https://www.wolframalpha.com/input/?i=Integrate%5Bx%5En%2FE%5E%28%28x-c%29%5E2%2F2%29%2C+%7Bx%2C0%2Cinfinity%7D%5D), but the result involves a Kummer confluent hypergeometric distribution:
![image](https://user-images.githubusercontent.com/648532/104130477-ef221c80-533e-11eb-8f80-9eedce89dbe6.png)
I suspect the result simplifies to a pair of expressions, one for even `n` and one for odd `n`.

## Tasks
- [x] implement a `constraints.sphere`
- [x] implement `ProjectedNormal.rsample()`
- [x] implement a `ProjectedNormal.log_prob()` for use as a likelihood
- [x] implement a `ProjectedNormalReparam` for use with autoguides
- [x] test `ProjectedNormal`
- [x] test `constraints.sphere`
- [x] test `ProjectedNormalReparam`
- [x] add helpful error messages to autoguides