### PR TITLE
Add type assertion for `model_args` and `model_kwargs` of `render_model`

### DIFF
--- a/pyro/infer/inspect.py
+++ b/pyro/infer/inspect.py
@@ -552,6 +552,9 @@ def render_model(
     assert model_args is None or isinstance(
         model_args, tuple
     ), "model_args must be None or tuple"
+    assert model_kwargs is None or isinstance(
+        model_kwargs, dict
+    ), "model_kwargs must be None or dict"
     relations = get_model_relations(model, model_args, model_kwargs)
     graph_spec = generate_graph_specification(relations, render_params=render_params)
     graph = render_graph(graph_spec, render_distributions=render_distributions)

--- a/pyro/infer/inspect.py
+++ b/pyro/infer/inspect.py
@@ -549,6 +549,7 @@ def render_model(
     :returns: A model graph.
     :rtype: graphviz.Digraph
     """
+    assert model_args is None or isinstance(model_args, tuple), "model_args must be None or tuple"
     relations = get_model_relations(model, model_args, model_kwargs)
     graph_spec = generate_graph_specification(relations, render_params=render_params)
     graph = render_graph(graph_spec, render_distributions=render_distributions)

--- a/pyro/infer/inspect.py
+++ b/pyro/infer/inspect.py
@@ -549,7 +549,9 @@ def render_model(
     :returns: A model graph.
     :rtype: graphviz.Digraph
     """
-    assert model_args is None or isinstance(model_args, tuple), "model_args must be None or tuple"
+    assert model_args is None or isinstance(
+        model_args, tuple
+    ), "model_args must be None or tuple"
     relations = get_model_relations(model, model_args, model_kwargs)
     graph_spec = generate_graph_specification(relations, render_params=render_params)
     graph = render_graph(graph_spec, render_distributions=render_distributions)


### PR DESCRIPTION
If a model contains only one parameter, then a user might attempt to pass an argument that is not a `tuple`. In that case, the user is likely to get an error message which does not point out the exact reason (see #3082). Therefore, adding this assertion would help them pinpoint the reason faster.