### PR TITLE
Exclude jupyter notebooks from black reformatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ tutorial: FORCE
 
 lint: FORCE
 	flake8
-	black --check .
+	black --extend-exclude=\.ipynb --check .
 	isort --check .
 	python scripts/update_headers.py --check
 	mypy pyro
@@ -30,7 +30,7 @@ license: FORCE
 	python scripts/update_headers.py
 
 format: license FORCE
-	black .
+	black --extend-exclude=\.ipynb .
 	isort .
 
 version: FORCE


### PR DESCRIPTION
Newer `black` reformats notebooks by default.  While we'd like to do this eventually, we'll need to spend time fixing comments and removing embedded data in a few notebooks (e.g. tensor shapes and enumeration).  This PR simply disables ipynb formatting until we have time to fix existing notebooks.