### PR TITLE
feat: add type hints for param_store.py in `params` module

### DIFF
--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -4,9 +4,8 @@
 import re
 import warnings
 import weakref
-
 from contextlib import contextmanager
-from typing import Callable, Generator, Optional, Tuple, Union, Iterator
+from typing import Callable, Generator, Iterator, Optional, Tuple, Union
 from typing.collections import KeysView
 
 import torch

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -4,9 +4,9 @@
 import re
 import warnings
 import weakref
-from collections.abc import Iterator, KeysView
+from collections.abc import KeysView
 from contextlib import contextmanager
-from typing import Callable, Generator, Optional, Tuple, Union
+from typing import Callable, Generator, Optional, Tuple, Union, Iterator
 
 import torch
 from torch.distributions import constraints, transform_to

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -58,7 +58,7 @@ class ParamStoreDict:
         self._param_to_name = {}
         self._constraints = {}
 
-    def items(self) -> Tuple[str, Constraint]:
+    def items(self) -> Iterator[Tuple[str, Constraint]]:
         """
         Iterate over ``(name, constrained_param)`` pairs. Note that `constrained_param` is
         in the constrained (i.e. user-facing) space.

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -4,9 +4,10 @@
 import re
 import warnings
 import weakref
-from collections.abc import KeysView
+
 from contextlib import contextmanager
 from typing import Callable, Generator, Optional, Tuple, Union, Iterator
+from typing.collections import KeysView
 
 import torch
 from torch.distributions import constraints, transform_to

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -4,14 +4,14 @@
 import re
 import warnings
 import weakref
-from contextlib import contextmanager
-
-from typing import Optional, Callable, Union, Tuple, Generator
 from collections.abc import Iterator, KeysView
+from contextlib import contextmanager
+from typing import Callable, Generator, Optional, Tuple, Union
 
 import torch
 from torch.distributions import constraints, transform_to
 from torch.distributions.constraints import Constraint
+
 
 class ParamStoreDict:
     """
@@ -135,7 +135,12 @@ class ParamStoreDict:
         self._params[name] = unconstrained_value
         self._param_to_name[unconstrained_value] = name
 
-    def setdefault(self, name: str, init_constrained_value: Union[torch.Tensor, Callable[[], torch.Tensor]], constraint: Constraint=constraints.real) -> torch.Tensor:
+    def setdefault(
+        self,
+        name: str,
+        init_constrained_value: Union[torch.Tensor, Callable[[], torch.Tensor]],
+        constraint: Constraint = constraints.real,
+    ) -> torch.Tensor:
         """
         Retrieve a *constrained* parameter value from the if it exists, otherwise
         set the initial value. Note that this is a little fancier than
@@ -188,7 +193,9 @@ class ParamStoreDict:
         )
         return self.keys()
 
-    def replace_param(self, param_name: str, new_param: torch.Tensor, old_param: torch.Tensor):
+    def replace_param(
+        self, param_name: str, new_param: torch.Tensor, old_param: torch.Tensor
+    ):
         warnings.warn(
             "ParamStore.replace_param() is deprecated; use .__setitem__() instead.",
             DeprecationWarning,
@@ -197,7 +204,11 @@ class ParamStoreDict:
         self[param_name] = new_param
 
     def get_param(
-        self, name: str, init_tensor: Optional[torch.Tensor]=None, constraint: Constraint=constraints.real, event_dim: Optional[int]=None
+        self,
+        name: str,
+        init_tensor: Optional[torch.Tensor] = None,
+        constraint: Constraint = constraints.real,
+        event_dim: Optional[int] = None,
     ) -> torch.Tensor:
         """
         Get parameter from its name. If it does not yet exist in the

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,3 +90,7 @@ ignore_errors = True
 [mypy-pyro.util.*]
 ignore_errors = True
 warn_unused_ignores = True
+
+[mypy-pyro.params.*]
+ignore_errors = True
+warn_unused_ignores = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,17 +80,9 @@ warn_unused_ignores = True
 [mypy-pyro.optm.*]
 warn_unused_ignores = True
 
-[mypy-pyro.params.*]
-ignore_errors = True
-warn_unused_ignores = True
-
 [mypy-pyro.poutine.*]
 ignore_errors = True
 
 [mypy-pyro.util.*]
-ignore_errors = True
-warn_unused_ignores = True
-
-[mypy-pyro.params.*]
 ignore_errors = True
 warn_unused_ignores = True


### PR DESCRIPTION
This PR adds type hints to the `params` module. This address [this a section of this issue to add type hints](https://github.com/pyro-ppl/pyro/issues/2550).

I intend to add more type hints wherever I can in future PRs.