### PR TITLE
Maintenance fixes

### DIFF
--- a/pyro/distributions/omt_mvn.py
+++ b/pyro/distributions/omt_mvn.py
@@ -68,7 +68,7 @@ class _OMTMVNSample(Function):
         diff_L_ab = 0.5 * sum_leftmost(g_ja * epsilon_jb + g_R_inv * z_ja, -2)
 
         Sigma_inv = torch.mm(R_inv, R_inv.t())
-        V, D, _ = torch.svd(Sigma_inv + jitter)
+        V, D, _ = torch.linalg.svd(Sigma_inv + jitter)
         D_outer = D.unsqueeze(-1) + D.unsqueeze(0)
 
         expand_tuple = tuple([-1] * (z.dim() - 1) + [dim, dim])

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -29,7 +29,7 @@ class ConditionedHouseholder(Transform):
     # Construct normalized vectors for Householder transform
     def u(self):
         u_unnormed = self.u_unnormed() if callable(self.u_unnormed) else self.u_unnormed
-        norm = torch.linalg.norm(u_unnormed, p=2, dim=-1, keepdim=True)
+        norm = torch.linalg.norm(u_unnormed, ord=2, dim=-1, keepdim=True)
         return torch.div(u_unnormed, norm)
 
     def _call(self, x):

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -29,7 +29,7 @@ class ConditionedHouseholder(Transform):
     # Construct normalized vectors for Householder transform
     def u(self):
         u_unnormed = self.u_unnormed() if callable(self.u_unnormed) else self.u_unnormed
-        norm = torch.norm(u_unnormed, p=2, dim=-1, keepdim=True)
+        norm = torch.linalg.norm(u_unnormed, p=2, dim=-1, keepdim=True)
         return torch.div(u_unnormed, norm)
 
     def _call(self, x):

--- a/pyro/distributions/transforms/sylvester.py
+++ b/pyro/distributions/transforms/sylvester.py
@@ -92,11 +92,11 @@ class Sylvester(Householder):
         u = self.u()
         partial_Q = torch.eye(
             self.input_dim, dtype=x.dtype, layout=x.layout, device=x.device
-        ) - 2.0 * torch.ger(u[0], u[0])
+        ) - 2.0 * torch.outer(u[0], u[0])
 
         for idx in range(1, self.u_unnormed.size(-2)):
             partial_Q = torch.matmul(
-                partial_Q, torch.eye(self.input_dim) - 2.0 * torch.ger(u[idx], u[idx])
+                partial_Q, torch.eye(self.input_dim) - 2.0 * torch.outer(u[idx], u[idx])
             )
 
         return partial_Q

--- a/pyro/infer/autoguide/effect.py
+++ b/pyro/infer/autoguide/effect.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
+from operator import attrgetter
 from typing import Callable, Optional, Tuple, Union
 
 import torch
@@ -14,7 +15,7 @@ from pyro.poutine.guide import GuideMessenger
 from pyro.poutine.runtime import get_plates
 
 from .initialization import init_to_feasible, init_to_mean
-from .utils import deep_getattr, deep_setattr, helpful_support_errors
+from .utils import deep_setattr, helpful_support_errors
 
 
 class AutoMessengerMeta(type(GuideMessenger), type(PyroModule)):
@@ -175,8 +176,8 @@ class AutoNormalMessenger(AutoMessenger):
 
     def _get_params(self, name: str, prior: Distribution):
         try:
-            loc = deep_getattr(self.locs, name)
-            scale = deep_getattr(self.scales, name)
+            loc = attrgetter(name)(self.locs)
+            scale = attrgetter(name)(self.scales)
             return loc, scale
         except AttributeError:
             pass
@@ -287,10 +288,10 @@ class AutoHierarchicalNormalMessenger(AutoNormalMessenger):
 
     def _get_params(self, name: str, prior: Distribution):
         try:
-            loc = deep_getattr(self.locs, name)
-            scale = deep_getattr(self.scales, name)
+            loc = attrgetter(name)(self.locs)
+            scale = attrgetter(name)(self.scales)
             if (self._hierarchical_sites is None) or (name in self._hierarchical_sites):
-                weight = deep_getattr(self.weights, name)
+                weight = attrgetter(name)(self.weights)
                 return loc, scale, weight
             else:
                 return loc, scale
@@ -427,8 +428,8 @@ class AutoRegressiveMessenger(AutoMessenger):
 
     def _get_params(self, name: str, prior: Distribution):
         try:
-            loc = deep_getattr(self.locs, name)
-            scale = deep_getattr(self.scales, name)
+            loc = attrgetter(name)(self.locs)
+            scale = attrgetter(name)(self.scales)
             return loc, scale
         except AttributeError:
             pass

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -20,6 +20,7 @@ import operator
 import warnings
 import weakref
 from contextlib import ExitStack
+from operator import attrgetter
 
 import torch
 from torch import nn
@@ -38,7 +39,7 @@ from pyro.ops.tensor_utils import periodic_repeat
 from pyro.poutine.util import site_is_subsample
 
 from .initialization import InitMessenger, init_to_feasible, init_to_median
-from .utils import _product, deep_getattr, deep_setattr, helpful_support_errors
+from .utils import _product, deep_setattr, helpful_support_errors
 
 
 def prototype_hide_fn(msg):
@@ -491,8 +492,8 @@ class AutoNormal(AutoGuide):
             )
 
     def _get_loc_and_scale(self, name):
-        site_loc = deep_getattr(self.locs, name)
-        site_scale = deep_getattr(self.scales, name)
+        site_loc = attrgetter(name)(self.locs)
+        site_scale = attrgetter(name)(self.scales)
         return site_loc, site_scale
 
     def forward(self, *args, **kwargs):

--- a/pyro/infer/autoguide/utils.py
+++ b/pyro/infer/autoguide/utils.py
@@ -18,12 +18,6 @@ def _product(shape):
     return result
 
 
-def deep_getattr(obj, key):
-    for part in key.split("."):
-        obj = getattr(obj, part)
-    return obj
-
-
 def deep_setattr(obj, key, val):
     """
     Set an attribute `key` on the object. If any of the prefix attributes do

--- a/pyro/ops/welford.py
+++ b/pyro/ops/welford.py
@@ -33,7 +33,7 @@ class WelfordCovariance:
         if self.diagonal:
             self._m2 += delta_pre * delta_post
         else:
-            self._m2 += torch.ger(delta_post, delta_pre)
+            self._m2 += torch.outer(delta_post, delta_pre)
 
     def get_covariance(self, regularize=True):
         if self.n_samples < 2:
@@ -72,7 +72,7 @@ class WelfordArrowheadCovariance:
         self._mean = self._mean + delta_pre / self.n_samples
         delta_post = sample - self._mean
         if self.head_size > 0:
-            self._m2_top = self._m2_top + torch.ger(
+            self._m2_top = self._m2_top + torch.outer(
                 delta_post[: self.head_size], delta_pre
             )
         else:

--- a/pyro/primitives.py
+++ b/pyro/primitives.py
@@ -6,6 +6,7 @@ import warnings
 from collections import OrderedDict
 from contextlib import ExitStack, contextmanager
 from inspect import isclass
+from operator import attrgetter
 from typing import Callable, Iterator, Optional, Sequence, Union
 
 import torch
@@ -28,7 +29,7 @@ from pyro.poutine.runtime import (
     effectful,
 )
 from pyro.poutine.subsample_messenger import SubsampleMessenger
-from pyro.util import deep_getattr, set_rng_seed  # noqa: F401
+from pyro.util import set_rng_seed  # noqa: F401
 
 
 def get_param_store() -> ParamStoreDict:
@@ -493,7 +494,7 @@ def module(
                 mod_name = _name
             if _name in target_state_dict.keys():
                 if not is_param:
-                    deep_getattr(nn_module, mod_name)._parameters[param_name] = (
+                    attrgetter(mod_name)(nn_module)._parameters[param_name] = (
                         target_state_dict[_name]
                     )
                 else:

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017-2019 Uber Technologies, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-import functools
 import math
 import numbers
 import random
@@ -702,14 +701,6 @@ def ignore_experimental_warning():
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=ExperimentalWarning)
         yield
-
-
-def deep_getattr(obj: object, name: str) -> Any:
-    """
-    Python getattr() for arbitrarily deep attributes
-    Throws an AttributeError if bad attribute
-    """
-    return functools.reduce(getattr, name.split("."), obj)
 
 
 class timed:

--- a/tests/infer/test_sampling.py
+++ b/tests/infer/test_sampling.py
@@ -78,9 +78,13 @@ class ImportanceTest(NormalNormalSamplingTestCase):
             self.model, guide=self.guide, num_samples=5000
         ).run()
         marginal = EmpiricalMarginal(posterior)
-        assert_equal(0, torch.norm(marginal.mean - self.loc_mean).item(), prec=0.01)
         assert_equal(
-            0, torch.norm(marginal.variance.sqrt() - self.loc_stddev).item(), prec=0.1
+            0, torch.linalg.norm(marginal.mean - self.loc_mean).item(), prec=0.01
+        )
+        assert_equal(
+            0,
+            torch.linalg.norm(marginal.variance.sqrt() - self.loc_stddev).item(),
+            prec=0.1,
         )
 
     @pytest.mark.init(rng_seed=0)
@@ -89,7 +93,11 @@ class ImportanceTest(NormalNormalSamplingTestCase):
             self.model, guide=None, num_samples=10000
         ).run()
         marginal = EmpiricalMarginal(posterior)
-        assert_equal(0, torch.norm(marginal.mean - self.loc_mean).item(), prec=0.01)
         assert_equal(
-            0, torch.norm(marginal.variance.sqrt() - self.loc_stddev).item(), prec=0.1
+            0, torch.linalg.norm(marginal.mean - self.loc_mean).item(), prec=0.01
+        )
+        assert_equal(
+            0,
+            torch.linalg.norm(marginal.variance.sqrt() - self.loc_stddev).item(),
+            prec=0.1,
         )

--- a/tests/ops/test_linalg.py
+++ b/tests/ops/test_linalg.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from pyro.ops.linalg import rinverse
-from tests.common import assert_close, assert_equal
+from tests.common import assert_equal
 
 
 @pytest.mark.parametrize(
@@ -35,29 +35,3 @@ def test_sym_rinverse(A, use_sym):
     batched_A = A.unsqueeze(0).unsqueeze(0).expand(5, 4, d, d)
     expected_A = torch.inverse(A).unsqueeze(0).unsqueeze(0).expand(5, 4, d, d)
     assert_equal(rinverse(batched_A, sym=use_sym), expected_A, prec=1e-8)
-
-
-# Tests migration from torch.triangular_solve -> torch.linalg.solve_triangular
-@pytest.mark.filterwarnings("ignore:torch.triangular_solve is deprecated")
-@pytest.mark.parametrize("upper", [False, True], ids=["lower", "upper"])
-def test_triangular_solve(upper):
-    b = torch.randn(5, 6)
-    A = torch.randn(5, 5)
-    expected = torch.triangular_solve(b, A, upper=upper).solution
-    actual = torch.linalg.solve_triangular(A, b, upper=upper)
-    assert_close(actual, expected)
-    A = A.triu() if upper else A.tril()
-    assert_close(A @ actual, b)
-
-
-# Tests migration from torch.triangular_solve -> torch.linalg.solve_triangular
-@pytest.mark.filterwarnings("ignore:torch.triangular_solve is deprecated")
-@pytest.mark.parametrize("upper", [False, True], ids=["lower", "upper"])
-def test_triangular_solve_transpose(upper):
-    b = torch.randn(5, 6)
-    A = torch.randn(5, 5)
-    expected = torch.triangular_solve(b, A, upper=upper, transpose=True).solution
-    actual = torch.linalg.solve_triangular(A.T, b, upper=not upper)
-    assert_close(actual, expected)
-    A = A.triu() if upper else A.tril()
-    assert_close(A.T @ actual, b)

--- a/tests/poutine/test_poutines.py
+++ b/tests/poutine/test_poutines.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def eq(x, y, prec=1e-10):
-    return torch.norm(x - y).item() < prec
+    return torch.linalg.norm(x - y).item() < prec
 
 
 # XXX name is a bit silly


### PR DESCRIPTION
- Deprecated API usages found by TorchFix linter (https://github.com/pyro-ppl/pyro/pull/3397#issuecomment-2357456164)
- Remove tests for deprecated `torch.triangular_solve`
- Replace `deep_getattr` function with Python's `operator.attrgetter`