### PR TITLE
Fix bitwise & for bool and Tensor in MaskMessenger

### DIFF
--- a/pyro/poutine/mask_messenger.py
+++ b/pyro/poutine/mask_messenger.py
@@ -27,5 +27,5 @@ class MaskMessenger(Messenger):
         self.mask = mask
 
     def _process_message(self, msg):
-        msg["mask"] = self.mask if msg["mask"] is None else self.mask & msg["mask"]
+        msg["mask"] = self.mask if msg["mask"] is None else msg["mask"] & self.mask
         return None


### PR DESCRIPTION
After the updates I got the error below for `self.mask & msg["mask"]` when `type(self.mask) == bool` and `type(msg["mask"]) == Tensor`

```
TypeError: unsupported operand type(s) for &: 'bool' and 'Tensor'
```

which seems can be fixed by rearranging the order of `msg["mask"] & self.mask`

Tested in Pytorch 1.7.1 and 1.8.0