### PR TITLE
Support obs_mask kwarg in sample statements

### DIFF
--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -72,11 +72,10 @@ def sample(name, fn, *args, **kwargs):
     :param fn: distribution class or function
     :param obs: observed datum (optional; should only be used in context of
         inference) optionally specified in kwargs
-    :param ~torch.Tensor obs_mask: EXPERIMENTAL Optional boolean tensor mask.
-        If provided, values with mask=True will be conditioned on ``obs`` and
-        remaining values will be imputed by sampling. This introduces a latent
-        sample site named ``name + "_unobserved"`` which should be used by
-        guides (this site name may change in a future version).
+    :param ~torch.Tensor obs_mask: Optional boolean tensor mask.  If provided,
+        values with mask=True will be conditioned on ``obs`` and remaining
+        values will be imputed by sampling. This introduces a latent sample
+        site named ``name + "_unobserved"`` which should be used by guides.
     :type obs_mask: bool or ~torch.Tensor
     :param dict infer: Optional dictionary of inference parameters specified
         in kwargs. See inference documentation for details.

--- a/tests/infer/mcmc/test_valid_models.py
+++ b/tests/infer/mcmc/test_valid_models.py
@@ -412,3 +412,28 @@ def test_potential_fn_initial_params(Kernel):
 
     mcmc.run()
     mcmc.get_samples()['points']
+
+
+@pytest.mark.parametrize("mask", [
+    torch.tensor(True),
+    torch.tensor(False),
+    torch.tensor([True]),
+    torch.tensor([False]),
+    torch.tensor([False, True, False]),
+])
+@pytest.mark.parametrize("Kernel, options", [
+    (HMC, {"adapt_step_size": True, "num_steps": 3}),
+    (NUTS, {"adapt_step_size": True, "max_tree_depth": 3}),
+])
+def test_obs_mask_ok(Kernel, options, mask):
+    data = torch.tensor([7., 7., 7.])
+
+    def model():
+        x = pyro.sample("x", dist.Normal(0., 1.))
+        with pyro.plate("plate", len(data)):
+            y = pyro.sample("y", dist.Normal(x, 1.),
+                            obs=data, obs_mask=mask)
+            assert ((y == data) == mask).all()
+
+    mcmc_kernel = Kernel(model, max_plate_nesting=0, **options)
+    assert_ok(mcmc_kernel)

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2211,7 +2211,7 @@ def test_obs_mask_ok(Elbo, mask, num_particles):
                            constraint=constraints.positive)
         x = pyro.sample("x", dist.Normal(loc, scale))
         with pyro.plate("plate", len(data)):
-            with poutine.mask(mask=mask ^ True):
+            with poutine.mask(mask=~mask):
                 pyro.sample("y_unobserved", dist.Normal(x, 1.))
 
     elbo = Elbo(num_particles=num_particles, vectorize_particles=True,

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2219,6 +2219,72 @@ def test_obs_mask_ok(Elbo, mask, num_particles):
     assert_ok(model, guide, elbo)
 
 
+@pytest.mark.parametrize("num_particles", [1, 2])
+@pytest.mark.parametrize("mask", [
+    torch.tensor(True),
+    torch.tensor(False),
+    torch.tensor([True]),
+    torch.tensor([False]),
+    torch.tensor([False, True, True, False]),
+])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+    TraceMeanField_ELBO,
+])
+def test_obs_mask_multivariate_ok(Elbo, mask, num_particles):
+    data = torch.full((4, 3), 7.0)
+
+    def model():
+        x = pyro.sample("x", dist.MultivariateNormal(torch.zeros(3), torch.eye(3)))
+        with pyro.plate("plate", len(data)):
+            y = pyro.sample("y", dist.MultivariateNormal(x, torch.eye(3)),
+                            obs=data, obs_mask=mask)
+            assert ((y == data).all(-1) == mask).all()
+
+    def guide():
+        loc = pyro.param("loc", torch.zeros(3))
+        cov = pyro.param("cov", torch.eye(3),
+                         constraint=constraints.positive_definite)
+        x = pyro.sample("x", dist.MultivariateNormal(loc, cov))
+        with pyro.plate("plate", len(data)):
+            with poutine.mask(mask=~mask):
+                pyro.sample("y_unobserved", dist.MultivariateNormal(x, torch.eye(3)))
+
+    elbo = Elbo(num_particles=num_particles, vectorize_particles=True,
+                strict_enumeration_warning=False)
+    assert_ok(model, guide, elbo)
+
+
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+    TraceMeanField_ELBO,
+])
+def test_obs_mask_multivariate_error(Elbo):
+    data = torch.full((3, 2), 7.0)
+    # This mask is invalid because it includes event shape.
+    mask = torch.tensor([[False, False], [False, True], [True, False]])
+
+    def model():
+        x = pyro.sample("x", dist.MultivariateNormal(torch.zeros(2), torch.eye(2)))
+        with pyro.plate("plate", len(data)):
+            pyro.sample("y", dist.MultivariateNormal(x, torch.eye(2)),
+                        obs=data, obs_mask=mask)
+
+    def guide():
+        loc = pyro.param("loc", torch.zeros(2))
+        x = pyro.sample("x", dist.MultivariateNormal(loc, torch.eye(2)))
+        with pyro.plate("plate", len(data)):
+            with poutine.mask(mask=~mask):
+                pyro.sample("y_unobserved", dist.MultivariateNormal(x, torch.eye(2)))
+
+    elbo = Elbo(strict_enumeration_warning=False)
+    assert_error(model, guide, elbo, match="Invalid obs_mask shape")
+
+
 @pytest.mark.parametrize("scale", [1, 0.1, torch.tensor(0.5)])
 @pytest.mark.parametrize("Elbo", [
     Trace_ELBO,

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -2181,6 +2181,7 @@ def test_reparam_mask_plate_ok(Elbo, mask):
     assert_ok(model, guide, Elbo())
 
 
+@pytest.mark.parametrize("num_particles", [1, 2])
 @pytest.mark.parametrize("mask", [
     torch.tensor(True),
     torch.tensor(False),
@@ -2194,7 +2195,7 @@ def test_reparam_mask_plate_ok(Elbo, mask):
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
 ])
-def test_obs_mask_ok(Elbo, mask):
+def test_obs_mask_ok(Elbo, mask, num_particles):
     data = torch.tensor([7., 7., 7.])
 
     def model():
@@ -2213,7 +2214,9 @@ def test_obs_mask_ok(Elbo, mask):
             with poutine.mask(mask=mask ^ True):
                 pyro.sample("y_unobserved", dist.Normal(x, 1.))
 
-    assert_ok(model, guide, Elbo(strict_enumeration_warning=False))
+    elbo = Elbo(num_particles=num_particles, vectorize_particles=True,
+                strict_enumeration_warning=False)
+    assert_ok(model, guide, elbo)
 
 
 @pytest.mark.parametrize("scale", [1, 0.1, torch.tensor(0.5)])


### PR DESCRIPTION
Resolves #1106 

This implements `pyro.sample(..., obs=___, obs_mask=___)` by transforming that one statement into a pair of `poutine.mask`ed `sample` statements plus a final `deterministic` statement. This solution is simple and non-invasive, with changes being limited to the `pyro.sample()` function.

One disadvantage of this approach is that the new latent variable site is named `name + "_unobserved"` rather than simply `name`. However fixing this would require a much more invasive change. In particular it is unclear how handlers should treat a single site that is partially observed and partially sampled. I suspect this 3-site-name approach is actually optimal.

I think to get this to work with `AutoGuide`s we may need to add masking logic in autoguides, otherwise I think some entirely-local guides may diverge to infinite entropy and eventually NAN out. However since that is really a shortcoming of handling of `poutine.mask` rather than `obs_mask`, I have not addressed autoguides in this PR.

## Tested
- [x] ELBO smoke tests in tests/infer/test_valid_models.py
- [x] MCMC smoke tests in tests/infer/mcmc/test_valid_models.py