### PR TITLE
Implement poutine.get_mask() and use it to optimize NeuTra etc

### DIFF
--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -264,12 +264,14 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
     :param scale: a positive scale
     :type scale: torch.Tensor or number
     :param mask: an optional masking tensor
-    :type mask: torch.BoolTensor or None
+    :type mask: torch.BoolTensor, bool, or None
     """
     if is_identically_zero(tensor) or (mask is None and is_identically_one(scale)):
         return tensor
-    if mask is None:
+    if mask is None or mask is True:
         return tensor * scale
+    if mask is False:
+        return torch.zeros_like(tensor)
     return torch.where(mask, tensor * scale, tensor.new_zeros(()))
 
 

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -509,10 +509,22 @@ class AutoNormal(AutoGuide):
                 )
 
                 value = transform(unconstrained_latent)
-                log_density = transform.inv.log_abs_det_jacobian(value, unconstrained_latent)
-                log_density = sum_rightmost(log_density, log_density.dim() - value.dim() + site["fn"].event_dim)
-                delta_dist = dist.Delta(value, log_density=log_density,
-                                        event_dim=site["fn"].event_dim)
+                if poutine.get_mask() is False:
+                    log_density = 0.0
+                else:
+                    log_density = transform.inv.log_abs_det_jacobian(
+                        value,
+                        unconstrained_latent,
+                    )
+                    log_density = sum_rightmost(
+                        log_density,
+                        log_density.dim() - value.dim() + site["fn"].event_dim,
+                    )
+                delta_dist = dist.Delta(
+                    value,
+                    log_density=log_density,
+                    event_dim=site["fn"].event_dim,
+                )
 
                 result[name] = pyro.sample(name, delta_dist)
 
@@ -709,9 +721,22 @@ class AutoContinuous(AutoGuide):
             name = site["name"]
             transform = biject_to(site["fn"].support)
             value = transform(unconstrained_value)
-            log_density = transform.inv.log_abs_det_jacobian(value, unconstrained_value)
-            log_density = sum_rightmost(log_density, log_density.dim() - value.dim() + site["fn"].event_dim)
-            delta_dist = dist.Delta(value, log_density=log_density, event_dim=site["fn"].event_dim)
+            if poutine.get_mask() is False:
+                log_density = 0.0
+            else:
+                log_density = transform.inv.log_abs_det_jacobian(
+                    value,
+                    unconstrained_value,
+                )
+                log_density = sum_rightmost(
+                    log_density,
+                    log_density.dim() - value.dim() + site["fn"].event_dim,
+                )
+            delta_dist = dist.Delta(
+                value,
+                log_density=log_density,
+                event_dim=site["fn"].event_dim,
+            )
 
             with ExitStack() as stack:
                 for frame in self._cond_indep_stacks[name]:

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -50,6 +50,7 @@ def _predictive_sequential(model, posterior_samples, model_args, model_kwargs,
 
 def _predictive(model, posterior_samples, num_samples, return_sites=(),
                 return_trace=False, parallel=False, model_args=(), model_kwargs={}):
+    model = torch.no_grad()(poutine.mask(model, mask=False))
     max_plate_nesting = _guess_max_plate_nesting(model, model_args, model_kwargs)
     vectorize = pyro.plate("_num_predictive_samples", num_samples, dim=-max_plate_nesting-1)
     model_trace = prune_subsample_sites(poutine.trace(model).get_trace(*model_args, **model_kwargs))

--- a/pyro/infer/reparam/conjugate.py
+++ b/pyro/infer/reparam/conjugate.py
@@ -3,6 +3,7 @@
 
 import pyro
 import pyro.distributions as dist
+import pyro.poutine as poutine
 
 from .reparam import Reparam
 
@@ -83,7 +84,10 @@ class ConjugateReparam(Reparam):
         #                        = normalizer integral p(x|z) dz
         # Hence in the exact case, downstream probability does not depend on the sampled z,
         # permitting this reparameterizer to be used in HMC.
-        log_density = log_normalizer - guide_dist.log_prob(value)  # By Eqn 1.
+        if poutine.get_mask() is False:
+            log_density = 0.0
+        else:
+            log_density = log_normalizer - guide_dist.log_prob(value)  # By Eqn 1.
 
         # Return an importance-weighted point estimate.
         new_fn = dist.Delta(value, log_density=log_density, event_dim=fn.event_dim)

--- a/pyro/infer/reparam/neutra.py
+++ b/pyro/infer/reparam/neutra.py
@@ -59,8 +59,8 @@ class NeuTraReparam(Reparam):
         if name not in self.guide.prototype_trace.nodes:
             return fn, obs
         assert obs is None, "NeuTraReparam does not support observe statements"
-        log_density = 0.
-        compute_density = (poutine.inspect()["mask"] is not False)
+        log_density = 0.0
+        compute_density = (poutine.get_mask() is not False)
         if not self.x_unconstrained:  # On first sample site.
             # Sample a shared latent.
             try:

--- a/pyro/infer/reparam/split.py
+++ b/pyro/infer/reparam/split.py
@@ -5,6 +5,7 @@ import torch
 
 import pyro
 import pyro.distributions as dist
+import pyro.poutine as poutine
 
 from .reparam import Reparam
 
@@ -52,6 +53,9 @@ class SplitReparam(Reparam):
         value = torch.cat(parts, dim=-self.event_dim)
 
         # Combine parts.
-        log_prob = fn.log_prob(value)
-        new_fn = dist.Delta(value, event_dim=fn.event_dim, log_density=log_prob)
+        if poutine.get_mask() is False:
+            log_density = 0.0
+        else:
+            log_density = fn.log_prob(value)
+        new_fn = dist.Delta(value, event_dim=fn.event_dim, log_density=log_density)
         return new_fn, value

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -127,14 +127,18 @@ def scale_and_mask(tensor, scale=1.0, mask=None):
     :param scale: a positive scale
     :type scale: torch.Tensor or number
     :param mask: an optional packed tensor mask
-    :type mask: torch.BoolTensor or None
+    :type mask: torch.BoolTensor, bool, or None
     """
     if isinstance(scale, torch.Tensor) and scale.dim():
         raise NotImplementedError('non-scalar scale is not supported')
-    if mask is None:
+    if mask is None or mask is True:
         if is_identically_one(scale):
             return tensor
         result = tensor * scale
+        result._pyro_dims = tensor._pyro_dims
+        return result
+    if mask is False:
+        result = torch.zeros_like(tensor)
         result._pyro_dims = tensor._pyro_dims
         return result
     tensor, mask = broadcast_all(tensor, mask)

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -3,7 +3,7 @@
 
 from .handlers import (block, broadcast, collapse, condition, do, enum, escape, infer_config, lift, markov, mask, queue,
                        reparam, replay, scale, seed, trace, uncondition)
-from .runtime import NonlocalExit
+from .runtime import NonlocalExit, inspect
 from .trace_struct import Trace
 from .util import enable_validation, is_validation_enabled
 
@@ -17,6 +17,7 @@ __all__ = [
     "enum",
     "escape",
     "infer_config",
+    "inspect",
     "is_validation_enabled",
     "lift",
     "markov",

--- a/pyro/poutine/__init__.py
+++ b/pyro/poutine/__init__.py
@@ -3,7 +3,7 @@
 
 from .handlers import (block, broadcast, collapse, condition, do, enum, escape, infer_config, lift, markov, mask, queue,
                        reparam, replay, scale, seed, trace, uncondition)
-from .runtime import NonlocalExit, inspect
+from .runtime import NonlocalExit, get_mask
 from .trace_struct import Trace
 from .util import enable_validation, is_validation_enabled
 
@@ -16,8 +16,8 @@ __all__ = [
     "enable_validation",
     "enum",
     "escape",
+    "get_mask",
     "infer_config",
-    "inspect",
     "is_validation_enabled",
     "lift",
     "markov",

--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -3,8 +3,6 @@
 
 import torch
 
-from pyro.util import ignore_jit_warnings
-
 from .messenger import Messenger
 
 
@@ -22,11 +20,9 @@ class MaskMessenger(Messenger):
         if isinstance(mask, torch.Tensor):
             if mask.dtype != torch.bool:
                 raise ValueError('Expected mask to be a BoolTensor but got {}'.format(type(mask)))
-        else:
-            if mask not in (True, False):
-                raise ValueError('Expected mask to be a boolean but got {}'.format(type(mask)))
-            with ignore_jit_warnings():
-                mask = torch.tensor(mask)
+
+        elif mask not in (True, False):
+            raise ValueError('Expected mask to be a boolean but got {}'.format(type(mask)))
         super().__init__()
         self.mask = mask
 

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -264,3 +264,30 @@ def effectful(fn=None, type=None):
             return msg["value"]
     _fn._is_effectful = True
     return _fn
+
+
+def inspect():
+    """
+    EXPERIMENTAL Inspect the Pyro stack.
+
+    :returns: A message with all effects applied.
+    :rtype: dict
+    """
+    msg = {
+        "type": "inspect",
+        "name": "_pyro_inspect",
+        "fn": lambda: True,
+        "is_observed": False,
+        "args": (),
+        "kwargs": {},
+        "value": None,
+        "infer": {"_do_not_trace": True},
+        "scale": 1.0,
+        "mask": None,
+        "cond_indep_stack": (),
+        "done": False,
+        "stop": False,
+        "continuation": None,
+    }
+    apply_stack(msg)
+    return msg

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -270,6 +270,9 @@ def inspect():
     """
     EXPERIMENTAL Inspect the Pyro stack.
 
+    .. warning:: The format of the returned message may change at any time and
+        does not guarantee backwards compatibility.
+
     :returns: A message with all effects applied.
     :rtype: dict
     """

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -266,7 +266,7 @@ def effectful(fn=None, type=None):
     return _fn
 
 
-def inspect():
+def _inspect():
     """
     EXPERIMENTAL Inspect the Pyro stack.
 
@@ -294,3 +294,23 @@ def inspect():
     }
     apply_stack(msg)
     return msg
+
+
+def get_mask():
+    """
+    Records the effects of enclosing ``poutine.mask`` handlers.
+
+    This is useful for avoiding expensive ``pyro.factor()`` computations during
+    prediction, when the log density need not be computed, e.g.::
+
+        def model():
+            # ...
+            if poutine.get_mask() is not False:
+                log_density = my_expensive_computation()
+                pyro.factor("foo", log_density)
+            # ...
+
+    :returns: The mask.
+    :rtype: None, bool, or torch.Tensor
+    """
+    return _inspect()["mask"]

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -150,3 +150,45 @@ def test_deterministic(with_plate, event_shape):
     assert actual["x3"].shape == (1000,) + x3_batch_shape + event_shape
     assert_close(actual["x2"].mean(), y, rtol=0.1)
     assert_close(actual["x3"].mean(), y, rtol=0.1)
+
+
+def test_get_mask_optimization():
+
+    def model():
+        x = pyro.sample("x", dist.Normal(0, 1))
+        pyro.sample("y", dist.Normal(x, 1), obs=torch.tensor(0.))
+        called.add("model-always")
+        if poutine.get_mask() is not False:
+            called.add("model-sometimes")
+            pyro.factor("f", x + 1)
+
+    def guide():
+        x = pyro.sample("x", dist.Normal(0, 1))
+        called.add("guide-always")
+        if poutine.get_mask() is not False:
+            called.add("guide-sometimes")
+            pyro.factor("g", 2 - x)
+
+    called = set()
+    trace = poutine.trace(guide).get_trace()
+    poutine.replay(model, trace)()
+    assert "model-always" in called
+    assert "guide-always" in called
+    assert "model-sometimes" in called
+    assert "guide-sometimes" in called
+
+    called = set()
+    with poutine.mask(mask=False):
+        trace = poutine.trace(guide).get_trace()
+        poutine.replay(model, trace)()
+    assert "model-always" in called
+    assert "guide-always" in called
+    assert "model-sometimes" not in called
+    assert "guide-sometimes" not in called
+
+    called = set()
+    Predictive(model, guide=guide, num_samples=2, parallel=True)()
+    assert "model-always" in called
+    assert "guide-always" in called
+    assert "model-sometimes" not in called
+    assert "guide-sometimes" not in called


### PR DESCRIPTION
Resolves #2744

This adds a `poutine.get_mask()` function to gate expensive computations. This is implemented via an internal primitive `poutine._inspect()` that creates a single message, applies all effects, and returns the message. While in theory effects may apply to more things, in practice `_inspect()` pulls out exactly the `mask` we need, and also `cond_indep_stack` and `scale` that we often access via hackery and may want in the future.

I also needed to change `poutine.mask(mask=False)` to avoid coercing its `mask` arg to a `torch.Tensor`.

## Tested
- [x] refactoring is covered by existing tests
- [x] non-masked case is covered by existing tests
- [x] unit test for masked case