### PR TITLE
Clean up handling of global settings

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Pyro Documentation
    optimization
    poutine
    ops
+   settings
    testing
 
 .. toctree::

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -1,0 +1,6 @@
+Settings
+--------
+
+.. automodule:: pyro.settings
+   :members:
+   :member-order: bysource

--- a/pyro/__init__.py
+++ b/pyro/__init__.py
@@ -25,6 +25,8 @@ from pyro.primitives import (
 )
 from pyro.util import set_rng_seed
 
+from . import settings
+
 # After changing this, run scripts/update_version.py
 version_prefix = "1.8.2"
 
@@ -58,6 +60,7 @@ __all__ = [
     "render_model",
     "sample",
     "set_rng_seed",
+    "settings",
     "subsample",
     "validation_enabled",
 ]

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -9,6 +9,7 @@ from pyro.distributions.torch_distribution import TorchDistributionMixin
 from pyro.distributions.util import broadcast_shape, sum_rightmost
 from pyro.ops.special import log_binomial
 
+from .. import settings
 from . import constraints
 
 
@@ -96,6 +97,22 @@ class Binomial(torch.distributions.Binomial, TorchDistributionMixin):
             - normalize_term
             + log_binomial(n, k, tol=self.approx_log_prob_tol)
         )
+
+
+@settings.register(
+    "binomial_approx_sample_thresh", __name__, "Binomial.approx_sample_thresh"
+)
+def _validate_thresh(thresh):
+    assert isinstance(thresh, float)
+    assert 0 < thresh
+
+
+@settings.register(
+    "binomial_approx_log_prob_tol", __name__, "Binomial.approx_log_prob_tol"
+)
+def _validate_tol(tol):
+    assert isinstance(tol, float)
+    assert 0 <= tol
 
 
 # This overloads .log_prob() and .enumerate_support() to speed up evaluating

--- a/pyro/distributions/util.py
+++ b/pyro/distributions/util.py
@@ -15,8 +15,17 @@ from torch.distributions.utils import broadcast_all
 
 from pyro.util import ignore_jit_warnings
 
+from .. import settings
+
 _VALIDATION_ENABLED = __debug__
 torch_dist.Distribution.set_default_validate_args(__debug__)
+
+settings.register("validate_distributions_pyro", __name__, "_VALIDATION_ENABLED")
+settings.register(
+    "validate_distributions_torch",
+    "torch.distributions.distribution",
+    "Distribution._validate_args",
+)
 
 log_sum_exp = logsumexp  # DEPRECATED
 

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -16,7 +16,11 @@ from pyro.ops.einsum.adjoint import require_backward
 from pyro.ops.rings import MarginalRing
 from pyro.poutine.util import site_is_subsample
 
+from .. import settings
+
 _VALIDATION_ENABLED = __debug__
+settings.register("validate_infer", __name__, "_VALIDATION_ENABLED")
+
 LAST_CACHE_SIZE = [Counter()]  # for profiling
 
 

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -6,8 +6,16 @@ import math
 import torch
 from torch.fft import irfft, rfft
 
+from .. import settings
+
 _ROOT_TWO_INVERSE = 1.0 / math.sqrt(2.0)
 CHOLESKY_RELATIVE_JITTER = 4.0  # in units of finfo.eps
+
+
+@settings.register("cholesky_relative_jitter", __name__, "CHOLESKY_RELATIVE_JITTER")
+def _validate_jitter(value):
+    assert isinstance(value, (float, int))
+    assert 0 <= value
 
 
 def as_complex(x):

--- a/pyro/poutine/util.py
+++ b/pyro/poutine/util.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from .. import settings
+
 _VALIDATION_ENABLED = __debug__
+settings.register("validate_poutine", __name__, "_VALIDATION_ENABLED")
 
 
 def enable_validation(is_validate):

--- a/pyro/settings.py
+++ b/pyro/settings.py
@@ -95,8 +95,9 @@ def set(**kwargs) -> None:
 
 @contextmanager
 def context(**kwargs) -> Iterator[None]:
-    """
-    Context manager to temporarily override one or more settings.
+    r"""
+    Context manager to temporarily override one or more settings. This also
+    works as a decorator.
 
     :param \*\*kwargs: alias=value pairs.
     """

--- a/pyro/settings.py
+++ b/pyro/settings.py
@@ -1,0 +1,113 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Example usage::
+
+    # Simple getting and setting.
+    print(pyro.settings.get())  # print all settings
+    print(pyro.settings.get("cholesky_relative_jitter"))  # print one
+    pyro.settings.set(cholesky_relative_jitter=0.5)  # set one
+    pyro.settings.set(**my_settings)  # set many
+
+    # Use as a contextmanager.
+    with pyro.settings.context(cholesky_relative_jitter=0.5):
+        my_function()
+
+    # Use as a decorator.
+    fn = pyro.settings.context(cholesky_relative_jitter=0.5)(my_function)
+    fn()
+
+    # Register a new setting.
+    pyro.settings.register(
+        "binomial_approx_sample_thresh",  # alias
+        "pyro.distributions.torch",  # module
+        "Binomial.approx_sample_thresh",  # deep name
+    )
+
+    # Register a new setting on a user-provided validator.
+    @pyro.settings.register(
+        "binomial_approx_sample_thresh",  # alias
+        "pyro.distributions.torch",  # module
+        "Binomial.approx_sample_thresh",  # deep name
+    )
+    def validate_thresh(thresh):  # called each time setting is set
+        assert isinstance(thresh, float)
+        assert thresh > 0
+"""
+
+# This library must have no other dependencies on pyro.
+import functools
+from contextlib import contextmanager
+from importlib import import_module
+from typing import Any, Callable, Dict, Optional, Tuple
+
+# Global registry mapping alias:str to (modulename, deepname, validator)
+# triples where deepname may have dots to indicate e.g. class variables.
+_REGISTRY: Dict[str, Tuple[str, str, Optional[Callable]]] = {}
+
+
+def register(
+    alias: str,
+    modulename: str,
+    deepname: str,
+    validator: Optional[Callable] = None,
+) -> Callable:
+    assert isinstance(alias, str)
+    assert isinstance(modulename, str)
+    assert isinstance(deepname, str)
+    _REGISTRY[alias] = modulename, deepname, validator
+
+    # Support use as a decorator on an optional user-provided validator.
+    if validator is None:
+        # Smoke test to check that setting exists.
+        get(alias)
+        # Return a decorator, but its fine if user discards this.
+        return functools.partial(register, alias, modulename, deepname)
+    else:
+        # Test current value passes validation.
+        validator(get(alias))
+        return validator
+
+
+def get(alias: Optional[str] = None) -> Any:
+    """
+    Gets one or all global settings.
+    """
+    if alias is None:
+        # Return dict of all settings.
+        return {alias: get(alias) for alias in sorted(_REGISTRY)}
+    # Get a single setting.
+    module, deepname, validator = _REGISTRY[alias]
+    value = import_module(module)
+    for name in deepname.split("."):
+        value = getattr(value, name)
+    return value
+
+
+def set(**kwargs) -> None:
+    """
+    Sets one or more settings.
+    """
+    for alias, value in kwargs.items():
+        module, deepname, validator = _REGISTRY[alias]
+        if validator is not None:
+            validator(value)
+        destin = import_module(module)
+        names = deepname.split(".")
+        for name in names[:-1]:
+            destin = getattr(destin, name)
+        setattr(destin, names[-1], value)
+
+
+@contextmanager
+def context(**kwargs):
+    """
+    Context manager to temporarily override one or more settings.
+    """
+    old = {alias: get(alias) for alias in kwargs}
+    try:
+        set(**kwargs)
+        yield
+    finally:
+        set(**old)

--- a/pyro/settings.py
+++ b/pyro/settings.py
@@ -34,6 +34,9 @@ Example usage::
     def validate_thresh(thresh):  # called each time setting is set
         assert isinstance(thresh, float)
         assert thresh > 0
+
+Settings
+--------
 """
 
 # This library must have no other dependencies on pyro.
@@ -53,15 +56,19 @@ def register(
     deepname: str,
     validator: Optional[Callable] = None,
 ) -> Callable:
+    global __doc__
     assert isinstance(alias, str)
     assert isinstance(modulename, str)
     assert isinstance(deepname, str)
+    is_new = alias not in _REGISTRY
     _REGISTRY[alias] = modulename, deepname, validator
+
+    # Add default value to module docstring.
+    if is_new:
+        __doc__ += f"- {alias} = {get(alias)}\n"
 
     # Support use as a decorator on an optional user-provided validator.
     if validator is None:
-        # Smoke test to check that setting exists.
-        get(alias)
         # Return a decorator, but its fine if user discards this.
         return functools.partial(register, alias, modulename, deepname)
     else:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,8 @@ from pyro import settings
 
 _TEST_SETTING: float = 0.1
 
+pytestmark = pytest.mark.stage("unit")
+
 
 def test_settings():
     v0 = settings.get()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,48 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from pyro import settings
+
+_TEST_SETTING: float = 0.1
+
+
+def test_settings():
+    v0 = settings.get()
+    assert isinstance(v0, dict)
+    assert all(isinstance(alias, str) for alias in v0)
+    assert settings.get("validate_distributions_pyro") is True
+    assert settings.get("validate_distributions_torch") is True
+    assert settings.get("validate_poutine") is True
+    assert settings.get("validate_infer") is True
+
+
+def test_register():
+    with pytest.raises(KeyError):
+        settings.get("test_setting")
+
+    @settings.register("test_setting", "tests.test_settings", "_TEST_SETTING")
+    def _validate(value):
+        assert isinstance(value, float)
+        assert 0 < value
+
+    # Test simple get and set.
+    assert settings.get("test_setting") == 0.1
+    settings.set(test_setting=0.2)
+    assert settings.get("test_setting") == 0.2
+    with pytest.raises(AssertionError):
+        settings.set(test_setting=-0.1)
+
+    # Test context manager.
+    with settings.context(test_setting=0.3):
+        assert settings.get("test_setting") == 0.3
+    assert settings.get("test_setting") == 0.2
+
+    # Test decorator.
+    @settings.context(test_setting=0.4)
+    def fn():
+        assert settings.get("test_setting") == 0.4
+
+    fn()
+    assert settings.get("test_setting") == 0.2


### PR DESCRIPTION
This responds to a comment in #3151 where it is currently cumbersome to configure global settings in Pyro.  The solution proposed in this PR is to add a `pyro.settings` module with the usual interface (set, get, context manager) while being extensible in the sense that settings are registered in their local modules, rather than in the settings module.

Hopefully this may slightly simplify @eb8680's new global setting in #3149, e.g. adding this one liner
```python
# in pyro/poutine/runtime.py
settings.register("module_local_param", __name__, "_PYRO_MODULE_LOCAL_PARAM")
```
will allow things like `pyro.settings.set("module_local_param", True)` or
```python
with pyro.settings(module_local_param=True):
    ...do stuff...
```

## Tested
- [x] added some unit tests