### PR TITLE
Fix nbshpinx rendering of tutorials

### DIFF
--- a/tutorial/source/conf.py
+++ b/tutorial/source/conf.py
@@ -53,7 +53,9 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = [".rst", ".ipynb"]
+source_suffix = [".rst"]
+# Note: do not add .ipynb when nbspinx is enabled, otherwise you get a
+# "missing title" error. See https://stackoverflow.com/questions/55297443
 
 # do not execute cells
 nbsphinx_execute = "never"


### PR DESCRIPTION
I was having trouble generating the index and seeing lots of errors like 
```
WARNING: toctree contains reference to document 'gp' that doesn't have a title: no link will be generated
```
Removing ".ipynb" from the `source_suffix` in tutorial/source/conf.py seemed to resolve the issue.

See these posts for similar issues
- https://stackoverflow.com/questions/14079655/cannot-get-toctree-in-sphinx-to-show-link
- https://stackoverflow.com/questions/55297443/including-notebook-with-nbsphinx-fails