### PR TITLE
Allow registering of custom exception handlers for potential_fn computations

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -14,8 +14,7 @@ from pyro.infer.autoguide import init_to_uniform
 from pyro.infer.mcmc.adaptation import WarmupAdapter
 from pyro.infer.mcmc.mcmc_kernel import MCMCKernel
 from pyro.infer.mcmc.util import initialize_model
-from pyro.ops.integrator import (_EXCEPTION_HANDLERS, potential_grad,
-                                 velocity_verlet)
+from pyro.ops.integrator import _EXCEPTION_HANDLERS, potential_grad, velocity_verlet
 from pyro.util import optional, torch_isnan
 
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -14,7 +14,8 @@ from pyro.infer.autoguide import init_to_uniform
 from pyro.infer.mcmc.adaptation import WarmupAdapter
 from pyro.infer.mcmc.mcmc_kernel import MCMCKernel
 from pyro.infer.mcmc.util import initialize_model
-from pyro.ops.integrator import potential_grad, velocity_verlet, _EXCEPTION_HANDLERS
+from pyro.ops.integrator import (_EXCEPTION_HANDLERS, potential_grad,
+                                 velocity_verlet)
 from pyro.util import optional, torch_isnan
 
 

--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -14,7 +14,7 @@ from pyro.infer.autoguide import init_to_uniform
 from pyro.infer.mcmc.adaptation import WarmupAdapter
 from pyro.infer.mcmc.mcmc_kernel import MCMCKernel
 from pyro.infer.mcmc.util import initialize_model
-from pyro.ops.integrator import potential_grad, velocity_verlet
+from pyro.ops.integrator import potential_grad, velocity_verlet, _EXCEPTION_HANDLERS
 from pyro.util import optional, torch_isnan
 
 
@@ -173,7 +173,16 @@ class HMC(MCMCKernel):
         # We are going to find a step_size which make accept_prob (Metropolis correction)
         # near the target_accept_prob. If accept_prob:=exp(-delta_energy) is small,
         # then we have to decrease step_size; otherwise, increase step_size.
-        potential_energy = self.potential_fn(z)
+        try:
+            potential_energy = self.potential_fn(z)
+        # handle exceptions as defined in the exception registry
+        except Exception as e:
+            if any(h(e) for h in _EXCEPTION_HANDLERS.values()):
+                # skip finding reasonable step size
+                return step_size
+            else:
+                raise e
+
         r, r_unscaled = self._sample_r(name="r_presample_0")
         energy_current = self._kinetic_energy(r_unscaled) + potential_energy
         # This is required so as to avoid issues with autograd when model

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable
+import warnings
+
+from typing import Callable, Dict
 
 from torch.autograd import grad
 
@@ -94,23 +96,23 @@ def potential_grad(potential_fn, z):
 
 
 def register_exception_handler(
-    name: str, handler: Callable[[Exception], bool], overwrite: bool = False
+    name: str, handler: Callable[[Exception], bool], warn_on_overwrite: bool = True
 ) -> None:
     """
     Register an exception handler for handling (primarily numerical) errors
     when evaluating the potential function.
 
     :param name: name of the handler (must be unique).
-    :param handler: A callable mapping an exception to a boolean. Exceptions
+    :param handler: A callable mapping an Exception to a boolean. Exceptions
         that evaluate to true in any of the handlers are handled in the computation
         of the potential energy.
-    :param overwrite: If True, overwrite handlers already registered under the
-        provided name.
+    :param warn_on_overwrite: If True, warns when overwriting a handler already
+        registered under the provided name.
     """
-    if name in _EXCEPTION_HANDLERS and not overwrite:
-        raise RuntimeError(
-            f"Exception handler already registered under key {name}. "
-            "Use `overwrite=True` to force overwriting the handler."
+    if name in _EXCEPTION_HANDLERS and warn_on_overwrite:
+        warnings.warn(
+            f"Overwriting Exception handler already registered under key {name}.",
+            RuntimeWarning,
         )
     _EXCEPTION_HANDLERS[name] = handler
 

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -118,7 +118,8 @@ def register_exception_handler(
 
 def _handle_torch_singular(exception: Exception) -> bool:
     """Exception handler for errors thrown on (numerically) singular matrices."""
-    if type(exception) == RuntimeError:
+    # the actual type of the exception thrown is torch._C._LinAlgError
+    if isinstance(exception, RuntimeError):
         msg = str(exception)
         return "singular" in msg or "input is not positive-definite" in msg
     return False

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -7,7 +7,7 @@ from torch.autograd import grad
 
 # Registry for exception handlers that can be used to catch certain failures
 # during computation of `potential_fn` within `potential_grad`.
-_EXCEPTION_HANDLERS = {}
+_EXCEPTION_HANDLERS: Dict[str, Callable[[Exception], bool]] = {}
 
 
 def velocity_verlet(
@@ -102,9 +102,9 @@ def register_exception_handler(
 
     :param name: name of the handler (must be unique).
     :param handler: A callable mapping an exception to a boolean. Exceptions
-        that evaluate to true in any of the handlers are handled in teh computation
+        that evaluate to true in any of the handlers are handled in the computation
         of the potential energy.
-    :param overwrite: If True, overwrite handlers already registerd under the
+    :param overwrite: If True, overwrite handlers already registered under the
         provided name.
     """
     if name in _EXCEPTION_HANDLERS and not overwrite:
@@ -118,9 +118,8 @@ def register_exception_handler(
 def _handle_torch_singular(exception: Exception) -> bool:
     """Exception handler for errors thrown on (numerically) singular matrices."""
     if type(exception) == RuntimeError:
-        return "singular" in str(exception) or "input is not positive-definite" in str(
-            exception
-        )
+        msg = str(exception)
+        return "singular" in msg or "input is not positive-definite" in msg
     return False
 
 

--- a/pyro/ops/integrator.py
+++ b/pyro/ops/integrator.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
-
 from typing import Callable, Dict
 
 from torch.autograd import grad


### PR DESCRIPTION
In some cases evaluation the potential funciton may result in numerical issues. Currently the code hard-codes the handling of a RuntimeError raised when matrices are (numerically) singular. This PR adds the ability to register custom exception handlers. This allows other code depending on pyro to register custom exception handlers without having to modify core pyro code.

There are some other places in which `potential_fn` is called that could benefit from being guarded by these handlers (one is `HMC._find_reasonable_step_size`). I'm not sure what the right thing to do there is when encountering numerical isssues, but happy to add this in as needed.