### PR TITLE
Replace torch._utils._accumulate with numpy.cumsum.

### DIFF
--- a/examples/contrib/mue/FactorMuE.py
+++ b/examples/contrib/mue/FactorMuE.py
@@ -86,7 +86,7 @@ def main(args):
         indices = torch.randperm(sum(data_lengths), device=device).tolist()
         dataset_train, dataset_test = [
             torch.utils.data.Subset(dataset, indices[(offset - length) : offset])
-            for offset, length in zip(pyro.util._accumulate(data_lengths), data_lengths)
+            for offset, length in zip(np.cumsum(data_lengths), data_lengths)
         ]
     else:
         dataset_train = dataset

--- a/examples/contrib/mue/ProfileHMM.py
+++ b/examples/contrib/mue/ProfileHMM.py
@@ -92,7 +92,7 @@ def main(args):
         indices = torch.randperm(sum(data_lengths), device=device).tolist()
         dataset_train, dataset_test = [
             torch.utils.data.Subset(dataset, indices[(offset - length) : offset])
-            for offset, length in zip(pyro.util._accumulate(data_lengths), data_lengths)
+            for offset, length in zip(np.cumsum(data_lengths), data_lengths)
         ]
     else:
         dataset_train = dataset

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -641,18 +641,3 @@ class timed:
 
 def torch_float(x):
     return x.float() if isinstance(x, torch.Tensor) else float(x)
-
-
-def _accumulate(iterable, fn=lambda x, y: x + y):
-    "Return running totals"
-    # _accumulate([1,2,3,4,5]) --> 1 3 6 10 15
-    # _accumulate([1,2,3,4,5], operator.mul) --> 1 2 6 24 120
-    it = iter(iterable)
-    try:
-        total = next(it)
-    except StopIteration:
-        return
-    yield total
-    for element in it:
-        total = fn(total, element)
-        yield total


### PR DESCRIPTION
This fixes failures in testing of `examples/contrib/mue/FactorMuE.py` and `examples/contrib/mue/ProfileHMM.py` as `torch._utils._accumulate` was removed in PyTorch 2.3.
