### PR TITLE
fix(infer): render_model draws edges through deterministic sites

### DIFF
--- a/pyro/infer/inspect.py
+++ b/pyro/infer/inspect.py
@@ -298,7 +298,7 @@ def get_model_relations(
     assert isinstance(model_kwargs, dict)
 
     with torch.random.fork_rng(), torch.no_grad(), pyro.validation_enabled(False):
-        with TrackProvenance(include_deterministic=include_deterministic):
+        with TrackProvenance(include_deterministic=True):
             trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
 
     sample_sample = {}

--- a/tests/infer/test_inspect.py
+++ b/tests/infer/test_inspect.py
@@ -526,7 +526,7 @@ def test_get_model_relations(include_deterministic):
                 "f": ["e"],
                 "g": ["e"],
                 "h": ["e"],
-                "i": ["e"],
+                "i": ["e", "f", "g", "h"],
             },
             "sample_param": {
                 "a": [],


### PR DESCRIPTION
Fixes #3441

`pyro.render_model` silently omitted edges when a sample site received values from a `pyro.deterministic` site or a Delta-transformed sample. Only regular sample sites were wrapped as provenance anchors in `TrackProvenance`, so downstream sites resolved their dependencies transitively, skipping the intermediate nodes.

**Root cause:** `get_model_relations` passed `include_deterministic` to `TrackProvenance`, so when `include_deterministic=False` (the default), deterministic and Delta sites were not wrapped with their own provenance anchor. A site like `y = Normal(y_mean, 1)` would show `x` as its parent instead of `y_mean`, and `y_mean -> y` edge was never built.

**Fix:** Always use `TrackProvenance(include_deterministic=True)` inside `get_model_relations` so every site acts as a provenance anchor for the dependency graph. The `include_deterministic` parameter still controls which nodes appear in the rendered output. Updated `test_get_model_relations` to reflect the now-correct direct-parent edges.