### PR TITLE
Fix a typo in air tutorial

### DIFF
--- a/tutorial/source/air.ipynb
+++ b/tutorial/source/air.ipynb
@@ -518,7 +518,7 @@
     "    h, c = rnn(rnn_input, (prev.h, prev.c))\n",
     "\n",
     "    # Compute parameters for all choices made this step, by passing\n",
-    "    # the RNN hidden start through another neural network.\n",
+    "    # the RNN hidden state through another neural network.\n",
     "    z_pres_p, z_where_loc, z_where_scale, z_what_loc, z_what_scale = predict_basic(h)\n",
     "\n",
     "    z_pres = pyro.sample('z_pres_{}'.format(t),\n",


### PR DESCRIPTION
I believe it meant `state` and not `start`.