### PR TITLE
Implement a SkewLogistic distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -337,6 +337,13 @@ SineSkewed
     :undoc-members:
     :show-inheritance:
 
+SkewLogistic
+------------
+.. autoclass:: pyro.distributions.SkewLogistic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 SoftAsymmetricLaplace
 ---------------------
 .. autoclass:: pyro.distributions.SoftAsymmetricLaplace

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -49,6 +49,7 @@ from pyro.distributions.hmm import (
 from pyro.distributions.improper_uniform import ImproperUniform
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.lkj import LKJ, LKJCorrCholesky
+from pyro.distributions.logistic import SkewLogistic
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.multivariate_studentt import MultivariateStudentT
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
@@ -137,6 +138,7 @@ __all__ = [
     "RelaxedOneHotCategoricalStraightThrough",
     "SineBivariateVonMises",
     "SineSkewed",
+    "SkewLogistic",
     "SoftLaplace",
     "SoftAsymmetricLaplace",
     "SpanningTree",

--- a/pyro/distributions/logistic.py
+++ b/pyro/distributions/logistic.py
@@ -1,0 +1,82 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch.distributions import constraints
+from torch.distributions.utils import broadcast_all
+from torch.nn.functional import logsigmoid
+
+from .torch_distribution import TorchDistribution
+
+
+class SkewLogistic(TorchDistribution):
+    r"""
+    Skewed generalization of the Logistic distribution (Type I in [1]).
+
+    This is a smooth distribution with asymptotically exponential tails and a
+    concave log density. For standard ``loc=0``, ``scale=1``, ``asymmetry=α``
+    the density is given by
+
+    .. math::
+
+        p(x;\alpha) = \frac {\alpha e^{-x}} {(1 + e^{-x})^{\alpha+1}}
+
+    Like the :class:`~pyro.distributions.AsymmetricLaplace` density, this
+    density has the heaviest possible tails (asymptotically) while still being
+    log-convex. Unlike the :class:`~pyro.distributions.AsymmetricLaplace`
+    distribution, this distribution is infinitely differentiable everywhere,
+    and is thus suitable for constructing Laplace approximations.
+
+    **References**
+
+    [1] Generalized logistic distribution
+        https://en.wikipedia.org/wiki/Generalized_logistic_distribution
+
+    :param loc: Location parameter.
+    :param scale: Scale parameter.
+    :param asymmetry: Asymmetry parameter (positive). The distribution skews
+        right when ``asymmetry > 1`` and left when ``asymmetry < 1``. Defaults
+        to ``asymmetry = 1`` corresponding to the standard Logistic
+        distribution.
+    """
+
+    arg_constraints = {"loc": constraints.real, "scale": constraints.positive,
+                       "asymmetry": constraints.positive}
+    support = constraints.real
+    has_rsample = True
+
+    def __init__(self, loc, scale, asymmetry=1., *, validate_args=None):
+        self.loc, self.scale, self.asymmetry = broadcast_all(loc, scale, asymmetry)
+        super().__init__(self.loc.shape, validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(SkewLogistic, _instance)
+        batch_shape = torch.Size(batch_shape)
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        new.asymmetry = self.asymmetry.expand(batch_shape)
+        super(SkewLogistic, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        z = (value - self.loc) / self.scale
+        a = self.asymmetry
+        return a.log() - z + logsigmoid(z) * (a + 1) - self.scale.log()
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = self._extended_shape(sample_shape)
+        u = self.loc.new_empty(shape).uniform_()
+        return self.icdf(u)
+
+    def cdf(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        z = (value - self.loc) / self.scale
+        return z.sigmoid().pow(self.asymmetry)
+
+    def icdf(self, value):
+        z = value.pow(self.asymmetry.reciprocal()).logit()
+        return self.loc + self.scale * z

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -386,6 +386,13 @@ continuous_dists = [
                 {'loc': [2.0, -50.0], 'scale': [2.0, 10.0], 'asymmetry': [0.5, 2.5],
                  'softness': [0.7, 1.4], 'test_data': [[2.0, 10.0], [-1.0, -50.0]]},
             ]),
+    Fixture(pyro_dist=dist.SkewLogistic,
+            examples=[
+                {'loc': [1.0], 'scale': [1.0], 'asymmetry': [2.0],
+                 'test_data': [2.0]},
+                {'loc': [2.0, -50.0], 'scale': [2.0, 10.0], 'asymmetry': [0.5, 2.5],
+                 'test_data': [[2.0, 10.0], [-1.0, -50.0]]},
+            ]),
 ]
 
 discrete_dists = [


### PR DESCRIPTION
Addresses #2868 

This is another smooth asymmetric distribution with asymptotically exponential tails addressing #2868 but hopefully more numerically stable than `SoftAsymmetricLaplace` #2872 which is waiting on `torch.special.logerfc()` https://github.com/pytorch/pytorch/issues/31945.

![image](https://user-images.githubusercontent.com/648532/122245797-45156600-ce83-11eb-8653-75920df28f16.png)
![image](https://user-images.githubusercontent.com/648532/122261520-b825d900-ce91-11eb-827a-96dcb420ad0d.png)

## Tested
- [x] added to conftest (thank goodness for gof tests!)
- [x] confirmed numerical stability in a large real-world model