### PR TITLE
Fix pyro.poutine.do to avoid duplicate entries in cond_indep_stack

### DIFF
--- a/pyro/poutine/do_messenger.py
+++ b/pyro/poutine/do_messenger.py
@@ -66,6 +66,7 @@ class DoMessenger(Messenger):
 
             # split node, avoid reapplying self recursively to new node
             new_msg = msg.copy()
+            new_msg["cond_indep_stack"] = ()  # avoid entering plates twice
             apply_stack(new_msg)
 
             # apply intervention


### PR DESCRIPTION
Resolves #2845 

This PR adds a one-line fix to `DoMessenger` to empty the `cond_indep_stack` of a duplicated sample site before the handler stack is reapplied. Without this fix, plates may appear twice in the new site's `cond_indep_stack`, which is incorrect in general and specifically breaks autoguide setup.

Tested:
- added a regression test adapted from @h1psta's example in #2845 that would have caught this