### PR TITLE
Allow autocorrelation() to run without MKL

### DIFF
--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -93,11 +93,6 @@ def autocorrelation(input, dim=0):
     :param int dim: the dimension to calculate autocorrelation.
     :returns torch.Tensor: autocorrelation of ``input``.
     """
-    if (not input.is_cuda) and (not torch.backends.mkl.is_available()):
-        raise NotImplementedError(
-            "For CPU tensor, this method is only supported " "with MKL installed."
-        )
-
     # Adapted from Stan implementation
     # https://github.com/stan-dev/math/blob/develop/stan/math/prim/mat/fun/autocorrelation.hpp
     N = input.size(dim)


### PR DESCRIPTION
This allows `pyro.ops.stats.autocorrelation()` to run on CPU even without MKL, as that has apparently been fixed upstream.  In retrospect, we should have implemented this as a `try ... except` block so that when the error was fixed upstream we could automatically use the function in Pyro; the `try .. except` block would merely have clarified the low-level error message.

## Tested
- covered by existing tests