### PR TITLE
Bump to version 1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - pip install -U pip
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-    - pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - pip install torch==1.7.0+cpu torchvision==0.8.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - pip install .[test]
     - pip install coveralls
     - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - pip install -U pip
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-    - pip install torch==1.7.0+cpu torchvision==0.8.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - pip install .[test]
     - pip install coveralls
     - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - pip install -U pip
     # Keep track of pyro-api master branch
     - pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-    - pip install torch==1.7.1+cpu torchvision==0.8.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    - pip install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - pip install .[test]
     - pip install coveralls
     - pip freeze

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -213,5 +213,5 @@ def setup(app):
 # @jpchen's hack to get rtd builder to install latest pytorch
 # See similar line in the install section of .travis.yml
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.7.1+cpu torchvision==0.8.2+cpu '
+    os.system('pip install torch==1.7.0+cpu torchvision==0.8.1+cpu '
               '-f https://download.pytorch.org/whl/torch_stable.html')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -213,5 +213,5 @@ def setup(app):
 # @jpchen's hack to get rtd builder to install latest pytorch
 # See similar line in the install section of .travis.yml
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.6.0+cpu torchvision==0.7.0+cpu '
+    os.system('pip install torch==1.7.0+cpu torchvision==0.8.0+cpu '
               '-f https://download.pytorch.org/whl/torch_stable.html')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -213,5 +213,5 @@ def setup(app):
 # @jpchen's hack to get rtd builder to install latest pytorch
 # See similar line in the install section of .travis.yml
 if 'READTHEDOCS' in os.environ:
-    os.system('pip install torch==1.7.0+cpu torchvision==0.8.0+cpu '
+    os.system('pip install torch==1.7.1+cpu torchvision==0.8.2+cpu '
               '-f https://download.pytorch.org/whl/torch_stable.html')

--- a/examples/air/main.py
+++ b/examples/air/main.py
@@ -248,7 +248,7 @@ def main(**kwargs):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Pyro AIR example", argument_default=argparse.SUPPRESS)
     parser.add_argument('-n', '--num-steps', type=int, default=int(1e8),
                         help='number of optimization steps to take')

--- a/examples/baseball.py
+++ b/examples/baseball.py
@@ -330,7 +330,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Baseball batting average using HMC")
     parser.add_argument("-n", "--num-samples", nargs="?", default=200, type=int)
     parser.add_argument("--num-chains", nargs='?', default=4, type=int)

--- a/examples/contrib/autoname/mixture.py
+++ b/examples/contrib/autoname/mixture.py
@@ -75,7 +75,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=200, type=int)
     parser.add_argument('--jit', action='store_true')

--- a/examples/contrib/autoname/scoping_mixture.py
+++ b/examples/contrib/autoname/scoping_mixture.py
@@ -67,7 +67,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=200, type=int)
     args = parser.parse_args()

--- a/examples/contrib/autoname/tree_data.py
+++ b/examples/contrib/autoname/tree_data.py
@@ -105,7 +105,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=100, type=int)
     args = parser.parse_args()

--- a/examples/contrib/cevae/synthetic.py
+++ b/examples/contrib/cevae/synthetic.py
@@ -81,7 +81,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Causal Effect Variational Autoencoder")
     parser.add_argument("--num-data", default=1000, type=int)
     parser.add_argument("--feature-dim", default=5, type=int)

--- a/examples/contrib/epidemiology/regional.py
+++ b/examples/contrib/epidemiology/regional.py
@@ -144,7 +144,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(
         description="Regional compartmental epidemiology modeling using HMC")
     parser.add_argument("-p", "--population", default=1000, type=int)

--- a/examples/contrib/epidemiology/sir.py
+++ b/examples/contrib/epidemiology/sir.py
@@ -295,7 +295,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(
         description="Compartmental epidemiology modeling using HMC")
     parser.add_argument("-p", "--population", default=1000, type=float)

--- a/examples/contrib/forecast/bart.py
+++ b/examples/contrib/forecast/bart.py
@@ -156,7 +156,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Bart Ridership Forecasting Example")
     parser.add_argument("--train-window", default=2160, type=int)
     parser.add_argument("--test-window", default=336, type=int)

--- a/examples/contrib/funsor/hmm.py
+++ b/examples/contrib/funsor/hmm.py
@@ -620,7 +620,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="MAP Baum-Welch learning Bach Chorales")
     parser.add_argument("-m", "--model", default="1", type=str,
                         help="one of: {}".format(", ".join(sorted(models.keys()))))

--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -165,7 +165,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description='Pyro GP MNIST Example')
     parser.add_argument('--data-dir', type=str, default=None, metavar='PATH',
                         help='default directory to cache MNIST data')

--- a/examples/contrib/oed/ab_test.py
+++ b/examples/contrib/oed/ab_test.py
@@ -115,7 +115,7 @@ def main(num_vi_steps, num_bo_steps, seed):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="A/B test experiment design using VI")
     parser.add_argument("-n", "--num-vi-steps", nargs="?", default=5000, type=int)
     parser.add_argument('--num-bo-steps', nargs="?", default=5, type=int)

--- a/examples/contrib/timeseries/gp_models.py
+++ b/examples/contrib/timeseries/gp_models.py
@@ -149,7 +149,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="contrib.timeseries example usage")
     parser.add_argument("-n", "--num-steps", default=300, type=int)
     parser.add_argument("-s", "--seed", default=0, type=int)

--- a/examples/cvae/main.py
+++ b/examples/cvae/main.py
@@ -82,7 +82,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-nq', '--num-quadrant-inputs', metavar='N', type=int,

--- a/examples/dmm.py
+++ b/examples/dmm.py
@@ -453,7 +453,7 @@ def main(args):
 
 # parse command-line arguments and execute the main method
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
 
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', type=int, default=5000)

--- a/examples/eight_schools/mcmc.py
+++ b/examples/eight_schools/mcmc.py
@@ -42,7 +42,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description='Eight Schools MCMC')
     parser.add_argument('--num-samples', type=int, default=1000,
                         help='number of MCMC samples (default: 1000)')

--- a/examples/eight_schools/svi.py
+++ b/examples/eight_schools/svi.py
@@ -75,7 +75,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description='Eight Schools SVI')
     parser.add_argument('--lr', type=float, default=0.01,
                         help='learning rate (default: 0.01)')

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -638,7 +638,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="MAP Baum-Welch learning Bach Chorales")
     parser.add_argument("-m", "--model", default="1", type=str,
                         help="one of: {}".format(", ".join(sorted(models.keys()))))

--- a/examples/inclined_plane.py
+++ b/examples/inclined_plane.py
@@ -123,7 +123,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=500, type=int)
     args = parser.parse_args()

--- a/examples/lda.py
+++ b/examples/lda.py
@@ -138,7 +138,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Amortized Latent Dirichlet Allocation")
     parser.add_argument("-t", "--num-topics", default=8, type=int)
     parser.add_argument("-w", "--num-words", default=1024, type=int)

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -49,7 +49,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Demonstrate the use of an LKJ Prior")
     parser.add_argument("--num-samples", nargs="?", default=200, type=int)
     parser.add_argument("--n", nargs="?", default=500, type=int)

--- a/examples/minipyro.py
+++ b/examples/minipyro.py
@@ -65,7 +65,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Mini Pyro demo")
     parser.add_argument("-b", "--backend", default="minipyro")
     parser.add_argument("-n", "--num-steps", default=1001, type=int)

--- a/examples/neutra.py
+++ b/examples/neutra.py
@@ -186,7 +186,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description='Example illustrating NeuTra Reparametrizer')
     parser.add_argument('-n', '--num-steps', default=10000, type=int,
                         help='number of SVI steps')

--- a/examples/rsa/generics.py
+++ b/examples/rsa/generics.py
@@ -157,7 +157,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     args = parser.parse_args()

--- a/examples/rsa/hyperbole.py
+++ b/examples/rsa/hyperbole.py
@@ -154,7 +154,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--price', default=10000, type=int)

--- a/examples/rsa/schelling.py
+++ b/examples/rsa/schelling.py
@@ -76,7 +76,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--depth', default=2, type=int)

--- a/examples/rsa/schelling_false.py
+++ b/examples/rsa/schelling_false.py
@@ -89,7 +89,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     parser.add_argument('--depth', default=3, type=int)

--- a/examples/rsa/semantic_parsing.py
+++ b/examples/rsa/semantic_parsing.py
@@ -340,7 +340,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-samples', default=10, type=int)
     args = parser.parse_args()

--- a/examples/scanvi/scanvi.py
+++ b/examples/scanvi/scanvi.py
@@ -351,7 +351,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     # Parse command line arguments
     parser = argparse.ArgumentParser(description="single-cell ANnotation using Variational Inference")
     parser.add_argument('-s', '--seed', default=0, type=int, help='rng seed')

--- a/examples/sir_hmc.py
+++ b/examples/sir_hmc.py
@@ -573,7 +573,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="SIR epidemiology modeling using HMC")
     parser.add_argument("-p", "--population", default=10, type=int)
     parser.add_argument("-m", "--min-observations", default=3, type=int)

--- a/examples/sparse_gamma_def.py
+++ b/examples/sparse_gamma_def.py
@@ -234,7 +234,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=1500, type=int, help='number of training epochs')

--- a/examples/sparse_regression.py
+++ b/examples/sparse_regression.py
@@ -311,7 +311,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description='Krylov KIT')
     parser.add_argument('--num-data', type=int, default=750)
     parser.add_argument('--num-steps', type=int, default=1000)

--- a/examples/svi_horovod.py
+++ b/examples/svi_horovod.py
@@ -150,7 +150,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Distributed training via Horovod")
     parser.add_argument("-o", "--outfile")
     parser.add_argument("-s", "--size", default=1000000, type=int)

--- a/examples/toy_mixture_model_discrete_enumeration.py
+++ b/examples/toy_mixture_model_discrete_enumeration.py
@@ -127,7 +127,7 @@ def get_true_pred_CPDs(CPD, posterior_param):
 
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description="Toy mixture model")
     parser.add_argument("-n", "--num-steps", default=4000, type=int)
     parser.add_argument("-o", "--num-obs", default=10000, type=int)

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -383,7 +383,7 @@ EXAMPLE_RUN = "example run: python ss_vae_M2.py --seed 0 --cuda -n 2 --aux-loss 
               "-sup 3000 -zd 50 -hl 500 -lr 0.00042 -b1 0.95 -bs 200 -log ./tmp.log"
 
 if __name__ == "__main__":
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
 
     parser = argparse.ArgumentParser(description="SS-VAE\n{}".format(EXAMPLE_RUN))
 

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -201,7 +201,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     # parse command line arguments
     parser = argparse.ArgumentParser(description="parse args")
     parser.add_argument('-n', '--num-epochs', default=101, type=int, help='number of training epochs')

--- a/examples/vae/vae_comparison.py
+++ b/examples/vae/vae_comparison.py
@@ -246,7 +246,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    assert pyro.__version__.startswith('1.5.1')
+    assert pyro.__version__.startswith('1.5.2')
     parser = argparse.ArgumentParser(description='VAE using MNIST dataset')
     parser.add_argument('-n', '--num-epochs', nargs='?', default=10, type=int)
     parser.add_argument('--batch_size', nargs='?', default=128, type=int)

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -10,7 +10,7 @@ from pyro.primitives import (barrier, clear_param_store, deterministic, enable_v
 from pyro.util import set_rng_seed
 
 # After changing this, run scripts/update_version.py
-version_prefix = '1.5.1'
+version_prefix = '1.5.2'
 
 # Get the __version__ string from the auto-generated _version.py file, if exists.
 try:

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'graphviz>=0.8',
     'matplotlib>=1.3',
-    'torchvision>=0.7.0',
+    'torchvision>=0.7.0<=1.8.2',
     'visdom>=0.1.4',
     'pandas',
     'scikit-learn',
@@ -88,7 +88,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
-        'torch>=1.6.0',
+        'torch>=1.6.0<=1.7.1',
         'tqdm>=4.36',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         'horovod': ['horovod[pytorch]>=0.19'],
         'funsor': [
             # This must be a released version when Pyro is released.
-            'funsor[torch]==0.3.0',
+            'funsor[torch]==0.4.0',
         ],
     },
     python_requires='>=3.6',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'graphviz>=0.8',
     'matplotlib>=1.3',
-    'torchvision==0.8',
+    'torchvision>=0.8<0.9',
     'visdom>=0.1.4',
     'pandas',
     'scikit-learn',
@@ -88,7 +88,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
-        'torch==1.7',
+        'torch>=1.7<1.8',
         'tqdm>=4.36',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'graphviz>=0.8',
     'matplotlib>=1.3',
-    'torchvision>=0.8<0.9',
+    'torchvision>=0.7<0.9',
     'visdom>=0.1.4',
     'pandas',
     'scikit-learn',
@@ -88,7 +88,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
-        'torch>=1.7<1.8',
+        'torch>=1.6<1.8',
         'tqdm>=4.36',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'graphviz>=0.8',
     'matplotlib>=1.3',
-    'torchvision>=0.7.0<=1.8.2',
+    'torchvision==0.8',
     'visdom>=0.1.4',
     'pandas',
     'scikit-learn',
@@ -88,7 +88,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
-        'torch>=1.6.0<=1.7.1',
+        'torch==1.7',
         'tqdm>=4.36',
     ],
     extras_require={

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -195,7 +195,8 @@ def xfail_jit(*args, **kwargs):
 
 JIT_EXAMPLES = [
     'air/main.py --num-steps=1 --jit',
-    'baseball.py --num-samples=200 --warmup-steps=100 --jit',
+    xfail_jit('baseball.py --num-samples=200 --warmup-steps=100 --jit',
+              reason='unreproducible RuntimeError on CI'),
     'contrib/autoname/mixture.py --num-epochs=1 --jit',
     'contrib/cevae/synthetic.py --num-epochs=1 --jit',
     'contrib/epidemiology/sir.py --jit -np=128 -t=2 -w=2 -n=4 -d=20 -p=1000 -f 2',
@@ -205,8 +206,7 @@ JIT_EXAMPLES = [
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('dmm.py --num-epochs=1 --jit'),
     xfail_jit('dmm.py --num-epochs=1 --num-iafs=1 --jit'),
-    xfail_jit('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
-              reason='unreproducible RuntimeError on CI'),
+    'eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
     'eight_schools/svi.py --num-epochs=1 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=1 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=2 --jit',

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -187,8 +187,9 @@ CUDA_EXAMPLES = [
 ]
 
 
-def xfail_jit(*args):
-    return pytest.param(*args, marks=[pytest.mark.xfail(reason="not jittable"),
+def xfail_jit(*args, **kwargs):
+    reason = kwargs.pop("reason", "not jittable")
+    return pytest.param(*args, marks=[pytest.mark.xfail(reason=reason),
                                       pytest.mark.skipif('CI' in os.environ, reason='slow test')])
 
 
@@ -204,7 +205,8 @@ JIT_EXAMPLES = [
     xfail_jit('contrib/gp/sv-dkl.py --epochs=1 --num-inducing=4 --jit'),
     xfail_jit('dmm.py --num-epochs=1 --jit'),
     xfail_jit('dmm.py --num-epochs=1 --num-iafs=1 --jit'),
-    'eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
+    xfail_jit('eight_schools/mcmc.py --num-samples=500 --warmup-steps=100 --jit',
+              reason='unreproducible RuntimeError on CI'),
     'eight_schools/svi.py --num-epochs=1 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=1 --jit',
     'hmm.py --num-steps=1 --truncate=10 --model=2 --jit',

--- a/tutorial/source/air.ipynb
+++ b/tutorial/source/air.ipynb
@@ -41,7 +41,7 @@
     "import numpy as np\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/bayesian_regression.ipynb
+++ b/tutorial/source/bayesian_regression.ipynb
@@ -69,7 +69,7 @@
     "\n",
     "# for CI testing\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(1)\n",
     "pyro.enable_validation(True)\n",

--- a/tutorial/source/bayesian_regression_ii.ipynb
+++ b/tutorial/source/bayesian_regression_ii.ipynb
@@ -44,7 +44,7 @@
     "import pyro.optim as optim\n",
     "\n",
     "pyro.set_rng_seed(1)\n",
-    "assert pyro.__version__.startswith('1.5.1')"
+    "assert pyro.__version__.startswith('1.5.2')"
    ]
   },
   {

--- a/tutorial/source/bo.ipynb
+++ b/tutorial/source/bo.ipynb
@@ -54,7 +54,7 @@
     "import pyro\n",
     "import pyro.contrib.gp as gp\n",
     "\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)  # can help with debugging\n",
     "pyro.set_rng_seed(1)"
    ]

--- a/tutorial/source/dirichlet_process_mixture.ipynb
+++ b/tutorial/source/dirichlet_process_mixture.ipynb
@@ -76,7 +76,7 @@
     "from pyro.infer import Predictive, SVI, Trace_ELBO\n",
     "from pyro.optim import Adam\n",
     "\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/easyguide.ipynb
+++ b/tutorial/source/easyguide.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "pyro.enable_validation(True)\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')"
+    "assert pyro.__version__.startswith('1.5.2')"
    ]
   },
   {

--- a/tutorial/source/ekf.ipynb
+++ b/tutorial/source/ekf.ipynb
@@ -98,7 +98,7 @@
     "from pyro.contrib.tracking.measurements import PositionMeasurement\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/enumeration.ipynb
+++ b/tutorial/source/enumeration.ipynb
@@ -50,7 +50,7 @@
     "from pyro.ops.indexing import Vindex\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation()\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/epi_intro.ipynb
+++ b/tutorial/source/epi_intro.ipynb
@@ -58,7 +58,7 @@
     "from pyro.contrib.epidemiology import CompartmentalModel, binomial_dist, infection_dist\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "torch.set_default_dtype(torch.double)  # Required for MCMC inference.\n",
     "pyro.enable_validation(True)  # Always a good idea.\n",
     "smoke_test = ('CI' in os.environ)"

--- a/tutorial/source/forecasting_dlm.ipynb
+++ b/tutorial/source/forecasting_dlm.ipynb
@@ -46,7 +46,7 @@
     "from pyro.ops.stats import quantile\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(20200928)\n",

--- a/tutorial/source/forecasting_i.ipynb
+++ b/tutorial/source/forecasting_i.ipynb
@@ -47,7 +47,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(20200221)"
    ]

--- a/tutorial/source/forecasting_ii.ipynb
+++ b/tutorial/source/forecasting_ii.ipynb
@@ -40,7 +40,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(20200305)"
    ]

--- a/tutorial/source/forecasting_iii.ipynb
+++ b/tutorial/source/forecasting_iii.ipynb
@@ -40,7 +40,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "pyro.set_rng_seed(20200305)"
    ]

--- a/tutorial/source/gmm.ipynb
+++ b/tutorial/source/gmm.ipynb
@@ -41,7 +41,7 @@
     "from pyro.infer import SVI, TraceEnum_ELBO, config_enumerate, infer_discrete\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)"
    ]
   },

--- a/tutorial/source/gp.ipynb
+++ b/tutorial/source/gp.ipynb
@@ -60,7 +60,7 @@
     "import pyro.distributions as dist\n",
     "\n",
     "smoke_test = ('CI' in os.environ)  # ignore; used to check code integrity in the Pyro repo\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(0)"
    ]

--- a/tutorial/source/gplvm.ipynb
+++ b/tutorial/source/gplvm.ipynb
@@ -39,7 +39,7 @@
     "import pyro.ops.stats as stats\n",
     "\n",
     "smoke_test = ('CI' in os.environ)  # ignore; used to check code integrity in the Pyro repo\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)       # can help with debugging\n",
     "pyro.set_rng_seed(1)"
    ]

--- a/tutorial/source/jit.ipynb
+++ b/tutorial/source/jit.ipynb
@@ -48,7 +48,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!"
    ]
   },

--- a/tutorial/source/modules.ipynb
+++ b/tutorial/source/modules.ipynb
@@ -61,7 +61,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!"
    ]
   },

--- a/tutorial/source/stable.ipynb
+++ b/tutorial/source/stable.ipynb
@@ -62,7 +62,7 @@
     "from pyro.ops.tensor_utils import convolve\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "smoke_test = ('CI' in os.environ)"
    ]

--- a/tutorial/source/svi_part_i.ipynb
+++ b/tutorial/source/svi_part_i.ipynb
@@ -265,7 +265,7 @@
     "n_steps = 2 if smoke_test else 2000\n",
     "\n",
     "# enable validation (e.g. validate parameters of distributions)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "\n",
     "# clear the param store in case we're in a REPL\n",

--- a/tutorial/source/svi_part_iii.ipynb
+++ b/tutorial/source/svi_part_iii.ipynb
@@ -284,7 +284,7 @@
     "import sys\n",
     "\n",
     "# enable validation (e.g. validate parameters of distributions)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "\n",
     "# this is for running the notebook in our testing framework\n",

--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -52,7 +52,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "smoke_test = ('CI' in os.environ)\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)    # <---- This is always a good idea!\n",
     "\n",
     "# We'll ue this helper to check our models are correct.\n",

--- a/tutorial/source/tracking_1d.ipynb
+++ b/tutorial/source/tracking_1d.ipynb
@@ -30,7 +30,7 @@
     "from pyro.optim import Adam\n",
     "\n",
     "%matplotlib inline\n",
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "smoke_test = ('CI' in os.environ)"
    ]

--- a/tutorial/source/vae.ipynb
+++ b/tutorial/source/vae.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert pyro.__version__.startswith('1.5.1')\n",
+    "assert pyro.__version__.startswith('1.5.2')\n",
     "pyro.enable_validation(True)\n",
     "pyro.distributions.enable_validation(False)\n",
     "pyro.set_rng_seed(0)\n",


### PR DESCRIPTION
Addresses #2754 

**Summary**

- Pin to requirements to torch<1.8 to avoid breaking changes in torch 1.8.0 (introduced by me in https://github.com/pytorch/pytorch/pull/50547 https://github.com/pytorch/pytorch/pull/50581). These upstream changes will require many changes to Pyro's transforms and normalizing flows, which will be deferred to #2753.
- Pin travis and docs to torch==1.7.0
- Xfail a jit test for the baseball example
- Cherry pick an fft bugfix from #2731 
- Increment version

Note this will merge into master, then after release I'll merge master into dev.