### PR TITLE
Add ParamStoreDict.scope() method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,4 +241,4 @@ jobs:
       - name: Coveralls Finished
         run: |
           pip install --upgrade coveralls
-          coveralls --service=github --finish
+          coveralls --service=github --finish || true

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -244,21 +244,20 @@ class ParamStoreDict:
         Get the ParamStore state.
         """
         state = {
-            "params": self._params,
-            "constraints": self._constraints,
+            "params": self._params.copy(),
+            "constraints": self._constraints.copy(),
         }
         return state
 
     def set_state(self, state: dict):
         """
-        Set the ParamStore state using state from a previous get_state() call
+        Set the ParamStore state using state from a previous :meth:`get_state` call
         """
         assert isinstance(state, dict), "malformed ParamStore state"
         assert set(state.keys()) == set(
             ["params", "constraints"]
         ), "malformed ParamStore keys {}".format(state.keys())
 
-        self.clear()
         for param_name, param in state["params"].items():
             self._params[param_name] = param
             self._param_to_name[param] = param_name
@@ -271,7 +270,7 @@ class ParamStoreDict:
 
     def save(self, filename):
         """
-        Save parameters to disk
+        Save parameters to file
 
         :param filename: file name to save to
         :type filename: str
@@ -281,7 +280,7 @@ class ParamStoreDict:
 
     def load(self, filename, map_location=None):
         """
-        Loads parameters from disk
+        Loads parameters from file
 
         .. note::
 
@@ -330,9 +329,12 @@ class ParamStoreDict:
             state = {"params": {}, "constraints": {}}
         old_state = self.get_state()
         try:
+            self.clear()
             self.set_state(state)
             yield state
+            state.update(self.get_state())
         finally:
+            self.clear()
             self.set_state(old_state)
 
 

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -157,8 +157,20 @@ def test_scope():
     x1 = torch.randn(3)
     y1 = torch.randn(2, 1).exp()
     y2 = torch.randn(2, 1).exp()
-    z2 = torch.randn(1, 4)
+    z2 = torch.randn(1, 4).exp()
     z2 /= z2.sum()
+
+    constraint_table = {
+        "z0": constraints.positive,
+        "y1": constraints.positive,
+        "y2": constraints.positive,
+        "z2": constraints.simplex,
+    }
+
+    def check_constraint(name):
+        expected = constraint_table.get(name, constraints.real)
+        actual = param_store._constraints[name[:1]]
+        assert actual == expected
 
     param_store = pyro.get_param_store()
 
@@ -169,6 +181,8 @@ def test_scope():
     assert set(param_store) == {"x", "z"}
     assert_equal(pyro.param("x"), x0)
     assert_equal(pyro.param("z"), z0)
+    check_constraint("x0")
+    check_constraint("z0")
 
     # Create scope1.
     with param_store.scope() as scope1:
@@ -178,21 +192,29 @@ def test_scope():
         assert set(param_store) == {"x", "y"}
         assert_equal(pyro.param("x"), x1)
         assert_equal(pyro.param("y"), y1)
+        check_constraint("x1")
+        check_constraint("y1")
     assert set(param_store) == {"x", "z"}
     assert_equal(pyro.param("x"), x0)
     assert_equal(pyro.param("z"), z0)
+    check_constraint("x0")
+    check_constraint("z0")
 
     # Create scope2.
     with param_store.scope() as scope2:
         assert not param_store
         pyro.param("y", y2, constraint=constraints.positive)
-        pyro.param("z", z2)
+        pyro.param("z", z2, constraint=constraints.simplex)
         assert set(param_store) == {"y", "z"}
         assert_equal(pyro.param("y"), y2)
         assert_equal(pyro.param("z"), z2)
+        check_constraint("y2")
+        check_constraint("z2")
     assert set(param_store) == {"x", "z"}
     assert_equal(pyro.param("x"), x0)
     assert_equal(pyro.param("z"), z0)
+    check_constraint("x0")
+    check_constraint("z0")
 
     # Reload scope1.
     with param_store.scope(scope1) as s:
@@ -200,9 +222,13 @@ def test_scope():
         assert set(param_store) == {"x", "y"}
         assert_equal(pyro.param("x"), x1)
         assert_equal(pyro.param("y"), y1)
+        check_constraint("x1")
+        check_constraint("y1")
     assert set(param_store) == {"x", "z"}
     assert_equal(pyro.param("x"), x0)
     assert_equal(pyro.param("z"), z0)
+    check_constraint("x0")
+    check_constraint("z0")
 
     # Reload scope2.
     with param_store.scope(scope2) as s:
@@ -210,6 +236,10 @@ def test_scope():
         assert set(param_store) == {"y", "z"}
         assert_equal(pyro.param("y"), y2)
         assert_equal(pyro.param("z"), z2)
+        check_constraint("y2")
+        check_constraint("z2")
     assert set(param_store) == {"x", "z"}
     assert_equal(pyro.param("x"), x0)
     assert_equal(pyro.param("z"), z0)
+    check_constraint("x0")
+    check_constraint("z0")

--- a/tests/params/test_param.py
+++ b/tests/params/test_param.py
@@ -149,3 +149,67 @@ def test_dict_interface():
     assert list(param_store.keys()) == []
     assert list(key for key, value in param_store.items()) == []
     assert len(list(param_store.values())) == 0
+
+
+def test_scope():
+    x0 = torch.randn(())
+    z0 = torch.randn(5).exp()
+    x1 = torch.randn(3)
+    y1 = torch.randn(2, 1).exp()
+    y2 = torch.randn(2, 1).exp()
+    z2 = torch.randn(1, 4)
+    z2 /= z2.sum()
+
+    param_store = pyro.get_param_store()
+
+    # Create base scope.
+    assert not param_store
+    pyro.param("x", x0)
+    pyro.param("z", z0, constraint=constraints.positive)
+    assert set(param_store) == {"x", "z"}
+    assert_equal(pyro.param("x"), x0)
+    assert_equal(pyro.param("z"), z0)
+
+    # Create scope1.
+    with param_store.scope() as scope1:
+        assert not param_store
+        pyro.param("x", x1)
+        pyro.param("y", y1, constraint=constraints.positive)
+        assert set(param_store) == {"x", "y"}
+        assert_equal(pyro.param("x"), x1)
+        assert_equal(pyro.param("y"), y1)
+    assert set(param_store) == {"x", "z"}
+    assert_equal(pyro.param("x"), x0)
+    assert_equal(pyro.param("z"), z0)
+
+    # Create scope2.
+    with param_store.scope() as scope2:
+        assert not param_store
+        pyro.param("y", y2, constraint=constraints.positive)
+        pyro.param("z", z2)
+        assert set(param_store) == {"y", "z"}
+        assert_equal(pyro.param("y"), y2)
+        assert_equal(pyro.param("z"), z2)
+    assert set(param_store) == {"x", "z"}
+    assert_equal(pyro.param("x"), x0)
+    assert_equal(pyro.param("z"), z0)
+
+    # Reload scope1.
+    with param_store.scope(scope1) as s:
+        assert s is scope1
+        assert set(param_store) == {"x", "y"}
+        assert_equal(pyro.param("x"), x1)
+        assert_equal(pyro.param("y"), y1)
+    assert set(param_store) == {"x", "z"}
+    assert_equal(pyro.param("x"), x0)
+    assert_equal(pyro.param("z"), z0)
+
+    # Reload scope2.
+    with param_store.scope(scope2) as s:
+        assert s is scope2
+        assert set(param_store) == {"y", "z"}
+        assert_equal(pyro.param("y"), y2)
+        assert_equal(pyro.param("z"), z2)
+    assert set(param_store) == {"x", "z"}
+    assert_equal(pyro.param("x"), x0)
+    assert_equal(pyro.param("z"), z0)


### PR DESCRIPTION
Resolves #2912 

This addresses @tillahoffman's idea of a context-manager-based way of handling multiple param store states in a single process, simplifying the manual use of `.get_state()`, `.clear()`, and `.set_state()`.

## Tested
- [x] unit tests