### PR TITLE
fix typo in svi part iv tutorial

### DIFF
--- a/tutorial/source/svi_part_iv.ipynb
+++ b/tutorial/source/svi_part_iv.ipynb
@@ -120,7 +120,7 @@
     "For example the `scale` parameter of a Normal distribution needs to be positive. Thus the following `bad_guide` is problematic:\n",
     "```python\n",
     "def bad_guide():\n",
-    "    scale = pyro.sample(\"scale\", torch.tensor(1.0))\n",
+    "    scale = pyro.param(\"scale\", torch.tensor(1.0))\n",
     "    pyro.sample(\"x\", dist.Normal(0.0, scale))\n",
     "``` \n",
     "while the following `good_guide` correctly uses a constraint to ensure positivity:\n",
@@ -128,7 +128,7 @@
     "from pyro.distributions import constraints\n",
     "\n",
     "def good_guide():\n",
-    "    scale = pyro.sample(\"scale\", torch.tensor(0.05),               \n",
+    "    scale = pyro.param(\"scale\", torch.tensor(0.05),               \n",
     "                        constraint=constraints.positive)\n",
     "    pyro.sample(\"x\", dist.Normal(0.0, scale))\n",
     "``` "
@@ -370,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`sample` -> `param`