### PR TITLE
Support for transformed distributions, based on stacking or concatenation transforms, in SplitReparam

### DIFF
--- a/pyro/infer/reparam/split.py
+++ b/pyro/infer/reparam/split.py
@@ -12,22 +12,22 @@ from .reparam import Reparam
 
 
 def same_support(fn: TorchDistributionMixin):
-    '''
+    """
     Returns support of the `fn` distribution.
 
     :param fn: distribution class
     :returns: distribution support
-    '''
+    """
     return fn.support
 
 
 def real_support(fn: TorchDistributionMixin):
-    '''
+    """
     Returns real support with same event dimension as that of the `fn` distribution.
 
     :param fn: distribution class
     :returns: distribution support
-    '''
+    """
     return dist.constraints.independent(dist.constraints.real, fn.event_dim)
 
 

--- a/pyro/infer/reparam/split.py
+++ b/pyro/infer/reparam/split.py
@@ -11,9 +11,10 @@ from pyro.distributions.torch_distribution import TorchDistributionMixin
 from .reparam import Reparam
 
 
-def same_support(fn: TorchDistributionMixin):
+def same_support(fn: TorchDistributionMixin, *args):
     """
-    Returns support of the `fn` distribution.
+    Returns support of the `fn` distribution. Used in :class:`SplitReparam` in
+    order to determine the support of the split value.
 
     :param fn: distribution class
     :returns: distribution support
@@ -21,14 +22,43 @@ def same_support(fn: TorchDistributionMixin):
     return fn.support
 
 
-def real_support(fn: TorchDistributionMixin):
+def real_support(fn: TorchDistributionMixin, *args):
     """
     Returns real support with same event dimension as that of the `fn` distribution.
+    Used in :class:`SplitReparam` in order to determine the support of the split value.
 
     :param fn: distribution class
     :returns: distribution support
     """
     return dist.constraints.independent(dist.constraints.real, fn.event_dim)
+
+
+def default_support(fn: TorchDistributionMixin, slice, dim):
+    """
+    Returns support of the `fn` distribution, corrected for split stacking and
+    concatenation transforms. Used in :class:`SplitReparam` in
+    order to determine the support of the split value.
+
+    :param fn: distribution class
+    :param slice: slice for which to return support
+    :param dim: dimension for which to return support
+    :returns: distribution support
+    """
+    support = fn.support
+    # Unwrap support
+    reinterpreted_batch_ndims_vec = []
+    while isinstance(support, dist.constraints.independent):
+        reinterpreted_batch_ndims_vec.append(support.reinterpreted_batch_ndims)
+        support = support.base_constraint
+    # Slice concatenation and stacking transforms
+    if isinstance(support, dist.constraints.stack) and support.dim == dim:
+        support = dist.constraints.stack(support.cseq[slice], dim)
+    elif isinstance(support, dist.constraints.cat) and support.dim == dim:
+        support = dist.constraints.cat(support.cseq[slice], dim, support.lengths[slice])
+    # Wrap support
+    for reinterpreted_batch_ndims in reinterpreted_batch_ndims_vec[::-1]:
+        support = dist.constraints.independent(support, reinterpreted_batch_ndims)
+    return support
 
 
 class SplitReparam(Reparam):
@@ -50,13 +80,14 @@ class SplitReparam(Reparam):
     :type: list(int)
     :param int dim: Dimension along which to split. Defaults to -1.
     :param callable support_fn: Function which derives the split support
-        from the site's sampling function. Default is :func:`same_support`
-        as the sampling function, but in some cases such as sampling functions
-        which are stacked transforms, you would have to explicitly specify
-        the support with :func:`real_support`
+        from the site's sampling function, split size, and split dimension.
+        Default is :func:`default_support` which correctly handles stacking
+        and concatenation transforms. Other options are :func:`same_support`
+        which returns the same support as that of the sampling function, and
+        :func:`real_support` which returns a real support.
     """
 
-    def __init__(self, sections, dim, support_fn=same_support):
+    def __init__(self, sections, dim, support_fn=default_support):
         assert isinstance(dim, int) and dim < 0
         assert isinstance(sections, list)
         assert all(isinstance(size, int) for size in sections)
@@ -80,14 +111,20 @@ class SplitReparam(Reparam):
         dim = fn.event_dim - self.event_dim
         left_shape = fn.event_shape[:dim]
         right_shape = fn.event_shape[1 + dim :]
+        start = 0
         for i, size in enumerate(self.sections):
             event_shape = left_shape + (size,) + right_shape
             value_split[i] = pyro.sample(
                 f"{name}_split_{i}",
-                dist.ImproperUniform(self.support_fn(fn), fn.batch_shape, event_shape),
+                dist.ImproperUniform(
+                    self.support_fn(fn, slice(start, start + size), -self.event_dim),
+                    fn.batch_shape,
+                    event_shape,
+                ),
                 obs=value_split[i],
                 infer={"is_observed": is_observed},
             )
+            start += size
 
         # Combine parts into value.
         if value is None:


### PR DESCRIPTION
# The Problem

The `SplitReparam` reparameterization does not support transformed distributions that are based on stacking or concatenation transforms.

Consider the code

```py
import pyro
import pyro.distributions as dist
from pyro.infer.reparam import SplitReparam

import torch

batch_shape = (6, 5)
num_samples = 10

transform = dist.transforms.StackTransform([
        dist.transforms.OrderedTransform(),
        dist.transforms.DiscreteCosineTransform(),
        dist.transforms.HaarTransform()], dim=-1)

num_transforms = len(transform.transforms)

def model():
    scale_tril = pyro.sample("scale_tril", dist.LKJCholesky(num_transforms, 1))
    with pyro.plate_stack("plates", batch_shape):
        x_dist = dist.TransformedDistribution(
            dist.MultivariateNormal(
                torch.zeros(num_samples, num_transforms), scale_tril=scale_tril
            ).to_event(1),
            [transform])
        return pyro.sample("x", x_dist)

split_model = pyro.poutine.reparam(model, config={"x": SplitReparam([2, 1], -1)})

pyro.clear_param_store()
guide = pyro.infer.autoguide.AutoMultivariateNormal(split_model)
guide_sites = guide()
```

which raises the error

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\SW\pyro-ppl\pyro\nn\module.py", line 527, in __call__
    result = super().__call__(*args, **kwargs)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 1553, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\nn\modules\module.py", line 1562, in _call_impl  
    return forward_call(*args, **kwargs)
  File "C:\SW\pyro-ppl\pyro\infer\autoguide\guides.py", line 759, in forward
    self._setup_prototype(*args, **kwargs)
  File "C:\SW\pyro-ppl\pyro\infer\autoguide\guides.py", line 875, in _setup_prototype
    super()._setup_prototype(*args, **kwargs)
  File "C:\SW\pyro-ppl\pyro\infer\autoguide\guides.py", line 644, in _setup_prototype
    biject_to(site["fn"].support).inv(site["value"]).shape
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\distributions\transforms.py", line 263, in __call__
    return self._inv._inv_call(x)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\distributions\transforms.py", line 170, in _inv_call
    return self._inverse(y)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\distributions\transforms.py", line 455, in _inverse
    return self.base_transform.inv(y)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\distributions\transforms.py", line 263, in __call__
    return self._inv._inv_call(x)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\distributions\transforms.py", line 170, in _inv_call
    return self._inverse(y)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\distributions\transforms.py", line 1172, in _inverse
    assert y.size(self.dim) == len(self.transforms)
AssertionError
```

The error is due to `SplitReparam` not creating the right support for the sites of the split reparameterization.

# The Solution

Change the way `SplitReparam` figures out the support of slices of transformed distributions that are based on stacking or concatenation transforms.
