### PR TITLE
Fix mypy and line-too-long errors

### DIFF
--- a/pyro/poutine/indep_messenger.py
+++ b/pyro/poutine/indep_messenger.py
@@ -24,11 +24,11 @@ class CondIndepStackFrame(NamedTuple):
         return self.dim is not None
 
     def _key(self) -> Tuple[str, Optional[int], int, int]:
+        size = self.size
         with ignore_jit_warnings(["Converting a tensor to a Python number"]):
-            size = (
-                self.size.item() if isinstance(self.size, torch.Tensor) else self.size  # type: ignore[attr-defined, unreachable]
-            )
-            return self.name, self.dim, size, self.counter
+            if isinstance(size, torch.Tensor):  # type: ignore[unreachable]
+                size = size.item()  # type: ignore[unreachable]
+        return self.name, self.dim, size, self.counter
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CondIndepStackFrame):

--- a/pyro/poutine/runtime.py
+++ b/pyro/poutine/runtime.py
@@ -351,7 +351,7 @@ def effectful(
         if not am_i_wrapped():
             return fn(*args, **kwargs)
         else:
-            msg = Message[_P, _T](
+            msg = Message(
                 type=type,
                 name=name,
                 fn=fn,


### PR DESCRIPTION
This fixes two errors I was seeing on Python 3.8.11 and Python 3.11.4:

## 1. A mypy error

<details>

```
    @functools.wraps(fn)
    def _fn(
        *args: _P.args,
        name: Optional[str] = None,
        infer: Optional[InferDict] = None,
        obs: Optional[_T] = None,
        **kwargs: _P.kwargs,
    ) -> Optional[_T]:
        is_observed = obs is not None

        if not am_i_wrapped():
            return fn(*args, **kwargs)
        else:
>           msg = Message[_P, _T](
                type=type,
                name=name,
                fn=fn,
                is_observed=is_observed,
                args=args,
                kwargs=kwargs,
                value=obs,
                scale=1.0,
                mask=None,
                cond_indep_stack=(),
                done=False,
                stop=False,
                continuation=None,
                infer=infer if infer is not None else {},
            )
E           TypeError: '_TypedDictMeta' object is not subscriptable

../../pyro-ppl/pyro/pyro/poutine/runtime.py:354: TypeError
```

</details>

## 2. A ruff line too long error
```
ruff check .
pyro/poutine/indep_messenger.py:29:121: E501 Line too long (129 > 120 characters)
```