### PR TITLE
VAE: Improved ELBO plots

### DIFF
--- a/examples/vae/utils/vae_plots.py
+++ b/examples/vae/utils/vae_plots.py
@@ -26,21 +26,38 @@ def plot_conditional_samples_ssvae(ssvae, visdom_session):
 
 
 def plot_llk(train_elbo, test_elbo):
+    from pathlib import Path
+
     import matplotlib.pyplot as plt
-    import numpy as np
     import pandas as pd
-    import scipy as sp
     import seaborn as sns
+
+    Path("vae_results").mkdir(parents=True, exist_ok=True)
 
     plt.figure(figsize=(30, 10))
     sns.set_style("whitegrid")
-    data = np.concatenate(
-        [np.arange(len(test_elbo))[:, sp.newaxis], -test_elbo[:, sp.newaxis]], axis=1
+    df1 = pd.DataFrame(
+        {
+            "Epoch": train_elbo.keys(),
+            "ELBO": [-val for val in train_elbo.values()],
+            "dataset": "Train",
+        }
     )
-    df = pd.DataFrame(data=data, columns=["Training Epoch", "Test ELBO"])
-    g = sns.FacetGrid(df, size=10, aspect=1.5)
-    g.map(plt.scatter, "Training Epoch", "Test ELBO")
-    g.map(plt.plot, "Training Epoch", "Test ELBO")
+    df2 = pd.DataFrame(
+        {
+            "Epoch": test_elbo.keys(),
+            "ELBO": [-val for val in test_elbo.values()],
+            "dataset": "Test",
+        }
+    )
+    df = pd.concat([df1, df2], axis=0)
+
+    # Create the FacetGrid with scatter plot
+    g = sns.FacetGrid(df, height=4, aspect=1.5, hue="dataset")
+    g.map(sns.scatterplot, "Epoch", "ELBO")
+    g.map(sns.lineplot, "Epoch", "ELBO", linestyle="--")
+    g.ax.yaxis.get_major_locator().set_params(integer=True)
+    g.add_legend()
     plt.savefig("./vae_results/test_elbo_vae.png")
     plt.close("all")
 

--- a/examples/vae/vae.py
+++ b/examples/vae/vae.py
@@ -147,8 +147,8 @@ def main(args):
     if args.visdom_flag:
         vis = visdom.Visdom()
 
-    train_elbo = []
-    test_elbo = []
+    train_elbo = {}
+    test_elbo = {}
     # training loop
     for epoch in range(args.num_epochs):
         # initialize loss accumulator
@@ -165,7 +165,7 @@ def main(args):
         # report training diagnostics
         normalizer_train = len(train_loader.dataset)
         total_epoch_loss_train = epoch_loss / normalizer_train
-        train_elbo.append(total_epoch_loss_train)
+        train_elbo[epoch] = total_epoch_loss_train
         print(
             "[epoch %03d]  average training loss: %.4f"
             % (epoch, total_epoch_loss_train)
@@ -203,14 +203,14 @@ def main(args):
             # report test diagnostics
             normalizer_test = len(test_loader.dataset)
             total_epoch_loss_test = test_loss / normalizer_test
-            test_elbo.append(total_epoch_loss_test)
+            test_elbo[epoch] = total_epoch_loss_test
             print(
                 "[epoch %03d]  average test loss: %.4f" % (epoch, total_epoch_loss_test)
             )
+            plot_llk(train_elbo, test_elbo)
 
         if epoch == args.tsne_iter:
             mnist_test_tsne(vae=vae, test_loader=test_loader)
-            plot_llk(np.array(train_elbo), np.array(test_elbo))
 
     return vae
 


### PR DESCRIPTION
Hey there,

this PR corrects and improves the plots in the [Pyro VAE](https://pyro.ai/examples/vae.html) tutorial. 

There seem to be three minor hiccups in the code:
- It looks like you are plotting the Test ELBO but with training epochs on the x-axis, [here](https://github.com/pyro-ppl/pyro/blob/dd4e0f81b4ddceb82ebd663b20333e175ce27c2a/examples/vae/utils/vae_plots.py#L40)
- The `size` argument [here](https://github.com/pyro-ppl/pyro/blob/dd4e0f81b4ddceb82ebd663b20333e175ce27c2a/examples/vae/utils/vae_plots.py#L41) does not exist in the current seaborn version anymore and raises an error.
- Currently both train and test ELBOs are passed to `plot_llk`, but only the test ELBO values are plotted. I guess this is not intended.

The PR plots both train and test performance and ensures ELBOs are correctly aligned with the epochs (even if ELBOs are computed at different frequencies) and moves the plotting function call into the if statement when the data is actually evaluated on the test data. 

I did not open a PR because this is a minor correction -- hope that's fine with you.

New example plot:
![image](https://user-images.githubusercontent.com/35061428/235480414-f91f6aa7-aa03-47d1-9d4b-3419ff34eba0.png)
