### PR TITLE
Fix regression in unfold/Approximate pattern in funsor#488

### DIFF
--- a/pyro/contrib/funsor/infer/tracetmc_elbo.py
+++ b/pyro/contrib/funsor/infer/tracetmc_elbo.py
@@ -8,7 +8,7 @@ import funsor
 from pyro.contrib.funsor import to_data
 from pyro.contrib.funsor.handlers import enum, plate, replay, trace
 from pyro.contrib.funsor.infer.elbo import ELBO, Jit_ELBO
-from pyro.contrib.funsor.infer.traceenum_elbo import terms_from_trace
+from pyro.contrib.funsor.infer.traceenum_elbo import apply_optimizer, terms_from_trace
 from pyro.distributions.util import copy_docs_from
 from pyro.infer import TraceTMC_ELBO as _OrigTraceTMC_ELBO
 
@@ -38,7 +38,7 @@ class TraceTMC_ELBO(ELBO):
                 plates=plate_vars
             )
 
-        return -to_data(funsor.optimizer.apply_optimizer(elbo))
+        return -to_data(apply_optimizer(elbo))
 
 
 class JitTraceTMC_ELBO(Jit_ELBO, TraceTMC_ELBO):


### PR DESCRIPTION
pair debugged with @eb8680 

This works around a regression in `funsor.optimizer.apply_optimizer()` introduced in https://github.com/pyro-ppl/funsor/pull/488 whereby the `unfold_contraction_generic_tuple` appears to incorrectly interact with `Approximate`. This fix is required for funsor versions after that pull.

## Tested
- tested locally with funsor master branch c77a54e3d434
  `pytest tests/contrib/funsor/test_enum_funsor.py`