### PR TITLE
Modified docker file to use wget instead of curl

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          build-essential \
          cmake \
          git \
-         curl \
+         wget \
          ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
@@ -33,7 +33,7 @@ RUN bash -c 'if [ ${ostype} == Linux ]; then groupadd -r --gid ${gid} ${USER_NAM
 USER ${USER_NAME}
 
 # Install conda
-RUN curl -o ~/miniconda.sh -O \
+RUN wget -O ~/miniconda.sh \
     https://repo.continuum.io/miniconda/Miniconda${python_version%%.*}-latest-Linux-x86_64.sh && \
     bash ~/miniconda.sh -f -b -p ${CONDA_DIR} && \
     rm ~/miniconda.sh && \


### PR DESCRIPTION
For some weird reason, I couldn't compile the script with python version 3 - seems like the curl command was having issues downloading the miniconda script. Hence modified the script to use wget instead of curl. This solved my problem.