### PR TITLE
Numerically stabilize ProjectedNormal.log_prob() via erfc

### DIFF
--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -127,7 +127,7 @@ def _dot(x, y):
 
 
 def _safe_log(x):
-    return x.clamp(min=torch.finfo(x.dtype).tiny).log()
+    return x.clamp(min=torch.finfo(x.dtype).eps).log()
 
 
 @ProjectedNormal._register_log_prob(dim=2)

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -131,7 +131,7 @@ def _log_prob_2(concentration, value):
     # We integrate along a ray, factorizing the integrand as a product of:
     # a truncated normal distribution over coordinate t parallel to the ray, and
     # a univariate normal distribution over coordinate r perpendicular to the ray.
-    t = _dot(concentration, value).clamp(min=torch.finfo(value.dtype).eps)
+    t = _dot(concentration, value)
     t2 = t.square()
     r2 = _dot(concentration, concentration) - t2
     perp_part = r2.mul(-0.5) - 0.5 * math.log(2 * math.pi)
@@ -139,12 +139,10 @@ def _log_prob_2(concentration, value):
     # This is the log of a definite integral, computed by mathematica:
     # Integrate[x/(E^((x-t)^2/2) Sqrt[2 Pi]), {x, 0, Infinity}]
     # = (t + Sqrt[2/Pi]/E^(t^2/2) + t Erf[t/Sqrt[2]])/2
+    # = (Sqrt[2/Pi]/E^(t^2/2) + t (1 + Erf[t/Sqrt[2]]))/2
     para_part = torch.logaddexp(
-        t.log(),
-        torch.logaddexp(
-            t2.mul(-0.5) - math.log(math.pi / 2) / 2,
-            t.log() + (t * 0.5**0.5).erf().log(),
-        ),
+        t2.mul(-0.5) - math.log(math.pi / 2) / 2,
+        t.log() + (t * 0.5**0.5).erf().log1p(),  # FIXME t.log() may be nan
     ) - math.log(2)
 
     return para_part + perp_part
@@ -155,7 +153,7 @@ def _log_prob_3(concentration, value):
     # We integrate along a ray, factorizing the integrand as a product of:
     # a truncated normal distribution over coordinate t parallel to the ray, and
     # a bivariate normal distribution over coordinate r perpendicular to the ray.
-    t = _dot(concentration, value).clamp(min=torch.finfo(value.dtype).eps)
+    t = _dot(concentration, value)
     t2 = t.square()
     r2 = _dot(concentration, concentration) - t2
     perp_part = r2.mul(-0.5) - math.log(2 * math.pi)
@@ -176,7 +174,7 @@ def _log_prob_4(concentration, value):
     # We integrate along a ray, factorizing the integrand as a product of:
     # a truncated normal distribution over coordinate t parallel to the ray, and
     # a bivariate normal distribution over coordinate r perpendicular to the ray.
-    t = _dot(concentration, value).clamp(min=torch.finfo(value.dtype).eps)
+    t = _dot(concentration, value)
     t2 = t.square()
     r2 = _dot(concentration, concentration) - t2
     perp_part = r2.mul(-0.5) - 1.5 * math.log(2 * math.pi)
@@ -186,6 +184,7 @@ def _log_prob_4(concentration, value):
     # = (2 + t^2)/(E^(t^2/2) Sqrt[2 Pi]) + (t (3 + t^2) (1 + Erf[t/Sqrt[2]]))/2
     para_part = torch.logaddexp(
         (2 + t2).log() + t2.mul(-0.5) - math.log(2 * math.pi) / 2,
+        # FIXME t.log() may be nan below:
         t.log() + (3 + t2).log() + (t * 0.5**0.5).erf().log1p() - math.log(2),
     )
 

--- a/pyro/ops/special.py
+++ b/pyro/ops/special.py
@@ -213,6 +213,6 @@ def _log_factorial_sum(x: torch.Tensor) -> torch.Tensor:
         return (x + 1).lgamma().sum()
     key = id(x)
     if key not in _log_factorial_cache:
-        weakref.finalize(x, _log_factorial_cache.pop, key, None)
+        weakref.finalize(x, _log_factorial_cache.pop, key, None)  # type: ignore
         _log_factorial_cache[key] = (x + 1).lgamma().sum()
     return _log_factorial_cache[key]

--- a/tests/common.py
+++ b/tests/common.py
@@ -103,6 +103,21 @@ def tensors_default_to(host):
 
 
 @contextlib.contextmanager
+def default_dtype(dtype):
+    """
+    Context manager to temporarily set PyTorch default dtype.
+
+    :param str host: Either "cuda" or "cpu".
+    """
+    old = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(dtype)
+        yield
+    finally:
+        torch.set_default_dtype(old)
+
+
+@contextlib.contextmanager
 def freeze_rng_state():
     rng_state = torch.get_rng_state()
     if torch.cuda.is_available():

--- a/tests/distributions/conftest.py
+++ b/tests/distributions/conftest.py
@@ -526,10 +526,13 @@ continuous_dists = [
         pyro_dist=dist.ProjectedNormal,
         examples=[
             {"concentration": [0.0, 0.0], "test_data": [1.0, 0.0]},
+            {"concentration": [0.2, 0.1], "test_data": [1.0, 0.0]},
             {"concentration": [2.0, 3.0], "test_data": [0.0, 1.0]},
-            {"concentration": [0.0, 0.0, 0.0], "test_data": [1.0, 0.0, 0.0]},
+            {"concentration": [0.1, 0.0, 0.0], "test_data": [1.0, 0.0, 0.0]},
+            {"concentration": [0.3, 0.2, 0.1], "test_data": [1.0, 0.0, 0.0]},
             {"concentration": [-1.0, 2.0, 3.0], "test_data": [0.0, 0.0, 1.0]},
             {"concentration": [0.0, 0.0, 0.0, 0.0], "test_data": [1.0, 0.0, 0.0, 0.0]},
+            {"concentration": [0.4, 0.3, 0.2, 0.1], "test_data": [1.0, 0.0, 0.0, 0.0]},
             {
                 "concentration": [-1.0, 2.0, 0.5, -0.5],
                 "test_data": [0.0, 1.0, 0.0, 0.0],

--- a/tests/distributions/test_distributions.py
+++ b/tests/distributions/test_distributions.py
@@ -143,7 +143,8 @@ def test_gof(continuous_dist):
     num_samples = 50000
     for i in range(continuous_dist.get_num_test_data()):
         d = Dist(**continuous_dist.get_dist_params(i))
-        samples = d.sample(torch.Size([num_samples]))
+        with torch.random.fork_rng():
+            samples = d.sample(torch.Size([num_samples]))
         with xfail_if_not_implemented():
             probs = d.log_prob(samples).exp()
 

--- a/tests/distributions/test_projected_normal.py
+++ b/tests/distributions/test_projected_normal.py
@@ -1,0 +1,20 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import pyro.distributions as dist
+from tests.common import default_dtype
+
+
+@pytest.mark.parametrize("strength", [0, 1, 10, 100, 1000])
+@pytest.mark.parametrize("dim", [2, 3, 4])
+@pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
+def test_log_prob(dtype, dim, strength):
+    with default_dtype(dtype):
+        concentration = torch.full((dim,), float(strength))
+        value = dist.ProjectedNormal(torch.zeros_like(concentration)).sample([10000])
+        d = dist.ProjectedNormal(concentration)
+        logp = d.log_prob(value)
+        assert logp.max().lt(1 + dim * strength).all()

--- a/tests/distributions/test_projected_normal.py
+++ b/tests/distributions/test_projected_normal.py
@@ -13,8 +13,12 @@ from tests.common import default_dtype
 @pytest.mark.parametrize("dtype", [torch.float, torch.double], ids=str)
 def test_log_prob(dtype, dim, strength):
     with default_dtype(dtype):
-        concentration = torch.full((dim,), float(strength))
+        concentration = torch.full((dim,), float(strength), requires_grad=True)
         value = dist.ProjectedNormal(torch.zeros_like(concentration)).sample([10000])
         d = dist.ProjectedNormal(concentration)
+
         logp = d.log_prob(value)
         assert logp.max().lt(1 + dim * strength).all()
+
+        logp.sum().backward()
+        assert not torch.isnan(concentration.grad).any()


### PR DESCRIPTION
This attempts to resolve @geoffwoollard's [forum issue](https://forum.pyro.ai/t/svi-nans-from-guide-when-trace-elbo-drops/4102) by numerically stabilizing `ProjectedNormal.log_prob()` using `torch.erfc()`.

## Tested
- covered by existing unit tests
- added new test cases
- added new test for nans