### PR TITLE
Add pyro.util.deep_to() to recursively call .to() on Python data structures

### DIFF
--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -140,8 +140,10 @@ class _DeepToMemo(dict):
         if result is default:
             # Assume key is the id of another object, and look up that object.
             old = ctypes.cast(key, ctypes.py_object).value
-            if isinstance(old, (torch.Tensor, torch.nn.Module)):
+            if isinstance(old, torch.Tensor):
                 self[key] = result = old.to(*self._to_args, **self._to_kwargs)
+            elif isinstance(old, torch.nn.Module):
+                old.to(*self._to_args, **self._to_kwargs)
         return result
 
 
@@ -150,6 +152,11 @@ def deep_to(obj, *args, **kwargs):
     Create a deep copy of an arbitrary Python object, calling ``.to(*args,
     **kwargs)`` on all :class:`torch.Tensor` s and :class:`torch.nn.Module` s
     in that object.
+
+    Like :meth:`torch.Tensor.to` but unlike :meth:`torch.nn.Module.to`, this
+    creates new objects. For compatibility with existing PyTorch module
+    behavior, this first calls :meth:`torch.nn.Module.to` in-place, then
+    creates a deep copy of the module.
 
     :param obj: Any python object.
     :param \*args:

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -129,6 +129,38 @@ def detach(obj):
     return copy.deepcopy(obj, memo)
 
 
+class _DeepToMemo(dict):
+    def __init__(self, to_args, to_kwargs):
+        super().__init__()
+        self._to_args = to_args
+        self._to_kwargs = to_kwargs
+
+    def get(self, key, default=None):
+        result = super().get(key, default)
+        if result is default:
+            # Assume key is the id of another object, and look up that object.
+            old = ctypes.cast(key, ctypes.py_object).value
+            if isinstance(old, (torch.Tensor, torch.nn.Module)):
+                self[key] = result = old.to(*self._to_args, **self._to_kwargs)
+        return result
+
+
+def deep_to(obj, *args, **kwargs):
+    r"""
+    Create a deep copy of an arbitrary Python object, calling ``.to(*args,
+    **kwargs)`` on all :class:`torch.Tensor` s and :class:`torch.nn.Module` s
+    in that object.
+
+    :param obj: Any python object.
+    :param \*args:
+    :param \*\*kwargs: See :meth:`torch.Tensor.to`.
+    :returns: A deep copy of ``obj`` with all :class:`torch.Tensor` s and
+        :class:`torch.nn.Module` s mapped.
+    """
+    memo = _DeepToMemo(args, kwargs)
+    return copy.deepcopy(obj, memo)
+
+
 # Import a lazy jit.script decorator only if available.
 torch_jit_script_if_tracing = getattr(
     torch.jit,

--- a/tests/distributions/test_util.py
+++ b/tests/distributions/test_util.py
@@ -307,6 +307,34 @@ def test_deep_to_transformed(shape, dtype):
     assert not d2.transforms[0].scale.requires_grad
 
 
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+def test_deep_to_structure(dtype):
+    data = [
+        None,
+        True,
+        "foo",
+        1.0,
+        {False},
+        torch.tensor(0.0),
+        (torch.tensor(1.0), torch.tensor([2.0, 3.0])),
+        [torch.tensor(4.0)],
+        {"bar": torch.tensor(5.0)},
+    ]
+    actual = deep_to(data)
+    expected = [
+        None,
+        True,
+        "foo",
+        1.0,
+        {False},
+        torch.tensor(0.0).to(dtype),
+        (torch.tensor(1.0).to(dtype), torch.tensor([2.0, 3.0]).to(dtype)),
+        [torch.tensor(4.0).to(dtype)],
+        {"bar": torch.tensor(5.0).to(dtype)},
+    ]
+    assert_equal(actual, expected)
+
+
 @pytest.mark.parametrize("shape", [None, (), (4,), (3, 2)], ids=str)
 def test_deep_to_jit(shape):
     loc = torch.tensor(0.0, requires_grad=True)


### PR DESCRIPTION
Addresses https://github.com/pytorch/pytorch/issues/7795
Addresses https://github.com/pytorch/pytorch/issues/17234

Many users of torch.distributions claim to want a `.to()` method on `Distribution` objects. What they really want is a general `deep_to()` function that operates on arbitrary Python data structures. This is advantageous to users because they can use it on any Python data structure. This is advantageous to developers and maintainers of PyTorch and Pyro because they can avoid interface bloat. See [jax.device_put()](https://jax.readthedocs.io/en/latest/jax.html#jax.device_put) for similar functionality in JAX.

This PR implements a `deep_to()` helper based on `copy.deepcopy()`, the same trick used in #2599.

## Tested
- [x] added unit tests