### PR TITLE
Fix Cholesky error handling

### DIFF
--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -76,7 +76,7 @@ def potential_grad(potential_fn, z):
         potential_energy = potential_fn(z)
     # deal with singular matrices
     except RuntimeError as e:
-        if "singular U" in str(e):
+        if "singular U" in str(e) or "input is not positive-definite" in str(e):
             grads = {k: v.new_zeros(v.shape) for k, v in z.items()}
             return grads, z_nodes[0].new_tensor(float("nan"))
         else:


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/63864 changes the error messages for Cholesky errors in PyTorch. Pyro relies on `"singular U"` being part of the error message, which isn't the case anymore on PyTorch master. 

Note that https://github.com/pytorch/pytorch/pull/63864 also introduces a bunch of new error messages for singular solves, eigendecompositions, etc. that Pyro may also rely so we may need to fix those as well.