### PR TITLE
Fix jit ELBO sign error

### DIFF
--- a/pyro/infer/trace_mean_field_elbo.py
+++ b/pyro/infer/trace_mean_field_elbo.py
@@ -120,7 +120,10 @@ class TraceMeanField_ELBO(Trace_ELBO):
                             kl_qp, scale=guide_site["scale"], mask=guide_site["mask"]
                         )
                         if torch.is_tensor(kl_qp):
-                            assert kl_qp.shape == guide_site["fn"].batch_shape
+                            assert (
+                                torch._C._get_tracing_state()
+                                or kl_qp.shape == guide_site["fn"].batch_shape
+                            )
                             kl_qp_sum = kl_qp.sum()
                         else:
                             kl_qp_sum = (

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -412,12 +412,12 @@ class JitTraceGraph_ELBO(TraceGraph_ELBO):
 
             self._jit_loss_and_surrogate_loss = jit_loss_and_surrogate_loss
 
-        loss, surrogate_loss = self._jit_loss_and_surrogate_loss(*args, **kwargs)
+        elbo, surrogate_loss = self._jit_loss_and_surrogate_loss(*args, **kwargs)
 
         surrogate_loss.backward(
             retain_graph=self.retain_graph
         )  # triggers jit compilation
 
-        loss = loss.item()
+        loss = -elbo.item()
         warn_if_nan(loss, "loss")
         return loss

--- a/pyro/ops/provenance.py
+++ b/pyro/ops/provenance.py
@@ -43,6 +43,9 @@ class ProvenanceTensor(torch.Tensor):
     :param frozenset provenance: An initial provenance set.
     """
 
+    _t: torch.Tensor
+    _provenance: frozenset
+
     def __new__(cls, data: torch.Tensor, provenance=frozenset(), **kwargs):
         assert not isinstance(data, ProvenanceTensor)
         if not provenance:

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -24,6 +24,7 @@ from pyro.infer import (
     TraceEnum_ELBO,
     TraceGraph_ELBO,
     TraceMeanField_ELBO,
+    TraceTMC_ELBO,
     infer_discrete,
 )
 from pyro.optim import Adam
@@ -262,6 +263,7 @@ def test_one_hot_categorical_enumerate(shape, expand):
         JitTraceEnum_ELBO,
         TraceMeanField_ELBO,
         JitTraceMeanField_ELBO,
+        TraceTMC_ELBO,
     ],
 )
 def test_loss(Elbo):
@@ -287,8 +289,11 @@ def test_loss(Elbo):
     )
     expected = 18.611
 
-    actual = elbo.loss(model, guide, data)
-    assert_close(actual, expected, rtol=0.1)
+    try:
+        actual = elbo.loss(model, guide, data)
+        assert_close(actual, expected, rtol=0.1)
+    except NotImplementedError:
+        pass
 
     actual = elbo.loss_and_grads(model, guide, data)
     assert_close(actual, expected, rtol=0.1)

--- a/tests/infer/test_jit.py
+++ b/tests/infer/test_jit.py
@@ -277,7 +277,7 @@ def test_loss(Elbo):
         loc_loc = pyro.param("loc_loc", lambda: torch.tensor(1.0))
         scale_loc = pyro.param("scale_loc", lambda: torch.tensor(-1.0))
         pyro.sample("loc", dist.Normal(loc_loc, 2))
-        pyro.sample("scale", dist.LogNormal(-1, 0.1))
+        pyro.sample("scale", dist.LogNormal(scale_loc, 0.1))
 
     elbo = Elbo(
         num_particles=10_000,


### PR DESCRIPTION
Fixes #2798 
Closes #2799

This fixes a sign error in `JitTraceGraph_ELBO` and adds a regression test for other ELBOs.

## Tested
- [x] added a regression test with a golden value ELBO computed via Trace_ELBO with 1e8 particles.