### PR TITLE
Fix custom guide in introductory tutorial

### DIFF
--- a/tutorial/source/intro_long.ipynb
+++ b/tutorial/source/intro_long.ipynb
@@ -990,8 +990,7 @@
     "    a_loc = pyro.param('a_loc', lambda: torch.tensor(0.))\n",
     "    a_scale = pyro.param('a_scale', lambda: torch.tensor(1.),\n",
     "                         constraint=constraints.positive)\n",
-    "    sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(1.),\n",
-    "                             constraint=constraints.positive)\n",
+    "    sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(1.))\n",
     "    weights_loc = pyro.param('weights_loc', lambda: torch.randn(3))\n",
     "    weights_scale = pyro.param('weights_scale', lambda: torch.ones(3),\n",
     "                               constraint=constraints.positive)\n",
@@ -999,7 +998,7 @@
     "    b_a = pyro.sample(\"bA\", dist.Normal(weights_loc[0], weights_scale[0]))\n",
     "    b_r = pyro.sample(\"bR\", dist.Normal(weights_loc[1], weights_scale[1]))\n",
     "    b_ar = pyro.sample(\"bAR\", dist.Normal(weights_loc[2], weights_scale[2]))\n",
-    "    sigma = pyro.sample(\"sigma\", dist.Normal(sigma_loc, torch.tensor(0.05)))\n",
+    "    sigma = pyro.sample(\"sigma\", dist.LogNormal(sigma_loc, torch.tensor(0.05)))\n",
     "    return {\"a\": a, \"b_a\": b_a, \"b_r\": b_r, \"b_ar\": b_ar, \"sigma\": sigma}"
    ]
   },

--- a/tutorial/source/intro_long.ipynb
+++ b/tutorial/source/intro_long.ipynb
@@ -990,7 +990,7 @@
     "    a_loc = pyro.param('a_loc', lambda: torch.tensor(0.))\n",
     "    a_scale = pyro.param('a_scale', lambda: torch.tensor(1.),\n",
     "                         constraint=constraints.positive)\n",
-    "    sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(1.))\n",
+    "    sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(0.))\n",
     "    weights_loc = pyro.param('weights_loc', lambda: torch.randn(3))\n",
     "    weights_scale = pyro.param('weights_scale', lambda: torch.ones(3),\n",
     "                               constraint=constraints.positive)\n",

--- a/tutorial/source/intro_long.ipynb
+++ b/tutorial/source/intro_long.ipynb
@@ -991,6 +991,7 @@
     "    a_scale = pyro.param('a_scale', lambda: torch.tensor(1.),\n",
     "                         constraint=constraints.positive)\n",
     "    sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(0.))\n",
+    "    \n",
     "    weights_loc = pyro.param('weights_loc', lambda: torch.randn(3))\n",
     "    weights_scale = pyro.param('weights_scale', lambda: torch.ones(3),\n",
     "                               constraint=constraints.positive)\n",


### PR DESCRIPTION
This PR changes the variational distribution for a scale parameter from `Normal` to `LogNormal` in the `custom_guide` defined in the introductory tutorial `intro_long.ipynb`.

The diff is messed up because of Jupyter, but the only changes are two lines in `custom_guide`:
```diff
+   sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(0.))
-   sigma_loc = pyro.param('sigma_loc', lambda: torch.tensor(1.), constraint=constraints.positive)
```
and
```diff
+    sigma = pyro.sample("sigma", dist.LogNormal(sigma_loc, torch.tensor(0.05)))
-    sigma = pyro.sample("sigma", dist.Normal(sigma_loc, torch.tensor(0.05)))
```