### PR TITLE
Use plate information in AutoStructured guide

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -41,9 +41,9 @@ ConditionalDenseNN
     :undoc-members:
     :show-inheritance:
 
-FlatBatchLinear
----------------
-.. autoclass:: pyro.nn.linear.FlatBatchLinear
+Structured Linear Layers
+------------------------
+.. automodule:: pyro.nn.linear
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -40,3 +40,10 @@ ConditionalDenseNN
     :members:
     :undoc-members:
     :show-inheritance:
+
+FlatBatchLinear
+---------------
+.. autoclass:: pyro.nn.linear.FlatBatchLinear
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pyro/nn/linear.py
+++ b/pyro/nn/linear.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+import operator
+from functools import reduce
 from typing import Set
 
 import torch
@@ -13,11 +15,11 @@ class FlatBatchLinear(torch.nn.Module):
 
     Like :class:`~torch.nn.Linear` , this inputs and outputs flat vectors
     (possibly batched). However unlike :class:`~torch.nn.Linear`, this
-    internally reshapes the flat input to :param:`shape_in`, and assumes
-    weights are constant across input dimensions specified in
-    :param:`batch_dims_in`, corresponding to output dimensions
-    :param:`batch_dims_out`. The result is flattened from :param:`shape_out` to
-    a one-dimensional vector (possibly batched).
+    internally reshapes the flat input to ``shape_in``, and assumes weights are
+    constant across input dimensions specified in ``batch_dims_in``,
+    corresponding to output dimensions ``batch_dims_out``. The result is
+    flattened from ``shape_out`` to a one-dimensional vector (possibly
+    batched).
 
     :param torch.Size shape_in: The internal shape of the input tensor.
     :param torch.Size shape_out: The internal shape of the output tensor.
@@ -52,7 +54,7 @@ class FlatBatchLinear(torch.nn.Module):
         for i, size in enumerate(shape_in):
             symbol = next(symbols)
             einsum_in += symbol
-            if i in batch_dims_in:
+            if i in batch_dims_in or size <= 1:
                 symbols_out.append(symbol)
             else:
                 einsum_weight += symbol
@@ -61,24 +63,80 @@ class FlatBatchLinear(torch.nn.Module):
         # Collect sizes and symbols from the output shape.
         symbols_out = iter(symbols_out)
         for i, size in enumerate(shape_out):
-            if i in batch_dims_out:
+            if i in batch_dims_out or size <= 1:
                 symbol = next(symbols_out)
             else:
                 symbol = next(symbols)
                 einsum_weight += symbol
                 shape_weight.append(size)
             einsum_out += symbol
+        assert all(size >= 2 for size in shape_weight)
 
-        self.einsum_spec = f"...{einsum_in},{einsum_weight}->...{einsum_out}"
-        self.weight = torch.nn.Parameter(torch.zeros(shape_weight))
         self.shape_in = shape_in
         self.shape_out = shape_out
         self.batch_dims_in = frozenset(batch_dims_in)
         self.batch_dims_out = frozenset(batch_dims_out)
+        self._init_einsum(shape_weight, einsum_weight, einsum_in, einsum_out)
+
+    def _init_einsum(self, shape_weight, einsum_weight, einsum_in, einsum_out):
+        self.einsum_spec = f"...{einsum_in},{einsum_weight}->...{einsum_out}"
+        self.weight = torch.nn.Parameter(torch.zeros(shape_weight))
+
+    def _apply_einsum(self, shaped_in):
+        return torch.einsum(self.einsum_spec, shaped_in, self.weight)
 
     def forward(self, flat_in: torch.Tensor) -> torch.Tensor:
         sample_shape = flat_in.shape[:-1]
         shaped_in = flat_in.reshape(sample_shape + self.shape_in)
-        shaped_out = torch.einsum(self.einsum_spec, shaped_in, self.weight)
+        shaped_out = self._apply_einsum(shaped_in)
         flat_out = shaped_out.reshape(sample_shape + (-1,))
         return flat_out
+
+
+class FlatRank2Linear(FlatBatchLinear):
+    """
+    A rank-2 approximation to :class:`FlatBatchLinear`.
+
+    This is just like :class:`FlatBatchLinear`, but where the ``weight`` tensor
+    is decomposed into a sum of tensors of rank at most 2. This is especially
+    useful for large high-rank models where full rank tensors would consume too
+    much memory.
+
+    :param torch.Size shape_in: The internal shape of the input tensor.
+    :param torch.Size shape_out: The internal shape of the output tensor.
+    :param set batch_dims_in: The set of (nonnegative integer) input dims over
+        which weights are shared.
+    :param set batch_dims_out: The set of (nonnegative integer) output dims
+        over which weights are shared.
+    """
+
+    def _init_einsum(self, shape_weight, einsum_weight, einsum_in, einsum_out):
+        self.einsum_specs = []
+        self.weights = []
+        if len(shape_weight) <= 2:
+            self.einsum_specs.append(f"...{einsum_in},{einsum_weight}->...{einsum_out}")
+            weight = torch.nn.Parameter(torch.zeros(shape_weight))
+            self.weights.append(weight)
+            self.weight = weight
+        else:
+            sizes = dict(zip(einsum_weight, shape_weight))
+            for i, a in enumerate(einsum_weight):
+                for b in einsum_weight[i + 1 :]:
+                    einsum_ab = a + b
+                    shape_ab = [sizes[a], sizes[b]]
+                    for c in set(einsum_out).difference(einsum_ab, einsum_in):
+                        einsum_ab += c
+                        shape_ab.append(1)
+                    self.einsum_specs.append(
+                        f"...{einsum_in},{einsum_ab}->...{einsum_out}"
+                    )
+                    weight = torch.nn.Parameter(torch.zeros(shape_ab))
+                    self.weights.append(weight)
+                    setattr(self, f"weight_{einsum_ab}", weight)
+        assert len(self.einsum_specs) == len(self.weights)
+
+    def _apply_einsum(self, shaped_in):
+        terms = []
+        for weight, einsum_spec in zip(self.weights, self.einsum_specs):
+            terms.append(torch.einsum(einsum_spec, shaped_in, weight))
+        return reduce(operator.add, terms)

--- a/pyro/nn/linear.py
+++ b/pyro/nn/linear.py
@@ -1,0 +1,84 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Set
+
+import torch
+
+
+class FlatBatchLinear(torch.nn.Module):
+    """
+    Like :class:`~torch.nn.Linear` but with with parameters shared along a
+    specified set of internal dimensions.
+
+    Like :class:`~torch.nn.Linear` , this inputs and outputs flat vectors
+    (possibly batched). However unlike :class:`~torch.nn.Linear`, this
+    internally reshapes the flat input to :param:`shape_in`, and assumes
+    weights are constant across input dimensions specified in
+    :param:`batch_dims_in`, corresponding to output dimensions
+    :param:`batch_dims_out`. The result is flattened from :param:`shape_out` to
+    a one-dimensional vector (possibly batched).
+
+    :param torch.Size shape_in: The internal shape of the input tensor.
+    :param torch.Size shape_out: The internal shape of the output tensor.
+    :param set batch_dims_in: The set of (nonnegative integer) input dims over
+        which weights are shared.
+    :param set batch_dims_out: The set of (nonnegative integer) output dims
+        over which weights are shared.
+    """
+
+    def __init__(
+        self,
+        shape_in: torch.Size,
+        shape_out: torch.Size,
+        batch_dims_in: Set[int],
+        batch_dims_out: Set[int],
+    ):
+        assert all(isinstance(i, int) and i >= 0 for i in batch_dims_in)
+        assert all(isinstance(i, int) and i >= 0 for i in batch_dims_out)
+        assert len(batch_dims_in) == len(batch_dims_out)
+        for i, j in zip(sorted(batch_dims_in), sorted(batch_dims_out)):
+            assert shape_in[i] == shape_out[j]
+        super().__init__()
+
+        einsum_in = ""
+        einsum_out = ""
+        einsum_weight = ""
+        shape_weight = []
+
+        # Collect sizes and symbols from the input shape.
+        symbols_out = []
+        symbols = iter("abcdefghijklmnopqrstuvwxyz")
+        for i, size in enumerate(shape_in):
+            symbol = next(symbols)
+            einsum_in += symbol
+            if i in batch_dims_in:
+                symbols_out.append(symbol)
+            else:
+                einsum_weight += symbol
+                shape_weight.append(size)
+
+        # Collect sizes and symbols from the output shape.
+        symbols_out = iter(symbols_out)
+        for i, size in enumerate(shape_out):
+            if i in batch_dims_out:
+                symbol = next(symbols_out)
+            else:
+                symbol = next(symbols)
+                einsum_weight += symbol
+                shape_weight.append(size)
+            einsum_out += symbol
+
+        self.einsum_spec = f"...{einsum_in},{einsum_weight}->...{einsum_out}"
+        self.weight = torch.nn.Parameter(torch.zeros(shape_weight))
+        self.shape_in = shape_in
+        self.shape_out = shape_out
+        self.batch_dims_in = frozenset(batch_dims_in)
+        self.batch_dims_out = frozenset(batch_dims_out)
+
+    def forward(self, flat_in: torch.Tensor) -> torch.Tensor:
+        sample_shape = flat_in.shape[:-1]
+        shaped_in = flat_in.reshape(sample_shape + self.shape_in)
+        shaped_out = torch.einsum(self.einsum_spec, shaped_in, self.weight)
+        flat_out = shaped_out.reshape(sample_shape + (-1,))
+        return flat_out

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -34,7 +34,7 @@ from pyro.infer.autoguide import (
     init_to_median,
     init_to_sample,
 )
-from pyro.infer.reparam import ProjectedNormalReparam
+from pyro.infer.reparam import LocScaleReparam, ProjectedNormalReparam
 from pyro.nn.module import PyroModule, PyroParam, PyroSample
 from pyro.optim import Adam
 from pyro.poutine.util import prune_subsample_sites
@@ -1216,3 +1216,160 @@ def test_exact_batch(Guide):
         actual_std = samples.std(0)
         assert_close(actual_mean, expected_mean, atol=0.05)
         assert_close(actual_std, expected_std, rtol=0.05)
+
+
+# Simplified from https://github.com/pyro-cov/tree/master/pyrocov/mutrans.py
+def pyrocov_model(dataset):
+    # Tensor shapes are commented at at the end of some lines.
+    features = dataset["features"]
+    local_time = dataset["local_time"][..., None]  # [T, P, 1]
+    T, P, _ = local_time.shape
+    S, F = features.shape
+    weekly_strains = dataset["weekly_strains"]
+    assert weekly_strains.shape == (T, P, S)
+
+    # Configure reparametrization (which does not affect model density).
+    local_time = local_time + pyro.param(
+        "local_time", lambda: torch.zeros(P, S)
+    )  # [T, P, S]
+
+    # Sample global random variables.
+    coef_scale = pyro.sample("coef_scale", dist.InverseGamma(5e3, 1e2))[..., None]
+    rate_scale = pyro.sample("rate_scale", dist.LogNormal(-4, 2))[..., None]
+    init_loc_scale = pyro.sample("init_loc_scale", dist.LogNormal(0, 2))[..., None]
+    init_scale = pyro.sample("init_scale", dist.LogNormal(0, 2))[..., None]
+
+    # Assume relative growth rate depends strongly on mutations and weakly on place.
+    coef_loc = torch.zeros(F)
+    coef = pyro.sample("coef", dist.Logistic(coef_loc, coef_scale).to_event(1))  # [F]
+    rate_loc = pyro.deterministic(
+        "rate_loc", 0.01 * coef @ features.T, event_dim=1
+    )  # [S]
+
+    # Assume initial infections depend strongly on strain and place.
+    init_loc = pyro.sample(
+        "init_loc", dist.Normal(torch.zeros(S), init_loc_scale).to_event(1)
+    )  # [S]
+    with pyro.plate("place", P, dim=-1):
+        rate = pyro.sample(
+            "rate", dist.Normal(rate_loc, rate_scale).to_event(1)
+        )  # [P, S]
+        init = pyro.sample(
+            "init", dist.Normal(init_loc, init_scale).to_event(1)
+        )  # [P, S]
+
+        # Finally observe counts.
+        with pyro.plate("time", T, dim=-2):
+            logits = init + rate * local_time  # [T, P, S]
+            pyro.sample(
+                "obs",
+                dist.Multinomial(logits=logits, validate_args=False),
+                obs=weekly_strains,
+            )
+
+
+def test_structured_pyrocov():
+    T, P, S, F = 3, 4, 5, 6
+    dataset = {
+        "features": torch.randn(S, F),
+        "local_time": torch.randn(T, P),
+        "weekly_strains": torch.randn(T, P, S).exp().round(),
+    }
+
+    guide = AutoStructured(pyrocov_model)
+    guide(dataset)  # initialize guide
+
+    # Check automatically determined dependencies.
+    # Without reparametrization the posterior dependencies are sparse.
+    _ = set()
+    expected_dependencies = {
+        "coef": {
+            "coef_scale": _,  # direct
+            "rate_scale": _,  # moralized
+        },
+        "init_loc": {
+            "init_loc_scale": _,  # direct
+            "init_scale": _,  # moralized
+        },
+        "rate": {
+            "coef": _,  # direct
+            "rate_scale": _,  # direct
+        },
+        "init": {
+            "init_loc": _,  # direct
+            "init_scale": _,  # direct
+            "rate": _,  # moralized
+        },
+    }
+    assert guide.dependencies == expected_dependencies
+
+
+def test_structured_pyrocov_reparam():
+    T, P, S, F = 3, 4, 5, 6
+    dataset = {
+        "features": torch.randn(S, F),
+        "local_time": torch.randn(T, P),
+        "weekly_strains": torch.randn(T, P, S).exp().round(),
+    }
+
+    # Reparametrize the model.
+    config = {
+        "coef": LocScaleReparam(),
+        "rate": LocScaleReparam(),
+        "init_loc": LocScaleReparam(),
+        "init": LocScaleReparam(),
+    }
+    model = poutine.reparam(pyrocov_model, config)
+    guide = AutoStructured(model)
+    guide(dataset)  # initialize guide
+
+    # Check automatically determined dependencies.
+    # With reparametrization the posterior dependencies are dense.
+    _ = set()
+    expected_dependencies = {
+        "rate_scale": {
+            "coef_scale": _,  # reparam moralized
+        },
+        "init_loc_scale": {
+            "coef_scale": _,  # reparam moralized
+            "rate_scale": _,  # reparam moralized
+        },
+        "init_scale": {
+            "coef_scale": _,  # reparam moralized
+            "rate_scale": _,  # reparam moralized
+            "init_loc_scale": _,  # reparam moralized
+        },
+        "coef_decentered": {
+            "coef_scale": _,  # direct
+            "rate_scale": _,  # moralized
+            "init_loc_scale": _,  # reparam moralized
+            "init_scale": _,  # reparam moralized
+        },
+        "init_loc_decentered": {
+            "init_loc_scale": _,  # direct
+            "init_scale": _,  # moralized
+            "coef_scale": _,  # reparam moralized
+            "rate_scale": _,  # reparam moralized
+            "coef_decentered": _,  # reparam moralized
+        },
+        "rate_decentered": {
+            "coef_decentered": _,  # direct
+            "coef_scale": _,  # reparam direct
+            "rate_scale": _,  # direct
+            "rate_scale": _,  # reparam direct
+            "init_loc_scale": _,  # reparam moralized
+            "init_scale": _,  # reparam moralized
+            "init_loc_decentered": _,  # reparam moralized
+        },
+        "init_decentered": {
+            "init_loc_decentered": _,  # direct
+            "init_scale": _,  # direct
+            "rate_decentered": _,  # moralized
+            "init_loc_scale": _,  # reparam direct
+            "coef_scale": _,  # reparam moralized
+            "rate_scale": _,  # reparam moralized
+            "coef_decentered": _,  # reparam moralized
+            "rate_decentered": _,  # reparam moralized
+        },
+    }
+    assert guide.dependencies == expected_dependencies

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -4,7 +4,7 @@
 import pytest
 import torch
 
-from pyro.nn.linear import FlatBatchLinear
+from pyro.nn.linear import FlatBatchLinear, FlatRank2Linear
 
 
 def check_num_parameters(module):
@@ -23,13 +23,15 @@ def check_num_parameters(module):
 
 @pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("batch_dims_in", [{}, {0}, {1}, {0, 1}], ids=str)
-def test_1(sample_shape, batch_dims_in):
+@pytest.mark.parametrize("cls", [FlatBatchLinear, FlatRank2Linear])
+def test_1(cls, batch_dims_in, sample_shape):
     shape_in = torch.Size((4, 3, 2))
     shape_out = torch.Size((5, 4, 3))
     batch_dims_out = {i + 1 for i in batch_dims_in}
 
-    f = FlatBatchLinear(shape_in, shape_out, batch_dims_in, batch_dims_out)
-    check_num_parameters(f)
+    f = cls(shape_in, shape_out, batch_dims_in, batch_dims_out)
+    if cls == FlatBatchLinear:
+        check_num_parameters(f)
 
     x = torch.randn(sample_shape + (shape_in.numel(),))
     y = f(x)
@@ -38,13 +40,15 @@ def test_1(sample_shape, batch_dims_in):
 
 @pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
 @pytest.mark.parametrize("batch_dims_in", [{}, {2}, {4}, {2, 4}], ids=str)
-def test_2(sample_shape, batch_dims_in):
+@pytest.mark.parametrize("cls", [FlatBatchLinear, FlatRank2Linear])
+def test_2(cls, batch_dims_in, sample_shape):
     shape_in = torch.Size((5, 1, 3, 1, 1))
     shape_out = torch.Size((4, 3, 2, 1))
     batch_dims_out = {i - 1 for i in batch_dims_in}
 
-    f = FlatBatchLinear(shape_in, shape_out, batch_dims_in, batch_dims_out)
-    check_num_parameters(f)
+    f = cls(shape_in, shape_out, batch_dims_in, batch_dims_out)
+    if cls == FlatBatchLinear:
+        check_num_parameters(f)
 
     x = torch.randn(sample_shape + (shape_in.numel(),))
     y = f(x)

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -1,0 +1,51 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pyro.nn.linear import FlatBatchLinear
+
+
+def check_num_parameters(module):
+    expected = 1
+    for shape, batch_dims in [
+        (module.shape_in, module.batch_dims_in),
+        (module.shape_out, module.batch_dims_out),
+    ]:
+        for i, size in enumerate(shape):
+            if i not in batch_dims:
+                expected *= size
+
+    actual = sum(p.numel() for p in module.parameters())
+    assert actual == expected
+
+
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("batch_dims_in", [{}, {0}, {1}, {0, 1}], ids=str)
+def test_1(sample_shape, batch_dims_in):
+    shape_in = torch.Size((4, 3, 2))
+    shape_out = torch.Size((5, 4, 3))
+    batch_dims_out = {i + 1 for i in batch_dims_in}
+
+    f = FlatBatchLinear(shape_in, shape_out, batch_dims_in, batch_dims_out)
+    check_num_parameters(f)
+
+    x = torch.randn(sample_shape + (shape_in.numel(),))
+    y = f(x)
+    assert y.shape == sample_shape + (shape_out.numel(),)
+
+
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("batch_dims_in", [{}, {2}, {4}, {2, 4}], ids=str)
+def test_2(sample_shape, batch_dims_in):
+    shape_in = torch.Size((5, 1, 3, 1, 1))
+    shape_out = torch.Size((4, 3, 2, 1))
+    batch_dims_out = {i - 1 for i in batch_dims_in}
+
+    f = FlatBatchLinear(shape_in, shape_out, batch_dims_in, batch_dims_out)
+    check_num_parameters(f)
+
+    x = torch.randn(sample_shape + (shape_in.numel(),))
+    y = f(x)
+    assert y.shape == sample_shape + (shape_out.numel(),)


### PR DESCRIPTION
Addresses #2813 
See [design doc](https://docs.google.com/document/d/1MVfG0po7M5UB2mNM2In6iKKq_OYNpa_I-FnJncUgXPI)

This follows #2824 by using the plate structure determined by `get_dependencies()` to implement sparse precision structure (tensor block diagonal structure) in the pairwise dependencies used in `AutoStructured` guides.

## Tested

- [x] shape tests for `FlatBatchLinear` module
- [x] new functionality is exercised by existing autoguide tests
- [x] unit tests of a real world model