### PR TITLE
Introducing pyro.infer.predictive.WeighedPredictive which reports weights along with predicted samples

### DIFF
--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -12,7 +12,7 @@ from pyro.infer.mcmc.api import MCMC
 from pyro.infer.mcmc.hmc import HMC
 from pyro.infer.mcmc.nuts import NUTS
 from pyro.infer.mcmc.rwkernel import RandomWalkKernel
-from pyro.infer.predictive import Predictive
+from pyro.infer.predictive import Predictive, WeighedPredictive
 from pyro.infer.renyi_elbo import RenyiELBO
 from pyro.infer.rws import ReweightedWakeSleep
 from pyro.infer.smcfilter import SMCFilter

--- a/pyro/infer/__init__.py
+++ b/pyro/infer/__init__.py
@@ -62,4 +62,5 @@ __all__ = [
     "TraceTailAdaptive_ELBO",
     "Trace_ELBO",
     "Trace_MMD",
+    "WeighedPredictive",
 ]

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -306,7 +306,7 @@ class Predictive(torch.nn.Module):
             self.model,
             posterior_samples,
             self.num_samples,
-            parallel=self.parallel,
+            parallel=True,
             model_args=args,
             model_kwargs=kwargs,
         ).trace

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -322,8 +322,8 @@ def trace_log_prob(trace: Union[Trace, List[Trace]]) -> torch.Tensor:
 class WeighedPredictiveResults(NamedTuple):
     samples: Union[dict, tuple]
     log_weights: torch.Tensor
-    guide_prob: torch.Tensor
-    model_prob: torch.Tensor
+    guide_log_prob: torch.Tensor
+    model_log_prob: torch.Tensor
 
 
 class WeighedPredictive(Predictive):
@@ -349,8 +349,8 @@ class WeighedPredictive(Predictive):
         return WeighedPredictiveResults(
             samples=tuple(v for _, v in sorted(result.items())),
             log_weights=result.log_weights,
-            guide_prob=result.guide_prob,
-            model_prob=result.model_prob,
+            guide_log_prob=result.guide_log_prob,
+            model_log_prob=result.model_log_prob,
         )
 
     def forward(self, *args, **kwargs):
@@ -389,8 +389,8 @@ class WeighedPredictive(Predictive):
             model_predictive.trace.compute_log_prob()
             guide_predictive.trace.pack_tensors()
             model_predictive.trace.pack_tensors(guide_predictive.trace.plate_to_symbol)
-        model_prob = trace_log_prob(model_predictive.trace)
-        guide_prob = trace_log_prob(guide_predictive.trace)
+        model_log_prob = trace_log_prob(model_predictive.trace)
+        guide_log_prob = trace_log_prob(guide_predictive.trace)
         return WeighedPredictiveResults(
             samples=(
                 _predictive(
@@ -405,7 +405,7 @@ class WeighedPredictive(Predictive):
                 if model_guide is not self.model
                 else model_predictive.samples
             ),
-            log_weights=model_prob - guide_prob,
-            guide_prob=guide_prob,
-            model_prob=model_prob,
+            log_weights=model_log_prob - guide_log_prob,
+            guide_log_prob=guide_log_prob,
+            model_log_prob=model_log_prob,
         )

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -35,6 +35,10 @@ def _guess_max_plate_nesting(model, args, kwargs):
 
 
 class _predictiveResults(NamedTuple):
+    """
+    Return value of call to ``_predictive`` and ``_predictive_sequential``.
+    """
+
     samples: dict
     trace: Union[Trace, List[Trace]]
 
@@ -313,6 +317,10 @@ class Predictive(torch.nn.Module):
 
 
 class WeighedPredictiveResults(NamedTuple):
+    """
+    Return value of call to instance of :class:`WeighedPredictive`.
+    """
+
     samples: Union[dict, tuple]
     log_weights: torch.Tensor
     guide_log_prob: torch.Tensor
@@ -351,6 +359,9 @@ class WeighedPredictive(Predictive):
         Method `.call` that is backwards compatible with the same method found in :class:`Predictive`
         but can be called with an additional keyword argument `model_guide`
         which is the model used to create and optimize the guide.
+
+        Returns :class:`WeighedPredictiveResults` which has attributes ``.samples`` and per sample
+        weights ``.log_weights``.
         """
         result = self.forward(*args, **kwargs)
         return WeighedPredictiveResults(
@@ -365,6 +376,9 @@ class WeighedPredictive(Predictive):
         Method `.forward` that is backwards compatible with the same method found in :class:`Predictive`
         but can be called with an additional keyword argument `model_guide`
         which is the model used to create and optimize the guide.
+
+        Returns :class:`WeighedPredictiveResults` which has attributes ``.samples`` and per sample
+        weights ``.log_weights``.
         """
         model_guide = kwargs.pop("model_guide", self.model)
         return_sites = self.return_sites

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -331,8 +331,9 @@ class WeighedPredictive(Predictive):
     Class used to construct a weighed predictive distribution that is based
     on the same initialization interface as :class:`Predictive`.
     
-    The methods `.forward` and `.call` must be called with an additional keyword argument
+    The methods `.forward` and `.call` can be called with an additional keyword argument
     `model_guide` which is the model used to create and optimize the guide, and they return both samples and log_weights.
+    If not provided `model_guide` defaults to `self.model`.
 
     The weights are calculated as the per sample gap between the model_guide log-probability
     and the guide log-probability (a guide must always be provided).
@@ -341,7 +342,7 @@ class WeighedPredictive(Predictive):
     def call(self, *args, **kwargs):
         """
         Method `.call` that is backwards compatible with the same method found in :class:`Predictive`
-        but must be called with an additional keyword argument `model_guide`
+        but can be called with an additional keyword argument `model_guide`
         which is the model used to create and optimize the guide.
         """
         result = self.forward(*args, **kwargs)
@@ -354,11 +355,11 @@ class WeighedPredictive(Predictive):
 
     def forward(self, *args, **kwargs):
         """
-        Method `.forward` that is backwards compatible with the same method found in :class:`Predictive`.
-        but must be called with an additional keyword argument `model_guide`
+        Method `.forward` that is backwards compatible with the same method found in :class:`Predictive`
+        but can be called with an additional keyword argument `model_guide`
         which is the model used to create and optimize the guide.
         """
-        model_guide = kwargs.pop('model_guide')
+        model_guide = kwargs.pop('model_guide', self.model)
         return_sites = self.return_sites
         # return all sites by default if a guide is provided.
         return_sites = None if not return_sites else return_sites
@@ -397,7 +398,7 @@ class WeighedPredictive(Predictive):
                                 return_sites=return_sites,
                                 parallel=self.parallel,
                                 model_args=args,
-                                model_kwargs=kwargs).samples,
+                                model_kwargs=kwargs).samples if model_guide is not self.model else model_predictive.samples,
             log_weights=model_prob - guide_prob,
             guide_prob=guide_prob,
             model_prob=model_prob)

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -325,11 +325,25 @@ class WeighedPredictive(Predictive):
     on the same initialization interface as :class:`Predictive`.
 
     The methods `.forward` and `.call` can be called with an additional keyword argument
-    `model_guide` which is the model used to create and optimize the guide (if not
-    provided `model_guide` defaults to `self.model`), and they return both samples and log_weights.
+    ``model_guide`` which is the model used to create and optimize the guide (if not
+    provided ``model_guide`` defaults to ``self.model``), and they return both samples and log_weights.
 
     The weights are calculated as the per sample gap between the model_guide log-probability
     and the guide log-probability (a guide must always be provided).
+
+    A typical use case would be based on a ``model`` :math:`p(x,z)=p(x|z)p(z)` and ``guide`` :math:`q(z)`
+    that has already been fitted to the model given observations :math:`p(X_{obs},z)`, both of which
+    are provided at itialization of :class:`WeighedPredictive` (same as you would do with :class:`Predictive`).
+    When calling an instance of :class:`WeighedPredictive` we provide the model given observations :math:`p(X_{obs},z)`
+    as the keyword argument ``model_guide``.
+    The resulting output would be the usual samples :math:`p(x|z)q(z)` returned by :class:`Predictive`,
+    along with per sample weights :math:`p(X_{obs},z)/q(z)`. The samples and weights can be fed into
+    :any:`weighed_quantile` in order to obtain the true quantiles of the resulting distribution.
+
+    Note that the ``model`` can be more elaborate with sample sites :math:`y` that are not observed
+    and are not part of the guide, if the samples sites :math:`y` are sampled after the observations
+    and the latent variables sampled by the guide, such that :math:`p(x,y,z)=p(y|x,z)p(x|z)p(z)` where
+    each element in the product represents a set of ``pyro.sample`` statements.
     """
 
     def call(self, *args, **kwargs):

--- a/pyro/infer/util.py
+++ b/pyro/infer/util.py
@@ -345,17 +345,16 @@ def check_fully_reparametrized(guide_site):
         )
 
 
-def plate_log_prob_sum(trace: Trace, plate_name: str) -> torch.Tensor:
+def plate_log_prob_sum(trace: Trace, plate_symbol: str) -> torch.Tensor:
     """
     Get log probability sum from trace while keeping indexing over the specified plate.
     """
-    wd = trace.plate_to_symbol[plate_name]
     log_prob_sum = 0.0
     for site in trace.nodes.values():
-        if site["type"] != "sample" or wd not in site["packed"]["log_prob"]._pyro_dims:
+        if site["type"] != "sample":
             continue
         log_prob_sum += torch.einsum(
-            site["packed"]["log_prob"]._pyro_dims + "->" + wd,
+            site["packed"]["log_prob"]._pyro_dims + "->" + plate_symbol,
             [site["packed"]["log_prob"]],
         )
     return log_prob_sum

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -277,14 +277,17 @@ def weighed_quantile(
     :param int dim: dimension to take quantiles from ``input``.
     :returns torch.Tensor: quantiles of ``input`` at ``probs``.
 
-    Example:
-    >>> from pyro.ops.stats import weighed_quantile
-    >>> import torch
-    >>> input = torch.Tensor([[10, 50, 40], [20, 30, 0]])
-    >>> probs = torch.Tensor([0.2, 0.8])
-    >>> log_weights = torch.Tensor([0.4, 0.5, 0.1]).log()
-    >>> result = weighed_quantile(input, probs, log_weights, -1)
-    >>> torch.testing.assert_close(result, torch.Tensor([[40.4, 47.6], [9.0, 26.4]]))
+    **Example:**
+
+    .. doctest::
+
+        >>> from pyro.ops.stats import weighed_quantile
+        >>> import torch
+        >>> input = torch.Tensor([[10, 50, 40], [20, 30, 0]])
+        >>> probs = torch.Tensor([0.2, 0.8])
+        >>> log_weights = torch.Tensor([0.4, 0.5, 0.1]).log()
+        >>> result = weighed_quantile(input, probs, log_weights, -1)
+        >>> torch.testing.assert_close(result, torch.Tensor([[40.4, 47.6], [9.0, 26.4]]))
     """
     dim = dim if dim >= 0 else (len(input.shape) + dim)
     if isinstance(probs, (list, tuple)):


### PR DESCRIPTION
# The Problem

When sampling from the posterior predictive distribution we are often using a guide as an approximation for the posterior. As mentioned in #3340 it is often desirable to correct for the non-uniform per sample gap between the model log-probability and the guide log-probability. This gap is essentially the weight that should be assigned to each sample.

The current implementation of `pyro.infer.predictive.Predictive` does not support calculation of these weights.

# The Proposed Solution

Add `pyro.infer.predictive.WeighedPredictive` which supports calculation of per sample weights.

The implementation relies on three objects:
- Model which samples from priors and observations (same as in instantiation of `pyro.infer.predictive.Predictive`).
- Guide which approximates the posterior given observations (same as in instantiation of `pyro.infer.predictive.Predictive`).
- Model with observations constrained to be the actual observations. This model was used in creating the guide and is provided to instances of `pyro.infer.predictive.WeighedPredictive` when called as the keyword argument `model_guide` (as in the model that was used when creating the guide).

The `model_guide` is what enables calculation of the weights. If not provided we use the model provided at instantiation of `pyro.infer.predictive.WeighedPredictive` as the `model_guide` (in this case the model provided at instantiation is usually already with observations constrained to be the actual observations).

# Design Considerations

- Maintain backwards compatibility of `pyro.infer.predictive.Predictive`.
- Reuse as much as possible from `pyro.infer.predictive.Predictive` when implementing `pyro.infer.predictive.WeighedPredictive`.
