### PR TITLE
Add jitter to Cholesky factorization in Gaussian ops

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -20,7 +20,7 @@ from pyro.ops.gaussian import (
 )
 from pyro.ops.indexing import Vindex
 from pyro.ops.special import safe_log
-from pyro.ops.tensor_utils import cholesky, cholesky_solve
+from pyro.ops.tensor_utils import cholesky_solve, safe_cholesky
 
 from . import constraints
 from .torch import Categorical, Gamma, Independent, MultivariateNormal
@@ -628,9 +628,9 @@ class GaussianHMM(HiddenMarkovModel):
 
         # Convert to a distribution
         precision = logp.precision
-        loc = cholesky_solve(logp.info_vec.unsqueeze(-1), cholesky(precision)).squeeze(
-            -1
-        )
+        loc = cholesky_solve(
+            logp.info_vec.unsqueeze(-1), safe_cholesky(precision)
+        ).squeeze(-1)
         return MultivariateNormal(
             loc, precision_matrix=precision, validate_args=self._validate_args
         )
@@ -928,7 +928,7 @@ class GammaGaussianHMM(HiddenMarkovModel):
             gamma_dist.concentration, gamma_dist.rate, validate_args=self._validate_args
         )
         # Conditional of last state on unit scale
-        scale_tril = cholesky(logp.precision)
+        scale_tril = safe_cholesky(logp.precision)
         loc = cholesky_solve(logp.info_vec.unsqueeze(-1), scale_tril).squeeze(-1)
         mvn = MultivariateNormal(
             loc, scale_tril=scale_tril, validate_args=self._validate_args

--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -489,6 +489,8 @@ class GaussianHMM(HiddenMarkovModel):
     :param int duration: Optional size of the time axis ``event_shape[0]``.
         This is required when sampling from homogeneous HMMs whose parameters
         are not expanded along the time axis.
+    :param float jitter: Optional constant added to matrix diagonals before
+        performing Cholesky decompositions, to improve stability.
     """
 
     has_rsample = True
@@ -504,6 +506,8 @@ class GaussianHMM(HiddenMarkovModel):
         observation_dist,
         validate_args=None,
         duration=None,
+        *,
+        jitter: float = 0.0,
     ):
         assert isinstance(initial_dist, torch.distributions.MultivariateNormal) or (
             isinstance(initial_dist, torch.distributions.Independent)
@@ -542,11 +546,13 @@ class GaussianHMM(HiddenMarkovModel):
         self._init = mvn_to_gaussian(initial_dist).expand(self.batch_shape)
         self._trans = matrix_and_mvn_to_gaussian(transition_matrix, transition_dist)
         self._obs = matrix_and_mvn_to_gaussian(observation_matrix, observation_dist)
+        self.jitter = jitter
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(GaussianHMM, _instance)
         new.hidden_dim = self.hidden_dim
         new.obs_dim = self.obs_dim
+        new.jitter = self.jitter
         new._obs = self._obs
         new._trans = self._trans
 
@@ -572,10 +578,14 @@ class GaussianHMM(HiddenMarkovModel):
         )
 
         # Eliminate time dimension.
-        result = sequential_gaussian_tensordot(result.expand(result.batch_shape))
+        result = sequential_gaussian_tensordot(
+            result.expand(result.batch_shape), jitter=self.jitter
+        )
 
         # Combine initial factor.
-        result = gaussian_tensordot(self._init, result, dims=self.hidden_dim)
+        result = gaussian_tensordot(
+            self._init, result, dims=self.hidden_dim, jitter=self.jitter
+        )
 
         # Marginalize out final state.
         result = result.event_logsumexp()
@@ -584,11 +594,13 @@ class GaussianHMM(HiddenMarkovModel):
     def rsample(self, sample_shape=torch.Size()):
         assert self.duration is not None
         sample_shape = torch.Size(sample_shape)
-        trans = self._trans + self._obs.marginalize(right=self.obs_dim).event_pad(
-            left=self.hidden_dim
-        )
+        trans = self._trans + self._obs.marginalize(
+            right=self.obs_dim, jitter=self.jitter
+        ).event_pad(left=self.hidden_dim)
         trans = trans.expand(trans.batch_shape[:-1] + (self.duration,))
-        z = sequential_gaussian_filter_sample(self._init, trans, sample_shape)
+        z = sequential_gaussian_filter_sample(
+            self._init, trans, sample_shape, jitter=self.jitter
+        )
         z = z[..., 1:, :]  # drop the initial hidden state
         x = self._obs.left_condition(z).rsample()
         return x
@@ -599,7 +611,9 @@ class GaussianHMM(HiddenMarkovModel):
         """
         trans = self._trans + self._obs.condition(value).event_pad(left=self.hidden_dim)
         trans = trans.expand(trans.batch_shape)
-        z = sequential_gaussian_filter_sample(self._init, trans, sample_shape)
+        z = sequential_gaussian_filter_sample(
+            self._init, trans, sample_shape, jitter=self.jitter
+        )
         z = z[..., 1:, :]  # drop the initial hidden state
         return z
 
@@ -621,10 +635,14 @@ class GaussianHMM(HiddenMarkovModel):
         logp = self._trans + self._obs.condition(value).event_pad(left=self.hidden_dim)
 
         # Eliminate time dimension.
-        logp = sequential_gaussian_tensordot(logp.expand(logp.batch_shape))
+        logp = sequential_gaussian_tensordot(
+            logp.expand(logp.batch_shape), jitter=self.jitter
+        )
 
         # Combine initial factor.
-        logp = gaussian_tensordot(self._init, logp, dims=self.hidden_dim)
+        logp = gaussian_tensordot(
+            self._init, logp, dims=self.hidden_dim, jitter=self.jitter
+        )
 
         # Convert to a distribution
         precision = logp.precision
@@ -664,6 +682,7 @@ class GaussianHMM(HiddenMarkovModel):
         new = self._get_checked_instance(GaussianHMM)
         new.hidden_dim = self.hidden_dim
         new.obs_dim = self.obs_dim
+        new.jitter = self.jitter
         new._init = self._init
         new._trans = self._trans
         new._obs = self._obs + mvn_to_gaussian(other.to_event(-1)).event_pad(
@@ -672,9 +691,9 @@ class GaussianHMM(HiddenMarkovModel):
 
         # Normalize.
         # TODO cache this computation for the forward pass of .rsample().
-        logp = new._trans + new._obs.marginalize(right=new.obs_dim).event_pad(
-            left=new.hidden_dim
-        )
+        logp = new._trans + new._obs.marginalize(
+            right=new.obs_dim, jitter=self.jitter
+        ).event_pad(left=new.hidden_dim)
         logp = sequential_gaussian_tensordot(logp.expand(logp.batch_shape))
         logp = gaussian_tensordot(new._init, logp, dims=new.hidden_dim)
         log_normalizer = logp.event_logsumexp()

--- a/pyro/distributions/transforms/cholesky.py
+++ b/pyro/distributions/transforms/cholesky.py
@@ -89,7 +89,7 @@ class CorrLCholeskyTransform(Transform):
 
 class CholeskyTransform(Transform):
     r"""
-    Transform via the mapping :math:`y = cholesky(x)`, where `x` is a
+    Transform via the mapping :math:`y = safe_cholesky(x)`, where `x` is a
     positive definite matrix.
     """
     bijective = True
@@ -116,7 +116,7 @@ class CholeskyTransform(Transform):
 
 class CorrMatrixCholeskyTransform(CholeskyTransform):
     r"""
-    Transform via the mapping :math:`y = cholesky(x)`, where `x` is a
+    Transform via the mapping :math:`y = safe_cholesky(x)`, where `x` is a
     correlation matrix.
     """
     bijective = True

--- a/pyro/ops/gaussian.py
+++ b/pyro/ops/gaussian.py
@@ -9,13 +9,7 @@ from torch.distributions.utils import lazy_property
 from torch.nn.functional import pad
 
 from pyro.distributions.util import broadcast_shape
-from pyro.ops.tensor_utils import (
-    cholesky,
-    cholesky_solve,
-    matmul,
-    matvecmul,
-    triangular_solve,
-)
+from pyro.ops.tensor_utils import cholesky, matmul, matvecmul, triangular_solve
 
 
 class Gaussian:
@@ -161,7 +155,7 @@ class Gaussian:
         Reparameterized sampler.
         """
         P_chol = cholesky(self.precision)
-        loc = cholesky_solve(self.info_vec.unsqueeze(-1), P_chol).squeeze(-1)
+        loc = self.info_vec.unsqueeze(-1).cholesky_solve(P_chol).squeeze(-1)
         shape = sample_shape + self.batch_shape + (self.dim(), 1)
         if noise is None:
             noise = torch.randn(shape, dtype=loc.dtype, device=loc.device)
@@ -236,9 +230,7 @@ class Gaussian:
         )
         return self.event_permute(perm).condition(value)
 
-    def marginalize(
-        self, left: int = 0, right: int = 0, *, jitter: float = 0.0
-    ) -> "Gaussian":
+    def marginalize(self, left=0, right=0) -> "Gaussian":
         """
         Marginalizing out variables on either side of the event dimension::
 
@@ -249,11 +241,6 @@ class Gaussian:
 
             g.condition(x).event_logsumexp()
               = g.marginalize(left=g.dim() - x.size(-1)).log_density(x)
-
-        :param int left: Number of left event dims to marginalize.
-        :param int right: Number of right event dims to marginalize.
-        :param float jitter: Optional constant added to matrix diagonals before
-            performing Cholesky decompositions, to improve stability.
         """
         if left == 0 and right == 0:
             return self
@@ -267,7 +254,7 @@ class Gaussian:
         P_aa = self.precision[..., a, a]
         P_ba = self.precision[..., b, a]
         P_bb = self.precision[..., b, b]
-        P_b = cholesky(P_bb, jitter=jitter)
+        P_b = cholesky(P_bb)
         P_a = triangular_solve(P_ba, P_b, upper=False)
         P_at = P_a.transpose(-1, -2)
         precision = P_aa - matmul(P_at, P_a)
@@ -416,9 +403,7 @@ class AffineNormal:
     def __add__(self, other):
         return self.to_gaussian() + other
 
-    def marginalize(
-        self, left: int = 0, right: int = 0, *, jitter: float = 0.0
-    ) -> Gaussian:
+    def marginalize(self, left=0, right=0):
         if left == 0 and right == self.loc.size(-1):
             n = self.matrix.size(-2)
             precision = self.scale.new_zeros(self.batch_shape + (n, n))
@@ -426,7 +411,7 @@ class AffineNormal:
             log_normalizer = self.scale.new_zeros(self.batch_shape)
             return Gaussian(log_normalizer, info_vec, precision)
         else:
-            return self.to_gaussian().marginalize(left, right, jitter=jitter)
+            return self.to_gaussian().marginalize(left, right)
 
 
 def mvn_to_gaussian(mvn):
@@ -522,9 +507,7 @@ def matrix_and_mvn_to_gaussian(matrix, mvn):
     return result
 
 
-def gaussian_tensordot(
-    x: Gaussian, y: Gaussian, dims: int = 0, *, jitter: float = 0.0
-) -> Gaussian:
+def gaussian_tensordot(x: Gaussian, y: Gaussian, dims: int = 0) -> Gaussian:
     """
     Computes the integral over two gaussians:
 
@@ -536,8 +519,6 @@ def gaussian_tensordot(
     :param x: a Gaussian instance
     :param y: a Gaussian instance
     :param dims: number of variables to contract
-    :param float jitter: Optional constant added to matrix diagonals before
-        performing Cholesky decompositions, to improve stability.
     """
     assert isinstance(x, Gaussian)
     assert isinstance(y, Gaussian)
@@ -569,7 +550,7 @@ def gaussian_tensordot(
         b = xb + yb
 
         # Pbb + Qbb needs to be positive definite, so that we can malginalize out `b` (to have a finite integral)
-        L = cholesky(Pbb + Qbb, jitter=jitter)
+        L = cholesky(Pbb + Qbb)
         LinvB = triangular_solve(B, L, upper=False)
         LinvBt = LinvB.transpose(-2, -1)
         Linvb = triangular_solve(b.unsqueeze(-1), L, upper=False)
@@ -589,17 +570,13 @@ def gaussian_tensordot(
     return Gaussian(log_normalizer, info_vec, precision)
 
 
-def sequential_gaussian_tensordot(
-    gaussian: Gaussian, *, jitter: float = 0.0
-) -> Gaussian:
+def sequential_gaussian_tensordot(gaussian: Gaussian) -> Gaussian:
     """
     Integrates a Gaussian ``x`` whose rightmost batch dimension is time, computes::
 
         x[..., 0] @ x[..., 1] @ ... @ x[..., T-1]
 
     :param Gaussian gaussian: A batched Gaussian whose rightmost dimension is time.
-    :param float jitter: Optional constant added to matrix diagonals before
-        performing Cholesky decompositions, to improve stability.
     :returns: A Markov product of the Gaussian along its time dimension.
     :rtype: Gaussian
     """
@@ -613,7 +590,7 @@ def sequential_gaussian_tensordot(
         even_part = gaussian[..., :even_time]
         x_y = even_part.reshape(batch_shape + (even_time // 2, 2))
         x, y = x_y[..., 0], x_y[..., 1]
-        contracted = gaussian_tensordot(x, y, state_dim, jitter=jitter)
+        contracted = gaussian_tensordot(x, y, state_dim)
         if time > even_time:
             contracted = Gaussian.cat((contracted, gaussian[..., -1:]), dim=-1)
         gaussian = contracted
@@ -625,8 +602,6 @@ def sequential_gaussian_filter_sample(
     trans: Gaussian,
     sample_shape: Tuple[int, ...] = (),
     noise: Optional[torch.Tensor] = None,
-    *,
-    jitter: float = 0.0,
 ) -> torch.Tensor:
     """
     Draws a reparameterized sample from a Markov product of Gaussians via
@@ -643,8 +618,6 @@ def sequential_gaussian_filter_sample(
         to be sampled, and ``state_dim = init.dim()`` is the state dimension.
         This is useful for computing the mean (pass zeros), varying temperature
         (pass scaled noise), and antithetic sampling (pass ``cat([z,-z])``).
-    :param float jitter: Optional constant added to matrix diagonals before
-        performing Cholesky decompositions, to improve stability.
     :returns: A reparametrized sample of shape
         ``sample_shape + batch_shape + (duration, state_dim)``.
     :rtype: torch.Tensor
@@ -680,7 +653,7 @@ def sequential_gaussian_filter_sample(
         y = y.event_pad(left=state_dim)
         joint = (x + y).event_permute(perm)
         tape.append(joint)
-        contracted = joint.marginalize(left=state_dim, jitter=jitter)
+        contracted = joint.marginalize(left=state_dim)
         if time > even_time:
             contracted = Gaussian.cat((contracted, gaussian[..., -1:]), dim=-1)
         gaussian = contracted

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -7,7 +7,7 @@ import torch
 from torch.fft import irfft, rfft
 
 _ROOT_TWO_INVERSE = 1.0 / math.sqrt(2.0)
-CHOLESKY_RELATIVE_JITTER = 1.0  # in units of finfo.eps
+CHOLESKY_RELATIVE_JITTER = 4.0  # in units of finfo.eps
 
 
 def as_complex(x):
@@ -403,7 +403,7 @@ def safe_cholesky(x):
     if CHOLESKY_RELATIVE_JITTER:
         # Add adaptive jitter.
         x = x.clone()
-        x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
+        x_max = x.data.abs().max(-1).values
         jitter = CHOLESKY_RELATIVE_JITTER * torch.finfo(x.dtype).eps * x_max
         x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import warnings
 from contextlib import contextmanager
 from typing import Optional
 
@@ -432,6 +433,7 @@ def cholesky(x, *, jitter: Optional[float] = None):
             return result
 
         # Try adding increasing amounts of jitter where needed.
+        warnings.warn("Singular matrix in cholesky(); adding jitter.")
         eye = torch.eye(x.size(-1), device=x.device, dtype=x.dtype)
         x = x.clone()
         while jitter < 1:

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -434,7 +434,6 @@ def cholesky(x, *, jitter: Optional[float] = None):
 
         # Try adding increasing amounts of jitter where needed.
         warnings.warn("Singular matrix in cholesky(); adding jitter.")
-        eye = torch.eye(x.size(-1), device=x.device, dtype=x.dtype)
         x = x.clone()
         x_diag = x.diagonal(dim1=-1, dim2=-2)
         while jitter < 1:

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -393,9 +393,11 @@ def inverse_haar_transform(x):
     return x
 
 
-def cholesky(x):
+def cholesky(x, *, jitter: float = 0.0):
     if x.size(-1) == 1:
         return x.sqrt()
+    if jitter > 0:
+        x = x + jitter * torch.eye(x.size(-1), device=x.device, dtype=x.dtype)
     return torch.linalg.cholesky(x)
 
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -393,17 +393,16 @@ def inverse_haar_transform(x):
     return x
 
 
-def cholesky(x, *, safe: bool = True):
+def cholesky(x):
     if x.size(-1) == 1:
-        if safe:
-            x = x.clamp(min=torch.finfo(x.dtype).tiny)
+        x = x.clamp(min=torch.finfo(x.dtype).tiny)
         return x.sqrt()
 
-    if safe:
-        x = x.clone()
-        x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
-        jitter = x_max * torch.finfo(x.dtype).eps
-        x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
+    # Add adaptive jitter.
+    x = x.clone()
+    x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
+    jitter = x_max * torch.finfo(x.dtype).eps
+    x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
 
     return torch.linalg.cholesky(x)
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -7,7 +7,7 @@ import torch
 from torch.fft import irfft, rfft
 
 _ROOT_TWO_INVERSE = 1.0 / math.sqrt(2.0)
-CHOLESKY_JITTER = 1.0  # in units of finfo.eps
+CHOLESKY_RELATIVE_JITTER = 1.0  # in units of finfo.eps
 
 
 def as_complex(x):
@@ -396,15 +396,15 @@ def inverse_haar_transform(x):
 
 def safe_cholesky(x):
     if x.size(-1) == 1:
-        if CHOLESKY_JITTER:
+        if CHOLESKY_RELATIVE_JITTER:
             x = x.clamp(min=torch.finfo(x.dtype).tiny)
         return x.sqrt()
 
-    if CHOLESKY_JITTER:
+    if CHOLESKY_RELATIVE_JITTER:
         # Add adaptive jitter.
         x = x.clone()
         x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
-        jitter = CHOLESKY_JITTER * torch.finfo(x.dtype).eps * x_max
+        jitter = CHOLESKY_RELATIVE_JITTER * torch.finfo(x.dtype).eps * x_max
         x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
 
     return torch.linalg.cholesky(x)

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -7,6 +7,7 @@ import torch
 from torch.fft import irfft, rfft
 
 _ROOT_TWO_INVERSE = 1.0 / math.sqrt(2.0)
+CHOLESKY_JITTER = 1.0
 
 
 def as_complex(x):
@@ -393,7 +394,7 @@ def inverse_haar_transform(x):
     return x
 
 
-def cholesky(x):
+def safe_cholesky(x):
     if x.size(-1) == 1:
         x = x.clamp(min=torch.finfo(x.dtype).tiny)
         return x.sqrt()
@@ -401,7 +402,7 @@ def cholesky(x):
     # Add adaptive jitter.
     x = x.clone()
     x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
-    jitter = x_max * torch.finfo(x.dtype).eps
+    jitter = CHOLESKY_JITTER * torch.finfo(x.dtype).eps * x_max
     x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
 
     return torch.linalg.cholesky(x)

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -436,8 +436,9 @@ def cholesky(x, *, jitter: Optional[float] = None):
         warnings.warn("Singular matrix in cholesky(); adding jitter.")
         eye = torch.eye(x.size(-1), device=x.device, dtype=x.dtype)
         x = x.clone()
+        x_diag = x.diagonal(dim1=-1, dim2=-2)
         while jitter < 1:
-            x[info > 0] += jitter * eye
+            x_diag[info > 0] += jitter
             result, info = torch.linalg.cholesky_ex(x)
             if not info.any():
                 return result

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -7,7 +7,7 @@ import torch
 from torch.fft import irfft, rfft
 
 _ROOT_TWO_INVERSE = 1.0 / math.sqrt(2.0)
-CHOLESKY_JITTER = 1.0
+CHOLESKY_JITTER = 1.0  # in units of finfo.eps
 
 
 def as_complex(x):
@@ -396,14 +396,16 @@ def inverse_haar_transform(x):
 
 def safe_cholesky(x):
     if x.size(-1) == 1:
-        x = x.clamp(min=torch.finfo(x.dtype).tiny)
+        if CHOLESKY_JITTER:
+            x = x.clamp(min=torch.finfo(x.dtype).tiny)
         return x.sqrt()
 
-    # Add adaptive jitter.
-    x = x.clone()
-    x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
-    jitter = CHOLESKY_JITTER * torch.finfo(x.dtype).eps * x_max
-    x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
+    if CHOLESKY_JITTER:
+        # Add adaptive jitter.
+        x = x.clone()
+        x_max = x.data.reshape(*x.shape[:-2], -1).abs().max(-1, True).values
+        jitter = CHOLESKY_JITTER * torch.finfo(x.dtype).eps * x_max
+        x.data.diagonal(dim1=-1, dim2=-2).add_(jitter)
 
     return torch.linalg.cholesky(x)
 

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -433,8 +433,7 @@ def test_gaussian_hmm_distribution(
         scale = obs_dist.scale_tril.diagonal(dim1=-2, dim2=-1)
         obs_dist = dist.Normal(obs_dist.loc, scale).to_event(1)
     d = dist.GaussianHMM(
-        init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=num_steps,
-        jitter=1e-8
+        init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=num_steps
     )
     if diag:
         obs_mvn = dist.MultivariateNormal(

--- a/tests/distributions/test_hmm.py
+++ b/tests/distributions/test_hmm.py
@@ -433,7 +433,8 @@ def test_gaussian_hmm_distribution(
         scale = obs_dist.scale_tril.diagonal(dim1=-2, dim2=-1)
         obs_dist = dist.Normal(obs_dist.loc, scale).to_event(1)
     d = dist.GaussianHMM(
-        init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=num_steps
+        init_dist, trans_mat, trans_dist, obs_mat, obs_dist, duration=num_steps,
+        jitter=1e-8
     )
     if diag:
         obs_mvn = dist.MultivariateNormal(

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -10,7 +10,6 @@ from torch.distributions import constraints, transform_to
 from torch.nn.functional import pad
 
 import pyro.distributions as dist
-import pyro.ops.tensor_utils
 from pyro.distributions.util import broadcast_shape
 from pyro.ops.gaussian import (
     AffineNormal,
@@ -611,9 +610,3 @@ def test_sequential_gaussian_filter_sample_stability(num_steps):
     # Check gradients.
     grads = torch.autograd.grad(x.sum(), [trans_matrix, noise])
     assert all(torch.isfinite(g).all() for g in grads)
-
-    if num_steps <= 1000:
-        # Check jitter did not significantly affect computation.
-        with pyro.ops.tensor_utils.settings(jitter=0.0):
-            x_nojitter = sequential_gaussian_filter_sample(init, trans, (), noise)
-            assert_close(x, x_nojitter, rtol=1e-4, atol=1e-2)

--- a/tests/ops/test_gaussian.py
+++ b/tests/ops/test_gaussian.py
@@ -561,6 +561,7 @@ def test_sequential_gaussian_filter_sample_antithetic(
     assert torch.allclose(sample3, expected)
 
 
+@pytest.mark.filterwarnings("ignore:Singular matrix in cholesky")
 @pytest.mark.parametrize("num_steps", [10, 100, 1000, 10000, 100000, 1000000])
 def test_sequential_gaussian_filter_sample_stability(num_steps):
     # This tests long-chain filtering at low precision.


### PR DESCRIPTION
This numerically stabilizes Gaussian parallel-scan operations for use in very long chains, say > 10000 items.  This use case is important for heterogeneous-length batching, where a batch of sequences can be concatenated and operated on as a single chain.  In this setting I was seeing Cholesky errors in both single and double precision.

The fix in this PR is to modify `pyro.ops.tensor_utils.cholesky()` to add a small adaptive amount of jitter to all computations.  This appears to both pass all existing tests (which are quite strong, it doesn't work to add a non-adaptive jitter), and to make Gaussian parallel-scan filtering work for very long sequences. :tada:

## Tested
- [x] added tests for very long sequences
- [x] tried on a real-world example of length up to 1e6