### PR TITLE
Minor cleanup: removed try/except around numpy import

### DIFF
--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -19,6 +19,7 @@ import warnings
 import weakref
 from collections import OrderedDict
 
+import numpy as np
 import torch
 
 from pyro.distributions import validation_enabled
@@ -119,15 +120,12 @@ class seed(Messenger):
         super().__init__(fn)
 
     def __enter__(self):
-        self.old_state = {'torch': torch.get_rng_state(), 'random': random.getstate()}
+        self.old_state = {
+            'torch': torch.get_rng_state(), 'random': random.getstate(), 'numpy': np.random.get_state()
+        }
         torch.manual_seed(self.rng_seed)
         random.seed(self.rng_seed)
-        try:
-            import numpy as np
-            np.random.seed(self.rng_seed)
-            self.old_state['numpy'] = np.random.get_state()
-        except ImportError:
-            pass
+        np.random.seed(self.rng_seed)
 
     def __exit__(self, type, value, traceback):
         torch.set_rng_state(self.old_state['torch'])

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from itertools import zip_longest
 
+import numpy as np
 import torch
 
 from pyro.poutine.util import site_is_subsample
@@ -25,21 +26,11 @@ def set_rng_seed(rng_seed):
     """
     torch.manual_seed(rng_seed)
     random.seed(rng_seed)
-    try:
-        import numpy as np
-        np.random.seed(rng_seed)
-    except ImportError:
-        pass
+    np.random.seed(rng_seed)
 
 
 def get_rng_state():
-    state = {'torch': torch.get_rng_state(), 'random': random.getstate()}
-    try:
-        import numpy as np
-        state['numpy'] = np.random.get_state()
-    except ImportError:
-        pass
-    return state
+    return {'torch': torch.get_rng_state(), 'random': random.getstate(), 'numpy': np.random.get_state()}
 
 
 def set_rng_state(state):


### PR DESCRIPTION
`numpy` is a required dependency of `pytorch` so this should be safe.

This change only affects `pyro.util` and the `minipyro` implementation. The tests for the latter fail, but that seems like a pre-existing condition.