### PR TITLE
Drop more references to Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ For additional blog posts, check out work on [experimental design](https://eng.u
 ### Installing a stable Pyro release
 
 **Install using pip:**
-
-Pyro supports Python 3.6+.
-
 ```sh
 pip install pyro-ppl
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ column_limit = 120
 # Global options:
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 warn_unused_configs = True
 warn_incomplete_stub = True

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ EXTRAS_REQUIRE = [
     "seaborn",
     "wget",
     "lap",
-    # 'biopython>=1.54',  # Requires Python 3.6
+    # 'biopython>=1.54',
     # 'scanpy>=1.4',  # Requires HDF5
     # 'scvi>=0.6',  # Requires loopy and other fragile packages
 ]

--- a/tests/distributions/test_pickle.py
+++ b/tests/distributions/test_pickle.py
@@ -76,14 +76,8 @@ def test_pickle(Dist):
         args = ARGS[Dist]
     else:
         # Optimistically try to initialize with Dist(1, 1, ..., 1).
-        try:
-            # Python 3.6+
-            spec = list(inspect.signature(Dist.__init__).parameters.values())
-            nargs = sum(1 for p in spec if p.default is p.empty) - 1
-        except AttributeError:
-            # Python 2.6-3.5
-            spec = inspect.getargspec(Dist.__init__)
-            nargs = len(spec.args) - 1 - (len(spec.defaults) if spec.defaults else 0)
+        spec = list(inspect.signature(Dist.__init__).parameters.values())
+        nargs = sum(1 for p in spec if p.default is p.empty) - 1
         args = (1,) * nargs
     try:
         dist = Dist(*args)

--- a/tutorial/source/cleannb.py
+++ b/tutorial/source/cleannb.py
@@ -15,7 +15,7 @@ def cleannb(nbfile):
     nb["metadata"]["kernelspec"]["name"] = "python3"
     nb["metadata"]["language_info"]["codemirror_mode"]["version"] = 3
     nb["metadata"]["language_info"]["pygments_lexer"] = "ipython3"
-    nb["metadata"]["language_info"]["version"] = "3.6.10"
+    nb["metadata"]["language_info"]["version"] = "3.7.1"
 
     with io.open(nbfile, "w", encoding="utf8") as f:
         nbformat.write(nb, f)


### PR DESCRIPTION
This drops more references to Python 3.6, following up on #3045 

@jamestwebber one reference that remains is the [docker/Makefile](https://github.com/pyro-ppl/pyro/blob/dev/docker/Makefile), which seems to use python==3.6 and an ubuntu image from 2016. Yikes actually, the [Dockerfile](https://github.com/pyro-ppl/pyro/blob/dev/docker/Dockerfile) is still on Python 2.7. I guess we should update this to Python 3.7 and a 2020 image?  Or should just we wait until users ask for an update?