### PR TITLE
Fix ruff settings & remove flake8 and isort settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,7 @@
 [tool.ruff]
 line-length = 120
+
+
+[tool.ruff.lint]
 ignore = ["E741", "E721"]
 select = ["E", "F", "I"]

--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -53,8 +53,6 @@ try:
 except ImportError:
     pass
 
-# isort: split
-
 from pyro.distributions.affine_beta import AffineBeta
 from pyro.distributions.asymmetriclaplace import (
     AsymmetricLaplace,

--- a/pyro/distributions/constraints.py
+++ b/pyro/distributions/constraints.py
@@ -42,8 +42,6 @@ try:
 except ImportError:
     pass
 
-# isort: split
-
 import torch
 from torch.distributions.constraints import __all__ as torch_constraints
 

--- a/pyro/distributions/transforms/__init__.py
+++ b/pyro/distributions/transforms/__init__.py
@@ -31,8 +31,6 @@ try:
 except ImportError:
     pass
 
-# isort: split
-
 from torch.distributions import biject_to, transform_to
 from torch.distributions.transforms import __all__ as torch_transforms
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,3 @@
-[flake8]
-max-line-length = 120
-exclude = docs/src, build, dist, .ipynb_checkpoints
-extend-ignore = E721,E741,E203
-
-[isort]
-profile = black
-skip_glob = .ipynb_checkpoints
-known_first_party = pyro, tests
-known_third_party = opt_einsum, six, torch, torchvision
-
 [tool:pytest]
 filterwarnings = error
     ignore:numpy.ufunc size changed:RuntimeWarning


### PR DESCRIPTION
Resolves #3230

Fixes this warning:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

Also removing flake8 and isort settings since they are not used anymore