### PR TITLE
Add Logistic distribution

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -232,6 +232,13 @@ LKJCorrCholesky
     :undoc-members:
     :show-inheritance:
 
+Logistic
+--------
+.. autoclass:: pyro.distributions.Logistic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 MaskedDistribution
 ------------------
 .. autoclass:: pyro.distributions.MaskedDistribution

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -49,7 +49,7 @@ from pyro.distributions.hmm import (
 from pyro.distributions.improper_uniform import ImproperUniform
 from pyro.distributions.inverse_gamma import InverseGamma
 from pyro.distributions.lkj import LKJ, LKJCorrCholesky
-from pyro.distributions.logistic import SkewLogistic
+from pyro.distributions.logistic import Logistic, SkewLogistic
 from pyro.distributions.mixture import MaskedMixture
 from pyro.distributions.multivariate_studentt import MultivariateStudentT
 from pyro.distributions.omt_mvn import OMTMultivariateNormal
@@ -120,9 +120,10 @@ __all__ = [
     "ImproperUniform",
     "IndependentHMM",
     "InverseGamma",
-    "LinearHMM",
     "LKJ",
     "LKJCorrCholesky",
+    "LinearHMM",
+    "Logistic",
     "MaskedDistribution",
     "MaskedMixture",
     "MixtureOfDiagNormals",

--- a/pyro/distributions/logistic.py
+++ b/pyro/distributions/logistic.py
@@ -1,12 +1,85 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import torch
 from torch.distributions import constraints
 from torch.distributions.utils import broadcast_all
 from torch.nn.functional import logsigmoid
 
 from .torch_distribution import TorchDistribution
+
+
+class Logistic(TorchDistribution):
+    r"""
+    Logistic distribution.
+
+    This is a smooth distribution with symmetric asymptotically exponential
+    tails and a concave log density. For standard ``loc=0``, ``scale=1``, the
+    density is given by
+
+    .. math::
+
+        p(x) = \frac {e^{-x}} {(1 + e^{-x})^2}
+
+    Like the :class:`~pyro.distributions.Laplace` density, this density has the
+    heaviest possible tails (asymptotically) while still being log-convex.
+    Unlike the :class:`~pyro.distributions.Laplace` distribution, this
+    distribution is infinitely differentiable everywhere, and is thus suitable
+    for constructing Laplace approximations.
+
+    :param loc: Location parameter.
+    :param scale: Scale parameter.
+    """
+
+    arg_constraints = {"loc": constraints.real, "scale": constraints.positive}
+    support = constraints.real
+    has_rsample = True
+
+    def __init__(self, loc, scale, *, validate_args=None):
+        self.loc, self.scale = broadcast_all(loc, scale)
+        super().__init__(self.loc.shape, validate_args=validate_args)
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(SkewLogistic, _instance)
+        batch_shape = torch.Size(batch_shape)
+        new.loc = self.loc.expand(batch_shape)
+        new.scale = self.scale.expand(batch_shape)
+        super(Logistic, new).__init__(batch_shape, validate_args=False)
+        new._validate_args = self._validate_args
+        return new
+
+    def log_prob(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        z = (value - self.loc) / self.scale
+        return logsigmoid(z) * 2 - z - self.scale.log()
+
+    def rsample(self, sample_shape=torch.Size()):
+        shape = self._extended_shape(sample_shape)
+        u = self.loc.new_empty(shape).uniform_()
+        return self.icdf(u)
+
+    def cdf(self, value):
+        if self._validate_args:
+            self._validate_sample(value)
+        z = (value - self.loc) / self.scale
+        return z.sigmoid()
+
+    def icdf(self, value):
+        return self.loc + self.scale * value.logit()
+
+    @property
+    def mean(self):
+        return self.loc
+
+    @property
+    def variance(self):
+        return self.scale ** 2 * (math.pi ** 2 / 3)
+
+    def entropy(self):
+        return self.scale.log() + 2
 
 
 class SkewLogistic(TorchDistribution):

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -646,6 +646,17 @@ continuous_dists = [
             },
         ],
     ),
+    Fixture(
+        pyro_dist=dist.Logistic,
+        examples=[
+            {"loc": [1.0], "scale": [1.0], "test_data": [2.0]},
+            {
+                "loc": [2.0, -50.0],
+                "scale": [2.0, 10.0],
+                "test_data": [[2.0, 10.0], [-1.0, -50.0]],
+            },
+        ],
+    ),
 ]
 
 discrete_dists = [


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/7857

This aims to replace the less standard `SoftLaplace` distribution of #2791 and #2800 .

![image](https://user-images.githubusercontent.com/648532/124517448-d730d000-dd98-11eb-8da2-257bade0af21.png)

## Tested
- added test examples to tests/distributions/conftest.py