### PR TITLE
Add the energy score scoring rule for comparing multivariate distributions

### DIFF
--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -510,9 +510,9 @@ def crps_empirical(pred, truth):
     return (pred - truth).abs().mean(0) - (diff * weight).sum(0) / num_samples**2
 
 
-def energy_score_empirical(pred, truth):
+def energy_score_empirical(pred: torch.Tensor, truth: torch.Tensor) -> torch.Tensor:
     """
-    Computes negative Energy Score ES* [1] between a
+    Computes negative Energy Score ES* (see equation 22 in [1]) between a
     set of multivariate samples ``pred`` and a true data vector ``truth``. Running time
     is quadratic in the number of samples ``n``. In case of univariate samples
     the output coincides with the CRPS::
@@ -522,9 +522,11 @@ def energy_score_empirical(pred, truth):
     Note that for a single sample this reduces to the Euclidean norm of the difference between
     the sample ``pred`` and the ``truth``.
 
-    This is a strictly proper metric so that for ``pred`` distirbuted according to a
+    This is a strictly proper score so that for ``pred`` distirbuted according to a
     distribution :math:`P` and ``truth`` distributed according to a distribution :math:`Q`
-    we have :math:`ES(P,Q) \ge ES(Q,Q)` with equality holding if and only if :math:`P=Q`.
+    we have :math:`ES*(P,Q) \ge ES*(Q,Q)` with equality holding if and only if :math:`P=Q', i.e.
+    if :math:`P` and :math:`Q` have the same multivariate distribution (it is not sufficient for
+    :math:`P` and :math:`Q` to have the same marginals in order for equality to hold).
 
     **References**
 

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -524,7 +524,7 @@ def energy_score_empirical(pred: torch.Tensor, truth: torch.Tensor) -> torch.Ten
 
     This is a strictly proper score so that for ``pred`` distirbuted according to a
     distribution :math:`P` and ``truth`` distributed according to a distribution :math:`Q`
-    we have :math:`ES*(P,Q) \ge ES*(Q,Q)` with equality holding if and only if :math:`P=Q', i.e.
+    we have :math:`ES^{*}(P,Q) \ge ES^{*}(Q,Q)` with equality holding if and only if :math:`P=Q`, i.e.
     if :math:`P` and :math:`Q` have the same multivariate distribution (it is not sufficient for
     :math:`P` and :math:`Q` to have the same marginals in order for equality to hold).
 

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -12,6 +12,7 @@ from pyro.ops.stats import (
     autocovariance,
     crps_empirical,
     effective_sample_size,
+    energy_score_empirical,
     fit_generalized_pareto,
     gelman_rubin,
     hpdi,
@@ -323,4 +324,18 @@ def test_crps_empirical(num_samples, event_shape):
     expected = (pred - truth).abs().mean(0) - 0.5 * (
         pred - pred.unsqueeze(1)
     ).abs().mean([0, 1])
+    assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("event_shape", [(), (4,), (3, 2)])
+@pytest.mark.parametrize("num_samples", [1, 2, 3, 4, 10])
+def test_energy_score_empirical(num_samples, event_shape):
+    truth = torch.randn(event_shape)
+    pred = truth + 0.1 * torch.randn((num_samples,) + event_shape)
+
+    actual = crps_empirical(pred, truth)
+    expected = energy_score_empirical(
+        pred[..., None].swapaxes(0, -1)[0, ..., None], truth[..., None]
+    )
+
     assert_close(actual, expected)

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -333,7 +333,7 @@ def test_crps_univariate_energy_score_empirical(num_samples, event_shape):
 
 
 @pytest.mark.parametrize("sample_dim", [3, 10, 30, 100])
-def test_multivariate_energy_score(sample_dim, num_samples = 10000):
+def test_multivariate_energy_score(sample_dim, num_samples=10000):
     pred_uncorrelated = torch.randn(num_samples, sample_dim)
 
     pred = torch.randn(num_samples, 1)
@@ -349,5 +349,9 @@ def test_multivariate_energy_score(sample_dim, num_samples = 10000):
         warnings.filterwarnings("ignore", category=RuntimeWarning)
         from scipy.stats import chi
 
-    assert_close(energy_score, torch.tensor(0.5*chi(1).mean()*(2*sample_dim)**0.5), rtol=0.02)
+    assert_close(
+        energy_score,
+        torch.tensor(0.5 * chi(1).mean() * (2 * sample_dim) ** 0.5),
+        rtol=0.02,
+    )
     assert energy_score * 1.02 < energy_score_uncorrelated

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -330,3 +330,24 @@ def test_crps_univariate_energy_score_empirical(num_samples, event_shape):
         pred[..., None].swapaxes(0, -1)[0, ..., None], truth[..., None]
     )
     assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("sample_dim", [3, 10, 30, 100])
+def test_multivariate_energy_score(sample_dim, num_samples = 10000):
+    pred_uncorrelated = torch.randn(num_samples, sample_dim)
+
+    pred = torch.randn(num_samples, 1)
+    pred = pred.expand(pred_uncorrelated.shape)
+
+    truth = torch.randn(num_samples, 1)
+    truth = truth.expand(pred_uncorrelated.shape)
+
+    energy_score = energy_score_empirical(pred, truth).mean()
+    energy_score_uncorrelated = energy_score_empirical(pred_uncorrelated, truth).mean()
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        from scipy.stats import chi
+
+    assert_close(energy_score, torch.tensor(0.5*chi(1).mean()*(2*sample_dim)**0.5), rtol=0.02)
+    assert energy_score * 1.02 < energy_score_uncorrelated

--- a/tests/ops/test_stats.py
+++ b/tests/ops/test_stats.py
@@ -314,7 +314,7 @@ def test_fit_generalized_pareto(k, sigma, n_samples=5000):
 
 @pytest.mark.parametrize("event_shape", [(), (4,), (3, 2)])
 @pytest.mark.parametrize("num_samples", [1, 2, 3, 4, 10])
-def test_crps_empirical(num_samples, event_shape):
+def test_crps_univariate_energy_score_empirical(num_samples, event_shape):
     truth = torch.randn(event_shape)
     pred = truth + 0.1 * torch.randn((num_samples,) + event_shape)
 
@@ -326,16 +326,7 @@ def test_crps_empirical(num_samples, event_shape):
     ).abs().mean([0, 1])
     assert_close(actual, expected)
 
-
-@pytest.mark.parametrize("event_shape", [(), (4,), (3, 2)])
-@pytest.mark.parametrize("num_samples", [1, 2, 3, 4, 10])
-def test_energy_score_empirical(num_samples, event_shape):
-    truth = torch.randn(event_shape)
-    pred = truth + 0.1 * torch.randn((num_samples,) + event_shape)
-
-    actual = crps_empirical(pred, truth)
     expected = energy_score_empirical(
         pred[..., None].swapaxes(0, -1)[0, ..., None], truth[..., None]
     )
-
     assert_close(actual, expected)


### PR DESCRIPTION

# Background

In order to compare a predicted univariate distribution to a true univariate distribution Pyro already has ``pyro.ops.stats.crps_empirical`` which implements the Continuous Ranked Probability Score (CRPS) scoring rule for univariate distributions.

For multivariate distributions we can only use the CRPS to compare marginals but not the full distribution, and therefore two predicted distributions with the same marginals but different full distribution will have the same per marginal CRPS score relative to the true distribution.

# Proposal

The energy score scoring rule implemented in ``pyro.ops.stats.energy_score_empirical`` can be used to compare a predicted multivariate distribution to a true multivariate distribution, such that the score is minimized only if the full predicted multivariate distribution is equal to the full true multivariate distribution, i.e. it is not sufficient for the marginals of the predicted and true distributions to be the same in order to minimize the score (see more details [here](https://benzickel-pyro.readthedocs.io/en/add_energy_score/ops.html#pyro.ops.stats.energy_score_empirical)).
