### PR TITLE
`TraceMarkovEnum_ELBO` with `dynamic_parial_sum_product` to support history > 1

### DIFF
--- a/pyro/contrib/funsor/infer/traceenum_elbo.py
+++ b/pyro/contrib/funsor/infer/traceenum_elbo.py
@@ -95,7 +95,7 @@ class TraceMarkovEnum_ELBO(ELBO):
             # incorporate the effects of subsampling and handlers.scale through a common scale factor
             markov_dims = frozenset({
                     plate for plate, step in model_terms["plate_to_step"].items() if step})
-            contracted_costs = [model_terms["scale"] * f for f in funsor.sum_product.modified_partial_sum_product(
+            contracted_costs = [model_terms["scale"] * f for f in funsor.sum_product.dynamic_partial_sum_product(
                 funsor.ops.logaddexp, funsor.ops.add,
                 model_terms["log_measures"] + contracted_factors,
                 plate_to_step=model_terms["plate_to_step"],

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         'horovod': ['horovod[pytorch]>=0.19'],
         'funsor': [
             # This must be a released version when Pyro is released.
-            'funsor[torch] @ git+git://github.com/pyro-ppl/funsor.git@d5574988665dd822ec64e41f2b54b9dc929959dc',
+            'funsor[torch] @ git+git://github.com/pyro-ppl/funsor.git@7be0ef9af6a100e52ac98ab13b203a4dec0ae42e',
         ],
     },
     python_requires='>=3.6',

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -507,8 +507,6 @@ def test_model_enumerated_elbo(model, guide, data, history):
     pyro.clear_param_store()
 
     with pyro_backend("contrib.funsor"):
-        #  if history > 1:
-        #      pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
 
         model = infer.config_enumerate(model, default="parallel")
         elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)

--- a/tests/contrib/funsor/test_vectorized_markov.py
+++ b/tests/contrib/funsor/test_vectorized_markov.py
@@ -507,8 +507,8 @@ def test_model_enumerated_elbo(model, guide, data, history):
     pyro.clear_param_store()
 
     with pyro_backend("contrib.funsor"):
-        if history > 1:
-            pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
+        #  if history > 1:
+        #      pytest.xfail(reason="TraceMarkovEnum_ELBO does not yet support history > 1")
 
         model = infer.config_enumerate(model, default="parallel")
         elbo = infer.TraceEnum_ELBO(max_plate_nesting=4)


### PR DESCRIPTION
This replaces `modified_partial_sum_product` in `TraceMarkovEnum_ELBO` with `dynamic_partial_sum_product` to support higher-order Markov models. Tested on `model_5` in `test_vectorized_markov`.