### PR TITLE
[docs] added note about graphviz in docs readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ make docs
 pip install -r requirements.txt
 ```
 
+Note that you will need to install [graphviz](https://www.graphviz.org/) separately.
+
 ## Workflow ##
 To change the documentation, update the `*.rst` files in `source`.
 


### PR DESCRIPTION
Was trying to build the docs so I could submit a different PR and ran into this issue, so I just added a note.

Side question: is there a particular reason that `docs/` has a separate requirements file, as opposed to being another extra in `setup.py`?  I ask partially because there is a fair amount of overlap with the `dev` extra requirements, but not everything.