### PR TITLE
fix sequential enumeration

### DIFF
--- a/pyro/infer/discrete.py
+++ b/pyro/infer/discrete.py
@@ -32,7 +32,7 @@ class SamplePosteriorMessenger(ReplayMessenger):
     # This acts like ReplayMessenger but additionally replays cond_indep_stack.
 
     def _pyro_sample(self, msg):
-        if msg["infer"].get("enumerate") == "parallel":
+        if msg["infer"].get("enumerate") in ["parallel", "sequential"]:
             super()._pyro_sample(msg)
         if msg["name"] in self.trace:
             msg["cond_indep_stack"] = self.trace.nodes[msg["name"]]["cond_indep_stack"]

--- a/pyro/poutine/enum_messenger.py
+++ b/pyro/poutine/enum_messenger.py
@@ -166,7 +166,7 @@ class EnumMessenger(Messenger):
                     param_dims.update(self._value_dims[name])
             self._markov_depths[msg["name"]] = msg["infer"]["_markov_depth"]
         self._param_dims[msg["name"]] = param_dims
-        if msg["is_observed"] or msg["infer"].get("enumerate") != "parallel":
+        if msg["is_observed"] or msg["infer"].get("enumerate") not in ["parallel", "sequential"]:
             return
 
         # Compute an enumerated value (at an arbitrary dim).


### PR DESCRIPTION
This is a pull request to fix the bug on the [github issue](https://github.com/pyro-ppl/pyro/issues/3080#issue-1224386196). 

with the same code, the sequential enumeration generates `0.6269999742507935` for 10000 `infer_discrete` operation with `temperature = 1`. Changing `enum` variable to `parallel` generates mean `0.6294000148773193`. Using `temperature=0` for MAP estimation of the `y_pre` will generate `mean=1` for both `parallel` and `sequential` enumeration. These tests are on a GCP VM machine with a Ubuntu docker image.

``` {python}
import pyro
import pyro.distributions as dist
import torch
from pyro.infer import config_enumerate
from pyro.infer import infer_discrete

enum = "sequential" 

@config_enumerate
def model(x_pa_obs=None, x_ch_obs=None, y_obs=None):
    p = x_pa_obs
    y = pyro.sample('y_pre', dist.Binomial(probs=p, total_count=1),
                    infer={"enumerate": enum},
                    obs=y_obs)

    d_ch = dist.Normal(y, 1.0)
    x_ch_pre = pyro.sample('x_ch_pre', d_ch, obs=x_ch_obs)

    return y


data_obs = {'x_pa_obs': torch.tensor(0.5), 'x_ch_obs': torch.tensor(1.0)}
model_discrete = infer_discrete(model, first_available_dim=-1, temperature=1)

y_posts = []
for ii in range(10**4):
    print(f'iteration {ii}', end='\r')
    y_posts.append(model_discrete(**data_obs))

smpl = torch.stack(y_posts)
print(smpl.shape)
print(f"mean: {smpl.mean()}")
```