### PR TITLE
Fix multi-sample tests in contribfunsor by scaling samples manually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,8 +135,8 @@ setup(
         "horovod": ["horovod[pytorch]>=0.19"],
         "funsor": [
             # This must be a released version when Pyro is released.
-            # "funsor[torch] @ git+git://github.com/pyro-ppl/funsor.git@383e7a6d05c9d5de9646d23698891e10c4cba927",
-            "funsor[torch]==0.4.1",
+            "funsor[torch] @ git+git://github.com/pyro-ppl/funsor.git@b25eecdaaf134c536f280131bddcf47a475a3c37",
+            # "funsor[torch]==0.4.1",
         ],
     },
     python_requires=">=3.6",


### PR DESCRIPTION
The Funsor pull request https://github.com/pyro-ppl/funsor/pull/549 changed the semantics of `Funsor.sample` so that it no longer rescales its result by the number of particles, which broke some TMC tests in `pyro.contrib.funsor`.

This PR performs the sample rescaling manually within Pyro, fixes the broken tests and pins Pyro's Funsor dependency to the `master` commit merging the above Funsor PR.