### PR TITLE
Fix bug in LRScheduler checkpointing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,6 @@ coverage.xml
 *,cover
 .hypothesis/
 *.out
-adam.unittest.save
 
 # Translations
 *.mo

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,17 +58,6 @@ def suppress_warnings(fn):
     return wrapper
 
 
-# backport of Python 3's context manager
-@contextlib.contextmanager
-def TemporaryDirectory():
-    try:
-        path = tempfile.mkdtemp()
-        yield path
-    finally:
-        if os.path.exists(path):
-            shutil.rmtree(path)
-
-
 requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="cuda is not available"
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,8 +5,6 @@ import contextlib
 import numbers
 import os
 import re
-import shutil
-import tempfile
 import warnings
 from itertools import product
 

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -372,8 +372,9 @@ def test_name_preserved_by_to_pyro_module():
 )
 def test_checkpoint(Optim, config):
     def model():
-        x_scale = pyro.param("x_scale", torch.tensor(1.0),
-                             constraint=constraints.positive)
+        x_scale = pyro.param(
+            "x_scale", torch.tensor(1.0), constraint=constraints.positive
+        )
         z = pyro.sample("z", Normal(0, 1))
         return pyro.sample("x", Normal(z, x_scale), obs=torch.tensor(0.1))
 

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -16,6 +16,7 @@ from pyro import poutine
 from pyro.distributions import Normal, Uniform
 from pyro.infer import SVI, Trace_ELBO, TraceGraph_ELBO
 from pyro.nn.module import PyroModule, PyroParam, to_pyro_module_
+from pyro.optim.optim import is_scheduler
 from tests.common import assert_equal
 
 
@@ -389,7 +390,7 @@ def test_checkpoint(Optim, config):
 
     def step(svi, optimizer):
         svi.step()
-        if hasattr(optimizer, "step"):
+        if is_scheduler(optimizer):
             if issubclass(
                 optimizer.pt_scheduler_constructor,
                 torch.optim.lr_scheduler.ReduceLROnPlateau,

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -343,7 +343,7 @@ def test_name_preserved_by_to_pyro_module():
             {
                 "optimizer": torch.optim.SGD,
                 "optim_args": {"lr": 0.01},
-                "lr_lambda": lambda epoch: 2.0 ** epoch,
+                "lr_lambda": lambda epoch: 0.9 ** epoch,
             },
         ),
         (
@@ -351,13 +351,13 @@ def test_name_preserved_by_to_pyro_module():
             {
                 "optimizer": torch.optim.SGD,
                 "optim_args": {"lr": 0.01},
-                "gamma": 2,
+                "gamma": 0.9,
                 "step_size": 1,
             },
         ),
         (
             optim.ExponentialLR,
-            {"optimizer": torch.optim.SGD, "optim_args": {"lr": 0.01}, "gamma": 2},
+            {"optimizer": torch.optim.SGD, "optim_args": {"lr": 0.01}, "gamma": 0.9},
         ),
         (
             optim.ReduceLROnPlateau,

--- a/tests/optim/test_optim.py
+++ b/tests/optim/test_optim.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
 import pytest
@@ -62,12 +63,14 @@ class OptimTests(TestCase):
         adam_initial_step_count = list(adam.get_state()["loc_q"]["state"].items())[0][
             1
         ]["step"]
-        adam.save("adam.unittest.save")
-        svi.step()
-        adam_final_step_count = list(adam.get_state()["loc_q"]["state"].items())[0][1][
-            "step"
-        ]
-        adam2.load("adam.unittest.save")
+        with TemporaryDirectory() as tempdir:
+            filename = os.path.join(tempdir, "adam.save")
+            adam.save(filename)
+            svi.step()
+            adam_final_step_count = list(
+                adam.get_state()["loc_q"]["state"].items()
+            )[0][1]["step"]
+            adam2.load(filename)
         svi2.step()
         adam2_step_count_after_load_and_step = list(
             adam2.get_state()["loc_q"]["state"].items()


### PR DESCRIPTION
This fixes a bug in `PyroOptim.save()`,`.load()` discovered by @sjfleming whereby LRSchedulers were saving only the state of the wrapping scheduler but missing the state of the underlying optimizer.

## Tested
- [x] regression test of checkpointing, including both raw optimizers and optimizers wrapped in learning-rate schedulers