### PR TITLE
fix autodetermination of plate device when running in a device contexf

### DIFF
--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -45,7 +45,7 @@ class _Subsample(Distribution):
                     )
                 )
         with ignore_jit_warnings(["torch.Tensor results are registered as constants"]):
-            self.device = device or torch.Tensor().device
+            self.device = device or torch.tensor(tuple()).device
 
     @ignore_jit_warnings(["Converting a tensor to a Python boolean"])
     def sample(self, sample_shape: torch.Size = torch.Size()) -> torch.Tensor:


### PR DESCRIPTION
Apparently, the torch.Tensor() constructor ignores device contexts, e.g. running 

```
with torch.device("cuda"):
    print(torch.Tensor().device)
````
still returns `cpu`.