### PR TITLE
Bump dependency versions to torch>=1.13 torchvision>=0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           python -m pip install --upgrade pip wheel 'setuptools!=58.5.*'
           # Keep track of pyro-api master branch
           pip install https://github.com/pyro-ppl/pyro-api/archive/master.zip
-          pip install torch==1.11.0+cpu torchvision==0.12.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==1.13.0+cpu torchvision==0.14.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install .[test]
           pip install -r docs/requirements.txt
           pip freeze

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -222,6 +222,6 @@ def setup(app):
 if "READTHEDOCS" in os.environ:
     os.system("pip install numpy")
     os.system(
-        "pip install torch==1.11.0+cpu torchvision==0.12.0+cpu "
+        "pip install torch==1.13.0+cpu torchvision==0.14.0+cpu "
         "-f https://download.pytorch.org/whl/torch_stable.html"
     )

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ EXTRAS_REQUIRE = [
     "jupyter>=1.0.0",
     "graphviz>=0.8",
     "matplotlib>=1.3",
-    "torchvision>=0.12.0",
+    "torchvision>=0.14.0",
     "visdom>=0.1.4,<0.2.2",  # FIXME visdom.utils is unavailable >=0.2.2
     "pandas",
     "pillow==8.2.0",  # https://github.com/pytorch/pytorch/issues/61125
@@ -102,7 +102,7 @@ setup(
         "numpy>=1.7",
         "opt_einsum>=2.3.2",
         "pyro-api>=0.1.1",
-        "torch>=1.11.0",
+        "torch>=1.13.0",
         "tqdm>=4.36",
     ],
     extras_require={


### PR DESCRIPTION
Do not merge.

This is only a test of compatibility with recent PyTorch releases.  I do not plan on increasing the minimum version requirement.