### PR TITLE
Implement pyro.ops.streaming module

### DIFF
--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -93,6 +93,14 @@ Statistical Utilities
     :show-inheritance:
     :member-order: bysource
 
+Streaming Statistics
+--------------------
+
+.. automodule:: pyro.ops.streaming
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :member-order: bysource
  
 State Space Model and GP Utilities
 ----------------------------------

--- a/pyro/ops/streaming.py
+++ b/pyro/ops/streaming.py
@@ -148,6 +148,7 @@ class CountMeanVarianceStats(StreamingStats):
     def __init__(self):
         self.shape = None
         self.welford = WelfordCovariance(diagonal=True)
+        super().__init__()
 
     def update(self, sample: torch.Tensor):
         assert isinstance(sample, torch.Tensor)

--- a/pyro/ops/streaming.py
+++ b/pyro/ops/streaming.py
@@ -4,7 +4,7 @@
 import copy
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Dict, Hashable, Type, Union
+from typing import Any, Callable, Dict, Hashable, Union
 
 import torch
 
@@ -116,8 +116,8 @@ class StatsOfDict(StreamingStats):
 
     def __init__(
         self,
-        types: Dict[Hashable, Type[StreamingStats]] = {},
-        default: Type[StreamingStats] = CountStats,
+        types: Dict[Hashable, Callable[[], StreamingStats]] = {},
+        default: Callable[[], StreamingStats] = CountStats,
     ):
         self.stats: Dict[Hashable, StreamingStats] = defaultdict(default)
         self.stats.update({k: v() for k, v in types.items()})

--- a/pyro/ops/streaming.py
+++ b/pyro/ops/streaming.py
@@ -62,9 +62,9 @@ class CountStats(StreamingStats):
     For example::
 
         >>> stats = CountStats()
-        >>> stats.update(torch.tensor(3, 3))
+        >>> stats.update(torch.randn(3, 3))
         >>> stats.get()
-        {"count": 1}
+        {'count': 1}
     """
 
     def __init__(self):
@@ -95,16 +95,18 @@ class StatsOfDict(StreamingStats):
     For example the following are equivalent::
 
         # Version 1. Hand encode statistics.
-        a_stats = CountStats()
-        b_stats = CountMeanStats()
-        a_stats.update(torch.tensor(0.))
-        b_stats.update(torch.tensor([1., 2.]))
-        summary = {"a": a_stats.get(), "b": b_stats.get()}
+        >>> a_stats = CountStats()
+        >>> b_stats = CountMeanStats()
+        >>> a_stats.update(torch.tensor(0.))
+        >>> b_stats.update(torch.tensor([1., 2.]))
+        >>> summary = {"a": a_stats.get(), "b": b_stats.get()}
 
         # Version 2. Collect samples into dictionaries.
-        stats = StatsOfDict({"a": CountStats, "b": CountMeanStats})
-        stats.update({"a": torch.tensor(0.), "b": torch.tensor([1., 2.])})
-        summary = stats.get()
+        >>> stats = StatsOfDict({"a": CountStats, "b": CountMeanStats})
+        >>> stats.update({"a": torch.tensor(0.), "b": torch.tensor([1., 2.])})
+        >>> summary = stats.get()
+        >>> summary
+        {'a': {'count': 1}, 'b': {'count': 1, 'mean': tensor([1., 2.])}}
 
     :param default: Default type of statistics of values of the dictionary.
         Defaults to the inexpensive :class:`CountStats`.

--- a/pyro/ops/streaming.py
+++ b/pyro/ops/streaming.py
@@ -4,7 +4,7 @@
 import copy
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Hashable, Type, Union
 
 import torch
 
@@ -48,9 +48,9 @@ class StreamingStats(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get(self) -> Dict[str, Any]:
+    def get(self) -> Any:
         """
-        Return the aggregate statistic, which should be a dictionary.
+        Return the aggregate statistic.
         """
         raise NotImplementedError
 
@@ -116,14 +116,14 @@ class StatsOfDict(StreamingStats):
 
     def __init__(
         self,
-        types: Dict[str, Type[StreamingStats]] = {},
+        types: Dict[Hashable, Type[StreamingStats]] = {},
         default: Type[StreamingStats] = CountStats,
     ):
-        self.stats: Dict[str, StreamingStats] = defaultdict(default)
-        self.stats.update(**{k: v() for k, v in types.items()})
+        self.stats: Dict[Hashable, StreamingStats] = defaultdict(default)
+        self.stats.update({k: v() for k, v in types.items()})
         super().__init__()
 
-    def update(self, sample: Dict[str, Any]) -> None:
+    def update(self, sample: Dict[Hashable, Any]) -> None:
         for k, v in sample.items():
             self.stats[k].update(v)
 
@@ -137,7 +137,7 @@ class StatsOfDict(StreamingStats):
                 result.stats[k] = self.stats[k].merge(other.stats[k])
         return result
 
-    def get(self) -> Dict[str, Any]:
+    def get(self) -> Dict[Hashable, Any]:
         """
         :returns: A dictionary of statistics. The keys of this dictionary are
             the same as the keys of the samples from which this object is

--- a/pyro/ops/streaming.py
+++ b/pyro/ops/streaming.py
@@ -1,0 +1,235 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Dict, Union
+
+import torch
+
+from pyro.ops.welford import WelfordCovariance
+
+
+class StreamingStats(ABC):
+    """
+    Base class for streamable statistics of dictionaries of tensors.
+
+    Derived classes must implelement :meth:`update`, :meth:`merge`, and
+    :meth:`get`.
+    """
+
+    @abstractmethod
+    def update(self, sample: Dict[str, torch.Tensor]) -> None:
+        """
+        Update state from a single sample.
+
+        This mutates ``self`` and returns nothing. Updates should be
+        independent of order, i.e. samples should be exchangeable.
+
+        :param dict sample: A sample dictionary mapping sample name to sample
+            value (a :class:`torch.Tensor`).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def merge(self, other: "StreamingStats") -> "StreamingStats":
+        """
+        Select two aggregate statistics, e.g. from different MCMC chains.
+
+        This is a pure function: it returns a new :class:`StreamingStats`
+        object and does not modify either ``self`` or ``other``.
+
+        :param other: Another streaming stats instance of the same type.
+        """
+        assert isinstance(other, type(self))
+        raise NotImplementedError
+
+    @abstractmethod
+    def get(self) -> Dict[str, object]:
+        """
+        Return the aggregate statistic. This is typically a tensor or
+        collection of tensors, but can be any Python object.
+        """
+        raise NotImplementedError
+
+
+class SelectStats(StreamingStats):
+    """
+    Collection to select different statistics for each sample name.
+
+    This is useful for computing statistics for only a subset of sample names,
+    or computing different statistics for different samples (e.g. expensive
+    statistics for small tensors and cheap statistis for large tensors).
+
+    :param stats: A dictionary mapping sample name to :class:`StreamingStats`
+        instance corresponding to that name. Note instances can be reused by
+        multiple keys.
+    """
+    def __init__(self, stats: Dict[object, StreamingStats]):
+        self.stats = stats
+
+    def update(self, sample: Dict[str, torch.Tensor]) -> None:
+        assert isinstance(sample, dict)
+        for k, stat in self.stats.items():
+            stat.update({k: sample[k]})
+
+    def merge(self, other: "SelectStats") -> "SelectStats":
+        assert isinstance(other, type(self))
+        assert set(self.stats) == set(other.stats)
+        merged: Dict[int, SelectStats] = {}
+        result: Dict[str, SelectStats] = {}
+        for key, lhs in self.stats.items():
+            rhs = other.stats[key]
+            ids = id(lhs), id(rhs)
+            if ids in merged:
+                stat = merged[ids]
+            else:
+                merged[ids] = stat = lhs.merge(rhs)
+            result[key] = stat
+        return type(self)(result)
+
+    def get(self) -> Dict[str, object]:
+        result = {}
+        for k, v in self.stats.items():
+            result.update(v.get())
+        return result
+
+
+class DictStats(StreamingStats):
+    """
+    Collection of multiple streaming statistics into a dictionary.
+
+    This is useful for computing multiple statistics for each sample.
+
+    :param stats: A dictionary mapping statistic name to
+        :class:`StreamingStats` instance corresponding to that name.
+    """
+
+    def __init__(self, stats: Dict[str, StreamingStats]):
+        self.stats = stats
+
+    def update(self, sample: Dict[str, torch.Tensor]) -> None:
+        assert isinstance(sample, dict)
+        for stat in self.stats.values():
+            stat.update(sample)
+
+    def merge(self, other: "DictStats") -> "DictStats":
+        assert isinstance(other, type(self))
+        assert set(other.stats) == set(self.stats)
+        stats = {
+            name: stat.merge(other.stats[name])
+            for name, stat in self.stats.items()
+        }
+        return type(self)(stats)
+
+    def get(self) -> Dict[str, Dict[str, object]]:
+        result = defaultdict(dict)
+        for name, stat in self.stats.items():
+            for k, v in stat.get().items():
+                result[k][name] = v
+        return dict(result)
+
+
+class CountMeanStats(StreamingStats):
+    """
+    Statistic tracking the count and mean of all sample tensors.
+    """
+
+    def __init__(self):
+        self.count = defaultdict(int)
+        self.mean = {}
+
+    def update(self, sample: Dict[str, torch.Tensor]):
+        assert isinstance(sample, dict)
+        for k, v in sample.items():
+            self.count[k] += 1
+            if self.count[k] == 1:
+                self.mean[k] = v.detach().clone()
+            else:
+                self.mean[k] += (v.detach() - self.mean[k]) / self.count[k]
+
+    def merge(self, other: "CountMeanStats") -> "CountMeanStats":
+        assert isinstance(other, type(self))
+        keys = set(self.count).union(other.count)
+        result = CountMeanStats()
+        for k in keys:
+            if self.count.get(k, 0) == 0:
+                result.count[k] = other.count[k]
+                result.mean[k] = other.mean[k].clone()
+            elif other.count.get(k, 0) == 0:
+                result.count[k] = self.count[k]
+                result.mean[k] = self.mean[k].clone()
+            else:
+                result.count[k] = self.count[k] + other.count[k]
+                result.mean[k] = (self.mean[k] * (self.count[k] / result.count[k])
+                                  + other.mean[k] * (other.count[k] / result.count[k]))
+        return result
+
+    def get(self) -> Dict[str, Dict[str, Union[int, torch.Tensor]]]:
+        return {k: {"count": self.count, "mean": v} for k, v in self.mean.items()}
+
+
+class CountMeanVarianceStats(StreamingStats):
+    """
+    Statistic tracking the count, mean, and (diagonal) variance of all sample
+    tensors.
+
+    Note the count is shared across all samples.
+    """
+    def __init__(self):
+        self.shape = {}
+        self.welford = {}
+
+    def update(self, sample: Dict[str, torch.Tensor]):
+        assert isinstance(sample, dict)
+        for k, v in sample.items():
+            if k not in self.shape:
+                self.shape[k] = v.shape
+                self.welford[k] = WelfordCovariance(diagonal=True)
+            assert v.shape == self.shape[k]
+            self.welford[k].update(v.detach().reshape(-1))
+
+    def merge(self, other: "CountMeanVarianceStats") -> "CountMeanVarianceStats":
+        assert isinstance(other, type(self))
+        keys = set(self.shape).union(other.shape)
+        result = copy.deepcopy(self)
+        for key in keys:
+            if key not in self.shape:
+                result.shape[key] = other.shape[key]
+                result.welford[key] = copy.deepcopy(other.welford[key])
+            elif key in other.shape:
+                assert other.shape[key] == self.shape[key]
+                lhs = self.welford[key]
+                rhs = other.welford[key]
+                res = result.welford[key]
+                res.n_samples = lhs.n_samples + rhs.n_samples
+                lhs_weight = lhs.n_samples / res.n_samples
+                rhs_weight = rhs.n_samples / res.n_samples
+                res._mean = lhs_weight * lhs._mean + rhs_weight * rhs._mean
+                res._m2 = (
+                    lhs._m2 + rhs._m2
+                    + (lhs.n_samples * rhs.n_samples / res.n_samples)
+                    * (lhs._mean - rhs._mean) ** 2
+                )
+        return result
+
+    def get(self) -> Dict[str, Dict[str, Union[int, torch.Tensor]]]:
+        result = {}
+        for k, welford in self.welford.items():
+            shape = self.shape[k]
+            result[k] = {
+                "count": welford.n_samples,
+                "mean": welford._mean.reshape(shape),
+                "variance": welford.get_covariance(regularize=False).reshape(shape),
+            }
+        return result
+
+
+__all__ = [
+    "StreamingStats",
+    "SelectStats",
+    "DictStats",
+    "CountMeanStats",
+    "CountMeanVarianceStats",
+]

--- a/pyro/ops/streaming.py
+++ b/pyro/ops/streaming.py
@@ -71,10 +71,10 @@ class CountStats(StreamingStats):
         self.count = 0
         super().__init__()
 
-    def update(self, sample):
+    def update(self, sample) -> None:
         self.count += 1
 
-    def merge(self, other: "CountStats"):
+    def merge(self, other: "CountStats") -> "CountStats":
         assert isinstance(other, type(self))
         result = CountStats()
         result.count = self.count + other.count
@@ -123,11 +123,11 @@ class StatsOfDict(StreamingStats):
         self.stats.update(**{k: v() for k, v in types.items()})
         super().__init__()
 
-    def update(self, sample: dict):
+    def update(self, sample: Dict[str, Any]) -> None:
         for k, v in sample.items():
             self.stats[k].update(v)
 
-    def merge(self, other):
+    def merge(self, other: "StatsOfDict") -> "StatsOfDict":
         assert isinstance(other, type(self))
         result = copy.deepcopy(self)
         for k in set(self.stats).union(other.stats):
@@ -155,7 +155,7 @@ class StackStats(StreamingStats):
     def __init__(self):
         self.samples = []
 
-    def update(self, sample: torch.Tensor):
+    def update(self, sample: torch.Tensor) -> None:
         assert isinstance(sample, torch.Tensor)
         self.samples.append(sample)
 
@@ -186,7 +186,7 @@ class CountMeanStats(StreamingStats):
         self.mean = 0
         super().__init__()
 
-    def update(self, sample: torch.Tensor):
+    def update(self, sample: torch.Tensor) -> None:
         assert isinstance(sample, torch.Tensor)
         self.count += 1
         self.mean += (sample.detach() - self.mean) / self.count
@@ -222,7 +222,7 @@ class CountMeanVarianceStats(StreamingStats):
         self.welford = WelfordCovariance(diagonal=True)
         super().__init__()
 
-    def update(self, sample: torch.Tensor):
+    def update(self, sample: torch.Tensor) -> None:
         assert isinstance(sample, torch.Tensor)
         if self.shape is None:
             self.shape = sample.shape

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,43 +35,45 @@ column_limit = 120
 python_version = 3.6
 warn_return_any = True
 warn_unused_configs = True
+warn_incomplete_stub = True
 
 # Per-module options:
 
 [mypy-pyro._version.*]
 ignore_errors = True
-warn_incomplete_stub = True
 
 [mypy-pyro.contrib.*]
 ignore_errors = True
-warn_incomplete_stub = True
 
 [mypy-pyro.distributions.*]
 ignore_errors = True
-warn_incomplete_stub = True
 warn_unused_ignores = True
 
 [mypy-pyro.generic.*]
 ignore_errors = True
-warn_incomplete_stub = True
 warn_unused_ignores = True
 
 [mypy-pyro.infer.*]
 ignore_errors = True
-warn_incomplete_stub = True
 warn_unused_ignores = True
 
 [mypy-pyro.nn.*]
 ignore_errors = True
-warn_incomplete_stub = True
 warn_unused_ignores = True
 
-[mypy-pyro.ops.*]
+[mypy-pyro.ops.einsum]
+ignore_errors = True
+warn_unused_ignores = True
+
+[mypy-pyro.ops.contract]
+ignore_errors = True
+warn_unused_ignores = True
+
+[mypy-pyro.ops.tensor_utils]
 ignore_errors = True
 warn_unused_ignores = True
 
 [mypy-pyro.optm.*]
-warn_incomplete_stub = True
 warn_unused_ignores = True
 
 [mypy-pyro.params.*]
@@ -83,5 +85,4 @@ ignore_errors = True
 
 [mypy-pyro.util.*]
 ignore_errors = True
-warn_incomplete_stub = True
 warn_unused_ignores = True

--- a/tests/common.py
+++ b/tests/common.py
@@ -225,7 +225,7 @@ def assert_close(actual, expected, atol=1e-7, rtol=0, msg=''):
         assert set(actual.keys()) == set(expected.keys())
         for key, x_val in actual.items():
             assert_close(x_val, expected[key], atol=atol, rtol=rtol,
-                         msg='At key{}: {} vs {}'.format(key, x_val, expected[key]))
+                         msg='At key {}: {} vs {}'.format(repr(key), x_val, expected[key]))
     elif isinstance(actual, str):
         assert actual == expected, msg
     elif is_iterable(actual) and is_iterable(expected):

--- a/tests/ops/test_streaming.py
+++ b/tests/ops/test_streaming.py
@@ -1,14 +1,16 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
+
 import pytest
 import torch
 
 from pyro.ops.streaming import (
     CountMeanStats,
     CountMeanVarianceStats,
-    DictStats,
-    SelectStats,
+    CountStats,
+    StatsOfDict,
 )
 from tests.common import assert_close
 
@@ -22,12 +24,21 @@ def generate_data(num_samples):
 
 
 EXAMPLE_STATS = [
-    lambda: CountMeanStats(),
-    lambda: CountMeanVarianceStats(),
-    lambda: SelectStats({"aaa": CountMeanVarianceStats(), "bbb": CountMeanStats()}),
-    lambda: DictStats({"cm": CountMeanStats(), "cmv": CountMeanVarianceStats()}),
+    CountStats,
+    functools.partial(StatsOfDict, default=CountMeanStats),
+    functools.partial(StatsOfDict, default=CountMeanVarianceStats),
+    StatsOfDict,
+    functools.partial(
+        StatsOfDict, {"aaa": CountMeanStats, "bbb": CountMeanVarianceStats}
+    ),
 ]
-EXAMPLE_STATS_IDS = [type(x()).__name__ for x in EXAMPLE_STATS]
+EXAMPLE_STATS_IDS = [
+    "CountStats",
+    "CountMeanStats",
+    "CountMeanVarianceStats",
+    "StatsOfDict1",
+    "StatsOfDict2",
+]
 
 
 @pytest.mark.parametrize("size", [0, 10])

--- a/tests/ops/test_streaming.py
+++ b/tests/ops/test_streaming.py
@@ -1,0 +1,72 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pyro.ops.streaming import (
+    CountMeanStats,
+    CountMeanVarianceStats,
+    DictStats,
+    SelectStats,
+)
+from tests.common import assert_close
+
+
+def generate_data(num_samples):
+    shapes = {"aaa": (), "bbb": (4,), "ccc": (3, 2), "ddd": (5, 1)}
+    return [
+        {k: torch.randn(v) for k, v in shapes.items()}
+        for _ in range(num_samples)
+    ]
+
+
+EXAMPLE_STATS = [
+    lambda: CountMeanStats(),
+    lambda: CountMeanVarianceStats(),
+    lambda: SelectStats({"aaa": CountMeanVarianceStats(), "bbb": CountMeanStats()}),
+    lambda: DictStats({"cm": CountMeanStats(), "cmv": CountMeanVarianceStats()}),
+]
+EXAMPLE_STATS_IDS = [type(x()).__name__ for x in EXAMPLE_STATS]
+
+
+@pytest.mark.parametrize("size", [0, 10])
+@pytest.mark.parametrize("make_stats", EXAMPLE_STATS, ids=EXAMPLE_STATS_IDS)
+def test_update_get(make_stats, size):
+    samples = generate_data(size)
+
+    expected_stats = make_stats()
+    for sample in samples:
+        expected_stats.update(sample)
+    expected = expected_stats.get()
+
+    actual_stats = make_stats()
+    for i in torch.randperm(len(samples)).tolist():
+        actual_stats.update(samples[i])
+    actual = actual_stats.get()
+
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("left_size, right_size", [(3, 5), (0, 8), (8, 0), (0, 0)])
+@pytest.mark.parametrize("make_stats", EXAMPLE_STATS, ids=EXAMPLE_STATS_IDS)
+def test_update_merge_get(make_stats, left_size, right_size):
+    left_samples = generate_data(left_size)
+    right_samples = generate_data(right_size)
+
+    expected_stats = make_stats()
+    for sample in left_samples + right_samples:
+        expected_stats.update(sample)
+    expected = expected_stats.get()
+
+    left_stats = make_stats()
+    for sample in left_samples:
+        left_stats.update(sample)
+    right_stats = make_stats()
+    for sample in right_samples:
+        right_stats.update(sample)
+    actual_stats = left_stats.merge(right_stats)
+    assert isinstance(actual_stats, type(expected_stats))
+
+    actual = actual_stats.get()
+    assert_close(actual, expected)


### PR DESCRIPTION
Addresses #2843 

This implements a new module `pyro.ops.streaming` to streamingly track various statistics.  The first intended use case is the planned `StreamingMCMC` class which will track statistics rather than store samples.  There are other potential uses in high-dimensional inference, e.g. recording statistics of gradients during SVI and computing sample moments from predictive when the samples don't fit in memory.

## Design choices

The two basic operations are `.update()` and `.get()`. The third operation `.merge()` will be useful for multiple-chain MCMC and computing things like rhat.

I have restricted to the data type to dictionaries of tensors, which is the basic datatype in pyro.infer.mcmc and in much of NumPyro. We could easily generalize this to pytrees by adding classes `StatsOfList` and `StatsOfTuple`.

## Tested

- [x] tested commutativity of update-get
- [x] tested commutativity and associativity of update-merge-get
- [x] ran mypy locally