### PR TITLE
Update base learning rate scheduler

### DIFF
--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -34,18 +34,16 @@ for _name, _Optim in torch.optim.__dict__.items():
     del _PyroOptim
 
 # Load all schedulers from PyTorch
-try:  # breaking change in torch >= 1.14: LRScheduler is new base class
+# breaking change in torch >= 1.14: LRScheduler is new base class
+if hasattr(torch.optim.lr_scheduler, "LRScheduler"):
     _torch_scheduler_base = torch.optim.lr_scheduler.LRScheduler
-except AttributeError:  # for torch < 1.13, _LRScheduler is base class
+else:  # for torch < 1.13, _LRScheduler is base class
     _torch_scheduler_base = torch.optim.lr_scheduler._LRScheduler
 
 for _name, _Optim in torch.optim.lr_scheduler.__dict__.items():
     if not isinstance(_Optim, type):
         continue
-    if (
-        not issubclass(_Optim, _torch_scheduler_base)
-        and _name != "ReduceLROnPlateau"
-    ):
+    if not issubclass(_Optim, _torch_scheduler_base) and _name != "ReduceLROnPlateau":
         continue
     if _Optim is torch.optim.Optimizer:
         continue

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -34,11 +34,16 @@ for _name, _Optim in torch.optim.__dict__.items():
     del _PyroOptim
 
 # Load all schedulers from PyTorch
+try:  # breaking change in torch >= 1.14: LRScheduler is new base class
+    _torch_scheduler_base = torch.optim.lr_scheduler.LRScheduler
+except AttributeError:  # for torch < 1.13, _LRScheduler is base class
+    _torch_scheduler_base = torch.optim.lr_scheduler._LRScheduler
+
 for _name, _Optim in torch.optim.lr_scheduler.__dict__.items():
     if not isinstance(_Optim, type):
         continue
     if (
-        not issubclass(_Optim, torch.optim.lr_scheduler._LRScheduler)
+        not issubclass(_Optim, _torch_scheduler_base)
         and _name != "ReduceLROnPlateau"
     ):
         continue


### PR DESCRIPTION
Resolves #3166 

PyTorch recently changed the name of the base class used in `pyro.optim` to identify and wrap the learning rate schedulers in `torch.optim` from [`_LRScheduler`](https://pytorch.org/docs/1.13/_modules/torch/optim/lr_scheduler.html) to [`LRScheduler`](https://pytorch.org/docs/master/_modules/torch/optim/lr_scheduler.html), leading to a silent failure to create wrappers.

This PR adds a backwards-compatible check to the wrapping logic to handle newer PyTorch releases.