### PR TITLE
Fix: Wrong codomain in LeakyReLUTransform

### DIFF
--- a/pyro/distributions/transforms/basic.py
+++ b/pyro/distributions/transforms/basic.py
@@ -53,7 +53,7 @@ class LeakyReLUTransform(Transform):
     Bijective transform via the mapping :math:`y = \text{LeakyReLU}(x)`.
     """
     domain = constraints.real
-    codomain = constraints.positive
+    codomain = constraints.real
     bijective = True
     sign = +1
 


### PR DESCRIPTION
The codomain constraint of the LeakyReLUTransform has been updated from 'constraints. positive' to 'constraints. real' to accurately reflect the Leaky ReLU activation function's behavior. This will allow the transform to produce both positive and negative values when applied to different inputs.
#3268 