### PR TITLE
Fix `pyro.poutine.handlers`

### DIFF
--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -66,7 +66,6 @@ from .infer_config_messenger import InferConfigMessenger
 from .lift_messenger import LiftMessenger
 from .markov_messenger import MarkovMessenger
 from .mask_messenger import MaskMessenger
-from .plate_messenger import PlateMessenger  # noqa F403
 from .reparam_messenger import ReparamMessenger
 from .replay_messenger import ReplayMessenger
 from .runtime import NonlocalExit
@@ -90,7 +89,6 @@ _msngrs = [
     EscapeMessenger,
     InferConfigMessenger,
     LiftMessenger,
-    MarkovMessenger,
     MaskMessenger,
     ReparamMessenger,
     ReplayMessenger,


### PR DESCRIPTION
Two fixes:

- `PlateMessenger` is not used in this file and not imported from it
- `MarkovMessenger` from the `_msngrs` list is used to add `markov` variable to the `locals()` but then `markov` is redefined. So I believe `MarkovMessenger` can be removed from `_msngrs`