### PR TITLE
Add InverseWishart distribution

### DIFF
--- a/pyro/distributions/__init__.py
+++ b/pyro/distributions/__init__.py
@@ -98,6 +98,7 @@ from pyro.distributions.improper_uniform import ImproperUniform
 
 if "InverseGamma" not in locals():  # Use PyTorch version if available.
     from pyro.distributions.inverse_gamma import InverseGamma
+from pyro.distributions.inverse_wishart import InverseWishart
 from pyro.distributions.lkj import LKJ, LKJCorrCholesky
 from pyro.distributions.log_normal_negative_binomial import LogNormalNegativeBinomial
 from pyro.distributions.logistic import Logistic, SkewLogistic
@@ -190,6 +191,7 @@ __all__ = [
     "Independent",
     "IndependentHMM",
     "InverseGamma",
+    "InverseWishart",
     "Kumaraswamy",
     "LKJ",
     "LKJCholesky",

--- a/pyro/distributions/inverse_wishart.py
+++ b/pyro/distributions/inverse_wishart.py
@@ -1,0 +1,86 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch.distributions import constraints
+from torch.distributions.transforms import Transform
+
+from pyro.distributions.torch import TransformedDistribution, Wishart
+
+
+class _MatrixInverseTransform(Transform):
+    r"""
+    Bijective transform mapping a positive-definite matrix to its inverse.
+
+    The log absolute determinant of the Jacobian of the matrix inverse map on
+    the space of :math:`p \times p` symmetric matrices is
+    :math:`-(p + 1)\log|\det X|`.
+    """
+
+    domain = constraints.positive_definite
+    codomain = constraints.positive_definite
+    bijective = True
+    sign = +1
+
+    def __eq__(self, other):
+        return isinstance(other, _MatrixInverseTransform)
+
+    def _call(self, x):
+        return torch.linalg.inv(x)
+
+    def _inverse(self, y):
+        return torch.linalg.inv(y)
+
+    def log_abs_det_jacobian(self, x, y):
+        p = x.shape[-1]
+        return -(p + 1) * torch.linalg.slogdet(x).logabsdet
+
+
+class InverseWishart(TransformedDistribution):
+    r"""
+    Creates an inverse Wishart distribution parameterized by a symmetric
+    positive-definite scale matrix :math:`\Psi` and degrees of freedom
+    :math:`\nu`.
+
+    If :math:`X \sim \text{Wishart}(\nu, \Psi^{-1})`, then
+    :math:`X^{-1} \sim \text{InverseWishart}(\nu, \Psi)`.
+
+    :param df: real-valued degrees of freedom, larger than ``dim - 1`` where
+        ``dim`` is the dimension of the square matrix.
+    :param scale_matrix: positive-definite scale matrix :math:`\Psi`.
+    """
+
+    arg_constraints = {
+        "df": constraints.positive,
+        "scale_matrix": constraints.positive_definite,
+    }
+    support = constraints.positive_definite
+
+    def __init__(self, df, scale_matrix, validate_args=None):
+        # If X ~ Wishart(df, precision=Psi), then X^{-1} ~ InverseWishart(df, Psi).
+        base_dist = Wishart(df, precision_matrix=scale_matrix)
+        super().__init__(
+            base_dist, _MatrixInverseTransform(), validate_args=validate_args
+        )
+
+    def expand(self, batch_shape, _instance=None):
+        new = self._get_checked_instance(InverseWishart, _instance)
+        return super().expand(batch_shape, _instance=new)
+
+    @property
+    def df(self):
+        return self.base_dist.df
+
+    @property
+    def scale_matrix(self):
+        return self.base_dist.precision_matrix
+
+    @property
+    def mean(self):
+        p = self.event_shape[-1]
+        return self.scale_matrix / (self.df.unsqueeze(-1).unsqueeze(-1) - p - 1)
+
+    @property
+    def mode(self):
+        p = self.event_shape[-1]
+        return self.scale_matrix / (self.df.unsqueeze(-1).unsqueeze(-1) + p + 1)

--- a/tests/distributions/test_inverse_wishart.py
+++ b/tests/distributions/test_inverse_wishart.py
@@ -1,0 +1,109 @@
+# Copyright Contributors to the Pyro project.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+
+from pyro.distributions import InverseWishart, Wishart
+from tests.common import assert_close, assert_equal
+
+# torch's Wishart.rsample emits a spurious "Singular sample detected" warning
+# on valid samples (the singularity check is inverted in torch 2.13); ignore it.
+pytestmark = pytest.mark.filterwarnings("ignore:Singular sample detected")
+
+
+def _make_scale_matrix(p):
+    # Build a symmetric positive-definite scale matrix with a known structure.
+    a = torch.arange(1.0, p + 1).diag_embed()
+    return a @ a.transpose(-2, -1) + torch.eye(p)
+
+
+def _reference_log_prob(x, df, scale):
+    # Direct implementation of the inverse Wishart log density (see, e.g.,
+    # Gelman et al., Bayesian Data Analysis).
+    p = scale.shape[-1]
+    a = df / 2
+    log_det_scale = torch.linalg.slogdet(scale).logabsdet
+    log_det_x = torch.linalg.slogdet(x).logabsdet
+    log_norm = (
+        a * log_det_scale
+        - a * p * math.log(2.0)
+        - torch.special.multigammaln(a, p)
+    )
+    trace = (scale @ torch.linalg.inv(x)).diagonal(dim1=-2, dim2=-1).sum(-1)
+    return log_norm - (df + p + 1) / 2 * log_det_x - 0.5 * trace
+
+
+@pytest.mark.parametrize("p", [2, 3, 4])
+def test_log_prob(p):
+    torch.manual_seed(0)
+    df = torch.tensor(float(p + 3))
+    scale = _make_scale_matrix(p)
+    d = InverseWishart(df, scale)
+
+    for _ in range(3):
+        x = d.sample()
+        assert_close(d.log_prob(x), _reference_log_prob(x, df, scale), atol=1e-4)
+
+
+@pytest.mark.parametrize("p", [2, 3, 4])
+def test_mean_and_mode(p):
+    df = torch.tensor(float(p + 5))
+    scale = _make_scale_matrix(p)
+    d = InverseWishart(df, scale)
+
+    expected_mean = scale / (df - p - 1)
+    expected_mode = scale / (df + p + 1)
+
+    assert_equal(d.mean, expected_mean)
+    assert_equal(d.mode, expected_mode)
+
+
+@pytest.mark.parametrize("p", [2, 3])
+@pytest.mark.parametrize("batch_shape", [(), (3,)])
+def test_sample_shape_and_support(p, batch_shape):
+    torch.manual_seed(0)
+    df = torch.tensor(float(p + 5))
+    scale = _make_scale_matrix(p)
+    if batch_shape:
+        df = df.expand(batch_shape)
+        scale = scale.expand(batch_shape + (p, p))
+
+    d = InverseWishart(df, scale)
+    x = d.sample(sample_shape=torch.Size([5]))
+
+    expected_shape = (5,) + batch_shape + (p, p)
+    assert x.shape == expected_shape
+    assert (d.support.check(x) == 1).all()
+    assert_close(x, x.transpose(-2, -1))  # symmetric
+
+
+@pytest.mark.parametrize("p", [2, 3])
+def test_inverse_is_wishart(p):
+    torch.manual_seed(0)
+    df = torch.tensor(float(p + 5))
+    scale = _make_scale_matrix(p)
+
+    iw = InverseWishart(df, scale)
+    wishart = Wishart(df, precision_matrix=scale)
+
+    # If X ~ InverseWishart(df, Psi) then X^{-1} ~ Wishart(df, precision=Psi),
+    # so log_prob should match up to the Jacobian of the inverse map.
+    x = iw.sample()
+    x_inv = torch.linalg.inv(x)
+
+    log_det_x = torch.linalg.slogdet(x).logabsdet
+    assert_close(iw.log_prob(x), wishart.log_prob(x_inv) - (p + 1) * log_det_x, atol=1e-4)
+
+
+def test_expand():
+    df = torch.tensor(7.0)
+    scale = _make_scale_matrix(2)
+    d = InverseWishart(df, scale)
+    expanded = d.expand(torch.Size([4]))
+
+    assert expanded.batch_shape == torch.Size([4])
+    assert expanded.event_shape == torch.Size([2, 2])
+    assert expanded.scale_matrix.shape == torch.Size([4, 2, 2])


### PR DESCRIPTION
## Summary

Closes #3448.

Adds the inverse Wishart distribution, which is useful for econometric modelling (e.g., covariance priors).

## Implementation

`InverseWishart` is implemented as a `TransformedDistribution` wrapping `Wishart(df, precision_matrix=scale)` under a matrix-inverse transform. This relies on the identity: if `X ~ Wishart(df, Psi^{-1})` then `X^{-1} ~ InverseWishart(df, Psi)`.

The matrix inverse map on the space of `p x p` symmetric matrices has Jacobian determinant `|X|^{-(p+1)}`, which is applied via the (private) `_MatrixInverseTransform`.

## Tests

Added `tests/distributions/test_inverse_wishart.py` covering:
- `log_prob` checked against the closed-form density (via `torch.special.multigammaln`)
- analytic `mean` and `mode`
- sample shape, positive-definiteness and symmetry of samples
- the relationship `X^{-1} ~ Wishart` up to the Jacobian
- `expand`

All 13 tests pass locally.