### PR TITLE
Deprecate LKJCorrCholesky distribution

### DIFF
--- a/examples/contrib/forecast/bart.py
+++ b/examples/contrib/forecast/bart.py
@@ -66,14 +66,14 @@ class Model(ForecastingModel):
         trans_scale = pyro.sample("trans_scale",
                                   dist.LogNormal(torch.zeros(dim), 0.1).to_event(1))
         trans_corr = pyro.sample("trans_corr",
-                                 dist.LKJCorrCholesky(dim, torch.ones(())))
+                                 dist.LKJCholesky(dim, torch.ones(())))
         trans_scale_tril = trans_scale.unsqueeze(-1) * trans_corr
         assert trans_scale_tril.shape[-2:] == (dim, dim)
 
         obs_scale = pyro.sample("obs_scale",
                                 dist.LogNormal(torch.zeros(dim), 0.1).to_event(1))
         obs_corr = pyro.sample("obs_corr",
-                               dist.LKJCorrCholesky(dim, torch.ones(())))
+                               dist.LKJCholesky(dim, torch.ones(())))
         obs_scale_tril = obs_scale.unsqueeze(-1) * obs_corr
         assert obs_scale_tril.shape[-2:] == (dim, dim)
 

--- a/examples/lkj.py
+++ b/examples/lkj.py
@@ -25,8 +25,8 @@ def model(y):
     # Vector of variances for each of the d variables
     theta = pyro.sample("theta", dist.HalfCauchy(torch.ones(d, **options)))
     # Lower cholesky factor of a correlation matrix
-    eta = torch.ones(1, **options)  # Implies a uniform distribution over correlation matrices
-    L_omega = pyro.sample("L_omega", dist.LKJCorrCholesky(d, eta))
+    concentration = torch.ones((), **options)  # Implies a uniform distribution over correlation matrices
+    L_omega = pyro.sample("L_omega", dist.LKJCholesky(d, concentration))
     # Lower cholesky factor of the covariance matrix
     L_Omega = torch.mm(torch.diag(theta.sqrt()), L_omega)
     # For inference with SVI, one might prefer to use torch.bmm(theta.sqrt().diag_embed(), L_omega)

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,120 +1,14 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import math
-
 import torch
 
-from pyro.distributions.torch import Beta, TransformedDistribution
-from pyro.distributions.torch_distribution import TorchDistribution
-from pyro.distributions.transforms.cholesky import CorrMatrixCholeskyTransform, _vector_to_l_cholesky
+from pyro.distributions.torch import LKJCholesky, TransformedDistribution
+from pyro.distributions.transforms.cholesky import CorrMatrixCholeskyTransform
 
 from . import constraints
 
-
-# TODO: Modify class to support more than one eta value at a time?
-class LKJCorrCholesky(TorchDistribution):
-    """
-    Generates cholesky factors of correlation matrices using an LKJ prior.
-
-    The expected use is to combine it with a vector of variances and pass it
-    to the scale_tril parameter of a multivariate distribution such as MultivariateNormal.
-
-    E.g., if theta is a (positive) vector of covariances with the same dimensionality
-    as this distribution, and Omega is sampled from this distribution,
-    scale_tril=torch.mm(torch.diag(sqrt(theta)), Omega)
-
-    Note that the `event_shape` of this distribution is `[d, d]`
-
-    .. note::
-
-       When using this distribution with HMC/NUTS, it is important to
-       use a `step_size` such as 1e-4. If not, you are likely to experience LAPACK
-       errors regarding positive-definiteness.
-
-    For example usage, refer to
-    `pyro/examples/lkj.py <https://github.com/pyro-ppl/pyro/blob/dev/examples/lkj.py>`_.
-
-    :param int d: Dimensionality of the matrix
-    :param torch.Tensor eta: A single positive number parameterizing the distribution.
-    """
-    arg_constraints = {"eta": constraints.positive}
-    support = constraints.corr_cholesky
-    has_rsample = False
-
-    def __init__(self, d, eta, validate_args=None):
-        if eta.numel() != 1:
-            raise ValueError("eta must be a single number; for a larger batch size, call expand")
-        if d <= 1:
-            raise ValueError("d must be > 1 in any correlation matrix")
-        eta = eta.squeeze()
-        vector_size = (d * (d - 1)) // 2
-        alpha = eta.add(0.5 * (d - 1.0))
-
-        concentrations = torch.empty(vector_size, dtype=eta.dtype, device=eta.device)
-        i = 0
-        for k in range(d - 1):
-            alpha -= .5
-            concentrations[..., i:(i + d - k - 1)] = alpha
-            i += d - k - 1
-        self._gen = Beta(concentrations, concentrations)
-        self.eta = eta
-        self._d = d
-        self._lkj_constant = None
-        super().__init__(torch.Size(), torch.Size((d, d)), validate_args=validate_args)
-
-    def sample(self, sample_shape=torch.Size()):
-        with torch.no_grad():
-            y = self._gen.sample(sample_shape=sample_shape + self.batch_shape)
-        z = y.mul(2).add(-1.0)
-        return _vector_to_l_cholesky(z)
-
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(LKJCorrCholesky, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new._gen = self._gen
-        new.eta = self.eta
-        new._d = self._d
-        new._lkj_constant = self._lkj_constant
-        super(LKJCorrCholesky, new).__init__(batch_shape, self.event_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
-    def lkj_constant(self, eta, K):
-        if self._lkj_constant is not None:
-            return self._lkj_constant
-
-        Km1 = K - 1
-
-        constant = torch.lgamma(eta.add(0.5 * Km1)).mul(Km1)
-
-        k = torch.linspace(start=1, end=Km1, steps=Km1, dtype=eta.dtype, device=eta.device)
-        constant -= (k.mul(math.log(math.pi) * 0.5) + torch.lgamma(eta.add(0.5 * (Km1 - k)))).sum()
-
-        self._lkj_constant = constant
-        return constant
-
-    def log_prob(self, x):
-        if self._validate_args:
-            self._validate_sample(x)
-
-        eta = self.eta
-
-        lp = self.lkj_constant(eta, self._d)
-
-        Km1 = self._d - 1
-
-        log_diagonals = x.diagonal(offset=0, dim1=-1, dim2=-2)[..., 1:].log()
-        # TODO: Figure out why the `device` kwarg to torch.linspace seems to not work in certain situations,
-        # and a seemingly redundant .to(x.device) is needed below.
-        values = log_diagonals * torch.linspace(start=Km1 - 1, end=0, steps=Km1,
-                                                dtype=x.dtype,
-                                                device=x.device).expand_as(log_diagonals).to(x.device)
-
-        values += log_diagonals.mul(eta.mul(2).add(-2.0))
-        values = values.sum(-1) + lp
-        values, _ = torch.broadcast_tensors(values, torch.empty(self.batch_shape))
-        return values
+LKJCorrCholesky = LKJCholesky  # DEPRECATED
 
 
 class LKJ(TransformedDistribution):
@@ -142,15 +36,14 @@ class LKJ(TransformedDistribution):
     support = constraints.corr_matrix
 
     def __init__(self, dim, concentration=1., validate_args=None):
-        # TODO: use upstream LKJCholesky distribution
-        base_dist = LKJCorrCholesky(dim, concentration)
+        base_dist = LKJCholesky(dim, concentration)
         self.dim, self.concentration = base_dist._d, base_dist.eta
         super(LKJ, self).__init__(base_dist, CorrMatrixCholeskyTransform().inv,
                                   validate_args=validate_args)
 
     def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(LKJCorrCholesky, _instance)
-        return super(LKJCorrCholesky, self).expand(batch_shape, _instance=new)
+        new = self._get_checked_instance(LKJCholesky, _instance)
+        return super(LKJCholesky, self).expand(batch_shape, _instance=new)
 
     @property
     def mean(self):

--- a/pyro/distributions/lkj.py
+++ b/pyro/distributions/lkj.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import torch
 
 from pyro.distributions.torch import LKJCholesky, TransformedDistribution
@@ -11,8 +13,11 @@ from . import constraints
 
 class LKJCorrCholesky(LKJCholesky):  # DEPRECATED
     def __init__(self, d, eta, validate_args=None):
-        raise FutureWarning('class LKJCorrCholesky(d, eta, validate_args=None) is deprecated ' +
-                            'in favor of LKJCholesky(dim, concentration, validate_args=None).')
+        warnings.warn(
+            'class LKJCorrCholesky(d, eta, validate_args=None) is deprecated '
+            'in favor of LKJCholesky(dim, concentration, validate_args=None).',
+            FutureWarning,
+        )
         super().__init__(d, concentration=eta, validate_args=validate_args)
 
 

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -277,7 +277,7 @@ continuous_dists = [
                      [[1.0000, -0.8800, -0.9493], [-0.8800,  1.0000,  0.9088], [-0.9493,  0.9088,  1.0000]],
                      [[1.0000,  0.2284, -0.1283], [0.2284,   1.0000,  0.0146], [-0.1283,  0.0146,  1.0000]]]},
                 ]),
-    Fixture(pyro_dist=dist.LKJCorrCholesky,
+    Fixture(pyro_dist=dist.LKJCholesky,
             examples=[
                 {
                     'd': 3,

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -105,7 +105,7 @@ def test_support_is_not_discrete(continuous_dist):
 
 def test_gof(continuous_dist):
     Dist = continuous_dist.pyro_dist
-    if Dist in [dist.LKJ, dist.LKJCorrCholesky]:
+    if Dist in [dist.LKJ, dist.LKJCholesky]:
         pytest.xfail(reason="incorrect submanifold scaling")
 
     num_samples = 50000
@@ -285,8 +285,8 @@ def test_expand_error(dist, initial_shape, proposed_shape, default):
             with xfail_if_not_implemented():
                 large = small.expand(torch.Size(initial_shape) + small.batch_shape)
         proposed_batch_shape = torch.Size(proposed_shape) + small.batch_shape
-        if dist.get_test_distribution_name() == 'LKJCorrCholesky':
-            pytest.skip('LKJCorrCholesky can expand to a shape not' +
+        if dist.get_test_distribution_name() == 'LKJCholesky':
+            pytest.skip('LKJCholesky can expand to a shape not' +
                         'broadcastable with its original batch_shape.')
         with pytest.raises((RuntimeError, ValueError)):
             large.expand(proposed_batch_shape)

--- a/tests/distributions/test_lkj.py
+++ b/tests/distributions/test_lkj.py
@@ -8,7 +8,7 @@ import torch
 from torch.distributions import AffineTransform, Beta, TransformedDistribution, biject_to, transform_to
 
 from pyro.distributions import constraints, transforms
-from pyro.distributions.lkj import LKJCorrCholesky
+from pyro.distributions.torch import LKJCholesky
 from tests.common import assert_equal, assert_tensors_equal
 
 
@@ -83,7 +83,7 @@ def test_corr_cholesky_transform(x_shape, mapping):
 
 @pytest.mark.parametrize("d", [2, 3, 4, 10])
 def test_log_prob_eta1(d):
-    dist = LKJCorrCholesky(d, torch.tensor([1.]))
+    dist = LKJCholesky(d, torch.tensor([1.]))
 
     a_sample = dist.sample(torch.Size([100]))
     lp = dist.log_prob(a_sample)
@@ -100,7 +100,7 @@ def test_log_prob_eta1(d):
 
 @pytest.mark.parametrize("eta", [.1, .5, 1., 2., 5.])
 def test_log_prob_d2(eta):
-    dist = LKJCorrCholesky(2, torch.tensor([eta]))
+    dist = LKJCholesky(2, torch.tensor([eta]))
     test_dist = TransformedDistribution(Beta(eta, eta), AffineTransform(loc=-1., scale=2.0))
 
     samples = dist.sample(torch.Size([100]))
@@ -113,7 +113,7 @@ def test_log_prob_d2(eta):
 
 def test_sample_batch():
     # Regression test for https://github.com/pyro-ppl/pyro/issues/2615
-    dist = LKJCorrCholesky(d=3, eta=torch.ones(())).expand([12])
+    dist = LKJCholesky(d=3, eta=torch.ones(())).expand([12])
     # batch shape and event shape are as you'd expect
     assert dist.batch_shape == torch.Size([12])
     assert dist.event_shape == torch.Size([3, 3])

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -468,7 +468,7 @@ def test_empty_model_error():
 
 def test_unpack_latent():
     def model():
-        return pyro.sample('x', dist.LKJCorrCholesky(2, torch.tensor(1.)))
+        return pyro.sample('x', dist.LKJCholesky(2, torch.tensor(1.)))
 
     guide = AutoDiagonalNormal(model)
     assert guide()['x'].shape == model().shape


### PR DESCRIPTION
This deprecates Pyro's `LKJCorrCholesky` in favor of the upstream `LKJCholesky` distribution, as suggested by @neerajprad  in #2753.

Note that whereas the older `LKJCorrCholesky`'s `eta` param has shape `(1,)`, the newer `LKJCholesky`'s `concentration` param has empty shape `()`.

cc @neerajprad @fehiepsi