### PR TITLE
Add goodness of fit test helpers for testing distributions

### DIFF
--- a/docs/source/distributions.testing.rst
+++ b/docs/source/distributions.testing.rst
@@ -1,0 +1,6 @@
+Distribution Testing
+--------------------
+
+.. automodule:: pyro.distributions.testing.gof
+   :members:
+   :member-order: bysource

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ Pyro Documentation
    optimization
    poutine
    ops
-   distributions.testing
+   testing
 
 .. toctree::
    :glob:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Pyro Documentation
    optimization
    poutine
    ops
+   distributions.testing
 
 .. toctree::
    :glob:

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -1,5 +1,5 @@
-Distribution Testing
---------------------
+Testing Utilities
+-----------------
 
 .. automodule:: pyro.distributions.testing.gof
    :members:

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from pyro.distributions.torch import Beta, TransformedDistribution
 from torch.distributions import constraints

--- a/pyro/distributions/testing/__init__.py
+++ b/pyro/distributions/testing/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-This module contains distributions that are useful for testing new Pyro
-inference algorithms.
+This module contains tools for testing new distributions and distributions for
+testing new Pyro inference algorithms.
 """

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -50,6 +50,9 @@ assert ``gof > TEST_FAILURE_RATE``. For example::
         probs = d.log_prob(samples).exp()
         gof = auto_goodness_of_fit(samples, probs)
         assert gof > TEST_FAILURE_RATE
+
+This module is a port of the
+`goftests <https://github.com/posterior/goftests>`_ library.
 """
 
 import warnings
@@ -84,7 +87,7 @@ def multinomial_goodness_of_fit(
 ):
     """
     Pearson's chi^2 test, on possibly truncated data.
-    http://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
+    https://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
 
     :param Tensor probs: Vector of probabilities.
     :param Tensor counts: Vector of counts.
@@ -223,9 +226,16 @@ def vector_density_goodness_of_fit(samples, probs, *, dim=None, plot=False):
     distribution via nearest neighbor distribution [1,2,3] and assess goodness
     of fit via binned Pearson's chi^2 test.
 
-    [1] http://projecteuclid.org/download/pdf_1/euclid.aop/1176993668
-    [2] http://arxiv.org/pdf/1006.3019v2.pdf
-    [3] http://en.wikipedia.org/wiki/Nearest_neighbour_distribution
+    [1] Peter J. Bickel and Leo Breiman (1983)
+        "Sums of Functions of Nearest Neighbor Distances, Moment Bounds, Limit
+        Theorems and a Goodness of Fit Test"
+        https://projecteuclid.org/download/pdf_1/euclid.aop/1176993668
+    [2] Mike Williams (2010)
+        "How good are your fits? Unbinned multivariate goodness-of-fit tests in
+        high energy physics."
+        https://arxiv.org/abs/1006.3019
+    [3] Nearest Neighbour Distribution
+        https://en.wikipedia.org/wiki/Nearest_neighbour_distribution
 
     :param Tensor samples: A tensor of real-vector-valued samples from a
         distribution.

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -148,7 +148,8 @@ def unif01_goodness_of_fit(samples, *, plot=False):
         raise InvalidTest('imprecise test, use more samples')
     probs = torch.ones(bin_count) / bin_count
     binned = samples.mul(bin_count).long().clamp(min=0, max=bin_count - 1)
-    counts = torch.zeros(bin_count).scatter_add_(0, binned, torch.ones(()))
+    counts = torch.zeros(bin_count)
+    counts.scatter_add_(0, binned, torch.ones(binned.shape))
     return multinomial_goodness_of_fit(probs, counts, plot=plot)
 
 

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2019, Gamalon, Inc.
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
-#
+
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -89,8 +89,8 @@ def multinomial_goodness_of_fit(
     Pearson's chi^2 test, on possibly truncated data.
     https://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
 
-    :param Tensor probs: Vector of probabilities.
-    :param Tensor counts: Vector of counts.
+    :param torch.Tensor probs: Vector of probabilities.
+    :param torch.Tensor counts: Vector of counts.
     :param int total_count: Optional total count in case data is truncated,
         otherwise None.
     :param bool plot: Whether to print a histogram. Defaults to False.
@@ -138,8 +138,8 @@ def unif01_goodness_of_fit(samples, *, plot=False):
     """
     Bin uniformly distributed samples and apply Pearson's chi^2 test.
 
-    :param Tensor samples: A vector of real-valued samples from a candidate
-        distribution that should be Uniform(0, 1)-distributed.
+    :param torch.Tensor samples: A vector of real-valued samples from a
+        candidate distribution that should be Uniform(0, 1)-distributed.
     :param bool plot: Whether to print a histogram. Defaults to False.
     :returns: Goodness of fit, as a p-value.
     :rtype: float
@@ -162,8 +162,8 @@ def exp_goodness_of_fit(samples, plot=False):
     Transform exponentially distribued samples to Uniform(0,1) distribution and
     assess goodness of fit via binned Pearson's chi^2 test.
 
-    :param Tensor samples: A vector of real-valued samples from a candidate
-        distribution that should be Exponential(1)-distributed.
+    :param torch.Tensor samples: A vector of real-valued samples from a
+        candidate distribution that should be Exponential(1)-distributed.
     :param bool plot: Whether to print a histogram. Defaults to False.
     :returns: Goodness of fit, as a p-value.
     :rtype: float
@@ -178,10 +178,10 @@ def density_goodness_of_fit(samples, probs, plot=False):
     Transform arbitrary continuous samples to Uniform(0,1) distribution and
     assess goodness of fit via binned Pearson's chi^2 test.
 
-    :param Tensor samples: A vector list of real-valued samples from a
+    :param torch.Tensor samples: A vector list of real-valued samples from a
         distribution.
-    :param Tensor probs: A vector of probability densities evaluated at those
-        samples.
+    :param torch.Tensor probs: A vector of probability densities evaluated at
+        those samples.
     :param bool plot: Whether to print a histogram. Defaults to False.
     :returns: Goodness of fit, as a p-value.
     :rtype: float
@@ -237,10 +237,10 @@ def vector_density_goodness_of_fit(samples, probs, *, dim=None, plot=False):
     [3] Nearest Neighbour Distribution
         https://en.wikipedia.org/wiki/Nearest_neighbour_distribution
 
-    :param Tensor samples: A tensor of real-vector-valued samples from a
+    :param torch.Tensor samples: A tensor of real-vector-valued samples from a
         distribution.
-    :param Tensor probs: A vector of probability densities evaluated at those
-        samples.
+    :param torch.Tensor probs: A vector of probability densities evaluated at
+        those samples.
     :param int dim: Optional dimension of the submanifold on which data lie.
         Defaults to ``samples.shape[-1]``.
     :param bool plot: Whether to print a histogram. Defaults to False.
@@ -267,9 +267,10 @@ def auto_goodness_of_fit(samples, probs, *, dim=None, plot=False):
     Dispatch on sample dimension and delegate to either
     :func:`density_goodness_of_fit` or :func:`vector_density_goodness_of_fit`.
 
-    :param Tensor samples: A tensor of samples stacked on their leftmost
+    :param torch.Tensor samples: A tensor of samples stacked on their leftmost
         dimension.
-    :param Tensor probs: A vector of probabilities evaluated at those samples.
+    :param torch.Tensor probs: A vector of probabilities evaluated at those
+        samples.
     :param int dim: Optional manifold dimension, defaults to
         ``samples.shape[1:].numel()``.
     :param bool plot: Whether to print a histogram. Defaults to False.

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -1,0 +1,396 @@
+# Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
+# Copyright (c) 2015, Gamelan Labs, Inc.
+# Copyright (c) 2016, Google, Inc.
+# Copyright (c) 2019, Gamalon, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of Salesforce.com nor the names of its contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import division
+from collections import defaultdict
+from math import gamma
+try:
+    from itertools import izip as zip
+except ImportError:
+    pass
+import random
+import sys
+
+import numpy
+import numpy.random
+from numpy import pi
+from scipy.spatial import cKDTree
+
+from .utils import chi2sf
+
+NoneType = type(None)
+
+#: Data types for integral random variables.
+#:
+#: For Python 2.7, this tuple also includes `long`.
+INTEGRAL_TYPES = (int, )
+
+#: Data types for continuous random variables.
+CONTINUOUS_TYPES = (float, numpy.float32, numpy.float64)
+
+#: Data types for discrete random variables.
+#:
+#: For Python 2.7, this tuple also includes `long` and `basestring`.
+DISCRETE_TYPES = (NoneType, bool, int, str, numpy.int32, numpy.int64)
+
+if sys.version_info < (3, ):
+    # `str` is a subclass of `basestring`, so this is doing a little
+    # more work than is necessary, but it should not cause a problem.
+    DISCRETE_TYPES += (long, basestring)  # noqa
+    INTEGRAL_TYPES += (long, )  # noqa
+
+
+def seed_all(seed):
+    random.seed(seed)
+    numpy.random.seed(seed)
+
+
+def get_dim(thing):
+    if hasattr(thing, '__len__'):
+        return len(thing)
+    else:
+        return 1
+
+
+def print_histogram(probs, counts):
+    WIDTH = 60.0
+    max_count = max(counts)
+    print('{: >8} {: >8}'.format('Prob', 'Count'))
+    for prob, count in sorted(zip(probs, counts), reverse=True):
+        width = int(round(WIDTH * count / max_count))
+        print('{: >8.3f} {: >8d} {}'.format(prob, count, '-' * width))
+
+
+def multinomial_goodness_of_fit(
+        probs,
+        counts,
+        total_count,
+        truncated=False,
+        plot=False):
+    """
+    Pearson's chi^2 test, on possibly truncated data.
+    http://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test
+
+    Returns:
+        p-value of truncated multinomial sample.
+    """
+    assert len(probs) == len(counts)
+    assert truncated or total_count == sum(counts)
+    chi_squared = 0
+    dof = 0
+    if plot:
+        print_histogram(probs, counts)
+    for p, c in zip(probs, counts):
+        if abs(p - 1) < 1e-8:
+            return 1 if c == total_count else 0
+        assert p < 1, 'bad probability: %g' % p
+        if p > 0:
+            mean = total_count * p
+            variance = total_count * p * (1 - p)
+            assert variance > 1,\
+                'WARNING goodness of fit is inaccurate; use more samples'
+            chi_squared += (c - mean) ** 2 / variance
+            dof += 1
+        else:
+            print('WARNING zero probability in goodness-of-fit test')
+            if c > 0:
+                return float('inf')
+
+    if not truncated:
+        dof -= 1
+
+    survival = chi2sf(chi_squared, dof)
+    return survival
+
+
+def unif01_goodness_of_fit(samples, plot=False):
+    """
+    Bin uniformly distributed samples and apply Pearson's chi^2 test.
+    """
+    samples = numpy.array(samples, dtype=float)
+    assert samples.min() >= 0.0
+    assert samples.max() <= 1.0
+    bin_count = int(round(len(samples) ** 0.333))
+    assert bin_count >= 7, 'WARNING imprecise test, use more samples'
+    probs = numpy.ones(bin_count, dtype=numpy.float) / bin_count
+    counts = numpy.zeros(bin_count, dtype=numpy.int)
+    for sample in samples:
+        counts[min(bin_count - 1, int(bin_count * sample))] += 1
+    return multinomial_goodness_of_fit(probs, counts, len(samples), plot=plot)
+
+
+def exp_goodness_of_fit(
+        samples,
+        plot=False,
+        normalized=True,
+        return_dict=False):
+    """
+    Transform exponentially distribued samples to unif01 distribution
+    and assess goodness of fit via binned Pearson's chi^2 test.
+
+    Inputs:
+        samples - a list of real-valued samples from a candidate distribution
+    """
+    result = {}
+    if not normalized:
+        result['norm'] = numpy.mean(samples)
+        samples /= result['norm']
+    unif01_samples = numpy.exp(-samples)
+    result['gof'] = unif01_goodness_of_fit(unif01_samples, plot=plot)
+    return result if return_dict else result['gof']
+
+
+def density_goodness_of_fit(
+        samples,
+        probs,
+        plot=False,
+        normalized=True,
+        return_dict=False):
+    """
+    Transform arbitrary continuous samples to unif01 distribution
+    and assess goodness of fit via binned Pearson's chi^2 test.
+
+    Inputs:
+        samples - a list of real-valued samples from a distribution
+        probs - a list of probability densities evaluated at those samples
+    """
+    assert len(samples) == len(probs)
+    assert len(samples) > 100, 'WARNING imprecision; use more samples'
+    pairs = list(zip(samples, probs))
+    pairs.sort()
+    samples = numpy.array([x for x, p in pairs])
+    probs = numpy.array([p for x, p in pairs])
+    density = len(samples) * numpy.sqrt(probs[1:] * probs[:-1])
+    gaps = samples[1:] - samples[:-1]
+    exp_samples = density * gaps
+    return exp_goodness_of_fit(exp_samples, plot, normalized, return_dict)
+
+
+def volume_of_sphere(dim, radius):
+    assert isinstance(dim, INTEGRAL_TYPES)
+    return radius ** dim * pi ** (0.5 * dim) / gamma(0.5 * dim + 1)
+
+
+def get_nearest_neighbor_distances(samples):
+    if not hasattr(samples[0], '__iter__'):
+        samples = numpy.array([samples]).T
+    distances, indices = cKDTree(samples).query(samples, k=2)
+    return distances[:, 1]
+
+
+def vector_density_goodness_of_fit(
+        samples,
+        probs,
+        plot=False,
+        normalized=True,
+        return_dict=False):
+    """
+    Transform arbitrary multivariate continuous samples
+    to unif01 distribution via nearest neighbor distribution [1,2,3]
+    and assess goodness of fit via binned Pearson's chi^2 test.
+
+    [1] http://projecteuclid.org/download/pdf_1/euclid.aop/1176993668
+    [2] http://arxiv.org/pdf/1006.3019v2.pdf
+    [3] http://en.wikipedia.org/wiki/Nearest_neighbour_distribution
+
+    Inputs:
+        samples - a list of real-vector-valued samples from a distribution
+        probs - a list of probability densities evaluated at those samples
+    """
+    assert len(samples)
+    assert len(samples) == len(probs)
+    dim = get_dim(samples[0])
+    assert dim
+    assert len(samples) > 1000 * dim, 'WARNING imprecision; use more samples'
+    radii = get_nearest_neighbor_distances(samples)
+    density = len(samples) * numpy.array(probs)
+    volume = volume_of_sphere(dim, radii)
+    exp_samples = density * volume
+    return exp_goodness_of_fit(exp_samples, plot, normalized, return_dict)
+
+
+def trivial_density_goodness_of_fit(
+        samples,
+        probs,
+        plot=False,
+        normalized=True,
+        return_dict=False):
+    assert len(samples)
+    assert all(sample == samples[0] for sample in samples)
+    result = {'gof': 1.0}
+    if not normalized:
+        result['norm'] = probs[0]
+    if return_dict:
+        return result
+    else:
+        return result['gof']
+
+
+def auto_density_goodness_of_fit(
+        samples,
+        probs,
+        plot=False,
+        normalized=True,
+        return_dict=False):
+    """
+    Dispatch on sample dimention and delegate to one of:
+    - density_goodness_of_fit
+    - vector_density_goodness_of_fit
+    - trivial_density_goodness_of_fit
+    """
+    assert len(samples)
+    dim = get_dim(samples[0])
+    if dim == 0:
+        fun = trivial_density_goodness_of_fit
+    elif dim == 1:
+        fun = density_goodness_of_fit
+        if hasattr(samples[0], '__len__'):
+            samples = [sample[0] for sample in samples]
+    else:
+        fun = vector_density_goodness_of_fit
+    return fun(samples, probs, plot, normalized, return_dict)
+
+
+def discrete_goodness_of_fit(
+        samples,
+        probs_dict,
+        truncate_beyond=8,
+        plot=False,
+        normalized=True):
+    """
+    Transform arbitrary discrete data to multinomial
+    and assess goodness of fit via Pearson's chi^2 test.
+    """
+    if not normalized:
+        norm = sum(probs_dict.values())
+        probs_dict = {i: p / norm for i, p in probs_dict.items()}
+    counts = defaultdict(lambda: 0)
+    for sample in samples:
+        assert sample in probs_dict
+        counts[sample] += 1
+    items = [(prob, counts.get(i, 0)) for i, prob in probs_dict.items()]
+    items.sort(reverse=True)
+    truncated = (truncate_beyond and truncate_beyond < len(items))
+    if truncated:
+        items = items[:truncate_beyond]
+    probs = [prob for prob, count in items]
+    counts = [count for prob, count in items]
+    assert sum(counts) > 100, 'WARNING imprecision; use more samples'
+    return multinomial_goodness_of_fit(
+        probs,
+        counts,
+        len(samples),
+        truncated=truncated,
+        plot=plot)
+
+
+def split_discrete_continuous(data):
+    """
+    Convert arbitrary data to a pair `(discrete, continuous)`
+    where `discrete` is hashable and `continuous` is a list of floats.
+    """
+    if isinstance(data, DISCRETE_TYPES):
+        return data, []
+    elif isinstance(data, CONTINUOUS_TYPES):
+        return None, [data]
+    elif isinstance(data, (tuple, list)):
+        discrete = []
+        continuous = []
+        for part in data:
+            d, c = split_discrete_continuous(part)
+            discrete.append(d)
+            continuous += c
+        return tuple(discrete), continuous
+    elif isinstance(data, numpy.ndarray):
+        assert data.dtype in [numpy.float64, numpy.float32]
+        return (None,) * len(data), list(map(float, data))
+    else:
+        raise TypeError(
+            'split_discrete_continuous does not accept {} of type {}'.format(
+                repr(data), str(type(data))))
+
+
+def mixed_density_goodness_of_fit(samples, probs, plot=False, normalized=True):
+    """
+    Test general mixed discrete+continuous datatypes by
+    (1) testing the continuous part conditioned on each discrete value
+    (2) testing the discrete part marginalizing over the continuous part
+    (3) testing the estimated total probability (if normalized = True)
+
+    Inputs:
+        samples - a list of plain-old-data samples from a distribution
+        probs - a list of probability densities evaluated at those samples
+    """
+    assert len(samples)
+    discrete_samples = []
+    strata = defaultdict(lambda: ([], []))
+    for sample, prob in zip(samples, probs):
+        d, c = split_discrete_continuous(sample)
+        discrete_samples.append(d)
+        samples, probs = strata[d]
+        samples.append(c)
+        probs.append(prob)
+
+    # Continuous part
+    gofs = []
+    discrete_probs = {}
+    for key, (samples, probs) in strata.items():
+        result = auto_density_goodness_of_fit(
+            samples,
+            probs,
+            plot=plot,
+            normalized=False,
+            return_dict=True)
+        gofs.append(result['gof'])
+        discrete_probs[key] = result['norm']
+
+    # Discrete part
+    if len(strata) > 1:
+        gofs.append(discrete_goodness_of_fit(
+            discrete_samples,
+            discrete_probs,
+            plot=plot,
+            normalized=False))
+
+    # Normalization
+    if normalized:
+        norm = sum(discrete_probs.values())
+        discrete_counts = [len(samples) for samples, _ in strata.values()]
+        norm_variance = sum(1.0 / count for count in discrete_counts)
+        dof = len(discrete_counts)
+        chi_squared = (1 - norm) ** 2 / norm_variance
+        gofs.append(chi2sf(chi_squared, dof))
+        if plot:
+            print('norm = {:.4g} +- {:.4g}'.format(norm, norm_variance ** 0.5))
+            print('     = {}'.format(
+                ' + '.join(map('{:.4g}'.format, discrete_probs.values()))))
+
+    return min(gofs)
+

--- a/pyro/distributions/testing/gof.py
+++ b/pyro/distributions/testing/gof.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2016, Google, Inc.
 # Copyright (c) 2019, Gamalon, Inc.
 # Copyright Contributors to the Pyro project.
-# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -59,7 +59,7 @@ import torch
 
 from .special import chi2sf
 
-HISTOGRAM_WIDTH = 60.0
+HISTOGRAM_WIDTH = 60
 
 
 class InvalidTest(ValueError):

--- a/pyro/distributions/testing/special.py
+++ b/pyro/distributions/testing/special.py
@@ -1,0 +1,107 @@
+# Copyright Contributors to the Pyro project.
+# Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
+# Copyright (c) 2015-2016, Gamelan Labs, Inc.
+# Copyright (c) 2016, Google, Inc.
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of Salesforce.com nor the names of its contributors
+#   may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+# TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+This module computes the chi^2 survival function and the required
+functions.
+"""
+
+import math
+import sys
+
+
+def log(x):
+    if x > sys.float_info.min:
+        value = math.log(x)
+    else:
+        value = -math.inf
+    return value
+
+
+def incomplete_gamma(x, s):
+    r"""
+    This function computes the incomplete lower gamma function
+    using the series expansion:
+
+    .. math::
+
+       \gamma(x, s) = x^s \Gamma(s)e^{-x}\sum^\infty_{k=0}
+                    \frac{x^k}{\Gamma(s + k + 1)}
+
+    This series will converge strongly because the Gamma
+    function grows factorially.
+
+    Because the Gamma function does grow so quickly, we can
+    run into numerical stability issues. To solve this we carry
+    out as much math as possible in the log domain to reduce
+    numerical error. This function matches the results from
+    scipy to numerical precision.
+    """
+    if x < 0:
+        return 1
+    if x > 1e3:
+        return math.gamma(s)
+    log_gamma_s = math.lgamma(s)
+    log_x = log(x)
+    value = 0
+    for k in range(100):
+        log_num = (k + s) * log_x + (-x) + log_gamma_s
+        log_denom = math.lgamma(k + s + 1)
+        value += math.exp(log_num - log_denom)
+    return value
+
+
+def chi2sf(x, s):
+    r"""
+    This function returns the survival function of the chi^2
+    distribution. The survival function is given as:
+
+    .. math::
+       1 - CDF
+
+    where rhe chi^2 CDF is given as
+
+    .. math::
+       F(x; s) = \frac{ \gamma( x/2, s/2 ) }{ \Gamma(s/2) },
+
+    with :math:`\gamma` is the incomplete gamma function defined above.
+    Therefore, the survival probability is givne by:
+
+    .. math::
+       1 - \frac{ \gamma( x/2, s/2 ) }{ \Gamma(s/2) }.
+
+    This function matches the results from
+    scipy to numerical precision.
+    """
+    top = incomplete_gamma(x / 2, s / 2)
+    bottom = math.gamma(s / 2)
+    value = top / bottom
+    return 1 - value

--- a/pyro/distributions/testing/special.py
+++ b/pyro/distributions/testing/special.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2015-2016, Gamelan Labs, Inc.
 # Copyright (c) 2016, Google, Inc.
 # Copyright Contributors to the Pyro project.
-# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/pyro/distributions/testing/special.py
+++ b/pyro/distributions/testing/special.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2016, Google, Inc.
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
-#
+
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/pyro/distributions/testing/special.py
+++ b/pyro/distributions/testing/special.py
@@ -1,7 +1,7 @@
-# Copyright Contributors to the Pyro project.
 # Copyright (c) 2014, Salesforce.com, Inc.  All rights reserved.
 # Copyright (c) 2015-2016, Gamelan Labs, Inc.
 # Copyright (c) 2016, Google, Inc.
+# Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tests/common.py
+++ b/tests/common.py
@@ -27,6 +27,7 @@ Source: https://github.com/pytorch/pytorch/blob/master/test/common.py
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 RESOURCE_DIR = os.path.join(TESTS_DIR, 'resources')
 EXAMPLES_DIR = os.path.join(os.path.dirname(TESTS_DIR), 'examples')
+TEST_FAILURE_RATE = 1 / 1000  # For all goodness-of-fit tests.
 
 
 def xfail_param(*args, **kwargs):

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -504,6 +504,13 @@ def all_distributions(request):
     return request.param
 
 
+@pytest.fixture(name='continuous_dist',
+                params=continuous_dists,
+                ids=lambda x: x.get_test_distribution_name())
+def continuous_distributions(request):
+    return request.param
+
+
 @pytest.fixture(name='discrete_dist',
                 params=discrete_dists,
                 ids=lambda x: x.get_test_distribution_name())

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -87,22 +87,24 @@ def test_score_errors_non_broadcastable_data_shape(dist):
 
 def test_gof(continuous_dist):
     Dist = continuous_dist.pyro_dist
-    d = Dist(**continuous_dist.get_dist_params(0))
-    samples = d.sample(torch.Size([20000]))
-    with xfail_if_not_implemented():
-        probs = d.log_prob(samples).exp()
-
-    # Select a single event.
-    for _ in range(len(d.batch_shape)):
-        samples = samples[:, 0]
-        probs = probs[:, 0]
-
-    gof = auto_goodness_of_fit(samples, probs)
     if "Dirichlet" in Dist.__name__:
         pytest.xfail(reason="incorrect submanifold scaling")
     if Dist is dist.LKJCorrCholesky:
         pytest.xfail(reason="incorrect submanifold scaling")
-    assert gof > TEST_FAILURE_RATE
+
+    num_samples = 20000
+    for i in range(continuous_dist.get_num_test_data()):
+        d = Dist(**continuous_dist.get_dist_params(i))
+        samples = d.sample(torch.Size([num_samples]))
+        with xfail_if_not_implemented():
+            probs = d.log_prob(samples).exp()
+
+        # Test each batch independently.
+        probs = probs.reshape(num_samples, -1)
+        samples = samples.reshape(probs.shape + d.event_shape)
+        for b in range(probs.size(-1)):
+            gof = auto_goodness_of_fit(samples[:, b], probs[:, b])
+            assert gof > TEST_FAILURE_RATE
 
 
 # Distributions tests - discrete distributions

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -10,9 +10,7 @@ import pyro.distributions as dist
 from pyro.distributions import TorchDistribution
 from pyro.distributions.testing.gof import auto_goodness_of_fit
 from pyro.distributions.util import broadcast_shape
-from tests.common import assert_equal, xfail_if_not_implemented
-
-TEST_FAILURE_RATE = 1 / 1000
+from tests.common import TEST_FAILURE_RATE, assert_equal, xfail_if_not_implemented
 
 
 def _log_prob_shape(dist, x_size=torch.Size()):
@@ -87,10 +85,10 @@ def test_score_errors_non_broadcastable_data_shape(dist):
 
 # Distributions tests - continuous distributions
 
-def test_density(continuous_dist):
+def test_gof(continuous_dist):
     Dist = continuous_dist.pyro_dist
     d = Dist(**continuous_dist.get_dist_params(0))
-    samples = d.sample(torch.Size([10000]))
+    samples = d.sample(torch.Size([20000]))
     with xfail_if_not_implemented():
         probs = d.log_prob(samples).exp()
 

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -9,7 +9,10 @@ import torch
 from torch import optim
 
 from pyro.distributions import VonMises, VonMises3D
-from tests.common import skipif_param
+from pyro.distributions.testing.gof import auto_goodness_of_fit
+from tests.common import skipif_param, xfail_if_not_implemented
+
+TEST_FAILURE_RATE = 1 / 1000
 
 
 def _eval_poly(y, coef):
@@ -107,6 +110,16 @@ def test_log_prob_normalized(concentration):
     assert abs(norm - 1) < 1e-3, norm
 
 
+@pytest.mark.parametrize('loc', [-math.pi/2.0, 0.0, math.pi/2.0])
+@pytest.mark.parametrize('concentration', [0.03, 0.1, 0.3, 1., 3., 10., 30.])
+def test_von_mises_density(loc, concentration):
+    d = VonMises(loc, concentration)
+    samples = d.sample(torch.Size([10000]))
+    probs = d.log_prob(samples).exp()
+    gof = auto_goodness_of_fit(samples, probs, dim=2)
+    assert gof > TEST_FAILURE_RATE
+
+
 @pytest.mark.parametrize('scale', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
 def test_von_mises_3d(scale):
     concentration = torch.randn(3)
@@ -121,3 +134,17 @@ def test_von_mises_3d(scale):
     expected_total = 1 / (4 * math.pi)
     ratio = actual_total / expected_total
     assert torch.abs(ratio - 1) < 0.01, ratio
+
+
+@pytest.mark.parametrize('scale', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
+def test_von_mises_3d_density(scale):
+    concentration = torch.randn(3)
+    concentration = concentration * (scale / concentration.norm(2))
+    d = VonMises3D(concentration, validate_args=True)
+
+    with xfail_if_not_implemented():
+        samples = d.sample(torch.Size([10000]))
+    probs = d.log_prob(samples).exp()
+
+    gof = auto_goodness_of_fit(samples, probs, dim=2)
+    assert gof > TEST_FAILURE_RATE

--- a/tests/distributions/test_von_mises.py
+++ b/tests/distributions/test_von_mises.py
@@ -10,9 +10,7 @@ from torch import optim
 
 from pyro.distributions import VonMises, VonMises3D
 from pyro.distributions.testing.gof import auto_goodness_of_fit
-from tests.common import skipif_param, xfail_if_not_implemented
-
-TEST_FAILURE_RATE = 1 / 1000
+from tests.common import TEST_FAILURE_RATE, skipif_param, xfail_if_not_implemented
 
 
 def _eval_poly(y, coef):
@@ -112,11 +110,11 @@ def test_log_prob_normalized(concentration):
 
 @pytest.mark.parametrize('loc', [-math.pi/2.0, 0.0, math.pi/2.0])
 @pytest.mark.parametrize('concentration', [0.03, 0.1, 0.3, 1., 3., 10., 30.])
-def test_von_mises_density(loc, concentration):
+def test_von_mises_gof(loc, concentration):
     d = VonMises(loc, concentration)
-    samples = d.sample(torch.Size([10000]))
+    samples = d.sample(torch.Size([100000]))
     probs = d.log_prob(samples).exp()
-    gof = auto_goodness_of_fit(samples, probs, dim=2)
+    gof = auto_goodness_of_fit(samples, probs, dim=1)
     assert gof > TEST_FAILURE_RATE
 
 
@@ -137,13 +135,13 @@ def test_von_mises_3d(scale):
 
 
 @pytest.mark.parametrize('scale', [0.1, 0.5, 0.9, 1.0, 1.1, 2.0, 10.0])
-def test_von_mises_3d_density(scale):
+def test_von_mises_3d_gof(scale):
     concentration = torch.randn(3)
     concentration = concentration * (scale / concentration.norm(2))
     d = VonMises3D(concentration, validate_args=True)
 
     with xfail_if_not_implemented():
-        samples = d.sample(torch.Size([10000]))
+        samples = d.sample(torch.Size([2000]))
     probs = d.log_prob(samples).exp()
 
     gof = auto_goodness_of_fit(samples, probs, dim=2)

--- a/tests/distributions/testing/test_special.py
+++ b/tests/distributions/testing/test_special.py
@@ -1,0 +1,17 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+
+import numpy as np
+import scipy
+
+from pyro.distributions.testing.special import chi2sf
+from tests.common import assert_close
+
+
+def test_chi2sf():
+    xlist = np.linspace(0, 100, 500)
+    slist = np.arange(1, 41, 1.5)
+    for s, x in itertools.product(slist, xlist):
+        assert_close(scipy.stats.chi2.sf(x, s), chi2sf(x, s))


### PR DESCRIPTION
Addresses #2658 

This adds a PyTorch port of the [goftests](https://github.com/posterior/goftests) library, enabling easy statistical testing between distributions' `.sample()` and `.log_prob()` methods. I've had good luck with these statistical tests in a number of past projects, including Loom and Gamalon's PPL.

The main function is `auto_goodness_of_fit(samples, probs)` which returns a p-value that should be Uniform(0,1)-distributed for good data but should be close to zero for bad data. This well-calibrated statistic allows precise balancing and tuning of failure rate across a suite of tests:
```py
TEST_FAILURE_RATE = 1 / 100  # For 1 in 100 chance of spurious failure.

def test_my_distribution():
    d = MyDistribution()
    samples = d.sample([10000])
    probs = d.log_prob(samples).exp()
    gof = auto_goodness_of_fit(samples, probs)
    assert gof > TEST_FAILURE_RATE
```

## Tested

The following tests take less than 4 seconds total:

- [x] added a generic test helper to `test_distributions.py`
- [x] added two tests to `test_von_mises.py` exercising strict submanifold behavior
- [x] ported the unit test for `chi2sf()`