### PR TITLE
Fix: Remove Callable parent from TorchDistributionMixin

### DIFF
--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -16,7 +16,7 @@ from .score_parts import ScoreParts
 from .util import broadcast_shape, scale_and_mask
 
 
-class TorchDistributionMixin(Distribution, Callable):
+class TorchDistributionMixin(Distribution):
     """
     Mixin to provide Pyro compatibility for PyTorch distributions.
 

--- a/pyro/distributions/torch_distribution.py
+++ b/pyro/distributions/torch_distribution.py
@@ -3,7 +3,6 @@
 
 import warnings
 from collections import OrderedDict
-from typing import Callable
 
 import torch
 from torch.distributions.kl import kl_divergence, register_kl


### PR DESCRIPTION
Removes `Callable` as a parent of `TorchDistributionMixin` to allow for more flexible subclassing, as the `__call__` method is sufficient for introspection.

Closes #3442