### PR TITLE
Effect handler that conditions a model on sample sites having the same value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tool.ruff]
+extend-exclude = ["*.ipynb"]
 line-length = 120
 
 

--- a/pyro/ops/stats.py
+++ b/pyro/ops/stats.py
@@ -511,7 +511,7 @@ def crps_empirical(pred, truth):
 
 
 def energy_score_empirical(pred: torch.Tensor, truth: torch.Tensor) -> torch.Tensor:
-    """
+    r"""
     Computes negative Energy Score ES* (see equation 22 in [1]) between a
     set of multivariate samples ``pred`` and a true data vector ``truth``. Running time
     is quadratic in the number of samples ``n``. In case of univariate samples

--- a/pyro/poutine/equalize_messenger.py
+++ b/pyro/poutine/equalize_messenger.py
@@ -96,9 +96,9 @@ class EqualizeMessenger(Messenger):
         if self.value is not None and self._is_matching(msg):  # type: ignore[unreachable]
             msg["value"] = self.value  # type: ignore[unreachable]
             if msg["type"] == "sample":
-                msg["infer"] = {"_deterministic": True}
                 msg["is_observed"] = True
                 if not self.keep_dist:
+                    msg["infer"] = {"_deterministic": True}
                     msg["fn"] = Delta(self.value, event_dim=msg["fn"].event_dim).mask(
                         False
                     )


### PR DESCRIPTION
# Problem Description

It would be helpful to have an effect handler that can condition a model on sample sites having the same value.

# Suggested Solution

Use the `EqualizeMessenger` effect handler with a newly added option `keep_dist`, that when set to `True` keeps the original distribution functions of the sample sites, as opposed to the default behavior of converting the second and subsequent sites to be deterministic.

# Usage Example

Consider the model
```
def model():
    x = pyro.sample('x', pyro.distributions.Normal(0, 1))
    y = pyro.sample('y', pyro.distributions.Normal(5, 3))
```

The model can be conditioned on ‘x’ and ‘y’ having the same value by
```
conditioned_model = pyro.poutine.equalize(model, ['x', 'y'], keep_dist=True)
```

which is equivalent to
```
def conditioned_model():
    x = pyro.sample('x', pyro.distributions.Normal(0, 1))
    y = pyro.sample('y', pyro.distributions.Normal(5, 3), obs=x)
```

as opposed to the default behavior of `EqualizeMessenger` with `keep_dist` equal to False such that
```
equalized_model = pyro.poutine.equalize(model, ['x', 'y'])
```

which is equivalent to
```
def equalized_model():
    x = pyro.sample('x', pyro.distributions.Normal(0, 1))
    y = pyro.deterministic('y', x)
```

Note that the conditioned model defined above calculates the correct unnormalized log-probablity density, but in order to correctly sample from it one must use SVI or MCMC techniques.

# Testing

I've added a test for the conditioned model case, with two normally distributed random variables, which allows for analytic calculation of the expected resulting normal distribution.
 