### PR TITLE
Add function for calculating quantiles of weighed samples.

### DIFF
--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -261,6 +261,57 @@ def quantile(input, probs, dim=0):
     return quantiles if probs.shape != torch.Size([]) else quantiles.squeeze(dim)
 
 
+def weighed_quantile(input, probs, log_weights, dim=0):
+    """
+    Computes quantiles of weighed ``input`` samples at ``probs``.
+
+    :param torch.Tensor input: the input tensor.
+    :param list probs: quantile positions.
+    :param torch.Tensor log_weights: sample weights tensor.
+    :param int dim: dimension to take quantiles from ``input``.
+    :returns torch.Tensor: quantiles of ``input`` at ``probs``.
+    
+    Example:
+    >>> from pyro.ops.stats import weighed_quantile
+    >>> from torch import Tensor
+    >>> input = Tensor([[10, 50, 40], [20, 30, 0]])
+    >>> probs = Tensor([0.2, 0.8])
+    >>> log_weights = Tensor([0.4, 0.5, 0.1]).log()
+    >>> weighed_quantile(input, probs, log_weights, -1)
+    tensor([[40.4000, 47.6000],
+            [ 9.0000, 26.4000]])
+    """
+    dim = dim if dim >= 0 else (len(input.shape) + dim)
+    if isinstance(probs, (list, tuple)):
+        probs = torch.tensor(probs, dtype=input.dtype, device=input.device)
+    # Calculate normalized weights
+    weights = (log_weights - torch.logsumexp(log_weights, 0)).exp()
+    # Sort input and weights
+    sorted_input, sorting_indices = input.sort(dim)
+    weights = weights[sorting_indices].cumsum(dim)
+    # Scale weights to be between zero and one
+    weights = weights - weights.min(dim, keepdim=True)[0]
+    weights = weights / weights.max(dim, keepdim=True)[0]
+    # Calculate indices
+    indices_above = (weights[..., None] <= probs).sum(dim, keepdim=True).swapaxes(dim, -1).clamp(max=input.size(dim) - 1)[..., 0]
+    indices_below = (indices_above - 1).clamp(min=0)
+    # Calculate below and above qunatiles
+    quantiles_below = sorted_input.gather(dim, indices_below)
+    quantiles_above = sorted_input.gather(dim, indices_above)
+    # Calculate weights for below and above quantiles
+    probs_shape = [None] * len(input.shape)
+    probs_shape[dim] = slice(None)
+    expanded_probs_shape = list(input.shape)
+    expanded_probs_shape[dim] = len(probs)
+    probs = probs[probs_shape].expand(*expanded_probs_shape)
+    weights_below = weights.gather(dim, indices_below)
+    weights_above = weights.gather(dim, indices_above)
+    weights_below = (weights_above - probs) / (weights_above - weights_below)
+    weights_above = 1 - weights_below
+    # Return quantiles
+    return weights_below * quantiles_below + weights_above * quantiles_above
+
+
 def pi(input, prob, dim=0):
     """
     Computes percentile interval which assigns equal probability mass

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -264,7 +264,7 @@ def quantile(input, probs, dim=0):
 
 def weighed_quantile(
     input: torch.Tensor,
-    probs: Union[List[float], Tuple[float], torch.Tensor],
+    probs: Union[List[float], Tuple[float, ...], torch.Tensor],
     log_weights: torch.Tensor,
     dim: int = 0,
 ) -> torch.Tensor:


### PR DESCRIPTION
# The Problem

When calculating distribution quantiles based on samples sampled from a guide it is often desirable to correct for the non-uniform gap between the model log-probability and the guide log-probability (this gap is already computed by the `pyro.infer.importance.Importance` module).

Currently there is only support for the below:
- Calculating quantiles from equally weighed samples by using `pyro.ops.stats.quantile` which interpolates quantiles over the sorted samples.
- Sampling with non-uniform weights using `pyro.distributions.empirical.Empirical` which does not support interpolation.

# The Proposed Solution

Add a function `pyro.ops.stats.weighed_quantile` which supports calculating interpolated quantiles with non-uniform weights. The implementation is similar to `pyro.ops.stats.quantile` but with different weights generated for each index of the input, according to the indices that sort that specific index.

