### PR TITLE
Remove python.version entry in rtd.yml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,5 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
It seems that python.version is deprecated in https://readthedocs.org/projects/pyro-ppl/builds/22588550/. Hopefully things work this time.