### PR TITLE
Fix metaclass conflict with ModuleList

### DIFF
--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -32,7 +32,7 @@ from pyro.distributions import constraints
 from pyro.distributions.transforms import affine_autoregressive, iterated
 from pyro.distributions.util import eye_like, sum_rightmost
 from pyro.infer.enum import config_enumerate
-from pyro.nn.module import PyroModule, PyroParam
+from pyro.nn.module import PyroModule, PyroModuleList, PyroParam
 from pyro.ops.hessian import hessian
 from pyro.ops.tensor_utils import periodic_repeat
 from pyro.poutine.util import site_is_subsample
@@ -180,7 +180,7 @@ class AutoGuide(PyroModule):
         raise NotImplementedError
 
 
-class AutoGuideList(AutoGuide, nn.ModuleList):
+class AutoGuideList(AutoGuide, PyroModuleList):
     """
     Container class to combine multiple automatic guides.
 

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -262,7 +262,7 @@ class _PyroModuleMeta(type):
         return result
 
 
-class _PyroModuleListMeta(_PyroModuleList, ABCMeta): pass
+class _PyroModuleListMeta(_PyroModuleMeta, ABCMeta): pass
 
 
 class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -263,6 +263,8 @@ class _PyroModuleMeta(type):
 
 
 class _PyroModuleListMeta(_PyroModuleMeta, ABCMeta): pass
+    # This is needed to avoid a metaclass conflict between PyroModule and
+    # torch.nn.ModuleList.
 
 
 class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
@@ -667,6 +669,7 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
 
 
 class PyroModuleList(torch.nn.ModuleList, metaclass=_PyroModuleListMeta): pass
+    # A ModuleList for PyroModules that avoids metaclass conflicts.
 
 
 def pyro_method(fn):

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -14,8 +14,8 @@ the :class:`PyroSample` struct::
 """
 import functools
 import inspect
+from abc import ABCMeta
 from collections import OrderedDict, namedtuple
-from typing import GenericMeta
 
 import torch
 from torch.distributions import constraints, transform_to
@@ -230,7 +230,7 @@ def _get_pyro_params(module):
         yield name, module._parameters[name]
 
 
-class _PyroModuleMeta(GenericMeta):
+class _PyroModuleMeta(type):
     _pyro_mixin_cache = {}
 
     # Unpickling helper to create an empty object of type PyroModule[Module].
@@ -260,6 +260,9 @@ class _PyroModuleMeta(GenericMeta):
         result.__name__ = "Pyro" + Module.__name__
         _PyroModuleMeta._pyro_mixin_cache[Module] = result
         return result
+
+
+class _PyroModuleListMeta(_PyroModuleList, ABCMeta): pass
 
 
 class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
@@ -661,6 +664,9 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
             return
 
         super().__delattr__(name)
+
+
+class PyroModuleList(torch.nn.ModuleList, metaclass=_PyroModuleListMeta): pass
 
 
 def pyro_method(fn):

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -15,6 +15,7 @@ the :class:`PyroSample` struct::
 import functools
 import inspect
 from collections import OrderedDict, namedtuple
+from typing import GenericMeta
 
 import torch
 from torch.distributions import constraints, transform_to
@@ -229,7 +230,7 @@ def _get_pyro_params(module):
         yield name, module._parameters[name]
 
 
-class _PyroModuleMeta(type):
+class _PyroModuleMeta(GenericMeta):
     _pyro_mixin_cache = {}
 
     # Unpickling helper to create an empty object of type PyroModule[Module].

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -262,9 +262,12 @@ class _PyroModuleMeta(type):
         return result
 
 
-class _PyroModuleListMeta(_PyroModuleMeta, ABCMeta): pass
-    # This is needed to avoid a metaclass conflict between PyroModule and
-    # torch.nn.ModuleList.
+class _PyroModuleListMeta(_PyroModuleMeta, ABCMeta):
+    """
+    This is needed to avoid a metaclass conflict between PyroModule and
+    torch.nn.ModuleList.
+    """
+    pass
 
 
 class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
@@ -668,8 +671,11 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
         super().__delattr__(name)
 
 
-class PyroModuleList(torch.nn.ModuleList, metaclass=_PyroModuleListMeta): pass
-    # A ModuleList for PyroModules that avoids metaclass conflicts.
+class PyroModuleList(torch.nn.ModuleList, metaclass=_PyroModuleListMeta):
+    """
+    A ModuleList for PyroModules that avoids metaclass conflicts.
+    """
+    pass
 
 
 def pyro_method(fn):


### PR DESCRIPTION
- https://github.com/pytorch/pytorch/pull/89135 changed the inheritance of `torch.nn.ModuleList`. This changed the metaclass of `ModuleList` from `type` to `abc.ABCMeta` (print `type(ModuleList)` before & after the change).
- `PyroModule` has its own metaclass `_PyroModuleMeta`. Attempting to create a class (`AutoGuideList`) with bases that have different metaclasses leads to: `TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases`
- The solution for this is to create a new metaclass that inherits from both metaclasses, which is the `_PyroModuleListMeta` introduced here. 
- Note that changing `_PyroModuleMeta` to inherit from `ABCMeta` does not work as this leads to a different `TypeError` (something with MRO conflict). If this worked, it'd be a more general solution.

Fixes https://github.com/pyro-ppl/pyro/issues/3172