### PR TITLE
Clear .unconstrained weakrefs before pickling; rebuild them more often

### DIFF
--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -230,7 +230,7 @@ class Group:
         self.event_shape = torch.Size([sum(self._site_sizes.values())])
 
     def __getstate__(self):
-        state = self.__dict__.copy()
+        state = getattr(super(), "__getstate__", self.__dict__.copy)()
         state["_guide"] = state["_guide"]()  # weakref -> ref
         return state
 

--- a/pyro/distributions/torch_patch.py
+++ b/pyro/distributions/torch_patch.py
@@ -44,13 +44,12 @@ def patch_dependency(target, root_module=torch):
 # TODO: Move upstream to allow for pickle serialization of transforms
 @patch_dependency("torch.distributions.transforms.Transform.__getstate__")
 def _Transform__getstate__(self):
-    attrs = {}
-    for k, v in self.__dict__.items():
+    super_ = super(torch.distributions.transforms.Transform, self)
+    state = getattr(super_, "__getstate__", self.__dict__.copy)()
+    for k, v in state.items():
         if isinstance(v, weakref.ref):
-            attrs[k] = None
-        else:
-            attrs[k] = v
-    return attrs
+            state[k] = None
+    return state
 
 
 # TODO move upstream

--- a/pyro/infer/elbo.py
+++ b/pyro/infer/elbo.py
@@ -66,9 +66,10 @@ class ELBO(object, metaclass=ABCMeta):
         behave unexpectedly relative to standard PyTorch when working with
         :class:`~pyro.nn.PyroModule` s.
 
-        Users are therefore strongly encouraged to use this interface in conjunction
-        with :func:`~pyro.enable_module_local_param` which will override the default
-        implicit sharing of parameters across :class:`~pyro.nn.PyroModule` instances.
+        Users are therefore strongly encouraged to use this interface in
+        conjunction with ``pyro.settings.set(module_local_params=True)`` which
+        will override the default implicit sharing of parameters across
+        :class:`~pyro.nn.PyroModule` instances.
 
     :param num_particles: The number of particles/samples used to form the ELBO
         (gradient) estimators.

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -666,14 +666,9 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
 
     def __getstate__(self):
         # Remove weakrefs in preparation for pickling.
-        for param in self.parameters(recurse=False):
+        for param in self.parameters(recurse=True):
             param.__dict__.pop("unconstrained", None)
-        try:
-            __getstate__ = super().__getstate__()
-        except AttributeError:
-            return self.__dict__  # torch<=2.0.1
-        else:
-            return __getstate__()  # torch>2.0.1
+        return getattr(super(), "__getstate__", self.__dict__.copy)()
 
 
 def pyro_method(fn):

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -14,6 +14,7 @@ the :class:`PyroSample` struct::
 """
 import functools
 import inspect
+import weakref
 from collections import OrderedDict, namedtuple
 
 import torch
@@ -503,7 +504,9 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
                         _PYRO_PARAM_STORE._param_to_name[unconstrained_value] = fullname
                     return pyro.param(fullname, event_dim=event_dim)
                 else:  # Cannot determine supermodule and hence cannot compute fullname.
-                    return transform_to(constraint)(unconstrained_value)
+                    constrained_value = transform_to(constraint)(unconstrained_value)
+                    constrained_value.unconstrained = weakref.ref(unconstrained_value)
+                    return constrained_value
 
         # PyroSample trigger pyro.sample statements.
         if "_pyro_samples" in self.__dict__:
@@ -660,6 +663,17 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
             return
 
         super().__delattr__(name)
+
+    def __getstate__(self):
+        # Remove weakrefs in preparation for pickling.
+        for param in self.parameters(recurse=False):
+            param.__dict__.pop("unconstrained", None)
+        try:
+            __getstate__ = super().__getstate__()
+        except AttributeError:
+            return self.__dict__  # torch<=2.0.1
+        else:
+            return __getstate__()  # torch>2.0.1
 
 
 def pyro_method(fn):

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -243,10 +243,11 @@ class ParamStoreDict:
         """
         Get the ParamStore state.
         """
-        state = {
-            "params": self._params.copy(),
-            "constraints": self._constraints.copy(),
-        }
+        params = self._params.copy()
+        # Remove weakrefs in preparation for pickling.
+        for param in params.values():
+            param.__dict__.pop("unconstrained", None)
+        state = {"params": params, "constraints": self._constraints.copy()}
         return state
 
     def set_state(self, state: dict):

--- a/pyro/poutine/guide.py
+++ b/pyro/poutine/guide.py
@@ -30,6 +30,12 @@ class GuideMessenger(TraceMessenger, ABC):
     def model(self):
         return self._model[0]
 
+    def __getstate__(self):
+        # Avoid pickling the trace.
+        state = super().__getstate__()
+        state.pop("trace")
+        return state
+
     def __call__(self, *args, **kwargs) -> Dict[str, torch.Tensor]:
         """
         Draws posterior samples from the guide and replays the model against

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -374,7 +374,9 @@ def test_clear(local_params):
 
         # mutate
         for _, x in m.named_pyro_params():
-            x.unconstrained().data += torch.randn(())
+            if hasattr(x, "unconstrained"):
+                x = x.unconstrained()
+            x.data += torch.randn(x.shape)
         state1 = m()
         for x, y in zip(state0, state1):
             assert not (x == y).all()


### PR DESCRIPTION
Resolves #3201 
Replaces #3206

This builds on @ilia-kats's diagnosis of why `torch.save` is failing with various Pyro objects in torch>=2, namely that the `.unconstrained` attributes of tensors are breaking pickling.  This PR:
- removes `.unconstrained` in one other place,
- rebuilds `.unconstrained` in one place,
- fixes `__getstate__` in a number of places to avoid serializing `weakref.ref`s
- fixes one module_local_param comment.

## Tested
- ran serialization tests locally under torch==2.0.1
