### PR TITLE
Update example reference

### DIFF
--- a/pyro/contrib/autoname/named.py
+++ b/pyro/contrib/autoname/named.py
@@ -42,9 +42,9 @@ alias Pyro statements. For example::
     >>> obs = state.x.sample_(dist.Normal(loc, scale), obs=z)
 
 For deeper examples of how these can be used in model code, see the
-`Tree Data <https://github.com/pyro-ppl/pyro/blob/dev/examples/contrib/named/tree_data.py>`_
+`Tree Data <https://github.com/pyro-ppl/pyro/blob/dev/examples/contrib/autoname/tree_data.py>`_
 and
-`Mixture <https://github.com/pyro-ppl/pyro/blob/dev/examples/contrib/named/mixture.py>`_
+`Mixture <https://github.com/pyro-ppl/pyro/blob/dev/examples/contrib/autoname/mixture.py>`_
 examples.
 
 Authors: Fritz Obermeyer, Alexander Rush


### PR DESCRIPTION
# PR Summary
PR #1161 moved the location of `tree_data.py` and `mixture.py`. This PR adjusts sources to change. Relevant [link](https://docs.pyro.ai/en/latest/contrib.autoname.html).