### PR TITLE
Add jupyter lab option to docker Makefile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -22,6 +22,8 @@ cmd?=bash
 # Determine name of docker image
 build run notebook: img_prefix=pyro-cpu
 build-gpu run-gpu notebook-gpu: img_prefix=pyro-gpu
+build run lab: img_prefix=pyro-cpu
+build-gpu run-gpu lab-gpu: img_prefix=pyro-gpu
 
 ifeq ($(img), )
 	IMG_NAME=${img_prefix}-${pyro_branch}-${python_version}
@@ -128,3 +130,25 @@ notebook-gpu: ##
 	docker run --runtime=nvidia --init -it -p 8888:8888 --user ${USER} \
 	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
 	${IMG_NAME}
+
+	notebook: create-host-workspace
+lab: ##
+	## Start jupyterlab on the Pyro CPU docker container.
+	## Args:
+	##   img: use image name given by `img`.
+	##
+	docker run --init -it -p 8888:8888 --user ${USER} \
+	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
+	${IMG_NAME} jupyter lab --port=8888 --no-browser --ip=0.0.0.0
+
+lab-gpu: create-host-workspace
+lab-gpu: ##
+	## Start jupyterlab on the Pyro GPU docker container.
+	## Args:
+	##   img: use image name given by `img`.
+	##
+	docker run --runtime=nvidia --init -it -p 8888:8888 --user ${USER} \
+	-v ${HOST_WORK_DIR}:${DOCKER_WORK_DIR} \
+	${IMG_NAME} jupyter lab --port=8888 --no-browser --ip=0.0.0.0
+
+

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -123,7 +123,7 @@ notebook: ##
 
 notebook-gpu: create-host-workspace
 notebook-gpu: ##
-	## Start a juptyer notebook on the Pyro GPU docker container.
+	## Start a jupyter notebook on the Pyro GPU docker container.
 	## Args:
 	##   img: use image name given by `img`.
 	##


### PR DESCRIPTION
This is a simple PR that just adds two options to the Makefile for the Docker image.

The gist is that I prefer jupyter lab over jupyter notebook (and it's now the "standard" interface anyway). So this just gives a convenient way to invoke the lab version in docker instead of the notebook version.

I know that it's not that hard to get to lab from a "notebook" server anyway (and vice versa) but I prefer lab because it's habit at this point and the URLs are slightly different so not all tooling is cross-compatible.

(There's also a trivial comment typo that I rolled in here as a second commit).