### PR TITLE
Fix ruff version to 0.3.4 in order to overcome issue with version 0.3.5.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel 'setuptools!=58.5.*,<60'
-        pip install ruff black mypy nbstripout nbformat
+        pip install ruff==0.3.4 black mypy nbstripout nbformat
     - name: Lint
       run: |
         make lint


### PR DESCRIPTION
- Linting with ruff version 0.3.5 fails as can be seen [here](https://github.com/pyro-ppl/pyro/actions/runs/8572360312/job/23494720392?pr=3352#step:5:16).
- The failure is due to ruff version 0.3.5 not respecting [this](https://github.com/pyro-ppl/pyro/blob/58080f81b662bd9575cdf4b466ab3d87236c95df/pyro/distributions/torch.py#L350) directive.
- The problem does not occur with ruff version 0.3.4.
