### PR TITLE
Implementation of rhat for StreamingMCMC

### DIFF
--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -219,25 +219,35 @@ def test_null_model_with_hook(run_mcmc_cls, kernel, model, jit, num_chains):
         assert iters == expected
 
 
+@pytest.mark.parametrize("run_mcmc_cls", [
+    run_default_mcmc,
+    run_streaming_mcmc
+])
 @pytest.mark.parametrize("num_chains", [
     1,
     2
 ])
 @pytest.mark.filterwarnings("ignore:num_chains")
-def test_mcmc_diagnostics(num_chains):
+def test_mcmc_diagnostics(run_mcmc_cls, num_chains):
     data = torch.tensor([2.0]).repeat(3)
     initial_params, _, transforms, _ = initialize_model(normal_normal_model,
                                                         model_args=(data,),
                                                         num_chains=num_chains)
     kernel = PriorKernel(normal_normal_model)
-    mcmc = MCMC(kernel, num_samples=10, warmup_steps=10, num_chains=num_chains, mp_context="spawn",
-                initial_params=initial_params, transforms=transforms)
+    if run_mcmc_cls == run_default_mcmc:
+        mcmc = MCMC(kernel, num_samples=10, warmup_steps=10, num_chains=num_chains, mp_context="spawn",
+                    initial_params=initial_params, transforms=transforms)
+    else:
+        mcmc = StreamingMCMC(kernel, num_samples=10, warmup_steps=10, num_chains=num_chains,
+                             initial_params=initial_params, transforms=transforms)
     mcmc.run(data)
     if not torch.backends.mkl.is_available():
         pytest.skip()
     diagnostics = mcmc.diagnostics()
-    assert diagnostics["y"]["n_eff"].shape == data.shape
+    # TODO n_eff for streaming MCMC
+    # assert diagnostics["y"]["n_eff"].shape == data.shape
     assert diagnostics["y"]["r_hat"].shape == data.shape
+    print(diagnostics["y"])
     assert diagnostics["dummy_key"] == {'chain {}'.format(i): 'dummy_value'
                                         for i in range(num_chains)}
 

--- a/tests/infer/mcmc/test_mcmc_api.py
+++ b/tests/infer/mcmc/test_mcmc_api.py
@@ -244,10 +244,9 @@ def test_mcmc_diagnostics(run_mcmc_cls, num_chains):
     if not torch.backends.mkl.is_available():
         pytest.skip()
     diagnostics = mcmc.diagnostics()
-    # TODO n_eff for streaming MCMC
-    # assert diagnostics["y"]["n_eff"].shape == data.shape
+    if run_mcmc_cls == run_default_mcmc:  # TODO n_eff for streaming MCMC
+        assert diagnostics["y"]["n_eff"].shape == data.shape
     assert diagnostics["y"]["r_hat"].shape == data.shape
-    print(diagnostics["y"])
     assert diagnostics["dummy_key"] == {'chain {}'.format(i): 'dummy_value'
                                         for i in range(num_chains)}
 


### PR DESCRIPTION
@fritzo Hi! Here's a draft/proposition of `rhat` diagnostic for `StreamingMCMC`. I now that in #2843 `rhat` is stated as a `streaming.ops` member but I just wanted to share this idea (not necessarily stick to this approach and merge it).

Current `StreamingMCMC` implementation is chain-aware and new samples are added to streaming statistics by `(chain_id, name)` key (via `StatsOfDict`). This makes it impossible to create a streaming operator consuming all chains simultaneously (I think).

This implementation introduces `def diagnostics(self):` to `StreamingMCMC` which follows existing `MCMC` methods and relies on `mean` and `variance` ops that must be computed (therefore are required to be present). I followed the existing `gelman_rubin(-)` implementation. WDYT?