### PR TITLE
fix documentation class names to VariationalSparseGP

### DIFF
--- a/examples/contrib/gp/sv-dkl.py
+++ b/examples/contrib/gp/sv-dkl.py
@@ -9,7 +9,7 @@ Follow the idea from reference [1], we will combine a convolutional neural netwo
 
     >>> deep_kernel = gp.kernels.Warping(rbf, iwarping_fn=cnn)
 
-SparseVariationalGP model allows us train the data in mini-batch (time complexity
+VariationalSparseGP model allows us train the data in mini-batch (time complexity
 scales linearly to the number of data points).
 
 Note that the implementation here is different from [1]. There the authors

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -62,7 +62,7 @@ class SparseGPRegression(GPModel):
 
     + Variational Free Energy (VFE), which is similar to DTC but has an additional
       `trace_term` in the model's log likelihood. This additional term makes "VFE"
-      equivalent to the variational approach in :class:`.SparseVariationalGP`
+      equivalent to the variational approach in :class:`.VariationalSparseGP`
       (see reference [2]).
 
     .. note:: This model has :math:`\\mathcal{O}(NM^2)` complexity for training,

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -32,7 +32,7 @@ class VariationalGP(GPModel):
     be learned during a variational inference process.
 
     .. note:: This model can be seen as a special version of
-        :class:`.SparseVariationalGP` model with :math:`X_u = X`.
+        :class:`.VariationalSparseGP` model with :math:`X_u = X`.
 
     .. note:: This model has :math:`\mathcal{O}(N^3)` complexity for training,
         :math:`\mathcal{O}(N^3)` complexity for testing. Here, :math:`N` is the number

--- a/tests/contrib/gp/test_models.py
+++ b/tests/contrib/gp/test_models.py
@@ -254,7 +254,7 @@ def test_inference_with_empty_latent_shape(model_class, X, y, kernel, likelihood
         return
     elif model_class is VariationalGP:
         gp = model_class(X, y, kernel, likelihood, latent_shape=torch.Size([]))
-    else:  # model_class is SparseVariationalGP
+    else:  # model_class is VariationalSparseGP
         gp = model_class(
             X, y, kernel, X.clone(), likelihood, latent_shape=torch.Size([])
         )
@@ -271,7 +271,7 @@ def test_inference_with_whiten(model_class, X, y, kernel, likelihood):
         return
     elif model_class is VariationalGP:
         gp = model_class(X, y, kernel, likelihood, whiten=True)
-    else:  # model_class is SparseVariationalGP
+    else:  # model_class is VariationalSparseGP
         gp = model_class(X, y, kernel, X.clone(), likelihood, whiten=True)
 
     train(gp, num_steps=1)


### PR DESCRIPTION
Fixed typos after discussion in the [issue 3073](https://github.com/pyro-ppl/pyro/issues/3073).