### PR TITLE
Use `functools.wraps` to preserve `handler` signature

### DIFF
--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -110,7 +110,7 @@ class BlockMessenger(Messenger):
     :param list hide: list of site names to hide
     :param list expose: list of site names to be exposed while all others hidden
     :param list hide_types: list of site types to be hidden
-    :param lits expose_types: list of site types to be exposed while all others hidden
+    :param list expose_types: list of site types to be exposed while all others hidden
     :returns: stochastic function decorated with a :class:`~pyro.poutine.block_messenger.BlockMessenger`
     """
 

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -81,6 +81,7 @@ from .uncondition_messenger import UnconditionMessenger
 
 def _make_handler(msngr_cls, module=None):
     def handler_decorator(func):
+        @functools.wraps(func)
         def handler(fn=None, *args, **kwargs):
             if fn is not None and not (
                 callable(fn) or isinstance(fn, collections.abc.Iterable)
@@ -101,7 +102,6 @@ def _make_handler(msngr_cls, module=None):
             )
             + (msngr_cls.__doc__ if msngr_cls.__doc__ else "")
         )
-        handler.__name__ = func.__name__
         if module is not None:
             handler.__module__ = module
         return handler


### PR DESCRIPTION
#3285 didn't fix the issue of the `_make_handler` function not preserving the signature of the handler. This PR fixes it by using `functools.wraps` as explained [here](https://stackoverflow.com/questions/147816/preserving-signatures-of-decorated-functions).

\+ small typo fix

Confirmed it by locally building the docs:

<img width="715" alt="Screenshot 2023-10-24 at 1 45 52 PM" src="https://github.com/pyro-ppl/pyro/assets/50752571/cce0a9ad-dfae-4491-a711-16da5f77f334">
