### PR TITLE
Fix pyro parameter nodes not showing up in graph of pyro deterministic nodes [bugfix]

### DIFF
--- a/pyro/distributions/hmm.py
+++ b/pyro/distributions/hmm.py
@@ -1091,7 +1091,7 @@ class LinearHMM(HiddenMarkovModel):
         self.transforms = transforms
 
     @constraints.dependent_property(event_dim=2)
-    def support(self):
+    def support(self):  # noqa: F811
         return constraints.independent(self.observation_dist.support, 1)
 
     def expand(self, batch_shape, _instance=None):

--- a/pyro/distributions/stable_log_prob.py
+++ b/pyro/distributions/stable_log_prob.py
@@ -44,7 +44,7 @@ def set_integrator(num_points):
 
 # Stub which is replaced by the default integrator when called for the first time
 # if a default integrator has not already been set.
-def integrate(*args, **kwargs):
+def integrate(*args, **kwargs):  # noqa: F811
     set_integrator(num_points=501)
     return integrate(*args, **kwargs)
 

--- a/pyro/infer/inspect.py
+++ b/pyro/infer/inspect.py
@@ -331,7 +331,7 @@ def get_model_relations(
 
         sample_param[name] = [
             upstream
-            for upstream in get_provenance(site["fn"].log_prob(site["value"]))
+            for upstream in provenance
             if upstream != name and _get_type_from_frozenname(upstream) == "param"
         ]
 

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -72,3 +72,13 @@ def test_psis_diagnostic(scale, krange, zdim, max_particles, num_particles=500 *
         scale=scale,
     )
     assert k > krange[0] and k < krange[1]
+
+
+def test_render_model_deterministic_param():
+    def model():
+        value = pyro.param("param", torch.tensor(0.))
+        pyro.deterministic("deterministic", value)
+
+    graph = pyro.render_model(model, render_params=True, render_deterministic=True)
+
+    assert '\tparam -> deterministic\n' in graph.body

--- a/tests/infer/test_util.py
+++ b/tests/infer/test_util.py
@@ -76,9 +76,9 @@ def test_psis_diagnostic(scale, krange, zdim, max_particles, num_particles=500 *
 
 def test_render_model_deterministic_param():
     def model():
-        value = pyro.param("param", torch.tensor(0.))
+        value = pyro.param("param", torch.tensor(0.0))
         pyro.deterministic("deterministic", value)
 
     graph = pyro.render_model(model, render_params=True, render_deterministic=True)
 
-    assert '\tparam -> deterministic\n' in graph.body
+    assert "\tparam -> deterministic\n" in graph.body


### PR DESCRIPTION
- Fixes #3371.
- Also had to instruct ruff to ignore newly introduced object redefinition checks.


