### PR TITLE
make ProvenanceTensor behave more like a Tensor (closes #3218)

### DIFF
--- a/pyro/ops/provenance.py
+++ b/pyro/ops/provenance.py
@@ -59,6 +59,8 @@ class ProvenanceTensor(torch.Tensor):
         if isinstance(data, ProvenanceTensor):
             provenance |= data._provenance
         self._provenance = provenance
+        if hasattr(data, "unconstrained"):
+            self._t.unconstrained = data.unconstrained
 
     def __repr__(self):
         return "Provenance:\n{}\nTensor:\n{}".format(self._provenance, self._t)

--- a/pyro/ops/provenance.py
+++ b/pyro/ops/provenance.py
@@ -47,7 +47,7 @@ class ProvenanceTensor(torch.Tensor):
         if not provenance:
             return data
         ret = data.view(data.shape)
-        ret._t = data.view(data.shape)  # this makes sure that detach_provenance always
+        ret._t = data  # this makes sure that detach_provenance always
         # returns the same object. This is important when
         # using the tensor as key in a dict, e.g. the global
         # param store

--- a/pyro/ops/provenance.py
+++ b/pyro/ops/provenance.py
@@ -46,18 +46,15 @@ class ProvenanceTensor(torch.Tensor):
         assert not isinstance(data, ProvenanceTensor)
         if not provenance:
             return data
-        ret = data.view(data.shape)
+        ret = data.as_subclass(cls)
         ret._t = data  # this makes sure that detach_provenance always
         # returns the same object. This is important when
         # using the tensor as key in a dict, e.g. the global
         # param store
-        ret.__class__ = cls
         return ret
 
     def __init__(self, data, provenance=frozenset()):
         assert isinstance(provenance, frozenset)
-        if isinstance(data, ProvenanceTensor):
-            provenance |= data._provenance
         self._provenance = provenance
 
     def __repr__(self):

--- a/pyro/ops/provenance.py
+++ b/pyro/ops/provenance.py
@@ -59,8 +59,6 @@ class ProvenanceTensor(torch.Tensor):
         if isinstance(data, ProvenanceTensor):
             provenance |= data._provenance
         self._provenance = provenance
-        if hasattr(data, "unconstrained"):
-            self._t.unconstrained = data.unconstrained
 
     def __repr__(self):
         return "Provenance:\n{}\nTensor:\n{}".format(self._provenance, self._t)

--- a/tests/ops/test_provenance.py
+++ b/tests/ops/test_provenance.py
@@ -1,0 +1,45 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pyro.ops.provenance import ProvenanceTensor
+from tests.common import assert_equal, requires_cuda
+
+
+@requires_cuda
+@pytest.mark.parametrize(
+    "dtype1",
+    [
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype2",
+    [
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+    ],
+)
+def test_provenance_tensor(dtype1, dtype2):
+    device = torch.device("cuda")
+    x = torch.tensor([1, 2, 3], dtype=dtype1)
+    y = ProvenanceTensor(x, frozenset(["x"]))
+    z = torch.as_tensor(y, device=device, dtype=dtype2)
+
+    assert x.shape == y.shape == z.shape
+    assert_equal(x, z.cpu())


### PR DESCRIPTION
The data is now stored in the Tensor itself instead of an attribute. This fixes torch.to_tensor returning empty tensors when called with a ProvenanceTensor and and a device as arguments.

This is super hacky, but I couldn't come up with a cleaner way. Note that this is the only way to use `pyro.infer.inspect.get_dependencies` when training on GPUs (I'm using it in a custom Messenger guide), since the `log_prob` function of some distributions (for example Gamma) calls `torch.to_tensor`.