### PR TITLE
Concatenate torch docstrings at end of distribution wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ scrub: FORCE
 	find tutorial -name "*.ipynb" | xargs python tutorial/source/cleannb.py
 
 doctest: FORCE
-	python -m pytest -p tests.doctest_fixtures --doctest-modules -o filterwarnings=ignore pyro
+	# We skip testing pyro.distributions.torch wrapper classes because
+	# they include torch docstrings which are tested upstream.
+	python -m pytest -p tests.doctest_fixtures --doctest-modules -o filterwarnings=ignore pyro --ignore=pyro/distributions/torch.py
 
 perf-test: FORCE
 	bash scripts/perf_test.sh ${ref}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinxcontrib.napoleon',
     "sphinx.ext.intersphinx",  #
     "sphinx.ext.todo",  #
     "sphinx.ext.mathjax",  #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,6 @@ sys.path.insert(0, os.path.abspath("../.."))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinxcontrib.napoleon',
     "sphinx.ext.intersphinx",  #
     "sphinx.ext.todo",  #
     "sphinx.ext.mathjax",  #
@@ -48,6 +47,7 @@ extensions = [
     "sphinx.ext.graphviz",  #
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
+    'sphinx.ext.napoleon',
 ]
 
 # Disable documentation inheritance so as to avoid inheriting

--- a/pyro/contrib/forecast/forecaster.py
+++ b/pyro/contrib/forecast/forecaster.py
@@ -70,6 +70,8 @@ class ForecastingModel(PyroModule, metaclass=_ForecastingModelMeta):
     @property
     def time_plate(self):
         """
+        Helper to create a ``pyro.plate`` over time.
+
         :returns: A plate named "time" with size ``covariates.size(-2)`` and
             ``dim=-1``. This is available only during model execution.
         :rtype: :class:`~pyro.plate`

--- a/pyro/distributions/torch.py
+++ b/pyro/distributions/torch.py
@@ -334,6 +334,13 @@ class Uniform(torch.distributions.Uniform, TorchDistributionMixin):
         return constraints.interval(self._unbroadcasted_low, self._unbroadcasted_high)
 
 
+def doctest_disable(docstring):
+    _ = ""
+    for line in docstring.splitlines():
+        _ += line + "#doctest: +DISABLE"
+    return _
+
+
 # Programmatically load all distributions from PyTorch.
 __all__ = []
 for _name, _Dist in torch.distributions.__dict__.items():
@@ -346,18 +353,25 @@ for _name, _Dist in torch.distributions.__dict__.items():
 
     try:
         _PyroDist = locals()[_name]
+        torchDistDocstring = _Dist.__doc__
+
     except KeyError:
         _PyroDist = type(_name, (_Dist, TorchDistributionMixin), {})
         _PyroDist.__module__ = __name__
         locals()[_name] = _PyroDist
+        torchDistDocstring = None
 
     _PyroDist.__doc__ = """
     Wraps :class:`{}.{}` with
     :class:`~pyro.distributions.torch_distribution.TorchDistributionMixin`.
+
     """.format(
         _Dist.__module__, _Dist.__name__
+    ) + (
+        "\n\n" + doctest_disable(torchDistDocstring)
+        if torchDistDocstring is not None
+        else ""
     )
-
     __all__.append(_name)
 
 


### PR DESCRIPTION
Fixes #3243 

This builds on @rtviii's PR and fixes errors:
- skips torch.py in doctest
- does some string munging to fix indentation
- removes pytorch xdoctest cruft
- fixes forecaster docstring error

@rtviii feel free to merge this into your branch, or we can merge this PR directly, either is fine 🙂 Thanks for contributing!

## For reviewers

[Before this PR](https://docs.pyro.ai/en/1.8.4/distributions.html#pytorch-distributions)
<img width="632" alt="image" src="https://github.com/pyro-ppl/pyro/assets/648532/4691a588-4d8e-4799-b8b8-4ce893d999f9">

[After this PR](https://fritzo.org/temp/pyro/html/distributions.html#pytorch-distributions)
<img width="704" alt="image" src="https://github.com/pyro-ppl/pyro/assets/648532/3e69ab2d-6353-4fe1-a5f9-af0a04289032">
