### PR TITLE
add link to tensor shapes tutorial

### DIFF
--- a/tutorial/source/tensor_shapes.ipynb
+++ b/tutorial/source/tensor_shapes.ipynb
@@ -6,7 +6,12 @@
    "source": [
     "# Tensor shapes in Pyro\n",
     "\n",
-    "This tutorial introduces Pyro's organization of tensor dimensions. Before starting, you should familiarize yourself with [PyTorch broadcasting semantics](http://pytorch.org/docs/master/notes/broadcasting.html).  After this tutorial, you may want to also read about [enumeration](http://pyro.ai/examples/enumeration.html).\n",
+    "This tutorial introduces Pyro's organization of tensor dimensions. \n",
+    "Before starting, you should familiarize yourself with [PyTorch broadcasting semantics](http://pytorch.org/docs/master/notes/broadcasting.html).  \n",
+    "After this tutorial, you may want to also read about [enumeration](http://pyro.ai/examples/enumeration.html).\n",
+    "\n",
+    "You may also find it useful to read Eric J. Ma's post [Reasoning about Shapes and Probability Distributions](https://ericmjl.github.io/blog/2019/5/29/reasoning-about-shapes-and-probability-distributions/). \n",
+    "While this post is specifically about TensorFlow Probability, many of the same concepts apply.\n",
     "\n",
     "#### Summary:\n",
     "- Tensors broadcast by aligning on the right: `torch.ones(3,4,5) + torch.ones(5)`.\n",
@@ -762,7 +767,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
add link to Eric J. Ma's post [Reasoning about Shapes and Probability Distributions](https://ericmjl.github.io/blog/2019/5/29/reasoning-about-shapes-and-probability-distributions/) to tensor shapes tutorial