### PR TITLE
Use dependencies in the AutoReparam strategy

### DIFF
--- a/pyro/infer/inspect.py
+++ b/pyro/infer/inspect.py
@@ -50,7 +50,6 @@ class TrackProvenance(Messenger):
             msg["value"] = ProvenanceTensor(value, provenance)
 
 
-@torch.enable_grad()
 def get_dependencies(
     model: Callable,
     model_args: Optional[tuple] = None,
@@ -172,7 +171,7 @@ def get_dependencies(
 
     # Collect sites with tracked provenance.
     with torch.random.fork_rng(), torch.no_grad(), pyro.validation_enabled(False):
-        with TrackProvenance():
+        with poutine.block(), TrackProvenance():
             trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
     sample_sites = [msg for msg in trace.nodes.values() if is_sample_site(msg)]
 
@@ -272,7 +271,7 @@ def get_model_relations(
         model_kwargs = {}
 
     with torch.random.fork_rng(), torch.no_grad(), pyro.validation_enabled(False):
-        with TrackProvenance():
+        with poutine.block(), TrackProvenance():
             trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
 
     sample_sample = {}


### PR DESCRIPTION
This attempts to apply `LocScaleReparam` in `AutoReparam` only for latent variables whose prior distributions depends on upstream variables. In case the prior has fixed parameters, there is no need to reparametrize, and reparametrizing introduces unnecessary complexity and obfuscation.

This first attempt is blocked by nuances in the interaction of `get_dependencies()` with `AutoReparam()`, since the model's latent variables are determined only dynamically, but they want to use dependencies to determine strategy. The fix may involve subtler use of `ProvenanceTensor` 🤔 