### PR TITLE
Port implementation of SimplexToOrderedTransform from numpyro

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -536,6 +536,13 @@ PositivePowerTransform
     :undoc-members:
     :show-inheritance:
 
+SimplexToOrderedTransform
+-------------------------
+.. autoclass:: pyro.distributions.transforms.SimplexToOrderedTransform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 SoftplusLowerCholeskyTransform
 ------------------------------
 .. autoclass:: pyro.distributions.transforms.SoftplusLowerCholeskyTransform

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -70,6 +70,7 @@ from .planar import ConditionalPlanar, Planar, conditional_planar, planar
 from .polynomial import Polynomial, polynomial
 from .power import PositivePowerTransform
 from .radial import ConditionalRadial, Radial, conditional_radial, radial
+from .simplex_to_ordered import SimplexToOrderedTransform
 from .softplus import SoftplusLowerCholeskyTransform, SoftplusTransform
 from .spline import ConditionalSpline, Spline, conditional_spline, spline
 from .spline_autoregressive import (
@@ -184,6 +185,7 @@ __all__ = [
     "Polynomial",
     "PositivePowerTransform",
     "Radial",
+    "SimplexToOrderedTransform",
     "SoftplusLowerCholeskyTransform",
     "SoftplusTransform",
     "Spline",

--- a/pyro/distributions/transforms/simplex_to_ordered.py
+++ b/pyro/distributions/transforms/simplex_to_ordered.py
@@ -1,0 +1,80 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch.distributions.transforms import Transform
+
+from .. import constraints
+
+
+def expit(x):
+    return 1.0 / (1 + torch.exp(-x))
+
+
+def logit(x):
+    return torch.log(x / (1.0 - x))
+
+
+# This class is a port of https://num.pyro.ai/en/stable/_modules/numpyro/distributions/transforms.html#SimplexToOrderedTransform
+class SimplexToOrderedTransform(Transform):
+    """
+    Transform a simplex into an ordered vector (via difference in Logistic CDF between cutpoints)
+    Used in [1] to induce a prior on latent cutpoints via transforming ordered category probabilities.
+
+    :param anchor_point: Anchor point is a nuisance parameter to improve the identifiability of the transform.
+        For simplicity, we assume it is a scalar value, but it is broadcastable x.shape[:-1].
+        For more details please refer to Section 2.2 in [1]
+
+    **References:**
+
+    1. *Ordinal Regression Case Study, section 2.2*,
+       M. Betancourt, https://betanalpha.github.io/assets/case_studies/ordinal_regression.html
+
+    """
+
+    domain = constraints.simplex
+    codomain = constraints.ordered_vector
+
+    def __init__(self, anchor_point=None):
+        super().__init__()
+        self.anchor_point = (
+            anchor_point if anchor_point is not None else torch.tensor(0.0)
+        )
+
+    def _call(self, x):
+        s = torch.cumsum(x[..., :-1], axis=-1)
+        y = logit(s) + torch.unsqueeze(self.anchor_point, -1)
+        return y
+
+    def _inverse(self, y):
+        y = y - torch.unsqueeze(self.anchor_point, -1)
+        s = expit(y)
+        # x0 = s0, x1 = s1 - s0, x2 = s2 - s1,..., xn = 1 - s[n-1]
+        # add two boundary points 0 and 1
+        s = torch.concat(
+            [torch.zeros_like(s)[..., :1], s, torch.ones_like(s)[..., :1]], dim=-1
+        )
+        x = s[..., 1:] - s[..., :-1]
+        return x
+
+    def log_abs_det_jacobian(self, x, y, intermediates=None):
+        # |dp/dc| = |dx/dy| = prod(ds/dy) = prod(expit'(y))
+        # we know log derivative of expit(y) is `-softplus(y) - softplus(-y)`
+        J_logdet = (
+            torch.nn.functional.softplus(y) + torch.nn.functional.softplus(-y)
+        ).sum(-1)
+        return J_logdet
+
+    def tree_flatten(self):
+        return (self.anchor_point,), (("anchor_point",), dict())
+
+    def __eq__(self, other):
+        if not isinstance(other, SimplexToOrderedTransform):
+            return False
+        return torch.all(torch.equal(self.anchor_point, other.anchor_point))
+
+    def forward_shape(self, shape):
+        return shape[:-1] + (shape[-1] - 1,)
+
+    def inverse_shape(self, shape):
+        return shape[:-1] + (shape[-1] + 1,)


### PR DESCRIPTION
This pull request adds support to Pyro for [`SimplexToOrderedTransform`](https://github.com/pyro-ppl/numpyro/blob/01089cfad4078e21e062c02147bcc636331548f1/numpyro/distributions/transforms.py#L919). The implementation used is a port of the `numpyro` implementation of the same class.

I was working on implementing a model based on [this numpyro guide](https://num.pyro.ai/en/stable/tutorials/ordinal_regression.html#Principled-prior-with-Dirichlet-Distribution) using Pyro, and this was the one thing which was necessary to reimplement.

Because this class is meant to be used on values greater than zero, I have additionally added the ability to specify the family of distribution which should be used in the transformation tests; this new transformation uses a Dirichlet distribution for its tests.