### PR TITLE
Fix infer.csis to ignore gradient when parameter not used, which has a gradient of None

### DIFF
--- a/pyro/infer/csis.py
+++ b/pyro/infer/csis.py
@@ -113,6 +113,8 @@ class CSIS(Importance):
                                    for site in particle_param_capture.trace.nodes.values())
                 guide_grads = torch.autograd.grad(particle_loss, guide_params, allow_unused=True)
                 for guide_grad, guide_param in zip(guide_grads, guide_params):
+                    if guide_grad is None:
+                        continue
                     guide_param.grad = guide_grad if guide_param.grad is None else guide_param.grad + guide_grad
 
             loss += torch_item(particle_loss)


### PR DESCRIPTION
Fixes #2827 

If some parameters are not used to produce the outputs, the gradients can be None. In this case, an error will be raised because of the addition between None and Tensor.
