### PR TITLE
Preserve explicit plate subsamples during replay

### DIFF
--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -4,6 +4,7 @@
 from typing import TYPE_CHECKING, Dict, Optional
 
 from pyro.poutine.messenger import Messenger
+from pyro.poutine.util import site_is_subsample
 
 if TYPE_CHECKING:
     import torch
@@ -70,6 +71,10 @@ class ReplayMessenger(Messenger):
         """
         assert msg["name"] is not None
         name = msg["name"]
+        # Preserve manually supplied plate indices. Automatically generated
+        # subsamples start with no value and should still be replayed.
+        if site_is_subsample(msg) and msg["value"] is not None:
+            return None
         if self.trace is not None and name in self.trace:
             guide_msg = self.trace.nodes[name]
             if msg["is_observed"]:

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -1058,6 +1058,24 @@ def test_replay_plates(auto_class, sample_shape):
     assert d.shape == sample_shape + (2, 3)
 
 
+def test_replay_preserves_explicit_subsample():
+    def model(subsample):
+        with pyro.plate("data", 6, dim=-1, subsample=subsample) as batch:
+            pyro.sample("z", dist.Normal(0, 1))
+        return batch
+
+    pyro.set_rng_seed(0)
+    subsample = torch.tensor([4, 0, 1])
+    guide = AutoNormal(model)
+    guide_trace = poutine.trace(guide).get_trace(subsample)
+    model_trace = poutine.trace(poutine.replay(model, trace=guide_trace)).get_trace(
+        subsample
+    )
+
+    assert not torch.equal(guide_trace.nodes["data"]["value"], subsample)
+    assert_equal(model_trace.nodes["data"]["value"], subsample)
+
+
 @pytest.mark.parametrize(
     "auto_class",
     [


### PR DESCRIPTION
## Summary

`poutine.replay` now preserves caller-provided indices at `pyro.plate(..., subsample=...)` sites. Automatically generated plate subsamples still replay from the guide so model and guide minibatches remain aligned.

The change fixes the silent mismatch reported in #3468. A default `AutoGuide` no longer replaces a model's explicit subsample with an independently generated guide index.

Fixes #3468

## Validation

- Added an AutoGuide regression that failed on the pristine base and passes with this change.
- `pytest -q tests/infer/test_autoguide.py -k "replay_preserves_explicit_subsample or replay_plates or subsample_guide"`: 53 passed. Optional Funsor cases were excluded because Funsor is not installed in the local environment.
- `pytest -q tests/poutine`: 3036 passed.
- `ruff check pyro/poutine/replay_messenger.py tests/infer/test_autoguide.py`: passed.
- `black --check pyro/poutine/replay_messenger.py tests/infer/test_autoguide.py`: passed.
- `mypy --warn-unused-ignores pyro/poutine/replay_messenger.py tests/infer/test_autoguide.py`: passed.
- The repository header check still reports the pre-existing generated `pyro/_version.py` outside this diff.

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.