### PR TITLE
Fix AutoStructured guide

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -1433,6 +1433,7 @@ class AutoStructured(AutoGuide):
             transform = biject_to(site["fn"].support)
             value = transform(unconstrained)
             if compute_density and conditional != "delta":
+                assert transform.codomain.event_dim == site["fn"].event_dim
                 log_density = log_density + transform.inv.log_abs_det_jacobian(
                     value, unconstrained
                 )

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -32,7 +32,7 @@ import pyro.distributions as dist
 import pyro.poutine as poutine
 from pyro.distributions import constraints
 from pyro.distributions.transforms import affine_autoregressive, iterated
-from pyro.distributions.util import broadcast_shape, eye_like, sum_rightmost
+from pyro.distributions.util import eye_like, is_identically_zero, sum_rightmost
 from pyro.infer.autoguide.initialization import (
     InitMessenger,
     init_to_feasible,
@@ -697,8 +697,8 @@ class AutoContinuous(AutoGuide):
             unconstrained_shape = self._unconstrained_shapes[name]
             size = _product(unconstrained_shape)
             event_dim = site["fn"].event_dim + len(unconstrained_shape) - len(constrained_shape)
-            unconstrained_shape = broadcast_shape(unconstrained_shape,
-                                                  batch_shape + (1,) * event_dim)
+            unconstrained_shape = torch.broadcast_shapes(unconstrained_shape,
+                                                         batch_shape + (1,) * event_dim)
             unconstrained_value = latent[..., pos:pos + size].view(unconstrained_shape)
             yield site, unconstrained_value
             pos += size
@@ -1294,7 +1294,8 @@ class AutoStructured(AutoGuide):
         self.scale_trils = PyroModule()
         self.conds = PyroModule()
         self.deps = PyroModule()
-        self._unconstrained_shapes = {}
+        self._batch_shapes = {}
+        self._unconstrained_event_shapes = {}
 
         # Collect unconstrained shapes.
         init_locs = {}
@@ -1302,7 +1303,8 @@ class AutoStructured(AutoGuide):
         for name, site in self.prototype_trace.iter_stochastic_nodes():
             with helpful_support_errors(site):
                 init_loc = biject_to(site["fn"].support).inv(site["value"].detach()).detach()
-            self._unconstrained_shapes[name] = init_loc.shape
+            self._batch_shapes[name] = site["fn"].batch_shape
+            self._unconstrained_event_shapes[name] = init_loc.shape[len(site["fn"].batch_shape):]
             numel[name] = init_loc.numel()
             init_locs[name] = init_loc.reshape(-1)
 
@@ -1384,7 +1386,7 @@ class AutoStructured(AutoGuide):
                 scale = _deep_getattr(self.scales, name)
                 aux_value = aux_value * scale
                 if compute_density:
-                    log_density = log_density - scale.log().sum(-1)
+                    log_density = (-scale.log()).expand_as(aux_value)
             elif conditional == "mvn":
                 # This overparametrizes by learning (scale,scale_tril),
                 # enabling faster learning of the more-global scale parameter.
@@ -1397,10 +1399,8 @@ class AutoStructured(AutoGuide):
                 scale_tril = _deep_getattr(self.scale_trils, name)
                 aux_value = aux_value @ scale_tril.T * scale
                 if compute_density:
-                    log_density = (
-                        log_density - scale.log().sum(-1)
-                        - scale_tril.diagonal(dim1=-2, dim2=-1).log().sum(-1)
-                    )
+                    log_density = (-scale_tril.diagonal(dim1=-2, dim2=-1).log()
+                                   - scale.log()).expand_as(aux_value)
             else:
                 raise ValueError(f"Unsupported conditional type: {conditional}")
 
@@ -1419,20 +1419,25 @@ class AutoStructured(AutoGuide):
                 aux_value = aux_value + dep(aux_values[upstream])
             aux_values[name] = aux_value
 
-            # Shift by loc, reshape, and transform to constrained space.
+            # Shift by loc and reshape.
             unconstrained = aux_value + loc
-            shape = self._unconstrained_shapes[name]
-            if torch._C._get_tracing_state() or unconstrained.shape != shape:
-                sample_shape = unconstrained.shape[:-1]
-                unconstrained = unconstrained.reshape(sample_shape + shape)
+            batch_shape = torch.broadcast_shapes(
+                unconstrained.shape[:-1], self._batch_shapes[name]
+            )
+            shape = batch_shape + self._unconstrained_event_shapes[name]
+            unconstrained = unconstrained.reshape(shape)
+            if not is_identically_zero(log_density):
+                log_density = log_density.reshape(batch_shape + (-1,)).sum(-1)
+
+            # Transform to constrained space.
             transform = biject_to(site["fn"].support)
             value = transform(unconstrained)
-
-            # Create a Delta distribution.
             if compute_density and conditional != "delta":
-                ldj = transform.inv.log_abs_det_jacobian(value, unconstrained)
-                ldj = sum_rightmost(ldj, ldj.dim() - value.dim() + site["fn"].event_dim)
-                log_density = log_density + ldj
+                log_density = log_density + transform.inv.log_abs_det_jacobian(
+                    value, unconstrained
+                )
+
+            # Create a reparametrized Delta distribution.
             deltas[name] = dist.Delta(value, log_density, site["fn"].event_dim)
 
         return deltas

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -162,6 +162,13 @@ def factor(name, log_factor):
     Factor statement to add arbitrary log probability factor to a
     probabilisitic model.
 
+    .. warning:: Beware using factor statements in guides. Factor statements
+        assume ``log_factor`` is computed from non-reparametrized statements
+        such as observation statements ``pyro.sample(..., obs=...)``. If
+        instead ``log_factor`` is computed from e.g. the Jacobian determinant
+        of a transformation of a reparametrized variable, factor statements
+        in the guide will result in incorrect results.
+
     :param str name: Name of the trivial sample
     :param torch.Tensor log_factor: A possibly batched log probability factor.
     """

--- a/tests/infer/reparam/test_structured.py
+++ b/tests/infer/reparam/test_structured.py
@@ -37,7 +37,9 @@ def test_neals_funnel_smoke(jit):
     mcmc = MCMC(nuts, num_samples=50, warmup_steps=50)
     mcmc.run(dim)
     samples = mcmc.get_samples()
-
+    # XXX: `MCMC.get_samples` adds a leftmost batch dim to all sites,
+    # not uniformly at -max_plate_nesting-1; hence the unsqueeze.
+    samples = {k: v.unsqueeze(1) for k, v in samples.items()}
     transformed_samples = rep.transform_samples(samples)
     assert isinstance(transformed_samples, dict)
     assert set(transformed_samples) == {"x", "y"}

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -15,7 +15,14 @@ from torch.distributions import constraints
 import pyro
 import pyro.distributions as dist
 import pyro.poutine as poutine
-from pyro.infer import SVI, Predictive, Trace_ELBO, TraceEnum_ELBO, TraceGraph_ELBO
+from pyro.infer import (
+    SVI,
+    JitTrace_ELBO,
+    Predictive,
+    Trace_ELBO,
+    TraceEnum_ELBO,
+    TraceGraph_ELBO,
+)
 from pyro.infer.autoguide import (
     AutoCallable,
     AutoDelta,
@@ -1010,3 +1017,84 @@ def test_sphere_raw_ok(auto_class, init_loc_fn):
 
     guide = auto_class(model, init_loc_fn=init_loc_fn)
     poutine.trace(guide).get_trace().compute_log_prob()
+
+
+class AutoStructured_exact(AutoStructured):
+    def __init__(self, model):
+        super().__init__(
+            model,
+            conditionals={"loc": "normal"},
+            dependencies={},
+        )
+
+
+@pytest.mark.parametrize("Guide", [
+    AutoNormal,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoStructured_exact,
+])
+def test_exact(Guide):
+
+    def model(data):
+        loc = pyro.sample("loc", dist.Normal(0, 1))
+        with pyro.plate("data", len(data)):
+            pyro.sample("obs", dist.Normal(loc, 1), obs=data)
+        return loc
+
+    data = torch.randn(3)
+    expected_mean = (0 + data.sum().item()) / (1 + len(data))
+    expected_std = (1 + len(data)) ** (-0.5)
+
+    guide = Guide(model)
+    elbo = Trace_ELBO(num_particles=100, vectorize_particles=True)
+    optim = Adam({"lr": 0.01})
+    svi = SVI(model, guide, optim, elbo)
+    for step in range(500):
+        loss = svi.step(data)
+
+    guide.requires_grad_(False)
+    with torch.no_grad():
+        vectorize = pyro.plate("particles", 10000, dim=-2)
+        guide_trace = poutine.trace(vectorize(guide)).get_trace(data)
+        samples = poutine.replay(vectorize(model), guide_trace)(data)
+        actual_mean = samples.mean().item()
+        actual_std = samples.std().item()
+        assert_close(actual_mean, expected_mean, atol=0.05)
+        assert_close(actual_std, expected_std, rtol=0.05)
+
+
+@pytest.mark.parametrize("Guide", [
+    AutoNormal,
+    AutoDiagonalNormal,
+    AutoMultivariateNormal,
+    AutoStructured_exact,
+])
+def test_exact_batch(Guide):
+
+    def model(data):
+        with pyro.plate("data", len(data)):
+            loc = pyro.sample("loc", dist.Normal(0, 1))
+            pyro.sample("obs", dist.Normal(loc, 1), obs=data)
+        return loc
+
+    data = torch.randn(3)
+    expected_mean = (0 + data) / (1 + 1)
+    expected_std = (1 + torch.ones_like(data)) ** (-0.5)
+
+    guide = Guide(model)
+    elbo = Trace_ELBO(num_particles=100, vectorize_particles=True)
+    optim = Adam({"lr": 0.01})
+    svi = SVI(model, guide, optim, elbo)
+    for step in range(500):
+        loss = svi.step(data)
+
+    guide.requires_grad_(False)
+    with torch.no_grad():
+        vectorize = pyro.plate("particles", 10000, dim=-2)
+        guide_trace = poutine.trace(vectorize(guide)).get_trace(data)
+        samples = poutine.replay(vectorize(model), guide_trace)(data)
+        actual_mean = samples.mean(0)
+        actual_std = samples.std(0)
+        assert_close(actual_mean, expected_mean, atol=0.05)
+        assert_close(actual_std, expected_std, rtol=0.05)


### PR DESCRIPTION
Addresses #2813 
Fixes the bug discussed in https://github.com/pyro-ppl/pyro/pull/2812#discussion_r622243256

This fixes a shape bug in `AutoStructured` that resulted in an extra factor of `batch_shape.numel()` being multiplied to the `scale` and `scale_tril` transformation `log_abs_det_jacobian`s, which then resulted in incorrect inference.

Note I've avoided using `pyro.factor` because it results in also-incorrect inference due to an implementation subtlety: `dist.Unit` is not reparametrized.  As discussed with @martinjankowiak, `pyro.factor` is dangerous when used in guides, so I've added a warning.

## Tested
- [x] regression tests for scalar models and `normal` and `mvn` guides
- [x] regression tests for batched models `normal` and `mvn` guides
- [x] strengthened shape tests
- [x] verified accuracy on a real-world model