### PR TITLE
Fixes #3430 (serializing an easyguide corrupts it).

### DIFF
--- a/pyro/contrib/easyguide/easyguide.py
+++ b/pyro/contrib/easyguide/easyguide.py
@@ -230,7 +230,7 @@ class Group:
         self.event_shape = torch.Size([sum(self._site_sizes.values())])
 
     def __getstate__(self):
-        state = getattr(super(), "__getstate__", self.__dict__.copy)()
+        state = getattr(super(), "__getstate__", lambda: self.__dict__)().copy()
         state["_guide"] = state["_guide"]()  # weakref -> ref
         return state
 

--- a/tests/contrib/easyguide/test_easyguide.py
+++ b/tests/contrib/easyguide/test_easyguide.py
@@ -79,7 +79,6 @@ class PickleGuide(EasyGuide):
             self.group(match="state_[0-9]*").map_estimate()
 
 
-@pytest.mark.xfail(reason="https://github.com/pyro-ppl/pyro/issues/3430")
 def test_serialize():
     guide = PickleGuide(model)
     check_guide(guide)


### PR DESCRIPTION
- The issue is that on Python 3.12 the `super()` object of `easyguide.Group` started having the `__getstate__` attribute (this doesn't happen in python 3.9), which is then called to return the state object, which is then modified without making a copy before modification, which causes the corruption.
- The solution is to ensure that we always make a copy of the state object before modifying it.
- This was tested on both python 3.9 and 3.12.
