### PR TITLE
Fix GammaPoisson distribution from ignoring validate_args param

### DIFF
--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -249,7 +249,8 @@ class GammaPoisson(TorchDistribution):
 
     def __init__(self, concentration, rate, validate_args=None):
         concentration, rate = broadcast_all(concentration, rate)
-        self._gamma = Gamma(concentration, rate)
+        self._gamma = Gamma(concentration, rate, validate_args=False)
+        self._gamma._validate_args = validate_args
         super().__init__(self._gamma._batch_shape, validate_args=validate_args)
 
     @property


### PR DESCRIPTION
Currently the GammaPoisson distribution doesn't propagate the validate_args parameter.