### PR TITLE
Bug in `elbo` calculation in `contrib.funsor.infer.trace_elbo.Trace_ELBO`

### DIFF
--- a/pyro/contrib/funsor/infer/trace_elbo.py
+++ b/pyro/contrib/funsor/infer/trace_elbo.py
@@ -29,19 +29,14 @@ class Trace_ELBO(ELBO):
         model_terms = terms_from_trace(model_tr)
         guide_terms = terms_from_trace(guide_tr)
 
-        log_measures = guide_terms["log_measures"] + model_terms["log_measures"]
-        log_factors = model_terms["log_factors"] + [
+        costs = model_terms["log_factors"] + [
             -f for f in guide_terms["log_factors"]
         ]
         plate_vars = model_terms["plate_vars"] | guide_terms["plate_vars"]
-        measure_vars = model_terms["measure_vars"] | guide_terms["measure_vars"]
 
-        elbo = funsor.Integrate(
-            sum(log_measures, to_funsor(0.0)),
-            sum(log_factors, to_funsor(0.0)),
-            measure_vars,
-        )
-        elbo = elbo.reduce(funsor.ops.add, plate_vars)
+        elbo = to_funsor(0.)
+        for cost in costs:
+            elbo += cost.reduce(funsor.ops.add, plate_vars & frozenset(cost.inputs))
 
         return -to_data(elbo)
 

--- a/pyro/contrib/funsor/infer/trace_elbo.py
+++ b/pyro/contrib/funsor/infer/trace_elbo.py
@@ -29,12 +29,10 @@ class Trace_ELBO(ELBO):
         model_terms = terms_from_trace(model_tr)
         guide_terms = terms_from_trace(guide_tr)
 
-        costs = model_terms["log_factors"] + [
-            -f for f in guide_terms["log_factors"]
-        ]
+        costs = model_terms["log_factors"] + [-f for f in guide_terms["log_factors"]]
         plate_vars = model_terms["plate_vars"] | guide_terms["plate_vars"]
 
-        elbo = to_funsor(0.)
+        elbo = to_funsor(0.0)
         for cost in costs:
             elbo += cost.reduce(funsor.ops.add, plate_vars & frozenset(cost.inputs))
 


### PR DESCRIPTION
I get wrong values for `elbo` (much larger absolute value compared to `pyro.infer.trace_elbo.Trace_ELBO`), presumably because `sum(log_factors, to_funsor(0.0))` in line 41 broadcasts terms in `log_factors` and then that leads to large absolute values after `elbo.reduce(funsor.ops.add, plate_vars)` summation.

Here I try to fix it by reducing each cost term individually similar to `TraceEnum_ELBO`. I'm also not sure if integration is needed here.