### PR TITLE
Preserve torch.Size through provenance tracking

### DIFF
--- a/pyro/ops/provenance.py
+++ b/pyro/ops/provenance.py
@@ -10,6 +10,13 @@ from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten
 _Tensor = TypeVar("_Tensor", bound=torch.Tensor)
 
 
+def _is_size(x: object) -> bool:
+    # ``torch.Size`` subclasses ``tuple``, so the pytree helpers below would
+    # otherwise flatten it and rebuild it as a plain tuple. Treating it as a
+    # leaf keeps the type intact.
+    return isinstance(x, torch.Size)
+
+
 class ProvenanceTensor(torch.Tensor):
     """
     Provenance tracking implementation in Pytorch.
@@ -85,6 +92,13 @@ def track_provenance(x, provenance: frozenset):
 track_provenance.register(torch.Tensor)(ProvenanceTensor)
 
 
+@track_provenance.register(torch.Size)
+def _track_provenance_size(x, provenance: frozenset):
+    # A torch.Size holds plain ints, so there is no provenance to add; return
+    # it unchanged rather than letting the tuple handler rebuild it.
+    return x
+
+
 @track_provenance.register(frozenset)
 @track_provenance.register(set)
 def _track_provenance_set(x, provenance: frozenset):
@@ -95,7 +109,9 @@ def _track_provenance_set(x, provenance: frozenset):
 @track_provenance.register(tuple)
 @track_provenance.register(dict)
 def _track_provenance_pytree(x, provenance: frozenset):
-    return tree_map(partial(track_provenance, provenance=provenance), x)
+    return tree_map(
+        partial(track_provenance, provenance=provenance), x, is_leaf=_is_size
+    )
 
 
 @track_provenance.register
@@ -123,6 +139,11 @@ def _extract_provenance_tensor(x):
     return x._t, x._provenance
 
 
+@extract_provenance.register(torch.Size)
+def _extract_provenance_size(x):
+    return x, frozenset()
+
+
 @extract_provenance.register(frozenset)
 @extract_provenance.register(set)
 def _extract_provenance_set(x):
@@ -140,7 +161,7 @@ def _extract_provenance_set(x):
 @extract_provenance.register(tuple)
 @extract_provenance.register(dict)
 def _extract_provenance_pytree(x):
-    flat_args, spec = tree_flatten(x)
+    flat_args, spec = tree_flatten(x, is_leaf=_is_size)
     xs = []
     provenance = frozenset()
     for x, p in map(extract_provenance, flat_args):

--- a/tests/ops/test_provenance.py
+++ b/tests/ops/test_provenance.py
@@ -4,7 +4,16 @@
 import pytest
 import torch
 
-from pyro.ops.provenance import ProvenanceTensor, get_provenance, track_provenance
+import pyro
+import pyro.distributions as dist
+from pyro.infer.inspect import get_model_relations
+from pyro.ops.provenance import (
+    ProvenanceTensor,
+    detach_provenance,
+    extract_provenance,
+    get_provenance,
+    track_provenance,
+)
 from tests.common import assert_equal, requires_cuda
 
 
@@ -66,3 +75,53 @@ def test_track_provenance(x):
     old_provenance = get_provenance(x)
     provenance = old_provenance | new_provenance
     assert provenance == get_provenance(track_provenance(x, new_provenance))
+
+
+@pytest.mark.parametrize(
+    "x",
+    [
+        torch.Size([3]),
+        torch.Size([2, 5]),
+        torch.Size([]),
+        [(torch.Size([3]),), {}],
+        [(), {"shape": torch.Size([2, 5])}],
+        [(torch.zeros(2), torch.Size([3])), {}],
+    ],
+    ids=["size", "size_2d", "size_empty", "in_args", "in_kwargs", "mixed_with_tensor"],
+)
+def test_provenance_preserves_torch_size(x):
+    """torch.Size subclasses tuple, so it must not be rebuilt as a plain tuple."""
+
+    def assert_sizes_intact(original, result):
+        if isinstance(original, torch.Tensor):
+            return  # tensors are legitimately wrapped/unwrapped
+        assert type(original) is type(result)
+        if isinstance(original, torch.Size):
+            assert result == original
+        elif isinstance(original, (list, tuple)):
+            for a, b in zip(original, result):
+                assert_sizes_intact(a, b)
+        elif isinstance(original, dict):
+            for key in original:
+                assert_sizes_intact(original[key], result[key])
+
+    assert_sizes_intact(x, track_provenance(x, frozenset({"a"})))
+    assert_sizes_intact(x, extract_provenance(x)[0])
+    assert_sizes_intact(x, detach_provenance(x))
+
+
+def test_multinomial_render_model():
+    """https://github.com/pyro-ppl/pyro/issues/3436"""
+
+    def model():
+        probs = pyro.param("probs", torch.tensor([0.1, 0.2, 0.7]))
+        return pyro.sample("y", dist.Multinomial(total_count=10, probs=probs))
+
+    relations = get_model_relations(model)
+    assert "y" in relations["sample_sample"] or "y" in relations["sample_param"]
+
+
+def test_provenance_tensor_new_with_size():
+    """Tensor.new() reads a torch.Size as a shape but a tuple as data."""
+    x = ProvenanceTensor(torch.zeros(4, dtype=torch.long), frozenset({"x"}))
+    assert tuple(x.new(torch.Size([3])).shape) == (3,)


### PR DESCRIPTION
Fixes #3436.

## The problem

`torch.Size` subclasses `tuple`. That means it matches the `list`/`tuple`/`dict` branches of `track_provenance` and `extract_provenance`, which run it through `tree_flatten`/`tree_unflatten`. Those decompose the `Size` into its plain int leaves and rebuild it as an ordinary `tuple`, so any `torch.Size` passing through the provenance machinery comes back out with its type erased:

```python
>>> from pyro.ops.provenance import extract_provenance
>>> extract_provenance(torch.Size([3, 4]))[0]
(3, 4)          # a plain tuple, not torch.Size([3, 4])
```

That looks harmless, but torch overloads on exactly this distinction: `Tensor.new()` treats a `torch.Size` as a *shape* and a `tuple` as *data*.

```python
>>> torch.zeros(3).new(torch.Size([3])).shape
torch.Size([3])   # shape
>>> torch.zeros(3).new((3,)).shape
torch.Size([1])   # 3 was read as data
```

`Multinomial.sample()` does `counts = samples.new(self._extended_shape(sample_shape)).zero_()`. Under `render_model` the sample is a `ProvenanceTensor`, so `__torch_function__` routes the args through `detach_provenance()`, the shape degrades to a tuple, `counts` comes back with shape `(1,)` instead of `(3,)`, and the next line fails:

```
RuntimeError: index 2 is out of bounds for dimension 0 with size 1
  File ".../torch/distributions/multinomial.py", line 123, in sample
    counts.scatter_add_(-1, samples, torch.ones_like(samples))
  File ".../pyro/ops/provenance.py", line 69, in __torch_function__
    ret = func(*_args, **_kwargs)
```

This is why the issue only shows up for `Multinomial` and only inside `render_model` — you need a distribution that reconstructs a tensor from its own shape, plus provenance tracking being active.

## The fix

Two parts, and both are needed:

1. Register `torch.Size` on `track_provenance` and `extract_provenance`. A `Size` holds plain ints, so there is no provenance to add or extract — return it unchanged.
2. Pass `is_leaf=_is_size` to the `tree_map`/`tree_flatten` calls in the pytree branches.

Part 2 is the one that actually repairs the reported crash. The failing path is `detach_provenance([args, kwargs])`, where the `Size` is *nested* inside a list, so the pytree helper flattens it before singledispatch ever gets a chance to see it. I checked this rather than assuming — registering the dispatch alone leaves the bug in place for every nested case:

| input | current | dispatch only | dispatch + `is_leaf` |
|---|---|---|---|
| bare `Size` | tuple | **Size** | **Size** |
| `Size` in args tuple | tuple | tuple | **Size** |
| `Size` nested in list | tuple | tuple | **Size** |
| `Size` in kwargs | tuple | tuple | **Size** |
| plain tuple (control) | tuple | tuple | tuple |

The control row confirms ordinary tuples still flatten normally.

## Testing

Added to `tests/ops/test_provenance.py`: a parametrized round-trip test covering bare/2-D/empty `Size` plus nesting in args, kwargs, and mixed with a tensor; a `Tensor.new()` test pinning the shape-vs-data behavior; and a `get_model_relations` test that is the issue's reproducer.

RED→GREEN, verified in a detached worktree so the buggy code ran against the new tests:

```
# pristine provenance.py + new tests
8 failed, 8 passed, 64 skipped        <- the 8 passing are the pre-existing control
# with the fix
16 passed, 64 skipped
```

Wider suites at the committed SHA:

```
tests/ops/test_provenance.py                    16 passed, 64 skipped
tests/infer/test_inspect.py                     25 passed
tests/infer/test_compute_downstream_costs.py    47 passed
tests/ops/                                      4607 passed, 3 failed, 76 skipped
```

The 3 failures are `test_gaussian_funsor` — `ModuleNotFoundError: No module named 'funsor'`. They fail identically on pristine upstream (checked in a clean worktree), so they're a missing optional dep, not this change.

`make lint` gates on the touched files: `ruff check` clean, `black --check` clean, `mypy pyro/ops/provenance.py` clean.
