### PR TITLE
Improve sequential_gaussian_filter_sample()

### DIFF
--- a/examples/contrib/forecast/bart.py
+++ b/examples/contrib/forecast/bart.py
@@ -31,6 +31,7 @@ def preprocess(args):
     arrivals = dataset["counts"][:, :, i].sum(-1)
     departures = dataset["counts"][:, i, :].sum(-1)
     data = torch.stack([arrivals, departures], dim=-1)
+    print(f"Loaded data of shape {tuple(data.shape)}")
 
     # This simple example uses no covariates, so we will construct a
     # zero-element tensor of the correct length as empty covariates.

--- a/profiler/gaussianhmm.py
+++ b/profiler/gaussianhmm.py
@@ -9,23 +9,14 @@ from tqdm.auto import tqdm
 import pyro.distributions as dist
 
 
-def random_mvn(batch_shape, dim):
+def random_mvn(batch_shape, dim, requires_grad=False):
     rank = dim + dim
-    loc = torch.randn(batch_shape + (dim,), requires_grad=True)
+    loc = torch.randn(batch_shape + (dim,), requires_grad=requires_grad)
     cov = torch.randn(batch_shape + (dim, rank))
     cov = cov.matmul(cov.transpose(-1, -2))
     scale_tril = torch.linalg.cholesky(cov)
-    scale_tril.requires_grad_()
+    scale_tril.requires_grad_(requires_grad)
     return dist.MultivariateNormal(loc, scale_tril=scale_tril)
-
-
-def find_parameters(params: list, *xs) -> None:
-    for x in xs:
-        if isinstance(x, torch.Tensor):
-            if x.requires_grad:
-                params.append(x)
-        elif isinstance(x, dist.Distribution):
-            find_parameters(params, *x.__dict__.values())
 
 
 def main(args):
@@ -38,28 +29,39 @@ def main(args):
     batch_shape = (args.batch_size,)
 
     # Initialize parts.
-    init_dist = random_mvn(batch_shape, hidden_dim)
-    trans_dist = random_mvn(batch_shape + (duration,), hidden_dim)
-    obs_dist = random_mvn(batch_shape + (1,), obs_dim)
-    trans_mat = (
-        torch.randn(batch_shape + (duration, hidden_dim, hidden_dim))
-        .mul_(0.1)
-        .requires_grad_()
+    init_dist = random_mvn(batch_shape, hidden_dim, requires_grad=args.grad)
+    trans_dist = random_mvn(
+        batch_shape + (duration,), hidden_dim, requires_grad=args.grad
     )
-    obs_mat = torch.randn(batch_shape + (1, hidden_dim, obs_dim), requires_grad=True)
+    obs_dist = random_mvn(batch_shape + (1,), obs_dim, requires_grad=args.grad)
+    trans_mat = 0.1 * torch.randn(batch_shape + (duration, hidden_dim, hidden_dim))
+    obs_mat = torch.randn(batch_shape + (1, hidden_dim, obs_dim))
 
-    # Collect parameters.
-    params = []
-    find_parameters(params, init_dist, trans_dist, obs_dist, trans_mat, obs_mat)
-    assert params
+    if args.grad:
+        # Collect parameters.
+        params = [
+            init_dist.loc,
+            init_dist.scale_tril,
+            trans_dist.loc,
+            trans_dist.scale_tril,
+            obs_dist.loc,
+            obs_dist.scale_tril,
+            trans_mat.requires_grad_(),
+            obs_mat.requires_grad_(),
+        ]
 
     # Build a distribution.
     d = dist.GaussianHMM(
         init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=duration
     )
 
-    # Time forward + backward.
     for step in tqdm(range(args.num_steps)):
+        if not args.grad:
+            # Time forward only.
+            d.sample()
+            continue
+
+        # Time forward + backward.
         x = d.rsample()
         grads = torch.autograd.grad(
             x.sum(), params, allow_unused=True, retain_graph=True
@@ -70,11 +72,12 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="GaussianHMM profiler")
-    parser.add_argument("--hidden-dim", type=int, default=10)
-    parser.add_argument("--obs-dim", type=int, default=20)
-    parser.add_argument("--duration", type=int, default=5000)
+    parser.add_argument("--hidden-dim", type=int, default=4)
+    parser.add_argument("--obs-dim", type=int, default=4)
+    parser.add_argument("--duration", type=int, default=10000)
     parser.add_argument("--batch-size", type=int, default=3)
-    parser.add_argument("--num-steps", type=int, default=10)
-    parser.add_argument("--cuda", action="store_true")
+    parser.add_argument("-n", "--num-steps", type=int, default=100)
+    parser.add_argument("--cuda", action="store_true", default=False)
+    parser.add_argument("--grad", action="store_true", default=False)
     args = parser.parse_args()
     main(args)

--- a/profiler/gaussianhmm.py
+++ b/profiler/gaussianhmm.py
@@ -1,0 +1,80 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+import torch
+from tqdm.auto import tqdm
+
+import pyro.distributions as dist
+
+
+def random_mvn(batch_shape, dim):
+    rank = dim + dim
+    loc = torch.randn(batch_shape + (dim,), requires_grad=True)
+    cov = torch.randn(batch_shape + (dim, rank))
+    cov = cov.matmul(cov.transpose(-1, -2))
+    scale_tril = torch.linalg.cholesky(cov)
+    scale_tril.requires_grad_()
+    return dist.MultivariateNormal(loc, scale_tril=scale_tril)
+
+
+def find_parameters(params: list, *xs) -> None:
+    for x in xs:
+        if isinstance(x, torch.Tensor):
+            if x.requires_grad:
+                params.append(x)
+        elif isinstance(x, dist.Distribution):
+            find_parameters(params, *x.__dict__.values())
+
+
+def main(args):
+    if args.cuda:
+        torch.set_default_tensor_type("torch.cuda.FloatTensor")
+
+    hidden_dim = args.hidden_dim
+    obs_dim = args.obs_dim
+    duration = args.duration
+    batch_shape = (args.batch_size,)
+
+    # Initialize parts.
+    init_dist = random_mvn(batch_shape, hidden_dim)
+    trans_dist = random_mvn(batch_shape + (duration,), hidden_dim)
+    obs_dist = random_mvn(batch_shape + (1,), obs_dim)
+    trans_mat = (
+        torch.randn(batch_shape + (duration, hidden_dim, hidden_dim))
+        .mul_(0.1)
+        .requires_grad_()
+    )
+    obs_mat = torch.randn(batch_shape + (1, hidden_dim, obs_dim), requires_grad=True)
+
+    # Collect parameters.
+    params = []
+    find_parameters(params, init_dist, trans_dist, obs_dist, trans_mat, obs_mat)
+    assert params
+
+    # Build a distribution.
+    d = dist.GaussianHMM(
+        init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=duration
+    )
+
+    # Time forward + backward.
+    for step in tqdm(range(args.num_steps)):
+        x = d.rsample()
+        grads = torch.autograd.grad(
+            x.sum(), params, allow_unused=True, retain_graph=True
+        )
+        assert not all(g is None for g in grads)
+        del x
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="GaussianHMM profiler")
+    parser.add_argument("--hidden-dim", type=int, default=10)
+    parser.add_argument("--obs-dim", type=int, default=20)
+    parser.add_argument("--duration", type=int, default=5000)
+    parser.add_argument("--batch-size", type=int, default=3)
+    parser.add_argument("--num-steps", type=int, default=10)
+    parser.add_argument("--cuda", action="store_true")
+    args = parser.parse_args()
+    main(args)

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -589,7 +589,8 @@ class GaussianHMM(HiddenMarkovModel):
         )
         trans = trans.expand(trans.batch_shape[:-1] + (self.duration,))
         z = sequential_gaussian_filter_sample(self._init, trans, sample_shape)
-        x = self._obs.left_condition(z).rsample()
+        z = z[..., 1:, :]  # drop the initial hidden state
+        x = self._obs.left_condition().rsample()
         return x
 
     def rsample_posterior(self, value, sample_shape=torch.Size()):
@@ -599,6 +600,7 @@ class GaussianHMM(HiddenMarkovModel):
         trans = self._trans + self._obs.condition(value).event_pad(left=self.hidden_dim)
         trans = trans.expand(trans.batch_shape)
         z = sequential_gaussian_filter_sample(self._init, trans, sample_shape)
+        z = z[..., 1:, :]  # drop the initial hidden state
         return z
 
     def filter(self, value):

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -590,7 +590,7 @@ class GaussianHMM(HiddenMarkovModel):
         trans = trans.expand(trans.batch_shape[:-1] + (self.duration,))
         z = sequential_gaussian_filter_sample(self._init, trans, sample_shape)
         z = z[..., 1:, :]  # drop the initial hidden state
-        x = self._obs.left_condition().rsample()
+        x = self._obs.left_condition(z).rsample()
         return x
 
     def rsample_posterior(self, value, sample_shape=torch.Size()):

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -683,16 +683,10 @@ def sequential_gaussian_filter_sample(
             cond = cond[..., 1:-1, :]  # [z0, z2, z2, z4]
             cond = cond.reshape(shape + (-1, 2 * state_dim))  # [z0z2, z2z4]
             sample = rsample(joint.condition(cond))  # [z1, z3]
-            sample = torch.nn.functional.pad(sample, (0, 0, 0, 1))  # [z1, z3, 0]
-            result = torch.stack(
-                [
-                    result,  # [z0, z2, z4]
-                    sample,  # [z1, z3, 0]
-                ],
-                dim=-2,
-            )  # [[z0, z1], [z2, z3], [z4, 0]]
-            result = result.reshape(shape + (-1, state_dim))  # [z0, z1, z2, z3, z4, 0]
-            result = result[..., :-1, :]  # [z0, z1, z2, z3, z4]
+            interleaved = torch.empty(shape + (2 * result.size(-2) - 1, state_dim))
+            interleaved[..., ::2, :] = result  # [z0, _, z2, _, z4]
+            interleaved[..., 1::2, :] = sample  # [_, z1, _, z3, _]
+            result = interleaved  # [z0, z1, z2, z3, z4]
         else:  # ODD case.
             assert joint.batch_shape[-1] == result.size(-2) - 2
             # Suppose e.g. result = [z0, z2, z3]
@@ -700,15 +694,11 @@ def sequential_gaussian_filter_sample(
             cond = cond[..., 1:-1, :]  # [z0, z2]
             cond = cond.reshape(shape + (-1, 2 * state_dim))  # [z0z2]
             sample = rsample(joint.condition(cond))  # [z1]
-            sample = torch.cat([sample, result[..., -1:, :]], dim=-2)  # [z1, z3]
-            result = torch.stack(
-                [
-                    result[..., :-1, :],  # [z0, z2]
-                    sample,  # [z1, z3]
-                ],
-                dim=-2,
-            )  # [[z0, z1], [z2, z3]]
-            result = result.reshape(shape + (-1, state_dim))  # [z0, z1, z2, z3]
+            interleaved = torch.empty(shape + (2 * result.size(-2) - 2, state_dim))
+            interleaved[..., ::2, :] = result[..., :-1, :]  # [z0, _, z2, _]
+            interleaved[..., -1, :] = result[..., -1, :]  # [_, _, _, z3]
+            interleaved[..., 1:-1:2, :] = sample  # [_, z1, _, _]
+            result = interleaved  # [z0, z1, z2, z3]
 
     assert noise_position == duration, "too much noise provided"
     assert result.shape == result_shape

--- a/tests/ops/gaussian.py
+++ b/tests/ops/gaussian.py
@@ -8,16 +8,17 @@ from pyro.ops.gaussian import Gaussian
 from tests.common import assert_close
 
 
-def random_gaussian(batch_shape, dim, rank=None):
+def random_gaussian(batch_shape, dim, rank=None, requires_grad=False):
     """
     Generate a random Gaussian for testing.
     """
     if rank is None:
         rank = dim + dim
-    log_normalizer = torch.randn(batch_shape)
-    info_vec = torch.randn(batch_shape + (dim,))
+    log_normalizer = torch.randn(batch_shape, requires_grad=requires_grad)
+    info_vec = torch.randn(batch_shape + (dim,), requires_grad=requires_grad)
     samples = torch.randn(batch_shape + (dim, rank))
     precision = torch.matmul(samples, samples.transpose(-2, -1))
+    precision.requires_grad_(requires_grad)
     result = Gaussian(log_normalizer, info_vec, precision)
     assert result.dim() == dim
     assert result.batch_shape == batch_shape

--- a/tests/ops/gaussian.py
+++ b/tests/ops/gaussian.py
@@ -8,7 +8,7 @@ from pyro.ops.gaussian import Gaussian
 from tests.common import assert_close
 
 
-def random_gaussian(batch_shape, dim, rank=None, requires_grad=False):
+def random_gaussian(batch_shape, dim, rank=None, *, requires_grad=False):
     """
     Generate a random Gaussian for testing.
     """
@@ -25,14 +25,15 @@ def random_gaussian(batch_shape, dim, rank=None, requires_grad=False):
     return result
 
 
-def random_mvn(batch_shape, dim):
+def random_mvn(batch_shape, dim, *, requires_grad=False):
     """
     Generate a random MultivariateNormal distribution for testing.
     """
     rank = dim + dim
-    loc = torch.randn(batch_shape + (dim,))
+    loc = torch.randn(batch_shape + (dim,), requires_grad=requires_grad)
     cov = torch.randn(batch_shape + (dim, rank))
     cov = cov.matmul(cov.transpose(-1, -2))
+    cov.requires_grad_(requires_grad)
     return dist.MultivariateNormal(loc, cov)
 
 

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -519,3 +519,29 @@ def test_sequential_gaussian_filter_sample(
     trans = random_gaussian(batch_shape + (num_steps,), state_dim + state_dim)
     sample = sequential_gaussian_filter_sample(init, trans, sample_shape)
     assert sample.shape == sample_shape + batch_shape + (num_steps, state_dim)
+
+
+@pytest.mark.parametrize("num_steps", list(range(1, 20)))
+@pytest.mark.parametrize("state_dim", [1, 2, 3])
+@pytest.mark.parametrize("batch_shape", [(), (4,), (3, 2)], ids=str)
+@pytest.mark.parametrize("sample_shape", [(), (4,), (3, 2)], ids=str)
+def test_sequential_gaussian_filter_sample_antithetic(
+    sample_shape, batch_shape, state_dim, num_steps
+):
+    init = random_gaussian(batch_shape, state_dim)
+    trans = random_gaussian(batch_shape + (num_steps,), state_dim + state_dim)
+
+    noise = torch.randn(sample_shape + batch_shape + (num_steps + 1, state_dim))
+    zero = torch.zeros_like(noise)
+    sample = sequential_gaussian_filter_sample(init, trans, sample_shape, noise)
+    mean = sequential_gaussian_filter_sample(init, trans, sample_shape, zero)
+    assert sample.shape == sample_shape + batch_shape + (num_steps, state_dim)
+    assert mean.shape == sample_shape + batch_shape + (num_steps, state_dim)
+
+    # Check that antithetic sampling works as expected.
+    noise3 = torch.stack([noise, zero, -noise])
+    sample3 = sequential_gaussian_filter_sample(
+        init, trans, (3,) + sample_shape, noise3
+    )
+    expected = torch.stack([sample, mean, 2 * mean - sample])
+    assert torch.allclose(sample3, expected)


### PR DESCRIPTION
This makes a number of improvements to `sequential_gaussian_filter_sample()`:
1. Allows user to pass in noise, rather than drawing noise internally (i.e. more JAX-style).  The motivation here is to allow both (1) computing the mean, and (2) supporting antithetic sampling where we can pass in `cat([noise, -noise])`.
2. Avoid dropping the first entry of the returned samples.  This makes `sequential_gaussian_filter_sample()` more useful outside of the context of `GaussianHMM`, e.g. it will be easier to use in a fully-observed Markov model.  This attempts to make up for my admittedly bad design choice of making the hidden Z series one step longer than the observed X series in `GaussianHMM` 😬 
3. Adds a profiling script.  I saw no speed changes due to this PR.
4. Refactors some backward-sample logic to use placement into a `torch.empty()`, rather than `torch.nn.functional.pad` and `torch.stack`.  This is admittedly less functional, but does reduce memory usage and IMHO reads cleaner.

This also exposes the helper `matrix_and_gaussian_to_gaussian()` which I'm finding useful.

## Tested
- [x] added new gradient tests
- [x] added tests for antithetic sampling
- [x] profiled with and without gradients, saw no time difference