### PR TITLE
Fix MNIST url redirection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,7 @@ install:
     - pip install numpy
     # TODO replace with torch_stable before release
     # - pip install torch==1.8.0+cpu torchvision==0.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-    # TODO replace with torch_test once torchvision binaries are released
-    # - pip install torch torchvision -f https://download.pytorch.org/whl/test/cpu/torch_test.html
-    # This is the last nightly release of 1.8.0 before splitting to 1.9.0.
-    - pip install --pre torch==1.8.0.dev20210210+cpu torchvision==0.9.0.dev20210210+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    - pip install torch==1.8.0+cpu torchvision==0.9.0 -f https://download.pytorch.org/whl/test/cpu/torch_test.html
     - pip install .[test]
     - pip install coveralls
     - pip freeze

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Make sure that the models come from the same release version of the [Pyro source
 ### Installing Pyro dev branch
 
 For recent features you can install Pyro from source.
-Pyro's dev branch requires PyTorch [nightly builds](https://pytorch.org/get-started/locally/).
+Pyro's dev branch currently requires PyTorch [test builds](https://pytorch.org/get-started/locally/).
 
-**Install PyTorch nightly:**
+**Install PyTorch test:**
 
 ```sh
 pip install numpy
-pip install --pre torch==1.8.0.dev20210210 torchvision==0.9.0.dev20210210 -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+pip install torch==1.8.0 torchvision==0.9.0 -f https://download.pytorch.org/whl/test/cpu/torch_test.html
 ```
 
 **Install Pyro using pip:**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -216,11 +216,5 @@ if 'READTHEDOCS' in os.environ:
     # TODO replace with torch_stable before release
     # os.system('pip install torch==1.8.0+cpu torchvision==0.9.0+cpu '
     #           '-f https://download.pytorch.org/whl/torch_stable.html')
-    # TODO replace with torch_test once torchvision binaries are released
-    # os.system('pip install torch torchvision '
-    #           '-f https://download.pytorch.org/whl/test/cpu/torch_test.html')
-    # This is the last nightly release of 1.8.0 before splitting to 1.9.0.
-    os.system('pip install --pre '
-              'torch==1.8.0.dev20210210+cpu '
-              'torchvision==0.9.0.dev20210210+cpu '
-              '-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html')
+    os.system('pip install torch==1.8.0+cpu torchvision==0.9.0 '
+              '-f https://download.pytorch.org/whl/test/cpu/torch_test.html')

--- a/examples/cvae/mnist.py
+++ b/examples/cvae/mnist.py
@@ -4,8 +4,9 @@
 import numpy as np
 import torch
 from torch.utils.data import DataLoader, Dataset
-from torchvision.datasets import MNIST
 from torchvision.transforms import Compose, functional
+
+from pyro.contrib.examples.util import MNIST
 
 
 class CVAEMNIST(Dataset):

--- a/examples/vae/utils/mnist_cached.py
+++ b/examples/vae/utils/mnist_cached.py
@@ -8,9 +8,8 @@ from functools import reduce
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-from torchvision.datasets import MNIST
 
-from pyro.contrib.examples.util import get_data_directory
+from pyro.contrib.examples.util import MNIST, get_data_directory
 
 # This file contains utilities for caching, transforming and splitting MNIST data
 # efficiently. By default, a PyTorch DataLoader will apply the transform every epoch

--- a/pyro/contrib/examples/util.py
+++ b/pyro/contrib/examples/util.py
@@ -4,17 +4,12 @@
 import os
 import sys
 
-import torchvision
 import torchvision.datasets as datasets
 from torch.utils.data import DataLoader
 from torchvision import transforms
-from torchvision.datasets import MNIST
-
-from pyro.distributions.torch_patch import patch_dependency
 
 
-@patch_dependency('torchvision.datasets.MNIST', torchvision)
-class _MNIST(getattr(MNIST, '_pyro_unpatched', MNIST)):
+class MNIST(datasets.MNIST):
     # For older torchvision.
     urls = [
         "https://d2hg8soec8ck9v.cloudfront.net/datasets/mnist/train-images-idx3-ubyte.gz",
@@ -40,7 +35,10 @@ def get_data_loader(dataset_name,
     if not dataset_transforms:
         dataset_transforms = []
     trans = transforms.Compose([transforms.ToTensor()] + dataset_transforms)
-    dataset = getattr(datasets, dataset_name)
+    if dataset_name == "MNIST":
+        dataset = MNIST
+    else:
+        dataset = getattr(datasets, dataset_name)
     print("downloading data")
     dset = dataset(root=data_dir,
                    train=is_training_set,

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS_REQUIRE = [
     'jupyter>=1.0.0',
     'graphviz>=0.8',
     'matplotlib>=1.3',
-    'torchvision>=0.9.0.dev20210210',
+    'torchvision>=0.9.0',
     'visdom>=0.1.4',
     'pandas',
     'scikit-learn',
@@ -89,7 +89,7 @@ setup(
         'numpy>=1.7',
         'opt_einsum>=2.3.2',
         'pyro-api>=0.1.1',
-        'torch>=1.8.0.dev20210210',
+        'torch>=1.8.0',
         'tqdm>=4.36',
     ],
     extras_require={


### PR DESCRIPTION
Blocking #2774 

This updates our rerouting of torchvision.datasets.mnist.MNIST after that class was moved in a recent torchvision. This also refactors from a sketchy `torch_patch` to a safer pyro-local subclass `MNIST` of the upstream class `MNIST`.

This also updates to use torch==1.8.0 and torchvision==0.9.0 test releases