### PR TITLE
store batch_shape as torch.Size object in MultivariateStudentT distribution

### DIFF
--- a/pyro/distributions/multivariate_studentt.py
+++ b/pyro/distributions/multivariate_studentt.py
@@ -36,7 +36,9 @@ class MultivariateStudentT(TorchDistribution):
         assert scale_tril.shape[-2:] == (dim, dim)
         if not isinstance(df, torch.Tensor):
             df = loc.new_tensor(df)
-        batch_shape = torch.broadcast_shapes(df.shape, loc.shape[:-1], scale_tril.shape[:-2])
+        batch_shape = torch.broadcast_shapes(
+            df.shape, loc.shape[:-1], scale_tril.shape[:-2]
+        )
         event_shape = torch.Size((dim,))
         self.df = df.expand(batch_shape)
         self.loc = loc.expand(batch_shape + event_shape)


### PR DESCRIPTION
resolves https://github.com/pyro-ppl/pyro/issues/3098
according to suggestions by @fritzo 

Since this is my first contribution here, I'd be happy if you could point out, things I should improve in the PR