### PR TITLE
Fix docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG base_img=ubuntu:18.04
+ARG base_img=ubuntu:24.04
 FROM ${base_img}
 
 # Optional args
-ARG cuda=0
 ARG python_version=3
 ARG pyro_branch=release
+ARG pytorch_whl=cpu
 ARG pytorch_branch=release
 ARG uid=1000
 ARG gid=1000
@@ -38,7 +38,7 @@ USER ${USER_NAME}
 
 # Install conda
 RUN wget -O ~/miniconda.sh \
-    https://repo.continuum.io/miniconda/Miniconda${python_version%%.*}-latest-Linux-x86_64.sh && \
+    https://repo.anaconda.com/miniconda/Miniconda${python_version%%.*}-latest-Linux-x86_64.sh && \
     bash ~/miniconda.sh -f -b -p ${CONDA_DIR} && \
     rm ~/miniconda.sh && \
     conda install python=${python_version}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,20 +5,18 @@
 .PHONY: help create-host-workspace build build-gpu run run-gpu notebook notebook-gpu
 
 DOCKER_FILE=Dockerfile
-BASE_IMG=ubuntu:18.04
-BASE_CUDA_IMG=nvidia/cuda:11.5.0-cudnn8-runtime-ubuntu18.04
+BASE_IMG=ubuntu:24.04
 DOCKER_CMD=docker
-DOCKER_GPU_CMD=nvidia-docker
 HOST_WORK_DIR=${HOME}/pyro_docker
-UID=$(shell id -u)
-GID=$(shell id -g)
+UID=999
+GID=999
 OSTYPE=$(shell uname)
 USER=pyromancer
 DOCKER_WORK_DIR=/home/${USER}/workspace/shared
 pyro_git_url=https://github.com/pyro-ppl/pyro.git
 
 # Optional args
-python_version?=3.6
+python_version?=3.12
 pytorch_branch?=release
 pyro_branch?=release
 cmd?=bash
@@ -45,12 +43,11 @@ help:
 
 build: ##
 	## Build a docker image for running Pyro on a CPU.
-	## Requires nvidia-docker (https://github.com/NVIDIA/nvidia-docker).
 	## Args:
-	##   python_version: version of python to use. default - python 3.6
+	##   python_version: version of python to use. default - python 3.12
 	##   pytorch_branch: whether to build PyTorch from conda or from source
 	##   (git branch specified by pytorch_branch)
-	##     default - latest pytorch version on conda
+	##     default - latest pytorch version on the torch python package index
 	##   pyro_branch: whether to use the released Pyro wheel or a git branch.
 	##     default - latest pyro-ppl wheel on pypi
 	##
@@ -66,21 +63,20 @@ build: ##
 
 build-gpu: ##
 	## Build a docker image for running Pyro on a GPU.
-	## Requires nvidia-docker (https://github.com/NVIDIA/nvidia-docker).
 	## Args:
-	##   python_version: version of python to use. default - python 3.6
+	##   python_version: version of python to use. default - python 3.12
 	##   pytorch_branch: whether to build PyTorch from conda or from source
 	##   (git branch specified by pytorch_branch)
-	##     default - latest pytorch version on conda
+	##     default - latest pytorch version on the torch python package index
 	##   pyro_branch: whether to use the released Pyro wheel or a git branch.
 	##     default - latest pyro-ppl wheel on pypi
 	##
-	${DOCKER_GPU_CMD} build -t ${IMG_NAME} \
-	--build-arg base_img=${BASE_CUDA_IMG} \
+	${DOCKER_CMD} build -t ${IMG_NAME} \
+	--build-arg base_img=${BASE_IMG} \
 	--build-arg uid=${UID} \
 	--build-arg gid=${GID} \
 	--build-arg ostype=${OSTYPE} \
-	--build-arg cuda=1 \
+	--build-arg pytorch_whl=cu118 \
 	--build-arg python_version=${python_version} \
 	--build-arg pytorch_branch=${pytorch_branch} \
 	--build-arg pyro_git_url=${pyro_git_url} \

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -13,17 +13,13 @@ pip install notebook ipywidgets matplotlib
 # Use conda package if pytorch_branch = 'release'.
 # Else, install from source, using git branch `pytorch_branch`
 
-if [ ${pytorch_branch} = "release" ]
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/${pytorch_whl}
+if [ ${pytorch_branch} != "release" ]
 then
-    conda install -y pytorch torchvision -c pytorch
-    if [ ${cuda} = 1 ]; then conda install -y cuda90 -c pytorch; fi
-else
-    conda install -y numpy pyyaml mkl mkl-include setuptools cmake cffi typing
-    conda install -c mingfeima mkldnn
-    if [ ${cuda} = 1 ]; then conda install -y cuda90 -c pytorch; fi
     git clone --recursive https://github.com/pytorch/pytorch.git
     pushd pytorch && git checkout ${pytorch_branch}
-    python setup.py install
+    pip uninstall torch
+    pip install -e .
     popd
 fi
 
@@ -36,5 +32,5 @@ then
     pip install pyro-ppl
 else
     git clone ${pyro_git_url}
-    (cd pyro && git checkout ${pyro_branch} && pip install .[dev])
+    (cd pyro && git checkout ${pyro_branch} && pip install -e .[dev])
 fi


### PR DESCRIPTION
# Bug fixes

- Update `miniconda` URL.
- Install `torch` via pip as the latest version is not available for installation via `conda`.

# Updates

- Use `ubuntu` 24.04.
- Change default python version to 3.12.
- Make non-release installations of `pyro` and `torch` local.
