### PR TITLE
Fix links in SVI part IV tutorial

### DIFF
--- a/tutorial/source/conf.py
+++ b/tutorial/source/conf.py
@@ -65,7 +65,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Pyro Tutorials'
-copyright = u'2017-2018, Uber Technologies, Inc'
+copyright = u'Pyro Contributors'
 author = u'Uber AI Labs'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/tutorial/source/svi_part_iv.ipynb
+++ b/tutorial/source/svi_part_iv.ipynb
@@ -351,13 +351,6 @@
     "```\n",
     "These kinds of tricks can help ensure that your models and guides stay away from numerically dangerous parts of parameter space."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -377,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/tutorial/source/svi_part_iv.ipynb
+++ b/tutorial/source/svi_part_iv.ipynb
@@ -48,8 +48,8 @@
    "source": [
     "### 2. Use Adam or ClippedAdam by default\n",
     "\n",
-    "Use [`Adam`](http://docs.pyro.ai/en/stable/optimization.html?highlight=clippedadam#pyro.optim.pytorch_optimizers.Adam)\n",
-    "or [`ClippedAdam`](http://docs.pyro.ai/en/stable/optimization.html?highlight=clippedadam#pyro.optim.optim.ClippedAdam) by default when doing Stochastic Variational Inference. Note that `ClippedAdam` is just a convenient extension of `Adam` that provides built-in support for learning rate decay and gradient clipping.\n",
+    "Use [Adam](http://docs.pyro.ai/en/stable/optimization.html?highlight=clippedadam#pyro.optim.pytorch_optimizers.Adam)\n",
+    "or [ClippedAdam](http://docs.pyro.ai/en/stable/optimization.html?highlight=clippedadam#pyro.optim.optim.ClippedAdam) by default when doing Stochastic Variational Inference. Note that `ClippedAdam` is just a convenient extension of `Adam` that provides built-in support for learning rate decay and gradient clipping.\n",
     "\n",
     "The basic reason these optimization algorithms often do well in the context of variational inference is that the smoothing they provide via per-parameter momentum is often essential when the optimization problem is very stochastic. Note that in SVI stochasticity can come from sampling latent variables, from subsampling data, or from both. \n",
     "\n",
@@ -72,7 +72,7 @@
     "\n",
     "While a moderately large learning rate can be useful at the beginning of optimization when you're far from the optimum and want to take large gradient steps, it's often useful to have a smaller learning rate later on so that you don't bounce around the optimum excessively without converging. \n",
     "One way to do this is to use the learning rate schedulers [provided](http://docs.pyro.ai/en/stable/optimization.html?highlight=scheduler#pyro.optim.lr_scheduler.PyroLRScheduler) by Pyro. For example usage see the code snippet [here](https://github.com/pyro-ppl/pyro/blob/a106882e8ffbfe6ac96f19aef9a218026482ed51/examples/scanvi/scanvi.py#L265). \n",
-    "Another convenient way to do this is to use the [`ClippedAdam`](http://docs.pyro.ai/en/stable/optimization.html?highlight=clippedadam#pyro.optim.optim.ClippedAdam) optimizer that has built-in support for learning rate decay via the `lrd` argument:\n",
+    "Another convenient way to do this is to use the [ClippedAdam](http://docs.pyro.ai/en/stable/optimization.html?highlight=clippedadam#pyro.optim.optim.ClippedAdam) optimizer that has built-in support for learning rate decay via the `lrd` argument:\n",
     "\n",
     "```python\n",
     "num_steps = 1000\n",
@@ -153,7 +153,7 @@
     "Alternatively, you can use MAP inference instead of full-blown variational inference. See the [MLE/MAP](http://pyro.ai/examples/mle_map.html) tutorial for further details. Once you have MAP inference working, there's good reason to believe that your model is setup correctly (at least as far as basic numerical stability is concerned). \n",
     "If you're interested in obtaining approximate posterior distributions, you can now follow-up with full-blown SVI. Indeed a natural order of operations might use the following sequence of increasingly flexible autoguides:\n",
     "\n",
-    "[AutoDelta](http://docs.pyro.ai/en/stable/infer.autoguide.html#autodelta)   =>  [AutoNormal](http://docs.pyro.ai/en/stable/infer.autoguide.html#autonormal)  =>  [AutoLowRankMultivariateNormal](http://docs.pyro.ai/en/stable/infer.autoguide.html#autolowrankmultivariatenormal)\n",
+    "[AutoDelta](http://docs.pyro.ai/en/stable/infer.autoguide.html#autodelta)   →  [AutoNormal](http://docs.pyro.ai/en/stable/infer.autoguide.html#autonormal)  →  [AutoLowRankMultivariateNormal](http://docs.pyro.ai/en/stable/infer.autoguide.html#autolowrankmultivariatenormal)\n",
     "\n",
     "If you find that you want a more flexible guide or that you want to take more control over how exactly the guide is defined, at this juncture you can proceed to build a custom guide. \n",
     "One way to go about doing this is to leverage [easy guides](http://pyro.ai/examples/easyguide.html), which strike a balance between the control of a fully custom guide and the automation of an autoguide.\n",
@@ -221,8 +221,8 @@
    "source": [
     "### 9. Use `TraceMeanField_ELBO` if applicable\n",
     "\n",
-    "The basic `ELBO` implementation in Pyro, [`Trace_ELBO`](http://docs.pyro.ai/en/stable/inference_algos.html?highlight=tracemeanfield#pyro.infer.trace_elbo.Trace_ELBO), uses stochastic samples to estimate the KL divergence term. \n",
-    "When analytic KL diverences are available, you may be able to lower ELBO variance by using analytic KL divergences instead. This functionality is provided by [`TraceMeanField_ELBO`](http://docs.pyro.ai/en/stable/inference_algos.html?highlight=tracemeanfield#pyro.infer.trace_elbo.Trace_ELBO)."
+    "The basic `ELBO` implementation in Pyro, [Trace_ELBO](http://docs.pyro.ai/en/stable/inference_algos.html?highlight=tracemeanfield#pyro.infer.trace_elbo.Trace_ELBO), uses stochastic samples to estimate the KL divergence term. \n",
+    "When analytic KL diverences are available, you may be able to lower ELBO variance by using analytic KL divergences instead. This functionality is provided by [TraceMeanField_ELBO](http://docs.pyro.ai/en/stable/inference_algos.html?highlight=tracemeanfield#pyro.infer.trace_elbo.Trace_ELBO)."
    ]
   },
   {
@@ -287,7 +287,7 @@
     "By default Pyro enables validation logic that can be helpful in debugging models and guides. \n",
     "For example, validation logic will inform you when distribution parameters become invalid.\n",
     "Unless you have good reason to do otherwise, keep the validation logic enabled. \n",
-    "Once you're satisfied with a model and inference procedure, you may wish to disable validation using [`pyro.enable_validation`](http://docs.pyro.ai/en/stable/primitives.html?highlight=enable_validation#pyro.primitives.enable_validation).\n",
+    "Once you're satisfied with a model and inference procedure, you may wish to disable validation using [pyro.enable_validation](http://docs.pyro.ai/en/stable/primitives.html?highlight=enable_validation#pyro.primitives.enable_validation).\n",
     "\n",
     "Similarly in the context of `ELBOs` it is a good idea to set \n",
     "```python\n",
@@ -336,7 +336,7 @@
     "### 16. Consider clipping gradients or constraining parameters defensively\n",
     "\n",
     "Certain parameters in your model or guide may control distribution parameters that can be sensitive to numerical issues. \n",
-    "For example, the `concentration` and `rate` parameters that defines a [`Gamma`](http://docs.pyro.ai/en/stable/distributions.html#gamma) distribution may exhibit such sensitivity. \n",
+    "For example, the `concentration` and `rate` parameters that defines a [Gamma](http://docs.pyro.ai/en/stable/distributions.html#gamma) distribution may exhibit such sensitivity. \n",
     "In these cases it may make sense to clip gradients or constrain parameters defensively. \n",
     "See [this code snippet](https://github.com/pyro-ppl/pyro/blob/dev/examples/sparse_gamma_def.py#L135) for an example of gradient clipping. \n",
     "For a simple example of \"defensive\" parameter constraints consider the `concentration` parameter of a `Gamma` distribution. \n",
@@ -351,6 +351,13 @@
     "```\n",
     "These kinds of tricks can help ensure that your models and guides stay away from numerically dangerous parts of parameter space."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -370,7 +377,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
It appears that code hilighting cannot be used inside markdown url links, because sphinx translates those links to rst links that use conflicting backticks.
```diff
- [`Adam`](https://...)
+ [Adam](https://...)
```

Also:
- change => to →
- update copyright

(I've already pushed this fix to the website)