### PR TITLE
Remove overly-narrow validation check from AutoStructured

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -1273,11 +1273,6 @@ class AutoStructured(AutoGuide):
                 assert upstream in conditionals
                 assert upstream != downstream
                 assert isinstance(dep, str) or callable(dep)
-                if conditionals[upstream] == "delta":
-                    raise ValueError(
-                        f"Site {repr(downstream)} cannot depend on "
-                        f"upstream point-estimated site {repr(upstream)}"
-                    )
         self.conditionals = conditionals
         self.dependencies = dependencies
 

--- a/pyro/infer/reparam/structured.py
+++ b/pyro/infer/reparam/structured.py
@@ -59,7 +59,7 @@ class StructuredReparam(Reparam):
 
     def __call__(self, name, fn, obs):
         assert obs is None, "StructuredReparam does not support observe statements"
-        if not self.deltas:  # On first sample site.
+        if name not in self.deltas:  # On first sample site.
             self.deltas = self.guide.get_deltas()
         new_fn = self.deltas.pop(name)
         value = new_fn.v


### PR DESCRIPTION
This PR allows a delta to depend on an upstream delta, which is reasonable if both deltas depend on other upstream latent variables.