### PR TITLE
Add an option to stop PyroModules from sharing parameters

### DIFF
--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -5,6 +5,7 @@ import pyro.poutine as poutine
 from pyro.infer.inspect import render_model
 from pyro.logger import log
 from pyro.poutine import condition, do, markov
+from pyro.poutine.runtime import enable_module_local_param
 from pyro.primitives import (
     barrier,
     clear_param_store,
@@ -41,6 +42,7 @@ __all__ = [
     "condition",
     "deterministic",
     "do",
+    "enable_module_local_param",
     "enable_validation",
     "factor",
     "get_param_store",

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -5,17 +5,18 @@ import pyro.poutine as poutine
 from pyro.infer.inspect import render_model
 from pyro.logger import log
 from pyro.poutine import condition, do, markov
-from pyro.poutine.runtime import enable_module_local_param
 from pyro.primitives import (
     barrier,
     clear_param_store,
     deterministic,
+    enable_module_local_param,
     enable_validation,
     factor,
     get_param_store,
     iarange,
     irange,
     module,
+    module_local_param_enabled,
     param,
     plate,
     plate_stack,
@@ -51,6 +52,7 @@ __all__ = [
     "log",
     "markov",
     "module",
+    "module_local_param_enabled",
     "param",
     "plate",
     "plate",

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -15,7 +15,7 @@ from pyro.util import check_site_shape
 
 
 class _ELBOModule(torch.nn.Module):
-    def __init__(self, model, guide, elbo):
+    def __init__(self, model: torch.nn.Module, guide: torch.nn.Module, elbo: "ELBO"):
         super().__init__()
         self.model = model
         self.guide = guide
@@ -35,6 +35,40 @@ class ELBO(object, metaclass=ABCMeta):
     :class:`~pyro.infer.trace_elbo.Trace_ELBO`,
     :class:`~pyro.infer.tracegraph_elbo.TraceGraph_ELBO`, or
     :class:`~pyro.infer.traceenum_elbo.TraceEnum_ELBO`.
+
+    .. note:: Derived classes now provide a more idiomatic PyTorch interface via
+        :meth:`__call__` for (model, guide) pairs that are :class:`~torch.nn.Module` s,
+        which is useful for integrating Pyro's variational inference tooling with
+        standard PyTorch interfaces like :class:`~torch.optim.Optimizer` s
+        and the large ecosystem of libraries like PyTorch Lightning
+        and the PyTorch JIT that work with these interfaces::
+
+            model = Model()
+            guide = pyro.infer.autoguide.AutoNormal(model)
+
+            elbo_ = pyro.infer.Trace_ELBO(num_particles=10)
+
+            # Fix the model/guide pair
+            elbo = elbo_(model, guide)
+
+            # perform any data-dependent initialization
+            elbo(data)
+
+            optim = torch.optim.Adam(elbo.parameters(), lr=0.001)
+
+            for _ in range(100):
+                optim.zero_grad()
+                loss = elbo(data)
+                loss.backward()
+                optim.step()
+
+        Note that Pyro's global parameter store may cause this new interface to
+        behave unexpectedly relative to standard PyTorch when working with
+        :class:`~pyro.nn.PyroModule` s.
+
+        Users are therefore strongly encouraged to use this interface in conjunction
+        with :func:`~pyro.enable_module_local_param` which will override the default
+        implicit sharing of parameters across :class:`~pyro.nn.PyroModule` instances.
 
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.
@@ -99,7 +133,13 @@ class ELBO(object, metaclass=ABCMeta):
         self.jit_options = jit_options
         self.tail_adaptive_beta = tail_adaptive_beta
 
-    def __call__(self, model, guide):
+    def __call__(
+        self, model: torch.nn.Module, guide: torch.nn.Module
+    ) -> torch.nn.Module:
+        """
+        Given a model and guide, returns a :class:`~torch.nn.Module` which
+        computes the ELBO loss when called with arguments to the model and guide.
+        """
         return _ELBOModule(model, guide, self)
 
     def _guess_max_plate_nesting(self, model, guide, args, kwargs):

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -21,7 +21,7 @@ from torch.distributions import constraints, transform_to
 
 import pyro
 from pyro.ops.provenance import detach_provenance
-from pyro.poutine.runtime import _PYRO_PARAM_STORE
+from pyro.poutine.runtime import _PYRO_PARAM_STORE, _module_local_param_enabled
 
 
 class PyroParam(namedtuple("PyroParam", ("init_value", "constraint", "event_dim"))):
@@ -180,7 +180,7 @@ class _Context:
         self.used = False
 
     def __enter__(self):
-        if not self.active:
+        if not self.active and _module_local_param_enabled():
             self._param_ctx = pyro.get_param_store().scope(state=None)
             self._param_ctx.__enter__()
         self.active += 1
@@ -190,8 +190,9 @@ class _Context:
         self.active -= 1
         if not self.active:
             self.cache.clear()
-            self._param_ctx.__exit__(type, value, traceback)
-            del self._param_ctx
+            if _module_local_param_enabled():
+                self._param_ctx.__exit__(type, value, traceback)
+                del self._param_ctx
 
     def get(self, name):
         if self.active:

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -180,6 +180,9 @@ class _Context:
         self.used = False
 
     def __enter__(self):
+        if not self.active:
+            self._param_ctx = pyro.get_param_store().scope(state=None)
+            self._param_ctx.__enter__()
         self.active += 1
         self.used = True
 
@@ -187,6 +190,8 @@ class _Context:
         self.active -= 1
         if not self.active:
             self.cache.clear()
+            self._param_ctx.__exit__(type, value, traceback)
+            del self._param_ctx
 
     def get(self, name):
         if self.active:

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -19,15 +19,6 @@ _PYRO_PARAM_STORE = ParamStoreDict()
 _PYRO_MODULE_LOCAL_PARAM = False
 
 
-def enable_module_local_param(flag: bool) -> None:
-    global _PYRO_MODULE_LOCAL_PARAM
-    _PYRO_MODULE_LOCAL_PARAM = flag
-
-
-def _module_local_param_enabled():
-    return _PYRO_MODULE_LOCAL_PARAM
-
-
 class _DimAllocator:
     """
     Dimension allocator for internal use by :class:`plate`.

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -15,6 +15,18 @@ _PYRO_STACK = []
 # the global ParamStore
 _PYRO_PARAM_STORE = ParamStoreDict()
 
+# toggle usage of local param stores in PyroModules
+_PYRO_MODULE_LOCAL_PARAM = False
+
+
+def enable_module_local_param(flag: bool) -> None:
+    global _PYRO_MODULE_LOCAL_PARAM
+    _PYRO_MODULE_LOCAL_PARAM = flag
+
+
+def _module_local_param_enabled():
+    return _PYRO_MODULE_LOCAL_PARAM
+
 
 class _DimAllocator:
     """

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -562,3 +562,35 @@ def validation_enabled(is_validate=True):
         dist.enable_validation(distribution_validation_status)
         infer.enable_validation(infer_validation_status)
         poutine.enable_validation(poutine_validation_status)
+
+
+def enable_module_local_param(is_enabled: bool = False) -> None:
+    """
+    Toggles the behavior of :class:`~pyro.nn.module.PyroModule` to use
+    local parameters instead of global parameters.
+
+    When this feature is enabled, :class:`~pyro.nn.module.PyroModule`
+    instances will not share parameters with other instances of the same
+    class through Pyro's global parameter store. Instead, each instance
+    will have its own local parameters, just like a standard :class:`torch.nn.Module`.
+
+    .. note:: This feature is disabled by default to ensure backwards compatibility
+        of :class:`~pyro.nn.module.PyroModule` with existing Pyro code.
+
+    :param bool is_enabled: (optional; defaults to False) whether to
+        enable local parameters.
+    """
+    poutine.runtime._PYRO_MODULE_LOCAL_PARAM = is_enabled
+
+
+@contextmanager
+def module_local_param_enabled(is_enabled=False):
+    """
+    Context manager to temporarily toggle local parameter stores in PyroModules.
+    """
+    old_flag = poutine.runtime._PYRO_MODULE_LOCAL_PARAM
+    poutine.runtime._PYRO_MODULE_LOCAL_PARAM = is_enabled
+    try:
+        yield
+    finally:
+        poutine.runtime._PYRO_MODULE_LOCAL_PARAM = old_flag

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def pytest_runtest_setup(item):
     if test_initialize_marker:
         rng_seed = test_initialize_marker.kwargs["rng_seed"]
         pyro.set_rng_seed(rng_seed)
+    pyro.enable_module_local_param(False)
 
 
 def pytest_addoption(parser):

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -499,33 +499,23 @@ class DecoratorModel(PyroModule):
 
 @pytest.mark.parametrize("Model", [AttributeModel, DecoratorModel])
 @pytest.mark.parametrize("size", [1, 2])
-@pytest.mark.parametrize("local_params", [False, True])
-def test_decorator(Model, size, local_params):
-    with pyro.module_local_param_enabled(local_params):
-        model = Model(size)
-        for i in range(2):
-            trace = poutine.trace(model).get_trace()
-            assert set(trace.nodes.keys()) == {
-                "_INPUT",
-                "x",
-                "y",
-                "z",
-                "s",
-                "t",
-                "_RETURN",
-            }
+def test_decorator(Model, size):
+    model = Model(size)
+    for i in range(2):
+        trace = poutine.trace(model).get_trace()
+        assert set(trace.nodes.keys()) == {"_INPUT", "x", "y", "z", "s", "t", "_RETURN"}
 
-            assert trace.nodes["x"]["type"] == "param"
-            assert trace.nodes["y"]["type"] == "param"
-            assert trace.nodes["z"]["type"] == "param"
-            assert trace.nodes["s"]["type"] == "sample"
-            assert trace.nodes["t"]["type"] == "sample"
+        assert trace.nodes["x"]["type"] == "param"
+        assert trace.nodes["y"]["type"] == "param"
+        assert trace.nodes["z"]["type"] == "param"
+        assert trace.nodes["s"]["type"] == "sample"
+        assert trace.nodes["t"]["type"] == "sample"
 
-            assert trace.nodes["x"]["value"].shape == (size,)
-            assert trace.nodes["y"]["value"].shape == (size,)
-            assert trace.nodes["z"]["value"].shape == (size,)
-            assert trace.nodes["s"]["value"].shape == ()
-            assert trace.nodes["t"]["value"].shape == (size,)
+        assert trace.nodes["x"]["value"].shape == (size,)
+        assert trace.nodes["y"]["value"].shape == (size,)
+        assert trace.nodes["z"]["value"].shape == (size,)
+        assert trace.nodes["s"]["value"].shape == ()
+        assert trace.nodes["t"]["value"].shape == (size,)
 
 
 def test_mixin_factory():


### PR DESCRIPTION
Replaces #2996 

This PR adds two small related features for easier Pyro-PyTorch integration:
1. A `__call__` method for the base `pyro.infer.elbo.ELBO` that binds `ELBO` instances to specific `nn.Module` model/guide pairs in a `Module` that exposes their PyTorch parameters
2. A global setting (off by default for full backwards compatibility) that prevents `PyroModule` instances from sharing parameter values with one another through the global Pyro parameter store, and a primitive and context manager for toggling it. One context where this is useful is for workflows that involve multiple models and autoguides with overlapping parameter names.

An edge case I haven't handled here is the behavior under the new local parameter setting of regular `pyro.param` statements (as opposed to `PyroParam`) within a `PyroModule` that don't have their data associated with any underlying `nn.Module`. I'm inclined to add some sort of warning or error rather than attempt to get this working, since I think it's usually a `PyroModule` programming anti-pattern to mix global and local parameter states in this way.

I am also hopeful that these changes will simplify the use of Pyro with the PyTorch JIT and other PyTorch compilers, but I have left testing this for future work, since I suspect it will require additional engineering that is out of scope for this PR.

Tested:
- Added test cases to some existing `PyroModule` tests in `tests/nn/test_module.py`
- Added a new test that checks the behavior of these two features together