### PR TITLE
Fix Delta.arg_constraints and .support

### DIFF
--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -87,6 +87,7 @@ class _OrderedVector(Constraint):
 
 
 corr_cholesky_constraint = _CorrCholesky()
+independent = IndependentConstraint
 integer = _Integer()
 ordered_vector = _OrderedVector()
 sphere = _Sphere()
@@ -94,6 +95,7 @@ sphere = _Sphere()
 __all__ = [
     'IndependentConstraint',
     'corr_cholesky_constraint',
+    'independent',
     'integer',
     'ordered_vector',
     'sphere',

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -4,10 +4,11 @@
 import numbers
 
 import torch
-from torch.distributions import constraints
 
 from pyro.distributions.torch_distribution import TorchDistribution
 from pyro.distributions.util import sum_rightmost
+
+from . import constraints
 
 
 class Delta(TorchDistribution):

--- a/pyro/distributions/delta.py
+++ b/pyro/distributions/delta.py
@@ -25,8 +25,8 @@ class Delta(TorchDistribution):
     :param int event_dim: Optional event dimension, defaults to zero.
     """
     has_rsample = True
-    arg_constraints = {'v': constraints.real, 'log_density': constraints.real}
-    support = constraints.real
+    arg_constraints = {'v': constraints.dependent,
+                       'log_density': constraints.real}
 
     def __init__(self, v, log_density=0.0, event_dim=0, validate_args=None):
         if event_dim > v.dim():
@@ -42,6 +42,10 @@ class Delta(TorchDistribution):
         self.v = v
         self.log_density = log_density
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    @constraints.dependent_property
+    def support(self):
+        return constraints.independent(constraints.real, self.event_dim)
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Delta, _instance)


### PR DESCRIPTION
Ports https://github.com/pyro-ppl/numpyro/pull/902 to Pyro.

Note Pyro does not use `support.is_discrete`, and `dependent_constraint` will not support `is_discrete` until #2753 .