### PR TITLE
Fix torch documentation link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,7 +193,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "torch": ("https://pytorch.org/docs/master/", None),
+    "torch": ("https://pytorch.org/docs/main/", None),
     "funsor": ("https://funsor.pyro.ai/en/stable/", None),
     "opt_einsum": ("https://optimized-einsum.readthedocs.io/en/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),


### PR DESCRIPTION
PyTorch's dev documentation has been updated to https://pytorch.org/docs/main/ This PR fixes the link to make sure that our CI passes.