### PR TITLE
Add conditional inverse and compose TransformModules

### DIFF
--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -39,10 +39,10 @@ class ConditionalTransformModule(ConditionalTransform, torch.nn.Module):
 
     @property
     def inv(self) -> "ConditionalTransformModule":
-        return _InverseConditionalTransformModule(self)
+        return _ConditionalInverseTransformModule(self)
 
 
-class _InverseConditionalTransformModule(ConditionalTransformModule):
+class _ConditionalInverseTransformModule(ConditionalTransformModule):
     def __init__(self, transform: ConditionalTransform):
         super().__init__()
         self._transform = transform

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -43,7 +43,6 @@ class ConditionalTransformModule(ConditionalTransform, torch.nn.Module):
 
 
 class _InverseConditionalTransformModule(ConditionalTransformModule):
-
     def __init__(self, transform: ConditionalTransform):
         super().__init__()
         self._transform = transform
@@ -56,8 +55,9 @@ class _InverseConditionalTransformModule(ConditionalTransformModule):
         return self._transform.condition(context).inv
 
 
-class ConditionalComposeTransformModule(ConditionalTransformModule, torch.nn.ModuleList):
-
+class ConditionalComposeTransformModule(
+    ConditionalTransformModule, torch.nn.ModuleList
+):
     def __init__(self, transforms: list, *, cache_size: int = 0):
         self.transforms = [
             ConstantConditionalTransform(t)
@@ -67,7 +67,7 @@ class ConditionalComposeTransformModule(ConditionalTransformModule, torch.nn.Mod
         ]
         super().__init__()
         if cache_size not in {0, 1}:
-            raise ValueError('cache_size must be 0 or 1')
+            raise ValueError("cache_size must be 0 or 1")
         self._cache_size = cache_size
         # for parameter storage
         for t in transforms:

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn
 
 from .torch import TransformedDistribution
+from .torch_transform import ComposeTransformModule
 
 
 class ConditionalDistribution(ABC):
@@ -35,6 +36,48 @@ class ConditionalTransformModule(ConditionalTransform, torch.nn.Module):
 
     def __hash__(self):
         return super().__hash__()
+
+    @property
+    def inv(self) -> "ConditionalTransformModule":
+        return InverseConditionalTransformModule(self)
+
+
+class InverseConditionalTransformModule(ConditionalTransformModule):
+
+    def __init__(self, transform: ConditionalTransform):
+        super().__init__()
+        self._transform = transform
+
+    @property
+    def inv(self) -> ConditionalTransform:
+        return self._transform
+
+    def condition(self, context: torch.Tensor):
+        return self._transform.condition(context).inv
+
+
+class ConditionalComposeTransformModule(ConditionalTransformModule, torch.nn.ModuleList):
+
+    def __init__(self, transforms: list, *, cache_size: int = 0):
+        self.transforms = [
+            ConstantConditionalTransform(t)
+            if not isinstance(t, ConditionalTransform)
+            else t
+            for t in transforms
+        ]
+        super().__init__()
+        if cache_size not in {0, 1}:
+            raise ValueError('cache_size must be 0 or 1')
+        self._cache_size = cache_size
+        # for parameter storage
+        for t in transforms:
+            if isinstance(t, torch.nn.Module):
+                self.append(t)
+
+    def condition(self, context: torch.Tensor):
+        return ComposeTransformModule(
+            [t.condition(context) for t in self.transforms]
+        ).with_cache(self._cache_size)
 
 
 class ConstantConditionalDistribution(ConditionalDistribution):

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -39,10 +39,10 @@ class ConditionalTransformModule(ConditionalTransform, torch.nn.Module):
 
     @property
     def inv(self) -> "ConditionalTransformModule":
-        return InverseConditionalTransformModule(self)
+        return _InverseConditionalTransformModule(self)
 
 
-class InverseConditionalTransformModule(ConditionalTransformModule):
+class _InverseConditionalTransformModule(ConditionalTransformModule):
 
     def __init__(self, transform: ConditionalTransform):
         super().__init__()
@@ -74,7 +74,7 @@ class ConditionalComposeTransformModule(ConditionalTransformModule, torch.nn.Mod
             if isinstance(t, torch.nn.Module):
                 self.append(t)
 
-    def condition(self, context: torch.Tensor):
+    def condition(self, context: torch.Tensor) -> ComposeTransformModule:
         return ComposeTransformModule(
             [t.condition(context) for t in self.transforms]
         ).with_cache(self._cache_size)

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -58,7 +58,27 @@ class _ConditionalInverseTransformModule(ConditionalTransformModule):
 class ConditionalComposeTransformModule(
     ConditionalTransformModule, torch.nn.ModuleList
 ):
-    def __init__(self, transforms: list, *, cache_size: int = 0):
+    """
+    Conditional analogue of :class:`~pyro.distributions.torch_transform.ComposeTransformModule` .
+
+    Useful as a base class for specifying complicated conditional distributions::
+
+        >>> class ConditionalFlowStack(dist.conditional.ConditionalComposeTransformModule):
+        ...     def __init__(self, input_dim, context_dim, hidden_dims, num_flows):
+        ...         super().__init__([
+        ...             dist.transforms.conditional_planar(input_dim, context_dim, hidden_dims)
+        ...             for _ in range(num_flows)
+        ...         ], cache_size=1)
+
+        >>> cond_dist = dist.conditional.ConditionalTransformedDistribution(
+        ...     dist.Normal(torch.zeros(3), torch.ones(3)).to_event(1),
+        ...     [ConditionalFlowStack(3, 2, [8, 8], num_flows=4).inv]
+        ... )
+
+        >>> nll = -cond_dist.condition(context).log_prob(data)
+    """
+
+    def __init__(self, transforms, cache_size: int = 0):
         self.transforms = [
             ConstantConditionalTransform(t)
             if not isinstance(t, ConditionalTransform)

--- a/pyro/distributions/conditional.py
+++ b/pyro/distributions/conditional.py
@@ -75,6 +75,8 @@ class ConditionalComposeTransformModule(
         ...     [ConditionalFlowStack(3, 2, [8, 8], num_flows=4).inv]
         ... )
 
+        >>> context = torch.rand(10, 2)
+        >>> data = torch.rand(10, 3)
         >>> nll = -cond_dist.condition(context).log_prob(data)
     """
 

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -35,6 +35,6 @@ class ComposeTransformModule(torch.distributions.ComposeTransform, torch.nn.Modu
         return super(torch.nn.Module, self).__hash__()
 
     def with_cache(self, cache_size=1):
-        if cache_size == 0:
+        if cache_size == self._cache_size:
             return self
         return ComposeTransformModule(self.parts, cache_size=cache_size)

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -25,11 +25,16 @@ class ComposeTransformModule(torch.distributions.ComposeTransform, torch.nn.Modu
     store when used in :class:`~pyro.nn.module.PyroModule` instances.
     """
 
-    def __init__(self, parts):
-        super().__init__(parts)
+    def __init__(self, parts, cache_size=0):
+        super().__init__(parts, cache_size=cache_size)
         for part in parts:
             if isinstance(part, torch.nn.Module):
                 self.append(part)
 
     def __hash__(self):
         return super(torch.nn.Module, self).__hash__()
+
+    def with_cache(self, cache_size=1):
+        if cache_size == 0:
+            return self
+        return ComposeTransformModule(self.parts, cache_size=cache_size)

--- a/pyro/distributions/torch_transform.py
+++ b/pyro/distributions/torch_transform.py
@@ -28,7 +28,8 @@ class ComposeTransformModule(torch.distributions.ComposeTransform, torch.nn.Modu
     def __init__(self, parts):
         super().__init__(parts)
         for part in parts:
-            self.append(part)
+            if isinstance(part, torch.nn.Module):
+                self.append(part)
 
     def __hash__(self):
         return super(torch.nn.Module, self).__hash__()

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -516,13 +516,12 @@ def test_conditional_compose_transform_module(
 
     context = torch.rand(batch_shape + (context_dim,))
     d = cond_dist.condition(context)
+    transform = d.transforms[0]
+    assert isinstance(transform, T.ComposeTransformModule)
 
     data = d.rsample()
     assert data.shape == batch_shape + (input_dim,)
     assert d.log_prob(data).shape == batch_shape
-
-    transform = d.transforms[0]
-    assert isinstance(transform, T.ComposeTransformModule)
 
     actual_params = set(cond_transform.parameters())
     expected_params = set(

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -10,7 +10,6 @@ import torch
 
 import pyro.distributions as dist
 import pyro.distributions.transforms as T
-
 from pyro.distributions import constraints
 from tests.common import assert_close
 
@@ -477,7 +476,6 @@ def test_lower_cholesky_transform(transform, batch_shape, dim):
 @pytest.mark.parametrize("input_dim", [2, 3, 5])
 @pytest.mark.parametrize("context_dim", [2, 3, 5])
 def test_inverse_conditional_transform_module(batch_shape, input_dim, context_dim):
-
     cond_transform = T.conditional_spline(input_dim, context_dim, [6])
 
     noise = torch.rand(batch_shape + (input_dim,))
@@ -499,7 +497,9 @@ def test_inverse_conditional_transform_module(batch_shape, input_dim, context_di
 @pytest.mark.parametrize("input_dim", [2, 3, 5])
 @pytest.mark.parametrize("context_dim", [2, 3, 5])
 @pytest.mark.parametrize("cache_size", [0, 1])
-def test_conditional_compose_transform_module(batch_shape, input_dim, context_dim, cache_size):
+def test_conditional_compose_transform_module(
+    batch_shape, input_dim, context_dim, cache_size
+):
     conditional_transforms = [
         T.AffineTransform(1.0, 2.0),
         T.Spline(input_dim),
@@ -516,8 +516,16 @@ def test_conditional_compose_transform_module(batch_shape, input_dim, context_di
 
     transform = cond_transform.condition(context)
     assert isinstance(transform, T.ComposeTransformModule)
-    assert set() != set(cond_transform.parameters()) == set.union(
-        *(set(t.parameters()) for t in conditional_transforms if isinstance(t, torch.nn.Module))
+    assert (
+        set()
+        != set(cond_transform.parameters())
+        == set.union(
+            *(
+                set(t.parameters())
+                for t in conditional_transforms
+                if isinstance(t, torch.nn.Module)
+            )
+        )
     )
 
     expected = noise

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -529,9 +529,3 @@ def test_conditional_compose_transform_module(batch_shape, input_dim, context_di
 
     assert_close(cond_transform.inv.condition(context)(actual), noise)
     assert_close(cond_transform.condition(context).inv(expected), noise)
-
-    noise_double = noise.clone().to(dtype=torch.float64)
-    context_double = context.clone().to(dtype=torch.float64)
-
-    out_double = cond_transform.to(dtype=torch.float64).condition(context_double)(noise_double)
-    assert_close(out_double.to(dtype=torch.float32), expected)


### PR DESCRIPTION
This PR adds conditional analogues of `ComposeTransformModule` and `InverseTransform` to `pyro.distributions.conditional`. I've found these helpful in building up learnable conditional `TransformedDistribution`s in Pyro models.

I also fixed a couple of small bugs in `ComposeTransformModule` that affected interoperability of `Transform`s and `TransformModule`s.

Tested:
- Unit tests for `ConditionalComposeTransformModule` and `_ConditionalInverseTransformModule`
- Tests for new transforms also exercise bugfixes