### PR TITLE
small update doc HMC

### DIFF
--- a/pyro/infer/mcmc/hmc.py
+++ b/pyro/infer/mcmc/hmc.py
@@ -66,8 +66,8 @@ class HMC(MCMCKernel):
         step size, hence the sampling will be slower and more robust. Default to 0.8.
     :param callable init_strategy: A per-site initialization function.
         See :ref:`autoguide-initialization` section for available functions.
-    :param min_stepsize (float): Lower bound on stepsize in adaptation strategy.
-    :param max_stepsize (float): Upper bound on stepsize in adaptation strategy.
+    :param float min_stepsize: Lower bound on stepsize in adaptation strategy.
+    :param float max_stepsize: Upper bound on stepsize in adaptation strategy.
 
     .. note:: Internally, the mass matrix will be ordered according to the order
         of the names of latent variables, not the order of their appearance in


### PR DESCRIPTION
Hi👋🏻 I saw a small typo in the documentation of HMC with `max_stepsize` and `min_stepsize`, basically inverting the order of the object name and type. I hope it is useful and thanks for the amazing work with the pyro repo!