### PR TITLE
Fix LocScaleReparam(centered=1.0)

### DIFF
--- a/pyro/infer/reparam/loc_scale.py
+++ b/pyro/infer/reparam/loc_scale.py
@@ -49,7 +49,7 @@ class LocScaleReparam(Reparam):
         assert obs is None, "LocScaleReparam does not support observe statements"
         centered = self.centered
         if is_identically_one(centered):
-            return name, fn, obs
+            return fn, obs
         event_shape = fn.event_shape
         fn, event_dim = self._unwrap(fn)
 

--- a/tests/infer/reparam/test_loc_scale.py
+++ b/tests/infer/reparam/test_loc_scale.py
@@ -46,9 +46,9 @@ def test_normal(dist_type, centered, shape):
     expected_probe = get_moments(value)
 
     if "dist_type" == "Normal":
-        reparam = LocScaleReparam()
+        reparam = LocScaleReparam(centered)
     else:
-        reparam = LocScaleReparam(shape_params=["df"])
+        reparam = LocScaleReparam(centered, shape_params=["df"])
     reparam_model = poutine.reparam(model, {"x": reparam})
     value = poutine.trace(reparam_model).get_trace().nodes["x"]["value"]
     actual_probe = get_moments(value)


### PR DESCRIPTION
This fixes the special case of `LocScaleReparam(centered)` when `centered = 1.0`, which is intended to allow easy disabling of the reparametrizer.  Although we had a test that intended to cover this case, the test also had an error and missed this case.

## Tested
- [x] fixed the existing test, and verified the fixed test caught the bug