### PR TITLE
Fix PyroModule registration of frozen parameters

### DIFF
--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -629,12 +629,14 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
         result = super().__getattr__(name)
 
         # Regular nn.Parameters trigger pyro.param statements.
-        if isinstance(result, torch.nn.Parameter) and not name.endswith(
-            "_unconstrained"
+        if (
+            isinstance(result, torch.nn.Parameter)
+            and not name.endswith("_unconstrained")
+            and self._pyro_context.active
         ):
-            if self._pyro_context.active and not _is_module_local_param_enabled():
+            if result.requires_grad and not _is_module_local_param_enabled():
                 pyro.param(self._pyro_get_fullname(name), result)
-            elif self._pyro_context.active and _is_module_local_param_enabled():
+            elif result.requires_grad:
                 # fake param statement to ensure any handlers of pyro.param are applied,
                 # even though we don't use the contents of the local parameter store
                 fullname = self._pyro_get_fullname(name)
@@ -740,7 +742,11 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
                 delattr(self, name)
             except AttributeError:
                 pass
-            if self._pyro_context.active and not _is_module_local_param_enabled():
+            if (
+                self._pyro_context.active
+                and value.requires_grad
+                and not _is_module_local_param_enabled()
+            ):
                 fullname = self._pyro_get_fullname(name)
                 value = pyro.param(fullname, value)
                 if not isinstance(value, torch.nn.Parameter):
@@ -748,7 +754,11 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
                     value = torch.nn.Parameter(detach_provenance(value))
                     _PYRO_PARAM_STORE._params[fullname] = value
                     _PYRO_PARAM_STORE._param_to_name[value] = fullname
-            elif self._pyro_context.active and _is_module_local_param_enabled():
+            elif (
+                self._pyro_context.active
+                and value.requires_grad
+                and _is_module_local_param_enabled()
+            ):
                 # fake param statement to ensure any handlers of pyro.param are applied,
                 # even though we don't use the contents of the local parameter store
                 fullname = self._pyro_get_fullname(name)

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -69,6 +69,36 @@ def test_svi_smoke():
         svi.step(data)
 
 
+@pytest.mark.parametrize("local_params", [False, True])
+def test_frozen_parameters_are_not_registered(local_params):
+    class Model(PyroModule):
+        def __init__(self):
+            super().__init__()
+            self.trainable = nn.Parameter(torch.zeros(1))
+            self.frozen = nn.Parameter(torch.ones(1), requires_grad=False)
+
+        def forward(self):
+            self.dynamic_frozen = nn.Parameter(
+                torch.full((1,), 2.0), requires_grad=False
+            )
+            return self.trainable + self.frozen + self.dynamic_frozen
+
+    with pyro.settings.context(module_local_params=local_params):
+        model = Model()
+        trace = poutine.trace(model).get_trace()
+
+    assert_equal(trace.nodes["_RETURN"]["value"], torch.tensor([3.0]))
+    assert "trainable" in trace.nodes
+    assert "frozen" not in trace.nodes
+    assert "dynamic_frozen" not in trace.nodes
+    assert model.frozen.requires_grad is False
+    assert model.dynamic_frozen.requires_grad is False
+    if local_params:
+        assert not pyro.get_param_store()
+    else:
+        assert set(pyro.get_param_store()) == {"trainable"}
+
+
 @pytest.mark.parametrize("local_params", [True, False])
 @pytest.mark.parametrize("num_particles", [1, 2])
 @pytest.mark.parametrize("vectorize_particles", [True, False])


### PR DESCRIPTION
## Proposed changes

`PyroModule` currently emits a `pyro.param` statement whenever a regular `torch.nn.Parameter` is read during a module call. `ParamStoreDict` makes registered tensors trainable, so this silently changes parameters created with `requires_grad=False` to `requires_grad=True` and adds them to the parameter store.

This change:

- skips parameter statements for frozen regular parameters, matching the registration contract of `pyro.module()`;
- applies the same rule when a regular parameter is assigned inside an active `PyroModule` context;
- preserves the existing global and module-local behavior for trainable parameters.

The regression test covers both parameter-store modes, parameters created during initialization, and parameters assigned dynamically during `forward()`.

Fixes #3438.

## Tests

- `pytest -q tests/nn/test_module.py` (69 passed, 1 xfailed)
- `pytest -q tests/params/test_module.py` (7 passed)
- `pytest -q tests/infer/test_autoguide.py -k 'test_exact and not AutoGaussianFunsor'` (29 passed)
- `pytest -q tests/distributions/test_spanning_tree.py` (66 passed, 60 skipped, 6 xfailed)
- `ruff check .`
- `black --check pyro/nn/module.py tests/nn/test_module.py`
- `python scripts/update_headers.py --check`
- `mypy --warn-unused-ignores pyro/nn/module.py tests/nn/test_module.py`
