### PR TITLE
Add a failing test for using init messenger with reparam inside plate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ tutorial: FORCE
 
 lint: FORCE
 	flake8
-	black --extend-exclude=\.ipynb --check .
+	black --extend-exclude=\.ipynb --check . || black --exclude=\.ipynb --check .
 	isort --check .
 	python scripts/update_headers.py --check
 	mypy pyro
@@ -30,7 +30,7 @@ license: FORCE
 	python scripts/update_headers.py
 
 format: license FORCE
-	black --extend-exclude=\.ipynb .
+	black --extend-exclude=\.ipynb --check . || black --exclude=\.ipynb --check .
 	isort .
 
 version: FORCE

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ tutorial: FORCE
 
 lint: FORCE
 	flake8
-	black --extend-exclude=\.ipynb --check . || black --exclude=\.ipynb --check .
+	black --check *.py pyro examples tests scripts profiler
 	isort --check .
 	python scripts/update_headers.py --check
 	mypy pyro
@@ -30,7 +30,7 @@ license: FORCE
 	python scripts/update_headers.py
 
 format: license FORCE
-	black --extend-exclude=\.ipynb --check . || black --exclude=\.ipynb --check .
+	black *.py pyro examples tests scripts profiler
 	isort .
 
 version: FORCE

--- a/tests/infer/reparam/test_loc_scale.py
+++ b/tests/infer/reparam/test_loc_scale.py
@@ -9,6 +9,7 @@ import pyro
 import pyro.distributions as dist
 from pyro import poutine
 from pyro.distributions.util import is_identically_one
+from pyro.infer.autoguide.initialization import InitMessenger, init_to_uniform
 from pyro.infer.reparam import LocScaleReparam
 from tests.common import assert_close
 
@@ -89,3 +90,15 @@ def test_init(dist_type, centered, shape):
                 return pyro.sample("x", dist.AsymmetricLaplace(loc, scale, 1.5))
 
     check_init_reparam(model, LocScaleReparam(centered))
+
+
+@pytest.mark.xfail(reason="reparam inside plate not compatible with init messenger")
+def test_init_with_reparam_inside_plate():
+    def model():
+        with pyro.plate("N", 10):
+            with poutine.reparam(config={"x": LocScaleReparam(centered=0.0)}):
+                return pyro.sample("x", dist.Normal(0, 1))
+
+    with InitMessenger(init_to_uniform()):
+        actual = model()
+        assert actual.shape == (10,)

--- a/tests/infer/reparam/test_loc_scale.py
+++ b/tests/infer/reparam/test_loc_scale.py
@@ -92,7 +92,12 @@ def test_init(dist_type, centered, shape):
     check_init_reparam(model, LocScaleReparam(centered))
 
 
-@pytest.mark.xfail(reason="reparam inside plate not compatible with init messenger")
+@pytest.mark.xfail(
+    reason=(
+        "reparam inside plate not compatible with init messenger,"
+        " issue https://github.com/pyro-ppl/pyro/issues/2990"
+    )
+)
 def test_init_with_reparam_inside_plate():
     def model():
         with pyro.plate("N", 10):


### PR DESCRIPTION
Added a test to catch the issue in #2970.

To resolve the issue, we need to apply `reparam` outside of plate statements. It would be nice to add a warning to help the users fix their model, but I'm not sure where we need to add such check.