### PR TITLE
fix saving the param store with PyTorch 2 (closes #3201)

### DIFF
--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -243,8 +243,9 @@ class ParamStoreDict:
         """
         Get the ParamStore state.
         """
+        params = {name: param[...] for name, param in self._params.items()}
         state = {
-            "params": self._params.copy(),
+            "params": params,
             "constraints": self._constraints.copy(),
         }
         return state


### PR DESCRIPTION
In ParamStoreDict.__getitem__, we add a weakref to the unconstrained value to the transformed parameter. Apparently, when the constrained is Real(), transform_to returns the same object that it was passed, so we end up with weakrefs in ParamStoreDict._params. This was fine with PyTorch1, but under Pytorch2 an exception is raised when saving a Parameter with a weakref. So let's explicitly remove the .unconstrained attribute from all parameters to be saved