### PR TITLE
Support for deterministic dependent samples in PyroSample [enhancement]

### DIFF
--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -491,9 +491,10 @@ class AttributeModel(PyroModule):
         )
         self.s = PyroSample(dist.Normal(0, 1))
         self.t = PyroSample(lambda self: dist.Normal(self.s, self.z))
+        self.u = PyroSample(lambda self: self.t**2)
 
     def forward(self):
-        return self.x + self.y + self.t
+        return self.x + self.y + self.u
 
 
 class DecoratorModel(PyroModule):
@@ -521,8 +522,12 @@ class DecoratorModel(PyroModule):
     def t(self):
         return dist.Normal(self.s, self.z).to_event(1)
 
+    @PyroSample
+    def u(self):
+        return self.t**2
+
     def forward(self):
-        return self.x + self.y + self.t
+        return self.x + self.y + self.u
 
 
 @pytest.mark.parametrize("Model", [AttributeModel, DecoratorModel])
@@ -531,19 +536,32 @@ def test_decorator(Model, size):
     model = Model(size)
     for i in range(2):
         trace = poutine.trace(model).get_trace()
-        assert set(trace.nodes.keys()) == {"_INPUT", "x", "y", "z", "s", "t", "_RETURN"}
+        assert set(trace.nodes.keys()) == {
+            "_INPUT",
+            "x",
+            "y",
+            "z",
+            "s",
+            "t",
+            "u",
+            "_RETURN",
+        }
 
         assert trace.nodes["x"]["type"] == "param"
         assert trace.nodes["y"]["type"] == "param"
         assert trace.nodes["z"]["type"] == "param"
         assert trace.nodes["s"]["type"] == "sample"
         assert trace.nodes["t"]["type"] == "sample"
+        assert trace.nodes["u"]["type"] == "sample"
 
         assert trace.nodes["x"]["value"].shape == (size,)
         assert trace.nodes["y"]["value"].shape == (size,)
         assert trace.nodes["z"]["value"].shape == (size,)
         assert trace.nodes["s"]["value"].shape == ()
         assert trace.nodes["t"]["value"].shape == (size,)
+        assert trace.nodes["u"]["value"].shape == (size,)
+
+        assert trace.nodes["u"]["infer"] == {"_deterministic": True}
 
 
 def test_mixin_factory():


### PR DESCRIPTION
Make `pyro.nn.PyroSample(prior)` statements sample deterministic values when the `prior` is a function that returns a `torch.Tensor` value, as described in the below example:

```
from pyro.nn import PyroSample, PyroModule
from pyro import distributions as dist

class Location(PyroModule):
    def __init__(self):
        super().__init__()
        # Independent priors
        self.radius = PyroSample(dist.LogNormal(0,1))
        self.theta = PyroSample(dist.Normal(0.5, 0.1))
        # Dependent deterministic
        self.true_x = PyroSample(lambda self: self.radius * self.theta.cos())
        self.true_y = PyroSample(lambda self: self.radius * self.theta.sin())
        # Dependent samples
        self.observed_x = PyroSample(lambda self: dist.Normal(self.true_x, 0.05))
        self.observed_y = PyroSample(lambda self: dist.Normal(self.true_y, 0.05))
        
    def forward(self):
        return self.true_x, self.true_y, self.observed_x, self.observed_y
```

In the above code the dependent deterministic samples can be converted to dependent samples by assigning them `pyro.nn.PyroSample(prior)` statements with the `prior` being a function returning a proper distribution, allowing simple exploration of various model complexity levels for the same problem.

The updated docs can be reviewed [here](https://benzickel-pyro.readthedocs.io/en/pyro_module_deterministic_dependent_sample/nn.html?highlight=pyrosample#pyro.nn.module.PyroSample).
