### PR TITLE
Add .github/workflows/publish.yml to publish to pypi.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+


### PR DESCRIPTION
This aims to automate part of pyro's release process, namely uploading the pyro-ppl package to pypi.

I don't know how to test this script. I've copied it from [github docs](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries) (which seems to be newer than the [starter workflow](https://github.com/actions/starter-workflows/blob/main/ci/python-publish.yml); see [all versions here](https://github.com/pypa/gh-action-pypi-publish)).

I've also created an org-wide secret `PYPI_API_TOKEN`. I'm unsure whether there's anything else I need to do to make this secret available to the workflow.