### PR TITLE
Switch to softplus transforms for autoguide scales

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -433,9 +433,7 @@ class AutoNormal(AutoGuide):
         automatically as usual. This is useful for data subsampling.
     """
 
-    # TODO consider switching to constraints.softplus_positive
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_constraint = constraints.positive
+    scale_constraint = constraints.softplus_positive
 
     def __init__(self, model, *,
                  init_loc_fn=init_to_feasible,
@@ -820,9 +818,7 @@ class AutoMultivariateNormal(AutoContinuous):
         (unconstrained transformed) latent variable.
     """
 
-    # TODO consider switching to constraints.softplus_lower_cholesky
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_tril_constraint = constraints.lower_cholesky
+    scale_tril_constraint = constraints.softplus_lower_cholesky
 
     def __init__(self, model, init_loc_fn=init_to_median, init_scale=0.1):
         if not isinstance(init_scale, float) or not (init_scale > 0):
@@ -874,9 +870,7 @@ class AutoDiagonalNormal(AutoContinuous):
         (unconstrained transformed) latent variable.
     """
 
-    # TODO consider switching to constraints.softplus_positive
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_constraint = constraints.positive
+    scale_constraint = constraints.softplus_positive
 
     def __init__(self, model, init_loc_fn=init_to_median, init_scale=0.1):
         if not isinstance(init_scale, float) or not (init_scale > 0):
@@ -933,9 +927,7 @@ class AutoLowRankMultivariateNormal(AutoContinuous):
         deviation of each (unconstrained transformed) latent variable.
     """
 
-    # TODO consider switching to constraints.softplus_positive
-    # See https://github.com/pyro-ppl/numpyro/issues/855
-    scale_constraint = constraints.positive
+    scale_constraint = constraints.softplus_positive
 
     def __init__(self, model, init_loc_fn=init_to_median, init_scale=0.1, rank=None):
         if not isinstance(init_scale, float) or not (init_scale > 0):


### PR DESCRIPTION
@vitkl's experiments in https://github.com/pyro-ppl/sandbox/pull/14 suggest that softplus transforms are more numerically stable for scale parameters in guides, in agreement with anecdotal experience of @martinjankowiak.

This PR changes to use softplus transforms by default in autoguides.