### PR TITLE
Update auto_reg_nn.sample_mask_indices() to be default device-aware 

### DIFF
--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -22,9 +22,7 @@ def sample_mask_indices(
     :param simple: True to space fractional indices by rounding to nearest int, false round randomly
     :type simple: bool
     """
-    indices = torch.linspace(1, input_dim, steps=hidden_dim, device="cpu").to(
-        torch.tensor(0.0).device
-    )
+    indices = torch.linspace(1, input_dim, steps=hidden_dim)
     if simple:
         # Simple procedure tries to space fractional indices evenly by rounding to nearest int
         return torch.round(indices)

--- a/pyro/nn/auto_reg_nn.py
+++ b/pyro/nn/auto_reg_nn.py
@@ -23,7 +23,7 @@ def sample_mask_indices(
     :type simple: bool
     """
     indices = torch.linspace(1, input_dim, steps=hidden_dim, device="cpu").to(
-        torch.Tensor().device
+        torch.tensor(0.0).device
     )
     if simple:
         # Simple procedure tries to space fractional indices evenly by rounding to nearest int


### PR DESCRIPTION
Hi Pyro team, thank you for making such a useful and cool library. I encountered a small bug with an easy fix and wanted to share.

As described in my [Pyro forum post](https://forum.pyro.ai/t/device-mismatch-in-autonormalizingflow/6010/2), there is a device mismatch in `auto_reg_nn.sample_mask_indices()`. The line 

```   
 indices = torch.linspace(1, input_dim, steps=hidden_dim, device="cpu").to(
      torch.Tensor().device
)
```

creates tensors on CPU, even when `torch.set_default_device('cuda')` is used (I believe this is because [torch.Tensor is an alias to torch.FloatTensor](https://pytorch.org/docs/stable/tensors.html#torch.Tensor), which is not the same as `torch.cuda.FloatTensor()`) . Minimum working example (from [Pyro docs](https://pyro4ci.readthedocs.io/en/latest/nn.html)):

```
import torch
import pyro
from pyro.nn import AutoRegressiveNN

torch.set_default_device('cuda')

x = torch.randn(100, 10)
print(x.device)
# cuda:0
print(torch.Tensor().device)
# cpu
print(torch.tensor(0.).device)
# cuda:0
arn = AutoRegressiveNN(10, [50], param_dims=[1])
p = arn(x)
```

The instantiation of a `AutoRegressiveNN` object will fail with the error

 ```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

The proposed fix is to replace `torch.Tensor().device` with `torch.tensor(0.0).device` (lower case `tensor`; adding a simple value since [torch.tensor() expects data](https://pytorch.org/docs/stable/generated/torch.tensor.html)). Then the object can be instantiated. This change is the sole element in this PR.