### PR TITLE
Disable pdf builds on readthedocs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,7 +164,9 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "Pyro.tex", u"Pyro Documentation", u"Uber AI Labs", "manual"),
+    # Disabled pdf builds to unblock readthedocs failed builds;
+    # see https://github.com/pyro-ppl/pyro/issues/3248
+    # (master_doc, "Pyro.tex", u"Pyro Documentation", u"Uber AI Labs", "manual"),
 ]
 
 # -- Options for manual page output ---------------------------------------


### PR DESCRIPTION
Resolves #3248 by disabling pdf builds on readthedocs.

I'd like to merge this branch into dev, then examine the build status on readthedocs. (I don't know a simpler way to test readthedocs builds 🤷)