### PR TITLE
Added tests for JIT Elbo classes in test_valid_models

### DIFF
--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -338,6 +338,6 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
 
         surrogate_loss.backward(retain_graph=self.retain_graph)  # triggers jit compilation
 
-        loss = loss.item()
+        loss = -loss.item()
         warn_if_nan(loss, "loss")
         return loss

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -16,15 +16,15 @@ from pyro.distributions.testing import fakes
 from pyro.infer import (
     SVI,
     EnergyDistance,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
     Trace_ELBO,
     TraceEnum_ELBO,
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
     TraceTailAdaptive_ELBO,
-    JitTrace_ELBO,
-    JitTraceEnum_ELBO,
-    JitTraceGraph_ELBO,
-    JitTraceMeanField_ELBO,
     config_enumerate,
 )
 from pyro.infer.reparam import LatentStableReparam

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -175,7 +175,7 @@ def test_empty_model_empty_guide_ok(Elbo, strict_enumeration_warning):
         pass
 
     elbo = Elbo(strict_enumeration_warning=strict_enumeration_warning)
-    if strict_enumeration_warning and Elbo in (TraceEnum_ELBO, TraceTMC_ELBO):
+    if strict_enumeration_warning and Elbo in (TraceEnum_ELBO, JitTraceEnum_ELBO, TraceTMC_ELBO):
         assert_warning(model, guide, elbo)
     else:
         assert_ok(model, guide, elbo)
@@ -254,7 +254,14 @@ def test_model_guide_shape_mismatch_error(Elbo):
                  match='Model and guide shapes disagree')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_variable_clash_in_guide_error(Elbo):
 
     def model():

--- a/tests/infer/test_valid_models.py
+++ b/tests/infer/test_valid_models.py
@@ -21,6 +21,10 @@ from pyro.infer import (
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
     TraceTailAdaptive_ELBO,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
     config_enumerate,
 )
 from pyro.infer.reparam import LatentStableReparam
@@ -104,6 +108,9 @@ def assert_warning(model, guide, elbo):
     TraceGraph_ELBO,
     TraceEnum_ELBO,
     TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])
@@ -130,6 +137,9 @@ def test_nonempty_model_empty_guide_ok(Elbo, strict_enumeration_warning):
     TraceGraph_ELBO,
     TraceEnum_ELBO,
     TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])
@@ -146,7 +156,15 @@ def test_nonempty_model_empty_guide_error(Elbo, strict_enumeration_warning):
     assert_error(model, guide, elbo)
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 @pytest.mark.parametrize("strict_enumeration_warning", [True, False])
 def test_empty_model_empty_guide_ok(Elbo, strict_enumeration_warning):
 
@@ -163,7 +181,15 @@ def test_empty_model_empty_guide_ok(Elbo, strict_enumeration_warning):
         assert_ok(model, guide, elbo)
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+])
 def test_variable_clash_in_model_error(Elbo):
 
     def model():
@@ -178,7 +204,15 @@ def test_variable_clash_in_model_error(Elbo):
     assert_error(model, guide, Elbo(), match='Multiple sample sites named')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_model_guide_dim_mismatch_error(Elbo):
 
     def model():
@@ -195,7 +229,15 @@ def test_model_guide_dim_mismatch_error(Elbo):
                  match='invalid log_prob shape|Model and guide event_dims disagree')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_model_guide_shape_mismatch_error(Elbo):
 
     def model():
@@ -228,7 +270,15 @@ def test_variable_clash_in_guide_error(Elbo):
 
 
 @pytest.mark.parametrize("has_rsample", [False, True])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_set_has_rsample_ok(has_rsample, Elbo):
 
     # This model has sparse gradients, so users may want to disable
@@ -243,7 +293,7 @@ def test_set_has_rsample_ok(has_rsample, Elbo):
         loc = pyro.param("loc", torch.tensor(0.))
         pyro.sample("z", dist.Normal(loc, 1).has_rsample_(has_rsample))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -251,7 +301,15 @@ def test_set_has_rsample_ok(has_rsample, Elbo):
     assert_ok(model, guide, Elbo(strict_enumeration_warning=False))
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_not_has_rsample_ok(Elbo):
 
     def model():
@@ -263,7 +321,7 @@ def test_not_has_rsample_ok(Elbo):
         loc = pyro.param("loc", torch.tensor(0.))
         pyro.sample("z", dist.Normal(loc, 1).has_rsample_(False))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -272,7 +330,15 @@ def test_not_has_rsample_ok(Elbo):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 2], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_iplate_ok(subsample_size, Elbo):
 
     def model():
@@ -285,7 +351,7 @@ def test_iplate_ok(subsample_size, Elbo):
         for i in pyro.plate("plate", 4, subsample_size):
             pyro.sample("x_{}".format(i), dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -293,7 +359,15 @@ def test_iplate_ok(subsample_size, Elbo):
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_iplate_variable_clash_error(Elbo):
 
     def model():
@@ -308,7 +382,7 @@ def test_iplate_variable_clash_error(Elbo):
             # Each loop iteration should give the sample site a different name.
             pyro.sample("x", dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -317,7 +391,15 @@ def test_iplate_variable_clash_error(Elbo):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_ok(subsample_size, Elbo):
 
     def model():
@@ -330,7 +412,7 @@ def test_plate_ok(subsample_size, Elbo):
         with pyro.plate("plate", 10, subsample_size) as ind:
             pyro.sample("x", dist.Bernoulli(p).expand_by([len(ind)]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -339,7 +421,15 @@ def test_plate_ok(subsample_size, Elbo):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_subsample_param_ok(subsample_size, Elbo):
 
     def model():
@@ -364,7 +454,15 @@ def test_plate_subsample_param_ok(subsample_size, Elbo):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_subsample_primitive_ok(subsample_size, Elbo):
 
     def model():
@@ -382,7 +480,7 @@ def test_plate_subsample_primitive_ok(subsample_size, Elbo):
             assert len(p) == len(ind)
             pyro.sample("x", dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -391,7 +489,15 @@ def test_plate_subsample_primitive_ok(subsample_size, Elbo):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 @pytest.mark.parametrize("shape,ok", [
     ((), True),
     ((1,), True),
@@ -414,7 +520,7 @@ def test_plate_param_size_mismatch_error(subsample_size, Elbo, shape, ok):
             p = pyro.param("p", torch.ones(10), event_dim=0)
             pyro.sample("x", dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -425,7 +531,15 @@ def test_plate_param_size_mismatch_error(subsample_size, Elbo, shape, ok):
         assert_error(model, guide, Elbo(), match="invalid shape of pyro.param")
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_no_size_ok(Elbo):
 
     def model():
@@ -438,7 +552,7 @@ def test_plate_no_size_ok(Elbo):
         with pyro.plate("plate"):
             pyro.sample("x", dist.Bernoulli(p).expand_by([10]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, default="parallel", num_samples=2)
@@ -448,7 +562,15 @@ def test_plate_no_size_ok(Elbo):
 
 @pytest.mark.parametrize("max_plate_nesting", [0, float('inf')])
 @pytest.mark.parametrize("subsample_size", [None, 2], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_iplate_iplate_ok(subsample_size, Elbo, max_plate_nesting):
 
     def model():
@@ -467,7 +589,7 @@ def test_iplate_iplate_ok(subsample_size, Elbo, max_plate_nesting):
             for j in inner_iplate:
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide, "parallel")
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -477,7 +599,15 @@ def test_iplate_iplate_ok(subsample_size, Elbo, max_plate_nesting):
 
 @pytest.mark.parametrize("max_plate_nesting", [0, float('inf')])
 @pytest.mark.parametrize("subsample_size", [None, 2], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_iplate_iplate_swap_ok(subsample_size, Elbo, max_plate_nesting):
 
     def model():
@@ -496,7 +626,7 @@ def test_iplate_iplate_swap_ok(subsample_size, Elbo, max_plate_nesting):
             for i in outer_iplate:
                 pyro.sample("x_{}_{}".format(i, j), dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide, "parallel")
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, default="parallel", num_samples=2)
@@ -505,7 +635,15 @@ def test_iplate_iplate_swap_ok(subsample_size, Elbo, max_plate_nesting):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_iplate_in_model_not_guide_ok(subsample_size, Elbo):
 
     def model():
@@ -518,7 +656,7 @@ def test_iplate_in_model_not_guide_ok(subsample_size, Elbo):
         p = pyro.param("p", torch.tensor(0.5, requires_grad=True))
         pyro.sample("x", dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -527,7 +665,15 @@ def test_iplate_in_model_not_guide_ok(subsample_size, Elbo):
 
 
 @pytest.mark.parametrize("subsample_size", [None, 5], ids=["full", "subsample"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 @pytest.mark.parametrize("is_validate", [True, False])
 def test_iplate_in_guide_not_model_error(subsample_size, Elbo, is_validate):
 
@@ -549,7 +695,14 @@ def test_iplate_in_guide_not_model_error(subsample_size, Elbo, is_validate):
             assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_broadcast_error(Elbo):
 
     def model():
@@ -560,7 +713,15 @@ def test_plate_broadcast_error(Elbo):
     assert_error(model, model, Elbo(), match='Shape mismatch inside plate')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_iplate_ok(Elbo):
 
     def model():
@@ -575,7 +736,7 @@ def test_plate_iplate_ok(Elbo):
             for i in pyro.plate("iplate", 3, 2):
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).expand_by([len(ind)]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -583,7 +744,15 @@ def test_plate_iplate_ok(Elbo):
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_iplate_plate_ok(Elbo):
 
     def model():
@@ -600,7 +769,7 @@ def test_iplate_plate_ok(Elbo):
             with inner_plate as ind:
                 pyro.sample("x_{}".format(i), dist.Bernoulli(p).expand_by([len(ind)]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -608,7 +777,15 @@ def test_iplate_plate_ok(Elbo):
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 @pytest.mark.parametrize("sizes", [(3,), (3, 4), (3, 4, 5)])
 def test_plate_stack_ok(Elbo, sizes):
 
@@ -622,7 +799,7 @@ def test_plate_stack_ok(Elbo, sizes):
         with pyro.plate_stack("plate_stack", sizes):
             pyro.sample("x", dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -630,7 +807,15 @@ def test_plate_stack_ok(Elbo, sizes):
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 @pytest.mark.parametrize("sizes", [(3,), (3, 4), (3, 4, 5)])
 def test_plate_stack_and_plate_ok(Elbo, sizes):
 
@@ -646,7 +831,7 @@ def test_plate_stack_and_plate_ok(Elbo, sizes):
             with pyro.plate("plate", 7):
                 pyro.sample("x", dist.Bernoulli(p))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(guide, num_samples=2)
@@ -666,7 +851,15 @@ def test_plate_stack_sizes(sizes):
     model()
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nested_plate_plate_ok(Elbo):
 
     def model():
@@ -676,7 +869,7 @@ def test_nested_plate_plate_ok(Elbo):
             with pyro.plate("plate_inner", 11, 6) as ind_inner:
                 pyro.sample("y", dist.Bernoulli(p).expand_by([len(ind_inner), len(ind_outer)]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(model)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(model, num_samples=2)
@@ -686,7 +879,15 @@ def test_nested_plate_plate_ok(Elbo):
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_plate_reuse_ok(Elbo):
 
     def model():
@@ -700,7 +901,7 @@ def test_plate_reuse_ok(Elbo):
         with plate_outer as ind_outer, plate_inner as ind_inner:
             pyro.sample("z", dist.Bernoulli(p).expand_by([len(ind_inner), len(ind_outer)]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(model)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(model, num_samples=2)
@@ -710,7 +911,15 @@ def test_plate_reuse_ok(Elbo):
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO, TraceTMC_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nested_plate_plate_dim_error_1(Elbo):
 
     def model():
@@ -721,7 +930,7 @@ def test_nested_plate_plate_dim_error_1(Elbo):
                 pyro.sample("y", dist.Bernoulli(p).expand_by([len(ind_inner)]))
                 pyro.sample("z", dist.Bernoulli(p).expand_by([len(ind_outer), len(ind_inner)]))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(model)
     elif Elbo is TraceTMC_ELBO:
         guide = config_enumerate(model, num_samples=2)
@@ -731,7 +940,14 @@ def test_nested_plate_plate_dim_error_1(Elbo):
     assert_error(model, guide, Elbo(), match='invalid log_prob shape')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nested_plate_plate_dim_error_2(Elbo):
 
     def model():
@@ -742,11 +958,18 @@ def test_nested_plate_plate_dim_error_2(Elbo):
                 pyro.sample("y", dist.Bernoulli(p).expand_by([len(ind_outer)]))  # error here
                 pyro.sample("z", dist.Bernoulli(p).expand_by([len(ind_outer), len(ind_inner)]))
 
-    guide = config_enumerate(model) if Elbo is TraceEnum_ELBO else model
+    guide = config_enumerate(model) if issubclass(Elbo, TraceEnum_ELBO) else model
     assert_error(model, guide, Elbo(), match='Shape mismatch inside plate')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nested_plate_plate_dim_error_3(Elbo):
 
     def model():
@@ -757,11 +980,18 @@ def test_nested_plate_plate_dim_error_3(Elbo):
                 pyro.sample("y", dist.Bernoulli(p).expand_by([len(ind_inner)]))
                 pyro.sample("z", dist.Bernoulli(p).expand_by([len(ind_inner), 1]))  # error here
 
-    guide = config_enumerate(model) if Elbo is TraceEnum_ELBO else model
+    guide = config_enumerate(model) if issubclass(Elbo, TraceEnum_ELBO) else model
     assert_error(model, guide, Elbo(), match='invalid log_prob shape|shape mismatch')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nested_plate_plate_dim_error_4(Elbo):
 
     def model():
@@ -772,11 +1002,18 @@ def test_nested_plate_plate_dim_error_4(Elbo):
                 pyro.sample("y", dist.Bernoulli(p).expand_by([len(ind_inner)]))
                 pyro.sample("z", dist.Bernoulli(p).expand_by([len(ind_outer), len(ind_outer)]))  # error here
 
-    guide = config_enumerate(model) if Elbo is TraceEnum_ELBO else model
+    guide = config_enumerate(model) if issubclass(Elbo, TraceEnum_ELBO) else model
     assert_error(model, guide, Elbo(), match='hape mismatch inside plate')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nested_plate_plate_subsample_param_ok(Elbo):
 
     def model():
@@ -799,12 +1036,19 @@ def test_nested_plate_plate_subsample_param_ok(Elbo):
                 assert py.shape == (6, 5)
                 pyro.sample("y", dist.Bernoulli(py))
 
-    if Elbo is TraceEnum_ELBO:
+    if issubclass(Elbo, TraceEnum_ELBO):
         guide = config_enumerate(guide)
     assert_ok(model, guide, Elbo())
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_nonnested_plate_plate_ok(Elbo):
 
     def model():
@@ -814,7 +1058,7 @@ def test_nonnested_plate_plate_ok(Elbo):
         with pyro.plate("plate_1", 11, 6) as ind2:
             pyro.sample("x1", dist.Bernoulli(p).expand_by([len(ind2)]))
 
-    guide = config_enumerate(model) if Elbo is TraceEnum_ELBO else model
+    guide = config_enumerate(model) if issubclass(Elbo, TraceEnum_ELBO) else model
     assert_ok(model, guide, Elbo())
 
 
@@ -932,7 +1176,14 @@ def test_block_plate_missing_error():
 
 
 @pytest.mark.parametrize("enumerate_", [None, "sequential", "parallel"])
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_enum_discrete_misuse_warning(Elbo, enumerate_):
 
     def model():
@@ -1345,6 +1596,10 @@ def test_enum_discrete_plate_shape_broadcasting_ok(enumerate_, expand, num_sampl
     (TraceGraph_ELBO, False),
     (TraceEnum_ELBO, False),
     (TraceEnum_ELBO, True),
+    (JitTrace_ELBO, False),
+    (JitTraceGraph_ELBO, False),
+    (JitTraceEnum_ELBO, False),
+    (JitTraceEnum_ELBO, True),
 ])
 def test_dim_allocation_ok(Elbo, expand):
     enumerate_ = (Elbo is TraceEnum_ELBO)
@@ -1384,9 +1639,13 @@ def test_dim_allocation_ok(Elbo, expand):
     (TraceGraph_ELBO, False),
     (TraceEnum_ELBO, False),
     (TraceEnum_ELBO, True),
+    (JitTrace_ELBO, False),
+    (JitTraceGraph_ELBO, False),
+    (JitTraceEnum_ELBO, False),
+    (JitTraceEnum_ELBO, True),
 ])
 def test_dim_allocation_error(Elbo, expand):
-    enumerate_ = (Elbo is TraceEnum_ELBO)
+    enumerate_ = issubclass(Elbo, TraceEnum_ELBO)
 
     def model():
         p = torch.tensor(0.5, requires_grad=True)
@@ -1407,7 +1666,7 @@ def test_dim_allocation_error(Elbo, expand):
             assert x.shape == (5, 1)
             assert y.shape == (5, 6)
 
-    guide = config_enumerate(model, expand=expand) if Elbo is TraceEnum_ELBO else model
+    guide = config_enumerate(model, expand=expand) if issubclass(Elbo, TraceEnum_ELBO) else model
     assert_error(model, guide, Elbo(), match='collide at dim=')
 
 
@@ -1573,7 +1832,14 @@ def test_enum_in_model_diamond_error(use_vindex):
                  match='Expected tree-structured plate nesting')
 
 
-@pytest.mark.parametrize("Elbo", [Trace_ELBO, TraceGraph_ELBO, TraceEnum_ELBO])
+@pytest.mark.parametrize("Elbo", [
+    Trace_ELBO,
+    TraceGraph_ELBO,
+    TraceEnum_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
+])
 def test_vectorized_num_particles(Elbo):
     data = torch.ones(1000, 2)
 
@@ -1589,7 +1855,7 @@ def test_vectorized_num_particles(Elbo):
             pyro.sample("p", dist.Beta(torch.tensor(1.1), torch.tensor(1.1)))
 
     pyro.clear_param_store()
-    guide = config_enumerate(guide) if Elbo is TraceEnum_ELBO else guide
+    guide = config_enumerate(guide) if issubclass(Elbo, TraceEnum_ELBO) else guide
     assert_ok(model, guide, Elbo(num_particles=10,
                                  vectorize_particles=True,
                                  max_plate_nesting=2,
@@ -1976,6 +2242,9 @@ def test_enum_recycling_plate():
     TraceGraph_ELBO,
     TraceEnum_ELBO,
     TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
 ])
 def test_factor_in_model_ok(Elbo):
 
@@ -1994,6 +2263,9 @@ def test_factor_in_model_ok(Elbo):
     TraceGraph_ELBO,
     TraceEnum_ELBO,
     TraceTMC_ELBO,
+    JitTrace_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceEnum_ELBO,
 ])
 def test_factor_in_guide_ok(Elbo):
 
@@ -2032,7 +2304,8 @@ def test_markov_history(history):
         assert_ok(model, guide, TraceEnum_ELBO(max_plate_nesting=0))
 
 
-def test_mean_field_ok():
+@pytest.mark.parametrize("Elbo", [TraceMeanField_ELBO, JitTraceMeanField_ELBO])
+def test_mean_field_ok(Elbo):
 
     def model():
         x = pyro.sample("x", dist.Normal(0., 1.))
@@ -2043,11 +2316,12 @@ def test_mean_field_ok():
         x = pyro.sample("x", dist.Normal(loc, 1.))
         pyro.sample("y", dist.Normal(x, 1.))
 
-    assert_ok(model, guide, TraceMeanField_ELBO())
+    assert_ok(model, guide, Elbo())
 
 
+@pytest.mark.parametrize("Elbo", [TraceMeanField_ELBO, JitTraceMeanField_ELBO])
 @pytest.mark.parametrize('mask', [True, False])
-def test_mean_field_mask_ok(mask):
+def test_mean_field_mask_ok(Elbo, mask):
 
     def model():
         x = pyro.sample("x", dist.Normal(0., 1.).mask(mask))
@@ -2058,10 +2332,11 @@ def test_mean_field_mask_ok(mask):
         x = pyro.sample("x", dist.Normal(loc, 1.).mask(mask))
         pyro.sample("y", dist.Normal(x, 1.))
 
-    assert_ok(model, guide, TraceMeanField_ELBO())
+    assert_ok(model, guide, Elbo())
 
 
-def test_mean_field_warn():
+@pytest.mark.parametrize("Elbo", [TraceMeanField_ELBO, JitTraceMeanField_ELBO])
+def test_mean_field_warn(Elbo):
 
     def model():
         x = pyro.sample("x", dist.Normal(0., 1.))
@@ -2072,7 +2347,7 @@ def test_mean_field_warn():
         y = pyro.sample("y", dist.Normal(loc, 1.))
         pyro.sample("x", dist.Normal(y, 1.))
 
-    assert_warning(model, guide, TraceMeanField_ELBO())
+    assert_warning(model, guide, Elbo())
 
 
 def test_tail_adaptive_ok():
@@ -2121,6 +2396,8 @@ def test_tail_adaptive_warning():
 @pytest.mark.parametrize("Elbo", [
     Trace_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceMeanField_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])
@@ -2141,6 +2418,8 @@ def test_reparam_ok(Elbo):
 @pytest.mark.parametrize("Elbo", [
     Trace_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceMeanField_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])
@@ -2168,6 +2447,8 @@ def test_reparam_mask_ok(Elbo, mask):
 @pytest.mark.parametrize("Elbo", [
     Trace_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceMeanField_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])
@@ -2202,6 +2483,10 @@ def test_reparam_mask_plate_ok(Elbo, mask):
     TraceEnum_ELBO,
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
 ])
 def test_obs_mask_ok(Elbo, mask, num_particles):
     data = torch.tensor([7., 7., 7.])
@@ -2240,6 +2525,10 @@ def test_obs_mask_ok(Elbo, mask, num_particles):
     TraceEnum_ELBO,
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
 ])
 def test_obs_mask_multivariate_ok(Elbo, mask, num_particles):
     data = torch.full((4, 3), 7.0)
@@ -2270,6 +2559,10 @@ def test_obs_mask_multivariate_ok(Elbo, mask, num_particles):
     TraceEnum_ELBO,
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceEnum_ELBO,
+    JitTraceGraph_ELBO,
+    JitTraceMeanField_ELBO,
 ])
 def test_obs_mask_multivariate_error(Elbo):
     data = torch.full((3, 2), 7.0)
@@ -2297,6 +2590,8 @@ def test_obs_mask_multivariate_error(Elbo):
 @pytest.mark.parametrize("Elbo", [
     Trace_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceMeanField_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])
@@ -2323,6 +2618,8 @@ def test_reparam_scale_ok(Elbo, scale):
 @pytest.mark.parametrize("Elbo", [
     Trace_ELBO,
     TraceMeanField_ELBO,
+    JitTrace_ELBO,
+    JitTraceMeanField_ELBO,
     EnergyDistance_prior,
     EnergyDistance_noprior,
 ])


### PR DESCRIPTION
I was attempting to fix #2798 by simply adding a minus sign to the `JitTraceGraph_ELBO` class and discovered some issues while testing. As I cannot figure out what is going on, @fritzo suggested I open a PR with failing tests for someone else to look at.

So, for every use of an ELBO in `test_valid_models`, I added another test that used the Jit version of that ELBO if there was one. For a few tests this meant introducing parametrization (the TraceMeanField_ELBO tests lived on their own, and now they have a parameter for the normal and Jit class). Also, in cases where the test used `if Elbo is TraceEnum_ELBO` I changed it to `if issubclass(Elbo, TraceEnum_ELBO)` so that the Jit version is included.

This adds more than 200 failing tests (and some passing ones as well). 😬  I suspect that many of them are simply because the test model is not compatible with JITting, but it also uncovers a number where the outputs simply don't match the expected value from `JitTraceGraph_ELBO` and `JitTraceMeanField_ELBO`.