### PR TITLE
Support constraints.sphere in AutoDelta

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -382,6 +382,13 @@ CorrLCholeskyTransform
     :undoc-members:
     :show-inheritance:
 
+DiscreteCosineTransform
+-----------------------
+.. autoclass:: pyro.distributions.transforms.DiscreteCosineTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ELUTransform
 ------------
 .. autoclass:: pyro.distributions.transforms.ELUTransform
@@ -410,6 +417,13 @@ LowerCholeskyAffine
     :undoc-members:
     :show-inheritance:
 
+Normalize
+---------
+.. autoclass:: pyro.distributions.transforms.Normalize
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 OrderedTransform
 ----------------
 .. autoclass:: pyro.distributions.transforms.OrderedTransform
@@ -420,13 +434,6 @@ OrderedTransform
 Permute
 -------
 .. autoclass:: pyro.distributions.transforms.Permute
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-DiscreteCosineTransform
------------------------
-.. autoclass:: pyro.distributions.transforms.DiscreteCosineTransform
     :members:
     :undoc-members:
     :show-inheritance:

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -5,51 +5,47 @@ from torch.distributions import biject_to, transform_to
 from torch.distributions.transforms import *  # noqa F403
 from torch.distributions.transforms import __all__ as torch_transforms
 
-from pyro.distributions.constraints import (
-                                            IndependentConstraint,
-                                            corr_cholesky_constraint,
-                                            ordered_vector)
-from pyro.distributions.torch_transform import ComposeTransformModule
-from pyro.distributions.transforms.affine_autoregressive import (AffineAutoregressive, ConditionalAffineAutoregressive,
-                                                                 affine_autoregressive,
-                                                                 conditional_affine_autoregressive)
-from pyro.distributions.transforms.affine_coupling import (AffineCoupling, ConditionalAffineCoupling, affine_coupling,
-                                                           conditional_affine_coupling)
-from pyro.distributions.transforms.basic import ELUTransform, LeakyReLUTransform, elu, leaky_relu
-from pyro.distributions.transforms.batchnorm import BatchNorm, batchnorm
-from pyro.distributions.transforms.block_autoregressive import BlockAutoregressive, block_autoregressive
-from pyro.distributions.transforms.cholesky import CorrLCholeskyTransform
-from pyro.distributions.transforms.discrete_cosine import DiscreteCosineTransform
-from pyro.distributions.transforms.generalized_channel_permute import (ConditionalGeneralizedChannelPermute,
-                                                                       GeneralizedChannelPermute,
-                                                                       conditional_generalized_channel_permute,
-                                                                       generalized_channel_permute)
-from pyro.distributions.transforms.haar import HaarTransform
-from pyro.distributions.transforms.householder import (ConditionalHouseholder, Householder, conditional_householder,
-                                                       householder)
-from pyro.distributions.transforms.lower_cholesky_affine import LowerCholeskyAffine
-from pyro.distributions.transforms.matrix_exponential import (ConditionalMatrixExponential, MatrixExponential,
-                                                              conditional_matrix_exponential, matrix_exponential)
-from pyro.distributions.transforms.neural_autoregressive import (ConditionalNeuralAutoregressive, NeuralAutoregressive,
-                                                                 conditional_neural_autoregressive,
-                                                                 neural_autoregressive)
-from pyro.distributions.transforms.ordered import OrderedTransform
-from pyro.distributions.transforms.permute import Permute, permute
-from pyro.distributions.transforms.planar import ConditionalPlanar, Planar, conditional_planar, planar
-from pyro.distributions.transforms.polynomial import Polynomial, polynomial
-from pyro.distributions.transforms.radial import ConditionalRadial, Radial, conditional_radial, radial
-from pyro.distributions.transforms.spline import ConditionalSpline, Spline, conditional_spline, spline
-from pyro.distributions.transforms.spline_autoregressive import (ConditionalSplineAutoregressive, SplineAutoregressive,
-                                                                 conditional_spline_autoregressive,
-                                                                 spline_autoregressive)
-from pyro.distributions.transforms.spline_coupling import SplineCoupling, spline_coupling
-from pyro.distributions.transforms.sylvester import Sylvester, sylvester
+from ..constraints import IndependentConstraint, corr_cholesky_constraint, ordered_vector, sphere
+from ..torch_transform import ComposeTransformModule
+from .affine_autoregressive import (AffineAutoregressive, ConditionalAffineAutoregressive, affine_autoregressive,
+                                    conditional_affine_autoregressive)
+from .affine_coupling import AffineCoupling, ConditionalAffineCoupling, affine_coupling, conditional_affine_coupling
+from .basic import ELUTransform, LeakyReLUTransform, elu, leaky_relu
+from .batchnorm import BatchNorm, batchnorm
+from .block_autoregressive import BlockAutoregressive, block_autoregressive
+from .cholesky import CorrLCholeskyTransform
+from .discrete_cosine import DiscreteCosineTransform
+from .generalized_channel_permute import (ConditionalGeneralizedChannelPermute, GeneralizedChannelPermute,
+                                          conditional_generalized_channel_permute, generalized_channel_permute)
+from .haar import HaarTransform
+from .householder import ConditionalHouseholder, Householder, conditional_householder, householder
+from .lower_cholesky_affine import LowerCholeskyAffine
+from .matrix_exponential import (ConditionalMatrixExponential, MatrixExponential, conditional_matrix_exponential,
+                                 matrix_exponential)
+from .neural_autoregressive import (ConditionalNeuralAutoregressive, NeuralAutoregressive,
+                                    conditional_neural_autoregressive, neural_autoregressive)
+from .ordered import OrderedTransform
+from .permute import Permute, permute
+from .planar import ConditionalPlanar, Planar, conditional_planar, planar
+from .polynomial import Polynomial, polynomial
+from .radial import ConditionalRadial, Radial, conditional_radial, radial
+from .normalize import Normalize
+from .spline import ConditionalSpline, Spline, conditional_spline, spline
+from .spline_autoregressive import (ConditionalSplineAutoregressive, SplineAutoregressive,
+                                    conditional_spline_autoregressive, spline_autoregressive)
+from .spline_coupling import SplineCoupling, spline_coupling
+from .sylvester import Sylvester, sylvester
 
 ########################################
 # register transforms
 
 biject_to.register(IndependentConstraint, lambda c: biject_to(c.base_constraint))
 transform_to.register(IndependentConstraint, lambda c: transform_to(c.base_constraint))
+
+
+@transform_to.register(sphere)
+def _transform_to_sphere(constraint):
+    return Normalize()
 
 
 @biject_to.register(corr_cholesky_constraint)
@@ -106,6 +102,7 @@ __all__ = [
     'LowerCholeskyAffine',
     'MatrixExponential',
     'NeuralAutoregressive',
+    'Normalize',
     'OrderedTransform',
     'Permute',
     'Planar',

--- a/pyro/distributions/transforms/normalize.py
+++ b/pyro/distributions/transforms/normalize.py
@@ -1,0 +1,41 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import numbers
+
+from torch.distributions.transforms import Transform
+
+from pyro.ops.tensor_utils import safe_normalize
+
+from .. import constraints
+
+
+class Normalize(Transform):
+    """
+    Safely project a vector onto the sphere wrt the ``p`` norm. This avoids
+    the singularity at zero by mapping to the vector ``[1, 0, 0, ..., 0]``.
+    """
+    domain = constraints.real_vector
+    codomain = constraints.sphere
+    event_dim = 1
+    bijective = False
+
+    def __init__(self, p=2, cache_size=0):
+        assert isinstance(p, numbers.Number)
+        assert p >= 0
+        self.p = p
+        super().__init__(cache_size=cache_size)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.p == other.p
+
+    def _call(self, x):
+        return safe_normalize(x, p=self.p)
+
+    def _inverse(self, y):
+        return y
+
+    def with_cache(self, cache_size=1):
+        if self._cache_size == cache_size:
+            return self
+        return Normalize(self.p, cache_size=cache_size)

--- a/pyro/infer/reparam/projected_normal.py
+++ b/pyro/infer/reparam/projected_normal.py
@@ -5,7 +5,7 @@ import torch
 
 import pyro
 import pyro.distributions as dist
-from pyro.distributions.projected_normal import safe_project
+from pyro.ops.tensor_utils import safe_normalize
 
 from .reparam import Reparam
 
@@ -27,7 +27,7 @@ class ProjectedNormalReparam(Reparam):
         x = pyro.sample("{}_normal".format(name), self._wrap(new_fn, event_dim))
 
         # Differentiably transform.
-        value = safe_project(x + fn.concentration)
+        value = safe_normalize(x + fn.concentration)
 
         # Simulate a pyro.deterministic() site.
         new_fn = dist.Delta(value, event_dim=event_dim).mask(False)

--- a/tests/distributions/test_constraints.py
+++ b/tests/distributions/test_constraints.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from pyro.distributions import constraints
-from pyro.distributions.projected_normal import safe_project
+from pyro.ops.tensor_utils import safe_normalize
 
 
 @pytest.mark.parametrize("dim", [2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000, 10000, 100000])
@@ -13,7 +13,7 @@ def test_sphere_check(dim):
     data = torch.randn(100, dim)
     assert not constraints.sphere.check(data).any()
 
-    data = safe_project(data)
+    data = safe_normalize(data)
     actual = constraints.sphere.check(data)
     assert actual.all()
     assert actual.shape == data.shape[:-1]

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -15,12 +15,12 @@ from torch.distributions import constraints
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-
-from pyro.infer import SVI, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO, Predictive
+from pyro.infer import SVI, Predictive, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO
 from pyro.infer.autoguide import (AutoCallable, AutoDelta, AutoDiagonalNormal, AutoDiscreteParallel, AutoGuide,
                                   AutoGuideList, AutoIAFNormal, AutoLaplaceApproximation, AutoLowRankMultivariateNormal,
-                                  AutoNormal, AutoMultivariateNormal, init_to_feasible, init_to_mean, init_to_median,
+                                  AutoMultivariateNormal, AutoNormal, init_to_feasible, init_to_mean, init_to_median,
                                   init_to_sample)
+from pyro.infer.reparam import ProjectedNormalReparam
 from pyro.nn.module import PyroModule, PyroParam, PyroSample
 from pyro.optim import Adam
 from pyro.poutine.util import prune_subsample_sites
@@ -842,7 +842,6 @@ def test_discrete_helpful_error(auto_class, init_loc_fn):
 
 
 @pytest.mark.parametrize("auto_class", [
-    AutoDelta,
     AutoDiagonalNormal,
     AutoMultivariateNormal,
     AutoNormal,
@@ -866,3 +865,35 @@ def test_sphere_helpful_error(auto_class, init_loc_fn):
     guide = auto_class(model, init_loc_fn=init_loc_fn)
     with pytest.raises(ValueError, match=".*ProjectedNormalReparam.*"):
         guide()
+
+
+@pytest.mark.parametrize("auto_class", [
+    AutoDelta,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoNormal,
+    AutoLowRankMultivariateNormal,
+    AutoLaplaceApproximation,
+])
+@pytest.mark.parametrize("init_loc_fn", [
+    init_to_feasible,
+    init_to_mean,
+    init_to_median,
+    init_to_sample,
+])
+def test_sphere_ok(auto_class, init_loc_fn):
+
+    def model():
+        x = pyro.sample("x", dist.Normal(0., 1.).expand([3]).to_event(1))
+        y = pyro.sample("y", dist.ProjectedNormal(x))
+        pyro.sample("obs", dist.Normal(y, 1),
+                    obs=torch.tensor([1., 0.]))
+
+    if auto_class is AutoDelta:
+        # AutoDelta should work even without ProjectedNormalReparam.
+        guide = auto_class(model, init_loc_fn=init_loc_fn)
+        poutine.trace(guide).get_trace().compute_log_prob()
+
+    model = poutine.reparam(model, {"y": ProjectedNormalReparam()})
+    guide = auto_class(model)
+    poutine.trace(guide).get_trace().compute_log_prob()


### PR DESCRIPTION
Addresses #2740
Follows #2736 

This ensures `AutoDelta` works with `ProjectedNormal` distributions even without the use of `poutine.reparam`. This is accomplished by creating an new `Normalize` transform and registering that transform with `transform_to`, thereby permitting spherically constrained parameters via `pyro.param(..., constraint=constraints.sphere)` as used by `AutoDelta`.

## Misc changes
- moves `safe_project()` to `pyro.ops.tensor_utils.safe_normalize()`
- cleans up `pyro/distributions/transforms/__init__.py` import order

## Tested
- [x] unit tests for `transforms.Normalize`
- [x] smoke tests for `AutoDelta` with a `ProjectedNormal` distribution