### PR TITLE
Enable loading optimizer to a specific device

### DIFF
--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -176,15 +176,17 @@ class PyroOptim:
         with open(filename, "wb") as output_file:
             torch.save(self.get_state(), output_file)
 
-    def load(self, filename: str) -> None:
+    def load(self, filename: str, map_location: Optional[str] = None) -> None:
         """
         :param filename: file name to load from
         :type filename: str
+        :param map_location: torch.load() map_location parameter
+        :type map_location: str
 
         Load optimizer state from disk
         """
         with open(filename, "rb") as input_file:
-            state = torch.load(input_file)
+            state = torch.load(input_file, map_location=map_location)
         self.set_state(state)
 
     def _get_optim(self, param: Union[Iterable[Tensor], Iterable[Dict[Any, Any]]]):

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -181,7 +181,7 @@ class PyroOptim:
         :param filename: file name to load from
         :type filename: str
         :param map_location: torch.load() map_location parameter
-        :type map_location: function, torch.device, string or a dict 
+        :type map_location: function, torch.device, string or a dict
 
         Load optimizer state from disk
         """

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -176,12 +176,12 @@ class PyroOptim:
         with open(filename, "wb") as output_file:
             torch.save(self.get_state(), output_file)
 
-    def load(self, filename: str, map_location: Optional[str] = None) -> None:
+    def load(self, filename: str, map_location=None) -> None:
         """
         :param filename: file name to load from
         :type filename: str
         :param map_location: torch.load() map_location parameter
-        :type map_location: str
+        :type map_location: function, torch.device, string or a dict 
 
         Load optimizer state from disk
         """


### PR DESCRIPTION
While playing with saving and loading checkpoint files, I ended up saving a checkpoint on a CUDA-enabled machine and then trying to load it on a CPU-only device.
This is normally made possible by using `torch.load()`'s `map_location` parameter.

While the param_store loader has the ability to specify a `map_location`
https://github.com/pyro-ppl/pyro/blob/c8dc40a75cc4ff1f43c6ff9178d91c08155d7973/pyro/params/param_store.py#L281-L300

the loader for pyro.optim does not:
https://github.com/pyro-ppl/pyro/blob/c8dc40a75cc4ff1f43c6ff9178d91c08155d7973/pyro/optim/optim.py#L179-L188

I would propose to add the `map_location` parameter to pyro.optim's loader so that we can completely achieve CPU-loading of a CUDA-saved checkpoint.