### PR TITLE
Implement sparse Poisson.log_prob() computation

### DIFF
--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -33,6 +33,11 @@ class FoldedNormal(dist.FoldedDistribution):
         return self.base_dist.scale
 
 
+class SparsePoisson(dist.Poisson):
+    def __init__(self, rate, *, validate_args=None):
+        super().__init__(rate, is_sparse=True, validate_args=validate_args)
+
+
 continuous_dists = [
     Fixture(pyro_dist=dist.Uniform,
             scipy_dist=sp.uniform,
@@ -522,6 +527,23 @@ discrete_dists = [
             min_samples=10000,
             is_discrete=True),
     Fixture(pyro_dist=dist.Poisson,
+            scipy_dist=sp.poisson,
+            examples=[
+                {'rate': [2.0],
+                 'test_data': [0.]},
+                {'rate': [3.0],
+                 'test_data': [1.]},
+                {'rate': [6.0],
+                 'test_data': [4.]},
+                {'rate': [2.0, 3.0, 6.0],
+                 'test_data': [[0., 1., 4.], [0., 1., 4.]]},
+                {'rate': [[2.0], [3.0], [6.0]],
+                 'test_data': [[0.], [1.], [4.]]}
+            ],
+            scipy_arg_fn=lambda rate: ((np.array(rate),), {}),
+            prec=0.08,
+            is_discrete=True),
+    Fixture(pyro_dist=SparsePoisson,
             scipy_dist=sp.poisson,
             examples=[
                 {'rate': [2.0],


### PR DESCRIPTION
Similar to #1740,  https://github.com/pyro-ppl/numpyro/pull/1003

This adds an `is_sparse` constructor arg to `dist.Poisson` to trigger a cheaper computation if most data is zero.

## Tested
- [x] registered standard unit test