### PR TITLE
Pin funsor to 0.4.8

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,6 @@ observations>=0.1.4
 opt_einsum>=2.3.2
 pyro-api>=0.1.1
 tqdm>=4.36
-funsor[torch] @ git+https://github.com/pyro-ppl/funsor.git@8a8ca81fcc61733ad82e163028c7ff78420df9f0
+funsor[torch]==0.4.8
 setuptools
 sphinx_copybutton

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ setup(
         "horovod": ["horovod[pytorch]>=0.19"],
         "lightning": ["lightning"],
         "funsor": [
-            "funsor[torch] @ git+https://github.com/pyro-ppl/funsor.git@8a8ca81fcc61733ad82e163028c7ff78420df9f0",
+            "funsor[torch]==0.4.8",
         ],
     },
     python_requires=">=3.8",


### PR DESCRIPTION
## Summary
- Pin the optional funsor extra to `funsor[torch]==0.4.8`.
- Align the docs build requirements with the package extra.

## Validation
- Not run; version availability is assumed for this PR.