### PR TITLE
Fix docstrings of distributions rendered on sphinx

### DIFF
--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
-from abc import ABCMeta, abstractmethod
 import inspect
+from abc import ABCMeta, abstractmethod
 
 from pyro.distributions.score_parts import ScoreParts
 

--- a/pyro/distributions/distribution.py
+++ b/pyro/distributions/distribution.py
@@ -3,6 +3,7 @@
 
 import functools
 from abc import ABCMeta, abstractmethod
+import inspect
 
 from pyro.distributions.score_parts import ScoreParts
 
@@ -10,16 +11,17 @@ COERCIONS = []
 
 
 class DistributionMeta(ABCMeta):
+    def __init__(cls, *args, **kwargs):
+        signature = inspect.signature(functools.partial(cls.__init__, None))
+        cls.__signature__ = signature
+        return super().__init__(*args, **kwargs)
+
     def __call__(cls, *args, **kwargs):
         for coerce_ in COERCIONS:
             result = coerce_(cls, args, kwargs)
             if result is not None:
                 return result
         return super().__call__(*args, **kwargs)
-
-    @property
-    def __wrapped__(cls):
-        return functools.partial(cls.__init__, None)
 
 
 class Distribution(metaclass=DistributionMeta):


### PR DESCRIPTION
Currently, our [readthedocs](https://docs.pyro.ai/en/stable/distributions.html) shows `(*args, **kwargs)` for all distributions. This PR tries to fix that issue.

Tested:
![image](https://user-images.githubusercontent.com/4736342/162618046-05bcbfa2-c204-4d8a-8d72-bee6322961a1.png)
