### PR TITLE
Add effective sample size analytics to WeighedPredictive results

### DIFF
--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -15,7 +15,59 @@ from .enum import get_importance_trace
 from .util import plate_log_prob_sum
 
 
-class Importance(TracePosterior):
+class WeightAnalytics:
+    def get_log_normalizer(self):
+        """
+        Estimator of the normalizing constant of the target distribution.
+        (mean of the unnormalized weights)
+        """
+        # ensure list is not empty
+        if len(self.log_weights) > 0:
+            log_w = (
+                self.log_weights
+                if isinstance(self.log_weights, torch.Tensor)
+                else torch.tensor(self.log_weights)
+            )
+            log_num_samples = torch.log(torch.tensor(log_w.numel() * 1.0))
+            return torch.logsumexp(log_w - log_num_samples, 0)
+        else:
+            warnings.warn(
+                "The log_weights list is empty, can not compute normalizing constant estimate."
+            )
+
+    def get_normalized_weights(self, log_scale=False):
+        """
+        Compute the normalized importance weights.
+        """
+        if len(self.log_weights) > 0:
+            log_w = (
+                self.log_weights
+                if isinstance(self.log_weights, torch.Tensor)
+                else torch.tensor(self.log_weights)
+            )
+            log_w_norm = log_w - torch.logsumexp(log_w, 0)
+            return log_w_norm if log_scale else torch.exp(log_w_norm)
+        else:
+            warnings.warn(
+                "The log_weights list is empty. There is nothing to normalize."
+            )
+
+    def get_ESS(self):
+        """
+        Compute (Importance Sampling) Effective Sample Size (ESS).
+        """
+        if len(self.log_weights) > 0:
+            log_w_norm = self.get_normalized_weights(log_scale=True)
+            ess = torch.exp(-torch.logsumexp(2 * log_w_norm, 0))
+        else:
+            warnings.warn(
+                "The log_weights list is empty, effective sample size is zero."
+            )
+            ess = 0
+        return ess
+
+
+class Importance(TracePosterior, WeightAnalytics):
     """
     :param model: probabilistic model defined as a function
     :param guide: guide used for sampling defined as a function
@@ -54,48 +106,6 @@ class Importance(TracePosterior):
             ).get_trace(*args, **kwargs)
             log_weight = model_trace.log_prob_sum() - guide_trace.log_prob_sum()
             yield (model_trace, log_weight)
-
-    def get_log_normalizer(self):
-        """
-        Estimator of the normalizing constant of the target distribution.
-        (mean of the unnormalized weights)
-        """
-        # ensure list is not empty
-        if self.log_weights:
-            log_w = torch.tensor(self.log_weights)
-            log_num_samples = torch.log(torch.tensor(self.num_samples * 1.0))
-            return torch.logsumexp(log_w - log_num_samples, 0)
-        else:
-            warnings.warn(
-                "The log_weights list is empty, can not compute normalizing constant estimate."
-            )
-
-    def get_normalized_weights(self, log_scale=False):
-        """
-        Compute the normalized importance weights.
-        """
-        if self.log_weights:
-            log_w = torch.tensor(self.log_weights)
-            log_w_norm = log_w - torch.logsumexp(log_w, 0)
-            return log_w_norm if log_scale else torch.exp(log_w_norm)
-        else:
-            warnings.warn(
-                "The log_weights list is empty. There is nothing to normalize."
-            )
-
-    def get_ESS(self):
-        """
-        Compute (Importance Sampling) Effective Sample Size (ESS).
-        """
-        if self.log_weights:
-            log_w_norm = self.get_normalized_weights(log_scale=True)
-            ess = torch.exp(-torch.logsumexp(2 * log_w_norm, 0))
-        else:
-            warnings.warn(
-                "The log_weights list is empty, effective sample size is zero."
-            )
-            ess = 0
-        return ess
 
 
 def vectorized_importance_weights(model, guide, *args, **kwargs):

--- a/pyro/infer/importance.py
+++ b/pyro/infer/importance.py
@@ -3,6 +3,7 @@
 
 import math
 import warnings
+from typing import List, Union
 
 import torch
 
@@ -15,7 +16,13 @@ from .enum import get_importance_trace
 from .util import plate_log_prob_sum
 
 
-class WeightAnalytics:
+class LogWeightsMixin:
+    """
+    Mixin class to compute analytics from a ``.log_weights`` attribute.
+    """
+
+    log_weights: Union[List[Union[float, torch.Tensor]], torch.Tensor]
+
     def get_log_normalizer(self):
         """
         Estimator of the normalizing constant of the target distribution.
@@ -67,7 +74,7 @@ class WeightAnalytics:
         return ess
 
 
-class Importance(TracePosterior, WeightAnalytics):
+class Importance(TracePosterior, LogWeightsMixin):
     """
     :param model: probabilistic model defined as a function
     :param guide: guide used for sampling defined as a function

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -9,6 +9,7 @@ import torch
 
 import pyro
 import pyro.poutine as poutine
+from pyro.infer.importance import WeightAnalytics
 from pyro.infer.util import plate_log_prob_sum
 from pyro.poutine.trace_struct import Trace
 from pyro.poutine.util import prune_subsample_sites
@@ -317,14 +318,18 @@ class Predictive(torch.nn.Module):
 
 
 class WeighedPredictiveResults(NamedTuple):
-    """
-    Return value of call to instance of :class:`WeighedPredictive`.
-    """
-
     samples: Union[dict, tuple]
     log_weights: torch.Tensor
     guide_log_prob: torch.Tensor
     model_log_prob: torch.Tensor
+
+
+class WeighedPredictiveResults(WeighedPredictiveResults, WeightAnalytics):
+    """
+    Return value of call to instance of :class:`WeighedPredictive`.
+    """
+
+    pass
 
 
 class WeighedPredictive(Predictive):

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -2,14 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
+from dataclasses import dataclass
 from functools import reduce
-from typing import List, NamedTuple, Union
+from typing import List, Union
 
 import torch
 
 import pyro
 import pyro.poutine as poutine
-from pyro.infer.importance import WeightAnalytics
+from pyro.infer.importance import LogWeightsMixin
 from pyro.infer.util import plate_log_prob_sum
 from pyro.poutine.trace_struct import Trace
 from pyro.poutine.util import prune_subsample_sites
@@ -35,7 +36,8 @@ def _guess_max_plate_nesting(model, args, kwargs):
     return max_plate_nesting
 
 
-class _predictiveResults(NamedTuple):
+@dataclass(frozen=True, eq=False)
+class _predictiveResults:
     """
     Return value of call to ``_predictive`` and ``_predictive_sequential``.
     """
@@ -317,19 +319,16 @@ class Predictive(torch.nn.Module):
         ).trace
 
 
-class WeighedPredictiveResults(NamedTuple):
-    samples: Union[dict, tuple]
-    log_weights: torch.Tensor
-    guide_log_prob: torch.Tensor
-    model_log_prob: torch.Tensor
-
-
-class WeighedPredictiveResults(WeighedPredictiveResults, WeightAnalytics):
+@dataclass(frozen=True, eq=False)
+class WeighedPredictiveResults(LogWeightsMixin):
     """
     Return value of call to instance of :class:`WeighedPredictive`.
     """
 
-    pass
+    samples: Union[dict, tuple]
+    log_weights: torch.Tensor
+    guide_log_prob: torch.Tensor
+    model_log_prob: torch.Tensor
 
 
 class WeighedPredictive(Predictive):


### PR DESCRIPTION
1. Allows calculation of the effective sample size of weighed sample results (returned by ``pyro.infer.predictive.WeighedPredictive``) by calling the ``.get_ESS`` method.
2. Code is shared with ``pyro.infer.importance.Importance``.