### PR TITLE
Fix `IndepMessenger.__iter__` type annotation

### DIFF
--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -138,7 +138,7 @@ class PyroParam(NamedTuple):
         if name not in obj.__dict__["_pyro_params"]:
             init_value, constraint, event_dim = self
             # bind method's self arg
-            init_value = functools.partial(init_value, obj)  # type: ignore[arg-type,misc,operator]
+            init_value = functools.partial(init_value, obj)  # type: ignore[arg-type,call-arg,misc,operator]
             setattr(obj, name, PyroParam(init_value, constraint, event_dim))
         value: PyroParam = obj.__getattr__(name)
         return value


### PR DESCRIPTION
Fixes type checking errors introduced by PyTorch 2.5. Unblocks #3405 