### PR TITLE
Numerically stabilize autocorrelation()

### DIFF
--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -93,11 +93,6 @@ def autocorrelation(input, dim=0):
     :param int dim: the dimension to calculate autocorrelation.
     :returns torch.Tensor: autocorrelation of ``input``.
     """
-    if (not input.is_cuda) and (not torch.backends.mkl.is_available()):
-        raise NotImplementedError(
-            "For CPU tensor, this method is only supported " "with MKL installed."
-        )
-
     # Adapted from Stan implementation
     # https://github.com/stan-dev/math/blob/develop/stan/math/prim/mat/fun/autocorrelation.hpp
     N = input.size(dim)

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -117,7 +117,7 @@ def autocorrelation(input, dim=0):
     autocorr = autocorr / torch.tensor(
         range(N, 0, -1), dtype=input.dtype, device=input.device
     )
-    autocorr = autocorr / autocorr[..., :1]
+    autocorr = autocorr / autocorr[..., :1].clamp(min=torch.finfo(autocorr.dtype).tiny)
     return autocorr.transpose(dim, -1)
 
 

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -114,6 +114,27 @@ def test_autocorrelation():
     )
 
 
+def test_autocorrelation_trivial():
+    x = torch.zeros(10)
+    with xfail_if_not_implemented():
+        actual = autocorrelation(x)
+    assert_equal(actual, torch.ones(10), prec=0.01)
+
+
+def test_autocorrelation_vectorized():
+    # make a mostly noisy x with a couple constant series
+    x = torch.randn(3, 4, 5)
+    x[1, 2] = 0
+    x[2, 3] = 1
+
+    actual = autocorrelation(x, dim=-1)
+    expected = torch.tensor([[autocorrelation(xij).tolist() for xij in xi] for xi in x])
+    assert_equal(actual, expected)
+
+    assert (actual[1, 2] == 1).all()
+    assert (actual[2, 3] == 1).all()
+
+
 def test_autocovariance():
     x = torch.arange(10.0)
     with xfail_if_not_implemented():

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -105,8 +105,7 @@ def test_statistics_A_ok_with_sample_shape(statistics, sample_shape):
 
 def test_autocorrelation():
     x = torch.arange(10.0)
-    with xfail_if_not_implemented():
-        actual = autocorrelation(x)
+    actual = autocorrelation(x)
     assert_equal(
         actual,
         torch.tensor([1, 0.78, 0.52, 0.21, -0.13, -0.52, -0.94, -1.4, -1.91, -2.45]),
@@ -116,8 +115,7 @@ def test_autocorrelation():
 
 def test_autocorrelation_trivial():
     x = torch.zeros(10)
-    with xfail_if_not_implemented():
-        actual = autocorrelation(x)
+    actual = autocorrelation(x)
     assert_equal(actual, torch.ones(10), prec=0.01)
 
 


### PR DESCRIPTION
This sets the autocorrelation of constant series to be 1.0 rather than NAN.

I believe this is the proper behavior for MCMC testing, where series with no variation should be seen as having effective sample size of 1.

My use case is in computing autocorrelation of discrete time series, where I'm using autocorrelation as a diagnostic to detect lack of mixing.  In that case I believe this PR is correct.

## Tested
- [x] added two unit tests
- [x] avoided NANs locally in [this notebook](https://github.com/fritzo/notebooks/blob/master/potts-locally-informed-mh.ipynb)