### PR TITLE
Allow saving of a subset of variables in MCMC

### DIFF
--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -301,7 +301,8 @@ class MCMC:
     :param dict transforms: dictionary that specifies a transform for a sample site
         with constrained support to unconstrained space.
     :param List[str] save_params: Optional list of a subset of parameter names to
-        save during sampling and diagnostics. Defaults to saving all params.
+        save during sampling and diagnostics. This is useful in models with
+        large nuisance variables. Defaults to None, saving all params.
     """
     def __init__(self, kernel, num_samples, warmup_steps=None, initial_params=None,
                  num_chains=1, hook_fn=None, mp_context=None, disable_progbar=False,

--- a/pyro/infer/mcmc/api.py
+++ b/pyro/infer/mcmc/api.py
@@ -436,7 +436,8 @@ class MCMC:
 
         # transform samples back to constrained space
         for name, z in z_acc.items():
-            z_acc[name] = self.transforms[name].inv(z)
+            if name in self.transforms:
+                z_acc[name] = self.transforms[name].inv(z)
         self._samples = z_acc
 
         # terminate the sampler (shut down worker processes)

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -270,3 +270,5 @@ def test_save_params(save_params, Kernel, options):
     diagnostics = mcmc.diagnostics()
     diagnostics = {k: v for k, v in diagnostics.items() if k in "xy"}
     assert set(diagnostics.keys()) == set(save_params)
+
+    mcmc.summary()  # smoke test

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -157,7 +157,7 @@ def _hook(iters, kernel, samples, stage, i):
 ])
 @pytest.mark.filterwarnings("ignore:num_chains")
 def test_null_model_with_hook(kernel, model, jit, num_chains):
-    warmup_steps, num_samples = 10, 10
+    num_warmup, num_samples = 10, 10
     initial_params, potential_fn, transforms, _ = initialize_model(model,
                                                                    num_chains=num_chains)
 
@@ -167,13 +167,13 @@ def test_null_model_with_hook(kernel, model, jit, num_chains):
     mp_context = "spawn" if "CUDA_TEST" in os.environ else None
 
     kern = kernel(potential_fn=potential_fn, transforms=transforms, jit_compile=jit)
-    mcmc = MCMC(kern, num_samples=num_samples, warmup_steps=warmup_steps,
+    mcmc = MCMC(kern, num_samples=num_samples, warmup_steps=num_warmup,
                 num_chains=num_chains, initial_params=initial_params, hook_fn=hook, mp_context=mp_context)
     mcmc.run()
     samples = mcmc.get_samples()
     assert samples == {}
     if num_chains == 1:
-        expected = [("Warmup", i) for i in range(warmup_steps)] + [("Sample", i) for i in range(num_samples)]
+        expected = [("Warmup", i) for i in range(num_warmup)] + [("Sample", i) for i in range(num_samples)]
         assert iters == expected
 
 


### PR DESCRIPTION
Addresses https://forum.pyro.ai/t/save-only-a-subset-of-latent-variables-in-mcmc/2753

This allows saving of only a subset of latent variables during MCMC.  This is useful in models with large nuisance variables that take up memory and screen space in `.summary()`.

## Tested
- [x] unit test with variables of different shape