### PR TITLE
fixed NaN with in `log_prob` corr < -1e-8 for `SineBivariateVonMises`

### DIFF
--- a/pyro/distributions/sine_bivariate_von_mises.py
+++ b/pyro/distributions/sine_bivariate_von_mises.py
@@ -137,7 +137,7 @@ class SineBivariateVonMises(TorchDistribution):
         m = torch.arange(50, device=self.phi_loc.device).view(-1, 1)
         fs = (
             SineBivariateVonMises._lbinoms(m.max() + 1).view(-1, 1)
-            + m * torch.log(corr ** 2)
+            + m * torch.log(corr**2)
             - m * torch.log(4 * torch.prod(conc, dim=-1))
         )
         fs += log_I1(m.max(), conc, 51).sum(-1)

--- a/pyro/distributions/sine_bivariate_von_mises.py
+++ b/pyro/distributions/sine_bivariate_von_mises.py
@@ -130,14 +130,14 @@ class SineBivariateVonMises(TorchDistribution):
 
     @lazy_property
     def norm_const(self):
-        corr = self.correlation.view(1, -1) + 1e-8
+        corr = self.correlation.view(1, -1)
         conc = torch.stack(
             (self.phi_concentration, self.psi_concentration), dim=-1
         ).view(-1, 2)
         m = torch.arange(50, device=self.phi_loc.device).view(-1, 1)
         fs = (
             SineBivariateVonMises._lbinoms(m.max() + 1).view(-1, 1)
-            + 2 * m * torch.log(corr)
+            + m * torch.log(corr ** 2)
             - m * torch.log(4 * torch.prod(conc, dim=-1))
         )
         fs += log_I1(m.max(), conc, 51).sum(-1)

--- a/pyro/distributions/sine_bivariate_von_mises.py
+++ b/pyro/distributions/sine_bivariate_von_mises.py
@@ -64,8 +64,8 @@ class SineBivariateVonMises(TorchDistribution):
     :param torch.Tensor phi_concentration: concentration of first angle
     :param torch.Tensor psi_concentration: concentration of second angle
     :param torch.Tensor correlation: correlation between the two angles
-    :param torch.Tensor weighted_correlation: set correlation to weigthed_corr * sqrt(phi_conc*psi_conc)
-        to avoid bimodality (see note). The `weightd_correlation` should be in [0,1].
+    :param torch.Tensor weighted_correlation: set correlation to weighted_corr * sqrt(phi_conc*psi_conc)
+        to avoid bimodality (see note). The `weighted_correlation` should be in [0,1].
     """
 
     arg_constraints = {
@@ -95,10 +95,8 @@ class SineBivariateVonMises(TorchDistribution):
             sqrt_ = (
                 torch.sqrt if isinstance(phi_concentration, torch.Tensor) else math.sqrt
             )
-            eps = torch.finfo(weighted_correlation.dtype).eps
-            correlation = (
-                (weighted_correlation * sqrt_(phi_concentration * psi_concentration)).clamp(min=eps)
-                + 1e-8
+            correlation = weighted_correlation * sqrt_(
+                phi_concentration * psi_concentration
             )
 
         (
@@ -136,10 +134,10 @@ class SineBivariateVonMises(TorchDistribution):
             (self.phi_concentration, self.psi_concentration), dim=-1
         ).view(-1, 2)
         m = torch.arange(50, device=self.phi_loc.device).view(-1, 1)
-        eps = torch.finfo(corr.dtype).eps
+        tiny = torch.finfo(corr.dtype).tiny
         fs = (
             SineBivariateVonMises._lbinoms(m.max() + 1).view(-1, 1)
-            + m * torch.log((corr**2).clamp(min=eps))
+            + m * torch.log((corr**2).clamp(min=tiny))
             - m * torch.log(4 * torch.prod(conc, dim=-1))
         )
         fs += log_I1(m.max(), conc, 51).sum(-1)


### PR DESCRIPTION
Fixes `NaN` in `log_prob` when the correlation is below zero in `SineBivariateVonMises`. Removes correlation bias (`+1e-8`) in normalization constant.

See PR [NumPyro#1515](https://github.com/pyro-ppl/numpyro/pull/1515) and issue [NumPyro#1511](https://github.com/pyro-ppl/numpyro/issues/1511).