### PR TITLE
fix: typo in log-absolute-derivative of exponential transform (normalizing flow tutorial) closes #3176

### DIFF
--- a/tutorial/source/normalizing_flows_i.ipynb
+++ b/tutorial/source/normalizing_flows_i.ipynb
@@ -126,7 +126,7 @@
     "\\begin{align}\n",
     "g(x) &= \\text{exp(x)}\\\\\n",
     "g^{-1}(y) &= \\log(y)\\\\\n",
-    "\\log\\left(\\left|\\frac{dg}{dx}\\right|\\right) &= y.\n",
+    "\\log\\left(\\left|\\frac{dg}{dx}\\right|\\right) &= x.\n",
     "\\end{align}\n",
     "\n",
     "\n",


### PR DESCRIPTION
This PR addresses Issue #3176

I ran `make test` and `make test-examples` locally just to be sure, but since only a single character inside a notebook markdown cell is changed, there shouldn't be bigger problems.