### PR TITLE
Fix interaction between PyroParam and torch.func.grad

### DIFF
--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -488,9 +488,9 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
                                 unconstrained_value = torch.nn.Parameter(
                                     unconstrained_value
                                 )
-                                _PYRO_PARAM_STORE._params[
-                                    fullname
-                                ] = unconstrained_value
+                                _PYRO_PARAM_STORE._params[fullname] = (
+                                    unconstrained_value
+                                )
                                 _PYRO_PARAM_STORE._param_to_name[
                                     unconstrained_value
                                 ] = fullname

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -488,9 +488,9 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
                                 unconstrained_value = torch.nn.Parameter(
                                     unconstrained_value
                                 )
-                                _PYRO_PARAM_STORE._params[fullname] = (
-                                    unconstrained_value
-                                )
+                                _PYRO_PARAM_STORE._params[
+                                    fullname
+                                ] = unconstrained_value
                                 _PYRO_PARAM_STORE._param_to_name[
                                     unconstrained_value
                                 ] = fullname

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -768,7 +768,6 @@ def test_bayesian_gru():
 
 
 def test_functorch_pyroparam():
-    pyro.settings.set(module_local_params=True)
 
     class ParamModule(PyroModule):
         def __init__(self):
@@ -785,30 +784,31 @@ def test_functorch_pyroparam():
         def forward(self, x, y):
             return ((self.param_module.a1 + self.param_module.a2) * x + self.b - y) ** 2
 
-    model = Model()
+    with pyro.settings.context(module_local_params=True):
+        model = Model()
 
-    model(torch.tensor(1.3), torch.tensor(0.2))
+        model(torch.tensor(1.3), torch.tensor(0.2))
 
-    params = dict(model.named_parameters())
+        params = dict(model.named_parameters())
 
-    grad_model = torch.func.grad(
-        lambda p, x, y: torch.func.functional_call(model, p, (x, y))
-    )
-    grad_params_func = grad_model(params, torch.tensor(1.3), torch.tensor(0.2))
+        grad_model = torch.func.grad(
+            lambda p, x, y: torch.func.functional_call(model, p, (x, y))
+        )
+        grad_params_func = grad_model(params, torch.tensor(1.3), torch.tensor(0.2))
 
-    gs = torch.autograd.grad(
-        model(torch.tensor(1.3), torch.tensor(0.2)), tuple(params.values())
-    )
-    grad_params_autograd = dict(zip(params.keys(), gs))
+        gs = torch.autograd.grad(
+            model(torch.tensor(1.3), torch.tensor(0.2)), tuple(params.values())
+        )
+        grad_params_autograd = dict(zip(params.keys(), gs))
 
-    assert len(grad_params_autograd) == len(grad_params_func) != 0
-    assert (
-        set(grad_params_autograd.keys())
-        == set(grad_params_func.keys())
-        == set(params.keys())
-    )
-    for k in grad_params_autograd.keys():
-        assert not torch.allclose(
-            grad_params_func[k], torch.zeros_like(grad_params_func[k])
-        ), k
-        assert torch.allclose(grad_params_autograd[k], grad_params_func[k]), k
+        assert len(grad_params_autograd) == len(grad_params_func) != 0
+        assert (
+            set(grad_params_autograd.keys())
+            == set(grad_params_func.keys())
+            == set(params.keys())
+        )
+        for k in grad_params_autograd.keys():
+            assert not torch.allclose(
+                grad_params_func[k], torch.zeros_like(grad_params_func[k])
+            ), k
+            assert torch.allclose(grad_params_autograd[k], grad_params_func[k]), k

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -768,7 +768,6 @@ def test_bayesian_gru():
 
 
 def test_functorch_pyroparam():
-
     class ParamModule(PyroModule):
         def __init__(self):
             super().__init__()
@@ -797,9 +796,7 @@ def test_functorch_pyroparam():
         )
         grad_params_func = grad_model(params, x, y)
 
-        gs = torch.autograd.grad(
-            model(x, y), tuple(params.values())
-        )
+        gs = torch.autograd.grad(model(x, y), tuple(params.values()))
         grad_params_autograd = dict(zip(params.keys(), gs))
 
         assert len(grad_params_autograd) == len(grad_params_func) != 0

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -786,18 +786,19 @@ def test_functorch_pyroparam():
 
     with pyro.settings.context(module_local_params=True):
         model = Model()
+        x, y = torch.tensor(1.3), torch.tensor(0.2)
 
-        model(torch.tensor(1.3), torch.tensor(0.2))
+        model(x, y)
 
         params = dict(model.named_parameters())
 
         grad_model = torch.func.grad(
             lambda p, x, y: torch.func.functional_call(model, p, (x, y))
         )
-        grad_params_func = grad_model(params, torch.tensor(1.3), torch.tensor(0.2))
+        grad_params_func = grad_model(params, x, y)
 
         gs = torch.autograd.grad(
-            model(torch.tensor(1.3), torch.tensor(0.2)), tuple(params.values())
+            model(x, y), tuple(params.values())
         )
         grad_params_autograd = dict(zip(params.keys(), gs))
 

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -768,7 +768,6 @@ def test_bayesian_gru():
 
 
 def test_functorch_pyroparam():
-
     pyro.settings.set(module_local_params=True)
 
     class ParamModule(PyroModule):
@@ -792,14 +791,24 @@ def test_functorch_pyroparam():
 
     params = dict(model.named_parameters())
 
-    grad_model = torch.func.grad(lambda p, x, y: torch.func.functional_call(model, p, (x, y)))
+    grad_model = torch.func.grad(
+        lambda p, x, y: torch.func.functional_call(model, p, (x, y))
+    )
     grad_params_func = grad_model(params, torch.tensor(1.3), torch.tensor(0.2))
 
-    gs = torch.autograd.grad(model(torch.tensor(1.3), torch.tensor(0.2)), tuple(params.values()))
+    gs = torch.autograd.grad(
+        model(torch.tensor(1.3), torch.tensor(0.2)), tuple(params.values())
+    )
     grad_params_autograd = dict(zip(params.keys(), gs))
 
     assert len(grad_params_autograd) == len(grad_params_func) != 0
-    assert set(grad_params_autograd.keys()) == set(grad_params_func.keys()) == set(params.keys())
+    assert (
+        set(grad_params_autograd.keys())
+        == set(grad_params_func.keys())
+        == set(params.keys())
+    )
     for k in grad_params_autograd.keys():
-        assert not torch.allclose(grad_params_func[k], torch.zeros_like(grad_params_func[k])), k
+        assert not torch.allclose(
+            grad_params_func[k], torch.zeros_like(grad_params_func[k])
+        ), k
         assert torch.allclose(grad_params_autograd[k], grad_params_func[k]), k

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -792,6 +792,7 @@ def test_functorch_pyroparam(use_local_params):
             self.param_module = ParamModule()
             self.b1 = PyroParam(torch.tensor(0.123), constraints.positive)
             self.b3 = torch.nn.Parameter(torch.tensor(0.789))
+            self.c = torch.nn.Linear(1, 1)
 
         @PyroParam(constraint=constraints.positive)
         def b2(self):
@@ -803,7 +804,7 @@ def test_functorch_pyroparam(use_local_params):
                 + self.b1
                 + self.b2
                 + self.b3
-                - y
+                - self.c(y.unsqueeze(-1)).squeeze(-1)
             ) ** 2
 
     with pyro.settings.context(module_local_params=use_local_params):


### PR DESCRIPTION
Addresses a bug described downstream in https://github.com/BasisResearch/chirho/issues/393

This PR adds a fix for compatibility of `PyroModule`s and `PyroParam`s with `torch.func.grad` and the other functional automatic differentiation transforms in `torch.func`. The  fix is basically to replace each `pyro.param` statement or other interaction with the parameter store with a dummy version that does not store and retrieve a parameter tensor from a nonlocal state (which is invisible to the tracing machinery in `torch.func`).

Without this fix, gradient computations in `torch.func.grad` do not propagate to the unconstrained parameters behind constrained `PyroParam`s even when using `pyro.settings.set(module_local_param=True)` and are always zero. After this fix, the functional AD system in `torch.func` behaves correctly with `AutoGuide`s and other `PyroModule`s when `module_local_param=True`, though it is still fundamentally incompatible with the global parameter store state when `module_local_param=False`.

Tested:
- Added simple regression test that fails without the fix in this PR