### PR TITLE
Fix Nyström Typo

### DIFF
--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -19,7 +19,7 @@ class SparseGPRegression(GPModel):
     the covariance matrix :math:`k(X, X)` will require a lot of computational steps to
     compute its inverse (for log likelihood and for prediction). By introducing an
     additional inducing-input parameter :math:`X_u`, we can reduce computational cost
-    by approximate :math:`k(X, X)` by a low-rank Nymstr\u00F6m approximation :math:`Q`
+    by approximate :math:`k(X, X)` by a low-rank Nystr\u00F6m approximation :math:`Q`
     (see reference [1]), where
 
     .. math:: Q = k(X, X_u) k(X_u,X_u)^{-1} k(X_u, X).


### PR DESCRIPTION
I believe that the relevant mathematician was called [Nyström](https://www.doi.org/10.1007/BF02547521).