### PR TITLE
Reject negative plate sizes

### DIFF
--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -115,6 +115,8 @@ class SubsampleMessenger(IndepMessenger):
             size = -1  # This is PyTorch convention for "arbitrary size"
             subsample_size = -1
         else:
+            if size < 0:
+                raise ValueError("size cannot be negative")
             msg = Message(
                 type="sample",
                 name=name,

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -36,6 +36,11 @@ def test_deterministic_ok():
     assert x.shape == ()
 
 
+def test_plate_negative_size_error():
+    with pytest.raises(ValueError, match="size cannot be negative"):
+        pyro.plate("data", -1)
+
+
 @pytest.mark.parametrize(
     "mask",
     [


### PR DESCRIPTION
## Proposed changes
- Raise a ValueError when pyro.plate receives an explicit negative size.
- Add unit coverage for the negative-size case while leaving size=None unchanged.

## Related issue
Fixes #3407

## Tests
Not run locally.