### PR TITLE
Replace flake8+isort with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel 'setuptools!=58.5.*,<60'
-        pip install flake8 black isort>=5.0 mypy nbstripout nbformat
+        pip install ruff black mypy nbstripout nbformat
     - name: Lint
       run: |
         make lint

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,8 @@ tutorial: FORCE
 	$(MAKE) -C tutorial html
 
 lint: FORCE
-	flake8
+	ruff check .
 	black --check *.py pyro examples tests scripts profiler
-	isort --check .
 	python scripts/update_headers.py --check
 	mypy --install-types --non-interactive pyro scripts
 
@@ -28,8 +27,8 @@ license: FORCE
 	python scripts/update_headers.py
 
 format: license FORCE
+	ruff check --fix .
 	black *.py pyro examples tests scripts profiler
-	isort .
 
 version: FORCE
 	python scripts/update_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.ruff]
+line-length = 120
+ignore = ["E741", "E721"]
+select = ["E", "F", "I"]

--- a/pyro/contrib/funsor/__init__.py
+++ b/pyro/contrib/funsor/__init__.py
@@ -3,9 +3,8 @@
 
 import pyroapi
 
-from pyro.contrib.funsor.handlers import condition, do, markov
+from pyro.contrib.funsor.handlers import condition, do, markov, vectorized_markov
 from pyro.contrib.funsor.handlers import plate as _plate
-from pyro.contrib.funsor.handlers import vectorized_markov
 from pyro.contrib.funsor.handlers.primitives import to_data, to_funsor
 from pyro.primitives import (
     clear_param_store,

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -6,14 +6,14 @@ from torch.distributions.constraints import *  # noqa F403
 # isort: split
 
 import torch
-from torch.distributions.constraints import Constraint
-from torch.distributions.constraints import __all__ as torch_constraints
 from torch.distributions.constraints import (
+    Constraint,
     independent,
     lower_cholesky,
     positive,
     positive_definite,
 )
+from torch.distributions.constraints import __all__ as torch_constraints
 
 
 # TODO move this upstream to torch.distributions

--- a/pyro/poutine/messenger.py
+++ b/pyro/poutine/messenger.py
@@ -85,7 +85,7 @@ class Messenger:
         Derived versions cannot be overridden to take arguments
         and must always return self.
         """
-        if not (self in _PYRO_STACK):
+        if self not in _PYRO_STACK:
             # if this poutine is not already installed,
             # put it on the bottom of the stack.
             _PYRO_STACK.append(self)

--- a/setup.py
+++ b/setup.py
@@ -110,18 +110,16 @@ setup(
         "test": EXTRAS_REQUIRE
         + [
             "black>=21.4b0",
-            "flake8",
             "nbval",
-            "pytest>=5.0",
             "pytest-cov",
+            "pytest>=5.0",
+            "ruff",
             "scipy>=1.1",
         ],
         "profile": ["prettytable", "pytest-benchmark", "snakeviz"],
         "dev": EXTRAS_REQUIRE
         + [
             "black>=21.4b0",
-            "flake8",
-            "isort>=5.0",
             "mypy>=0.812",
             "nbformat",
             "nbsphinx>=0.3.2",
@@ -129,8 +127,9 @@ setup(
             "nbval",
             "ninja",
             "pypandoc",
-            "pytest>=5.0",
             "pytest-xdist",
+            "pytest>=5.0",
+            "ruff",
             "scipy>=1.1",
             "sphinx",
             "sphinx_rtd_theme",


### PR DESCRIPTION
Addresses #3230

This PR replaces Pyro's use of `flake8` and `isort` with `ruff`, speeding up this phase of linting by about 200x.

**Before this PR**
```sh
$ time (flake8 ; isort --check .)
... 14.07s user 0.27s system 99% cpu 14.402 total
```
**After this PR**
```sh
$ time ruff check .
...  0.09s user 0.04s system 182% cpu 0.073 total
```

I've enabled only the most basic of ruff checks: E, F, and I.