### PR TITLE
Fix action link for publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 


### PR DESCRIPTION
I tested the workflow in https://github.com/pyro-ppl/numpyro/pull/1736 and found the link issue
https://github.com/pyro-ppl/numpyro/actions/runs/7935986924/job/21670294954