### PR TITLE
Add order parameter to spline_coupling helper (fixes #3417)

### DIFF
--- a/pyro/distributions/transforms/spline_coupling.py
+++ b/pyro/distributions/transforms/spline_coupling.py
@@ -166,7 +166,12 @@ class SplineCoupling(TransformModule):
 
 
 def spline_coupling(
-    input_dim, split_dim=None, hidden_dims=None, count_bins=8, bound=3.0
+    input_dim,
+    split_dim=None,
+    hidden_dims=None,
+    count_bins=8,
+    bound=3.0,
+    order="linear",
 ):
     """
     A helper function to create a
@@ -175,6 +180,9 @@ def spline_coupling(
 
     :param input_dim: Dimension of input variable
     :type input_dim: int
+    :param order: One of ``['linear', 'quadratic']`` specifying the order of the
+        spline.
+    :type order: str
 
     """
 
@@ -195,4 +203,4 @@ def spline_coupling(
         ],
     )
 
-    return SplineCoupling(input_dim, split_dim, nn, count_bins, bound)
+    return SplineCoupling(input_dim, split_dim, nn, count_bins, bound, order)

--- a/tests/distributions/test_transforms.py
+++ b/tests/distributions/test_transforms.py
@@ -419,7 +419,8 @@ class TransformTests(TestCase):
             self._test(partial(T.spline, order=order))
 
     def test_spline_coupling(self):
-        self._test(T.spline_coupling)
+        for order in ["linear", "quadratic"]:
+            self._test(partial(T.spline_coupling, order=order))
 
     def test_spline_autoregressive(self):
         self._test(T.spline_autoregressive)


### PR DESCRIPTION
## Summary

Adds the `order` parameter to the `spline_coupling` helper function for consistency with the `SplineCoupling` class and the `spline` helper.

## Changes

- **`pyro/distributions/transforms/spline_coupling.py`**: Added `order="linear"` parameter to `spline_coupling()` helper, passing it through to `SplineCoupling`
- **`tests/distributions/test_transforms.py`**: Updated `test_spline_coupling` to test both `"linear"` and `"quadratic"` orders (matching the pattern used by `test_spline`)

## Motivation

The `SplineCoupling` class already supports the `order` parameter, but the `spline_coupling` helper function did not expose it. This inconsistency meant users of the helper API couldn't specify quadratic splines without directly instantiating the class.

Closes #3417
