### PR TITLE
DirichletMultinomial is_sparse=True dtype error

### DIFF
--- a/pyro/distributions/conjugate.py
+++ b/pyro/distributions/conjugate.py
@@ -18,7 +18,7 @@ def _log_beta_1(alpha, value, is_sparse):
     if is_sparse:
         mask = value != 0
         value, alpha, mask = torch.broadcast_tensors(value, alpha, mask)
-        result = torch.zeros_like(value)
+        result = torch.zeros_like(value, dtype=alpha.dtype)
         value = value[mask]
         alpha = alpha[mask]
         result[mask] = (


### PR DESCRIPTION
The function __log_beta_1_ cannot handle the argument _is_sparse=True_ due to incorrect data type of instantiating _result = torch.zeros_like(value)_. I propose to add that the dtype should be the same as _alpha_; thus,  _result = torch.zeros_like(value, dtype=alpha.dtype)_.

The problem arises when:
_result[mask] = (torch.lgamma(1 + value) + torch.lgamma(alpha) - torch.lgamma(value + alpha))_, as result[mask].dtype >> torch.int64 and (torch.lgamma(1 + value) + torch.lgamma(alpha) - torch.lgamma(value + alpha)).dtype >> torch.float32