### PR TITLE
Add a Distribution.infer_shapes() method to statically infer shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ pyro/_version.py
 processed
 raw
 *.pkl
+baseline_net_q1.pth
+cvae_net_q1.pth
+cvae_plot_q1.png
+prep_seal_data.csv
+results.csv
 
 # Logs
 logs

--- a/pyro/distributions/affine_beta.py
+++ b/pyro/distributions/affine_beta.py
@@ -6,6 +6,7 @@ from torch.distributions import constraints
 from torch.distributions.transforms import AffineTransform
 
 from .torch import Beta, TransformedDistribution
+from .util import broadcast_shape
 
 
 class AffineBeta(TransformedDistribution):
@@ -42,6 +43,12 @@ class AffineBeta(TransformedDistribution):
             AffineTransform(loc=loc, scale=scale),
             validate_args=validate_args,
         )
+
+    @staticmethod
+    def infer_shapes(concentration1, concentration0, loc, scale):
+        batch_shape = broadcast_shape(concentration1, concentration0, loc, scale)
+        event_shape = torch.Size()
+        return batch_shape, event_shape
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(AffineBeta, _instance)

--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -148,6 +148,12 @@ class DirichletMultinomial(TorchDistribution):
     def concentration(self):
         return self._dirichlet.concentration
 
+    @staticmethod
+    def infer_shapes(concentration, total_count=()):
+        batch_shape = broadcast_shape(concentration[:-1], total_count)
+        event_shape = concentration[-1:]
+        return batch_shape, event_shape
+
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(DirichletMultinomial, _instance)
         batch_shape = torch.Size(batch_shape)

--- a/pyro/distributions/multivariate_studentt.py
+++ b/pyro/distributions/multivariate_studentt.py
@@ -60,6 +60,12 @@ class MultivariateStudentT(TorchDistribution):
         return torch.cholesky_solve(identity, self._unbroadcasted_scale_tril).expand(
             self._batch_shape + self._event_shape + self._event_shape)
 
+    @staticmethod
+    def infer_shapes(df, loc, scale_tril):
+        event_shape = loc[-1:]
+        batch_shape = broadcast_shape(df, loc[:-1], scale_tril[:-2])
+        return batch_shape, event_shape
+
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(MultivariateStudentT, _instance)
         batch_shape = torch.Size(batch_shape)

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -47,6 +47,12 @@ class ProjectedNormal(TorchDistribution):
         event_shape = concentration.shape[-1:]
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
 
+    @staticmethod
+    def infer_shapes(concentration):
+        batch_shape = concentration[:-1]
+        event_shape = concentration[-1:]
+        return batch_shape, event_shape
+
     def expand(self, batch_shape, _instance=None):
         batch_shape = torch.Size(batch_shape)
         new = self._get_checked_instance(ProjectedNormal, _instance)

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -34,6 +34,19 @@ def test_support_shape(dist):
         assert ok.all()
 
 
+def test_infer_shapes(dist):
+    if "LKJ" in dist.pyro_dist.__name__:
+        pytest.xfail(reason="cannot statically compute shape")
+    for idx in range(dist.get_num_test_data()):
+        dist_params = dist.get_dist_params(idx)
+        arg_shapes = {k: v.shape if isinstance(v, torch.Tensor) else ()
+                      for k, v in dist_params.items()}
+        batch_shape, event_shape = dist.pyro_dist.infer_shapes(**arg_shapes)
+        d = dist.pyro_dist(**dist_params)
+        assert d.batch_shape == batch_shape
+        assert d.event_shape == event_shape
+
+
 def test_batch_log_prob(dist):
     if dist.scipy_arg_fn is None:
         pytest.skip('{}.log_prob_sum has no scipy equivalent'.format(dist.pyro_dist.__name__))


### PR DESCRIPTION
Addresses https://github.com/pyro-ppl/funsor/issues/412
Requires https://github.com/pytorch/pytorch/pull/50547 and https://github.com/pytorch/pytorch/pull/50581

This adds a `TorchDistribution.infer_shapes()` method to statically compute `(batch_shape, event_shape)` for use in Funsor. This method inputs `*args,**kwargs` with the same signature as `.__init__()` but inputting shapes rather than tensors. The following should be equivalent:
```py
# Eager version.
d = MultivariateNormal(loc, covariance_matrix)
batch_shape = d.batch_shape
event_shape = d.event_shape

# Lazy version.
batch_shape, event_shape = MultivariateNormal.infer_shapes(loc.shape, covariance_matrix.shape)
```

The default implementation uses new `.support.event_dim` logic from https://github.com/pytorch/pytorch/pull/50547, so I've included backports in this PR (we can delete next time PyTorch is released).

## Tested
- [x] unit tests for `.support.is_discrete`
- [x] unit tests for `.support.event_dim`
- [x] unit tests for `.infer_shapes()`