### PR TITLE
Switch formatting from Black to Ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -40,9 +40,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -67,9 +67,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -93,9 +93,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -125,9 +125,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Graphviz
@@ -161,9 +161,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -193,9 +193,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -225,9 +225,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -258,9 +258,9 @@ jobs:
       matrix:
         python-version: [3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Coveralls Finished

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies
@@ -32,4 +32,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 Please follow our established coding style including variable names, module imports, and function definitions.
 The Pyro codebase follows the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/)
 (which you can check with `make lint`) and follows
-[`isort`](https://github.com/timothycrosley/isort) import order (which you can enforce with `make format`).
+Ruff's import order (which you can enforce with `make format`).
 When creating new files please add a license header; this can be done automatically via `make license` or simply `make format`.
 
 # Setup
@@ -29,7 +29,7 @@ pip install -e . --group dev
 
 Before submitting a pull request, please autoformat code and ensure that unit tests pass locally
 ```sh
-make format            # runs isort
+make format            # runs Ruff
 make test              # linting and unit tests
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ tutorial: FORCE
 
 lint: FORCE
 	ruff check .
-	black --check pyro examples tests scripts profiler
+	ruff format --check pyro examples tests scripts profiler
 	python scripts/update_headers.py --check
 	mypy --install-types --non-interactive --warn-unused-ignores pyro scripts tests
 
@@ -28,7 +28,7 @@ license: FORCE
 
 format: license FORCE
 	ruff check --fix .
-	black pyro examples tests scripts profiler
+	ruff format pyro examples tests scripts profiler
 
 version: FORCE
 	python scripts/update_version.py

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -209,12 +209,12 @@ class AIR(nn.Module):
             )
 
     def guide(self, data, batch_size, **kwargs):
-        pyro.module("rnn", self.rnn),
-        pyro.module("predict", self.predict),
-        pyro.module("encode", self.encode),
-        pyro.module("embed", self.embed),
-        pyro.module("bl_rnn", self.bl_rnn),
-        pyro.module("bl_predict", self.bl_predict),
+        (pyro.module("rnn", self.rnn),)
+        (pyro.module("predict", self.predict),)
+        (pyro.module("encode", self.encode),)
+        (pyro.module("embed", self.embed),)
+        (pyro.module("bl_rnn", self.bl_rnn),)
+        (pyro.module("bl_predict", self.bl_predict),)
         pyro.module("bl_embed", self.bl_embed)
 
         pyro.param("h_init", self.h_init)

--- a/examples/air/air.py
+++ b/examples/air/air.py
@@ -209,12 +209,12 @@ class AIR(nn.Module):
             )
 
     def guide(self, data, batch_size, **kwargs):
-        (pyro.module("rnn", self.rnn),)
-        (pyro.module("predict", self.predict),)
-        (pyro.module("encode", self.encode),)
-        (pyro.module("embed", self.embed),)
-        (pyro.module("bl_rnn", self.bl_rnn),)
-        (pyro.module("bl_predict", self.bl_predict),)
+        pyro.module("rnn", self.rnn)
+        pyro.module("predict", self.predict)
+        pyro.module("encode", self.encode)
+        pyro.module("embed", self.embed)
+        pyro.module("bl_rnn", self.bl_rnn)
+        pyro.module("bl_predict", self.bl_predict)
         pyro.module("bl_embed", self.bl_embed)
 
         pyro.param("h_init", self.h_init)

--- a/examples/contrib/funsor/hmm.py
+++ b/examples/contrib/funsor/hmm.py
@@ -571,10 +571,13 @@ def model_6(sequences, lengths, args, batch_size=None, include_prior=False):
         for t in pyro.markov(range(lengths.max()), history=2):
             with handlers.mask(mask=(t < lengths).unsqueeze(-1)):
                 probs_x_t = Vindex(probs_x)[x_prev, x_curr]
-                x_prev, x_curr = x_curr, pyro.sample(
-                    "x_{}".format(t),
-                    dist.Categorical(probs_x_t),
-                    infer={"enumerate": "parallel"},
+                x_prev, x_curr = (
+                    x_curr,
+                    pyro.sample(
+                        "x_{}".format(t),
+                        dist.Categorical(probs_x_t),
+                        infer={"enumerate": "parallel"},
+                    ),
                 )
                 with tones_plate:
                     probs_y_t = probs_y[x_curr.squeeze(-1)]

--- a/examples/contrib/timeseries/gp_models.py
+++ b/examples/contrib/timeseries/gp_models.py
@@ -93,8 +93,9 @@ def main(args):
 
         # do rolling prediction
         print("doing one-step-ahead forecasting...")
-        onestep_means, onestep_stds = np.zeros((T_onestep, obs_dim)), np.zeros(
-            (T_onestep, obs_dim)
+        onestep_means, onestep_stds = (
+            np.zeros((T_onestep, obs_dim)),
+            np.zeros((T_onestep, obs_dim)),
         )
         for t in range(T_onestep):
             # predict one step into the future, conditioning on all previous data.

--- a/examples/dmm.py
+++ b/examples/dmm.py
@@ -461,9 +461,9 @@ def main(args):
 
     # loads the model and optimizer states from disk
     def load_checkpoint():
-        assert exists(args.load_opt) and exists(
-            args.load_model
-        ), "--load-model and/or --load-opt misspecified"
+        assert exists(args.load_opt) and exists(args.load_model), (
+            "--load-model and/or --load-opt misspecified"
+        )
         logging.info("loading model from %s..." % args.load_model)
         dmm.load_state_dict(torch.load(args.load_model, weights_only=False))
         logging.info("loading optimizer states from %s..." % args.load_opt)

--- a/examples/hmm.py
+++ b/examples/hmm.py
@@ -560,10 +560,13 @@ def model_6(sequences, lengths, args, batch_size=None, include_prior=False):
         for t in pyro.markov(range(lengths.max()), history=2):
             with poutine.mask(mask=(t < lengths).unsqueeze(-1)):
                 probs_x_t = Vindex(probs_x)[x_prev, x_curr]
-                x_prev, x_curr = x_curr, pyro.sample(
-                    "x_{}".format(t),
-                    dist.Categorical(probs_x_t),
-                    infer={"enumerate": "parallel"},
+                x_prev, x_curr = (
+                    x_curr,
+                    pyro.sample(
+                        "x_{}".format(t),
+                        dist.Categorical(probs_x_t),
+                        infer={"enumerate": "parallel"},
+                    ),
                 )
                 with tones_plate:
                     probs_y_t = probs_y[x_curr.squeeze(-1)]

--- a/examples/mixed_hmm/experiment.py
+++ b/examples/mixed_hmm/experiment.py
@@ -143,12 +143,16 @@ def run_expt(args):
         re_str = "g" + (
             "n"
             if args["group"] is None
-            else "d" if args["group"] == "discrete" else "c"
+            else "d"
+            if args["group"] == "discrete"
+            else "c"
         )
         re_str += "i" + (
             "n"
             if args["individual"] is None
-            else "d" if args["individual"] == "discrete" else "c"
+            else "d"
+            if args["individual"] == "discrete"
+            else "c"
         )
         results_filename = "expt_{}_{}_{}.json".format(
             dataset, re_str, str(uuid.uuid4().hex)[0:5]

--- a/examples/rsa/search_inference.py
+++ b/examples/rsa/search_inference.py
@@ -35,9 +35,9 @@ class HashingMarginal(dist.Distribution):
     """
 
     def __init__(self, trace_dist, sites=None):
-        assert isinstance(
-            trace_dist, TracePosterior
-        ), "trace_dist must be trace posterior distribution object"
+        assert isinstance(trace_dist, TracePosterior), (
+            "trace_dist must be trace posterior distribution object"
+        )
 
         if sites is None:
             sites = "_RETURN"
@@ -169,9 +169,9 @@ def pqueue(fn, queue):
 
     def _fn(*args, **kwargs):
         for i in range(int(1e6)):
-            assert (
-                not queue.empty()
-            ), "trying to get() from an empty queue will deadlock"
+            assert not queue.empty(), (
+                "trying to get() from an empty queue will deadlock"
+            )
 
             priority, next_trace = queue.get()
             try:

--- a/examples/vae/ss_vae_M2.py
+++ b/examples/vae/ss_vae_M2.py
@@ -528,14 +528,14 @@ if __name__ == "__main__":
 
     # some assertions to make sure that batching math assumptions are met
     assert args.sup_num % args.batch_size == 0, "assuming simplicity of batching math"
-    assert (
-        MNISTCached.validation_size % args.batch_size == 0
-    ), "batch size should divide the number of validation examples"
-    assert (
-        MNISTCached.train_data_size % args.batch_size == 0
-    ), "batch size doesn't divide total number of training data examples"
-    assert (
-        MNISTCached.test_size % args.batch_size == 0
-    ), "batch size should divide the number of test examples"
+    assert MNISTCached.validation_size % args.batch_size == 0, (
+        "batch size should divide the number of validation examples"
+    )
+    assert MNISTCached.train_data_size % args.batch_size == 0, (
+        "batch size doesn't divide total number of training data examples"
+    )
+    assert MNISTCached.test_size % args.batch_size == 0, (
+        "batch size should divide the number of test examples"
+    )
 
     main(args)

--- a/examples/vae/utils/custom_mlp.py
+++ b/examples/vae/utils/custom_mlp.py
@@ -99,9 +99,9 @@ class MLP(nn.Module):
         )
 
         # assume int or list
-        assert isinstance(
-            input_size, (int, list, tuple)
-        ), "input_size must be int, list, tuple"
+        assert isinstance(input_size, (int, list, tuple)), (
+            "input_size must be int, list, tuple"
+        )
 
         # everything in MLP will be concatted if it's multiple arguments
         last_layer_size = input_size if type(input_size) == int else sum(input_size)
@@ -151,9 +151,9 @@ class MLP(nn.Module):
 
         # now we have all of our hidden layers
         # we handle outputs
-        assert isinstance(
-            output_size, (int, list, tuple)
-        ), "output_size must be int, list, tuple"
+        assert isinstance(output_size, (int, list, tuple)), (
+            "output_size must be int, list, tuple"
+        )
 
         if type(output_size) == int:
             all_modules.append(nn.Linear(last_layer_size, output_size))

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -74,10 +74,9 @@ def get_tool_cfg():
 @Profile(
     tool=get_tool,
     tool_cfg=get_tool_cfg,
-    fn_id=lambda dist, batch_size, *args, **kwargs: "sample_"
-    + dist.dist_class.__name__
-    + "_N="
-    + str(batch_size),
+    fn_id=lambda dist, batch_size, *args, **kwargs: (
+        "sample_" + dist.dist_class.__name__ + "_N=" + str(batch_size)
+    ),
 )
 def sample(dist, batch_size):
     return dist.sample(sample_shape=(batch_size,))
@@ -86,10 +85,12 @@ def sample(dist, batch_size):
 @Profile(
     tool=get_tool,
     tool_cfg=get_tool_cfg,
-    fn_id=lambda dist, batch, *args, **kwargs: "log_prob_"  #
-    + dist.dist_class.__name__
-    + "_N="
-    + str(batch.size()[0]),
+    fn_id=lambda dist, batch, *args, **kwargs: (
+        "log_prob_"  #
+        + dist.dist_class.__name__
+        + "_N="
+        + str(batch.size()[0])
+    ),
 )
 def log_prob(dist, batch):
     return dist.log_prob(batch)
@@ -138,7 +139,7 @@ def set_tool_cfg(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Profiling distributions library using various" "tools."
+        description="Profiling distributions library using varioustools."
     )
     parser.add_argument(
         "--tool",

--- a/profiler/distributions.py
+++ b/profiler/distributions.py
@@ -139,7 +139,7 @@ def set_tool_cfg(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Profiling distributions library using varioustools."
+        description="Profiling distributions library using various tools."
     )
     parser.add_argument(
         "--tool",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ funsor = [
 
 [dependency-groups]
 lint = [
-    "black>=21.4b0",
     "mypy>=0.812",
     "ruff",
 ]
@@ -157,15 +156,11 @@ markers = [
 
 [tool.ruff]
 extend-exclude = ["*.ipynb"]
-line-length = 120
+line-length = 88
 
 [tool.ruff.lint]
-ignore = ["E741", "E721"]
+ignore = ["E501", "E741", "E721"]
 select = ["E", "F", "I"]
-
-[tool.yapf]
-based_on_style = "google"
-column_limit = 120
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyro/contrib/bnn/hidden_layer.py
+++ b/pyro/contrib/bnn/hidden_layer.py
@@ -72,9 +72,9 @@ class HiddenLayer(TorchDistribution):
         self.X = X
         self.dim_X = X.size(-1)
         self.dim_H = A_mean.size(-1)
-        assert (
-            A_mean.size(0) == self.dim_X
-        ), "The dimensions of X and A_mean and A_scale must match accordingly; see documentation"
+        assert A_mean.size(0) == self.dim_X, (
+            "The dimensions of X and A_mean and A_scale must match accordingly; see documentation"
+        )
         self.A_mean = A_mean
         self.A_scale = A_scale
         self.non_linearity = non_linearity

--- a/pyro/contrib/conjugate/infer.py
+++ b/pyro/contrib/conjugate/infer.py
@@ -148,10 +148,10 @@ class UncollapseConjugateMessenger(Messenger):
                 if parent is not None and parent._latent.site_name == msg["name"]:
                     conj_node = self.trace.nodes[site_name]
                     break
-            assert (
-                conj_node is not None
-            ), "Collapsible latent site `{}` with no corresponding conjugate site.".format(
-                msg["name"]
+            assert conj_node is not None, (
+                "Collapsible latent site `{}` with no corresponding conjugate site.".format(
+                    msg["name"]
+                )
             )
             msg["fn"] = parent.posterior(conj_node["value"])
             msg["value"] = msg["fn"].sample()
@@ -222,9 +222,9 @@ def posterior_replay(model, posterior_samples, *args, **kwargs):
     """
     posterior_samples = posterior_samples.copy()
     num_samples = kwargs.pop("num_samples", None)
-    assert (
-        posterior_samples or num_samples
-    ), "`num_samples` must be provided if `posterior_samples` is empty."
+    assert posterior_samples or num_samples, (
+        "`num_samples` must be provided if `posterior_samples` is empty."
+    )
     if num_samples is None:
         num_samples = list(posterior_samples.values())[0].shape[0]
 

--- a/pyro/contrib/epidemiology/models.py
+++ b/pyro/contrib/epidemiology/models.py
@@ -1277,9 +1277,12 @@ __all__.sort(
     key=lambda name, vals=locals(): vals[name].__init__.__code__.co_firstlineno
 )
 __doc__ = "\n\n".join(
-    ["""
+    [
+        """
     {}
     ----------------------------------------------------------------
     .. autoclass:: pyro.contrib.epidemiology.models.{}
-    """.format(re.sub("([A-Z][a-z]+)", r"\1 ", _name[:-5]), _name) for _name in __all__]
+    """.format(re.sub("([A-Z][a-z]+)", r"\1 ", _name[:-5]), _name)
+        for _name in __all__
+    ]
 )

--- a/pyro/contrib/examples/scanvi_data.py
+++ b/pyro/contrib/examples/scanvi_data.py
@@ -70,8 +70,11 @@ class BatchDataLoader(object):
             _slice = slices[batch_order[i]]
             if _slice[1]:
                 # labeled
-                yield self.data_x[_slice[0]], nn.functional.one_hot(
-                    self.data_y[_slice[0]], num_classes=self.num_classes
+                yield (
+                    self.data_x[_slice[0]],
+                    nn.functional.one_hot(
+                        self.data_y[_slice[0]], num_classes=self.num_classes
+                    ),
                 )
             else:
                 # unlabeled

--- a/pyro/contrib/funsor/handlers/enum_messenger.py
+++ b/pyro/contrib/funsor/handlers/enum_messenger.py
@@ -240,9 +240,9 @@ def queue(
     def wrapper(wrapped):
         def _fn(*args, **kwargs):
             for i in range(max_tries):
-                assert (
-                    not queue.empty()
-                ), "trying to get() from an empty queue will deadlock"
+                assert not queue.empty(), (
+                    "trying to get() from an empty queue will deadlock"
+                )
 
                 next_trace = queue.get()
                 try:

--- a/pyro/contrib/funsor/handlers/named_messenger.py
+++ b/pyro/contrib/funsor/handlers/named_messenger.py
@@ -25,9 +25,9 @@ class NamedMessenger(ReentrantMessenger):
     """
 
     def __init__(self, first_available_dim=None):
-        assert (
-            first_available_dim is None or first_available_dim < 0
-        ), first_available_dim
+        assert first_available_dim is None or first_available_dim < 0, (
+            first_available_dim
+        )
         self.first_available_dim = first_available_dim
         self._saved_dims = set()
         return super().__init__()

--- a/pyro/contrib/gp/kernels/__init__.py
+++ b/pyro/contrib/gp/kernels/__init__.py
@@ -52,7 +52,9 @@ __all__ = [
 ]
 
 # Create sphinx documentation.
-__doc__ = "\n\n".join(["""
+__doc__ = "\n\n".join(
+    [
+        """
     {0}
     ----------------------------------------------------------------
     .. autoclass:: pyro.contrib.gp.kernels.{0}
@@ -61,4 +63,7 @@ __doc__ = "\n\n".join(["""
         :special-members: __call__
         :show-inheritance:
         :member-order: bysource
-    """.format(_name) for _name in __all__])
+    """.format(_name)
+        for _name in __all__
+    ]
+)

--- a/pyro/contrib/gp/kernels/kernel.py
+++ b/pyro/contrib/gp/kernels/kernel.py
@@ -83,7 +83,7 @@ class Combination(Kernel):
     def __init__(self, kern0, kern1):
         if not isinstance(kern0, Kernel):
             raise TypeError(
-                "The first component of a combined kernel must be a " "Kernel instance."
+                "The first component of a combined kernel must be a Kernel instance."
             )
         if not (isinstance(kern1, Kernel) or isinstance(kern1, numbers.Number)):
             raise TypeError(
@@ -235,13 +235,11 @@ class Warping(Transforming):
             for coef in owarping_coef:
                 if not isinstance(coef, int) and coef < 0:
                     raise ValueError(
-                        "Coefficients of the polynomial must be a "
-                        "non-negative integer."
+                        "Coefficients of the polynomial must be a non-negative integer."
                     )
             if len(owarping_coef) < 2 and sum(owarping_coef) == 0:
                 raise ValueError(
-                    "The ouput warping polynomial should have a degree "
-                    "of at least 1."
+                    "The ouput warping polynomial should have a degree of at least 1."
                 )
         self.owarping_coef = owarping_coef
 

--- a/pyro/contrib/gp/likelihoods/__init__.py
+++ b/pyro/contrib/gp/likelihoods/__init__.py
@@ -17,7 +17,9 @@ __all__ = [
 
 
 # Create sphinx documentation.
-__doc__ = "\n\n".join(["""
+__doc__ = "\n\n".join(
+    [
+        """
     {0}
     ----------------------------------------------------------------
     .. autoclass:: pyro.contrib.gp.likelihoods.{0}
@@ -26,4 +28,7 @@ __doc__ = "\n\n".join(["""
         :special-members: __call__
         :show-inheritance:
         :member-order: bysource
-    """.format(_name) for _name in __all__])
+    """.format(_name)
+        for _name in __all__
+    ]
+)

--- a/pyro/contrib/gp/models/gplvm.py
+++ b/pyro/contrib/gp/models/gplvm.py
@@ -60,8 +60,9 @@ class GPLVM(Parameterized):
         super().__init__()
         if base_model.X.dim() != 2:
             raise ValueError(
-                "GPLVM model only works with 2D latent X, but got "
-                "X.dim() = {}.".format(base_model.X.dim())
+                "GPLVM model only works with 2D latent X, but got X.dim() = {}.".format(
+                    base_model.X.dim()
+                )
             )
         self.base_model = base_model
 

--- a/pyro/contrib/gp/models/gpr.py
+++ b/pyro/contrib/gp/models/gpr.py
@@ -67,13 +67,13 @@ class GPRegression(GPModel):
     """
 
     def __init__(self, X, y, kernel, noise=None, mean_function=None, jitter=1e-6):
-        assert isinstance(
-            X, torch.Tensor
-        ), "X needs to be a torch Tensor instead of a {}".format(type(X))
+        assert isinstance(X, torch.Tensor), (
+            "X needs to be a torch Tensor instead of a {}".format(type(X))
+        )
         if y is not None:
-            assert isinstance(
-                y, torch.Tensor
-            ), "y needs to be a torch Tensor instead of a {}".format(type(y))
+            assert isinstance(y, torch.Tensor), (
+                "y needs to be a torch Tensor instead of a {}".format(type(y))
+            )
         super().__init__(X, y, kernel, mean_function, jitter)
 
         noise = self.X.new_tensor(1.0) if noise is None else noise

--- a/pyro/contrib/gp/models/model.py
+++ b/pyro/contrib/gp/models/model.py
@@ -90,13 +90,13 @@ class GPModel(Parameterized):
     """
 
     def __init__(self, X, y, kernel, mean_function=None, jitter=1e-6):
-        assert isinstance(
-            X, torch.Tensor
-        ), "X needs to be a torch Tensor instead of a {}".format(type(X))
+        assert isinstance(X, torch.Tensor), (
+            "X needs to be a torch Tensor instead of a {}".format(type(X))
+        )
         if y is not None:
-            assert isinstance(
-                y, torch.Tensor
-            ), "y needs to be a torch Tensor instead of a {}".format(type(y))
+            assert isinstance(y, torch.Tensor), (
+                "y needs to be a torch Tensor instead of a {}".format(type(y))
+            )
 
         super().__init__()
         self.set_data(X, y)

--- a/pyro/contrib/gp/models/sgpr.py
+++ b/pyro/contrib/gp/models/sgpr.py
@@ -98,16 +98,16 @@ class SparseGPRegression(GPModel):
     def __init__(
         self, X, y, kernel, Xu, noise=None, mean_function=None, approx=None, jitter=1e-6
     ):
-        assert isinstance(
-            X, torch.Tensor
-        ), "X needs to be a torch Tensor instead of a {}".format(type(X))
+        assert isinstance(X, torch.Tensor), (
+            "X needs to be a torch Tensor instead of a {}".format(type(X))
+        )
         if y is not None:
-            assert isinstance(
-                y, torch.Tensor
-            ), "y needs to be a torch Tensor instead of a {}".format(type(y))
-        assert isinstance(
-            Xu, torch.Tensor
-        ), "Xu needs to be a torch Tensor instead of a {}".format(type(Xu))
+            assert isinstance(y, torch.Tensor), (
+                "y needs to be a torch Tensor instead of a {}".format(type(y))
+            )
+        assert isinstance(Xu, torch.Tensor), (
+            "Xu needs to be a torch Tensor instead of a {}".format(type(Xu))
+        )
 
         super().__init__(X, y, kernel, mean_function, jitter)
 
@@ -122,8 +122,7 @@ class SparseGPRegression(GPModel):
             self.approx = approx
         else:
             raise ValueError(
-                "The sparse approximation method should be one of "
-                "'DTC', 'FITC', 'VFE'."
+                "The sparse approximation method should be one of 'DTC', 'FITC', 'VFE'."
             )
 
     @pyro_method

--- a/pyro/contrib/gp/models/vgp.py
+++ b/pyro/contrib/gp/models/vgp.py
@@ -71,13 +71,13 @@ class VariationalGP(GPModel):
         whiten=False,
         jitter=1e-6,
     ):
-        assert isinstance(
-            X, torch.Tensor
-        ), "X needs to be a torch Tensor instead of a {}".format(type(X))
+        assert isinstance(X, torch.Tensor), (
+            "X needs to be a torch Tensor instead of a {}".format(type(X))
+        )
         if y is not None:
-            assert isinstance(
-                y, torch.Tensor
-            ), "y needs to be a torch Tensor instead of a {}".format(type(y))
+            assert isinstance(y, torch.Tensor), (
+                "y needs to be a torch Tensor instead of a {}".format(type(y))
+            )
         super().__init__(X, y, kernel, mean_function, jitter)
 
         self.likelihood = likelihood

--- a/pyro/contrib/gp/models/vsgp.py
+++ b/pyro/contrib/gp/models/vsgp.py
@@ -92,16 +92,16 @@ class VariationalSparseGP(GPModel):
         whiten=False,
         jitter=1e-6,
     ):
-        assert isinstance(
-            X, torch.Tensor
-        ), "X needs to be a torch Tensor instead of a {}".format(type(X))
+        assert isinstance(X, torch.Tensor), (
+            "X needs to be a torch Tensor instead of a {}".format(type(X))
+        )
         if y is not None:
-            assert isinstance(
-                y, torch.Tensor
-            ), "y needs to be a torch Tensor instead of a {}".format(type(y))
-        assert isinstance(
-            Xu, torch.Tensor
-        ), "Xu needs to be a torch Tensor instead of a {}".format(type(Xu))
+            assert isinstance(y, torch.Tensor), (
+                "y needs to be a torch Tensor instead of a {}".format(type(y))
+            )
+        assert isinstance(Xu, torch.Tensor), (
+            "Xu needs to be a torch Tensor instead of a {}".format(type(Xu))
+        )
 
         super().__init__(X, y, kernel, mean_function, jitter)
 

--- a/pyro/contrib/minipyro.py
+++ b/pyro/contrib/minipyro.py
@@ -77,9 +77,9 @@ class trace(Messenger):
     # trace illustrates why we need postprocess_message in addition to process_message:
     # We only want to record a value after all other effects have been applied
     def postprocess_message(self, msg):
-        assert (
-            msg["type"] != "sample" or msg["name"] not in self.trace
-        ), "sample sites must have unique names"
+        assert msg["type"] != "sample" or msg["name"] not in self.trace, (
+            "sample sites must have unique names"
+        )
         self.trace[msg["name"]] = msg.copy()
 
     def get_trace(self, *args, **kwargs):

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -1191,9 +1191,7 @@ class EwmaLog:
         else:
             ewma = inputs * (1.0 - self.alpha) / (1 - self.alpha**self.n) + torch.exp(
                 self.s - s
-            ) * self.ewma * (self.alpha - self.alpha**self.n) / (
-                1 - self.alpha**self.n
-            )
+            ) * self.ewma * (self.alpha - self.alpha**self.n) / (1 - self.alpha**self.n)
         self.ewma = ewma.detach()
         self.s = s.detach()
         return _ewma_log_fn(inputs, ewma)

--- a/pyro/contrib/oed/glmm/glmm.py
+++ b/pyro/contrib/oed/glmm/glmm.py
@@ -455,9 +455,9 @@ def analytic_posterior_cov(prior_cov, x, obs_sd):
     # Use some kernel trick magic
     p = prior_cov.shape[-1]
     SigmaXX = prior_cov.mm(x.t().mm(x))
-    posterior_cov = prior_cov - torch.inverse(
-        SigmaXX + (obs_sd**2) * torch.eye(p)
-    ).mm(SigmaXX.mm(prior_cov))
+    posterior_cov = prior_cov - torch.inverse(SigmaXX + (obs_sd**2) * torch.eye(p)).mm(
+        SigmaXX.mm(prior_cov)
+    )
     return posterior_cov
 
 

--- a/pyro/contrib/timeseries/gp.py
+++ b/pyro/contrib/timeseries/gp.py
@@ -238,9 +238,7 @@ class LinearlyCoupledMaternGP(TimeSeriesModel):
             self.kernel.state_dim, dim=0
         ) * self.A.new_tensor([1.0] + [0.0] * (self.kernel.state_dim - 1)).repeat(
             self.num_gps
-        ).unsqueeze(
-            -1
-        )
+        ).unsqueeze(-1)
 
     def _stationary_covariance(self):
         return block_diag_embed(self.kernel.stationary_covariance())

--- a/pyro/contrib/tracking/distributions.py
+++ b/pyro/contrib/tracking/distributions.py
@@ -50,9 +50,9 @@ class EKFDistribution(TorchDistribution):
         self.dynamic_model = dynamic_model
         self.measurement_cov = measurement_cov
         self.dt = dt
-        assert (
-            not x0.shape[-1] % 2
-        ), "position and velocity vectors must be the same dimension"
+        assert not x0.shape[-1] % 2, (
+            "position and velocity vectors must be the same dimension"
+        )
         batch_shape = x0.shape[:-1]
         event_shape = (time_steps, x0.shape[-1] // 2)
         super().__init__(batch_shape, event_shape, validate_args=validate_args)

--- a/pyro/contrib/tracking/extended_kalman_filter.py
+++ b/pyro/contrib/tracking/extended_kalman_filter.py
@@ -147,9 +147,9 @@ class EKFState:
         :return: Innovation mean and covariance of hypothetical update.
         :rtype: tuple(``torch.Tensor``, ``torch.Tensor``)
         """
-        assert (
-            self._time == measurement.time
-        ), "State time and measurement time must be aligned!"
+        assert self._time == measurement.time, (
+            "State time and measurement time must be aligned!"
+        )
 
         # Compute innovation.
         x_pv = self._dynamic_model.mean2pv(self._mean)
@@ -188,13 +188,13 @@ class EKFState:
         :returns: EKF State, Innovation mean and covariance.
         """
         if self._time is not None:
-            assert (
-                self._time == measurement.time
-            ), "State time and measurement time must be aligned!"
+            assert self._time == measurement.time, (
+                "State time and measurement time must be aligned!"
+            )
         if self._frame_num is not None:
-            assert (
-                self._frame_num == measurement.frame_num
-            ), "State time and measurement time must be aligned!"
+            assert self._frame_num == measurement.frame_num, (
+                "State time and measurement time must be aligned!"
+            )
 
         x = self._mean
         x_pv = self._dynamic_model.mean2pv(x)

--- a/pyro/distributions/diag_normal_mixture.py
+++ b/pyro/distributions/diag_normal_mixture.py
@@ -56,21 +56,21 @@ class MixtureOfDiagNormals(TorchDistribution):
             "(or ... x B x K x D if doing batches)"
         )
         if not self.batch_mode:
-            assert (
-                coord_scale.dim() == 2
-            ), "The coord_scale parameter in MixtureOfDiagNormals should be K x D dimensional"
-            assert (
-                component_logits.dim() == 1
-            ), "The component_logits parameter in MixtureOfDiagNormals should be K dimensional"
+            assert coord_scale.dim() == 2, (
+                "The coord_scale parameter in MixtureOfDiagNormals should be K x D dimensional"
+            )
+            assert component_logits.dim() == 1, (
+                "The component_logits parameter in MixtureOfDiagNormals should be K dimensional"
+            )
             assert component_logits.size(-1) == locs.size(-2)
             batch_shape = ()
         else:
-            assert (
-                coord_scale.dim() > 2
-            ), "The coord_scale parameter in MixtureOfDiagNormals should be ... x B x K x D dimensional"
-            assert (
-                component_logits.dim() > 1
-            ), "The component_logits parameter in MixtureOfDiagNormals should be ... x B x K dimensional"
+            assert coord_scale.dim() > 2, (
+                "The coord_scale parameter in MixtureOfDiagNormals should be ... x B x K x D dimensional"
+            )
+            assert component_logits.dim() > 1, (
+                "The component_logits parameter in MixtureOfDiagNormals should be ... x B x K dimensional"
+            )
             assert component_logits.size(-1) == locs.size(-2)
             batch_shape = tuple(locs.shape[:-2])
 

--- a/pyro/distributions/diag_normal_mixture_shared_cov.py
+++ b/pyro/distributions/diag_normal_mixture_shared_cov.py
@@ -54,18 +54,18 @@ class MixtureOfDiagNormalsSharedCovariance(TorchDistribution):
             "(or ... x B x K x D in batch mode)"
         )
         if not self.batch_mode:
-            assert (
-                coord_scale.dim() == 1
-            ), "The coord_scale parameter in MixtureOfDiagNormalsSharedCovariance should be D dimensional"
-            assert (
-                component_logits.dim() == 1
-            ), "The component_logits parameter in MixtureOfDiagNormalsSharedCovariance should be K dimensional"
+            assert coord_scale.dim() == 1, (
+                "The coord_scale parameter in MixtureOfDiagNormalsSharedCovariance should be D dimensional"
+            )
+            assert component_logits.dim() == 1, (
+                "The component_logits parameter in MixtureOfDiagNormalsSharedCovariance should be K dimensional"
+            )
             assert component_logits.size(0) == locs.size(0)
             batch_shape = ()
         else:
-            assert (
-                coord_scale.dim() > 1
-            ), "The coord_scale parameter in MixtureOfDiagNormalsSharedCovariance should be ... x B x D dimensional"
+            assert coord_scale.dim() > 1, (
+                "The coord_scale parameter in MixtureOfDiagNormalsSharedCovariance should be ... x B x D dimensional"
+            )
             assert component_logits.dim() > 1, (
                 "The component_logits parameter in MixtureOfDiagNormalsSharedCovariance should be "
                 "... x B x K dimensional"

--- a/pyro/distributions/gaussian_scale_mixture.py
+++ b/pyro/distributions/gaussian_scale_mixture.py
@@ -61,18 +61,18 @@ class GaussianScaleMixture(TorchDistribution):
         self.dim = coord_scale.size(0)
         if self.dim < 2:
             raise NotImplementedError("This distribution does not support D = 1")
-        assert (
-            coord_scale.dim() == 1
-        ), "The coord_scale parameter in GaussianScaleMixture should be D dimensional"
-        assert (
-            component_scale.dim() == 1
-        ), "The component_scale parameter in GaussianScaleMixture should be K dimensional"
-        assert (
-            component_logits.dim() == 1
-        ), "The component_logits parameter in GaussianScaleMixture should be K dimensional"
-        assert (
-            component_logits.shape == component_scale.shape
-        ), "The component_logits and component_scale parameters in GaussianScaleMixture should be K dimensional"
+        assert coord_scale.dim() == 1, (
+            "The coord_scale parameter in GaussianScaleMixture should be D dimensional"
+        )
+        assert component_scale.dim() == 1, (
+            "The component_scale parameter in GaussianScaleMixture should be K dimensional"
+        )
+        assert component_logits.dim() == 1, (
+            "The component_logits parameter in GaussianScaleMixture should be K dimensional"
+        )
+        assert component_logits.shape == component_scale.shape, (
+            "The component_logits and component_scale parameters in GaussianScaleMixture should be K dimensional"
+        )
         self.coord_scale = coord_scale
         self.component_logits = component_logits
         self.component_scale = component_scale

--- a/pyro/distributions/projected_normal.py
+++ b/pyro/distributions/projected_normal.py
@@ -100,8 +100,7 @@ class ProjectedNormal(TorchDistribution):
             event_shape = value.shape[-1:]
             if event_shape != self.event_shape:
                 raise ValueError(
-                    f"Expected event shape {self.event_shape}, "
-                    f"but got {event_shape}"
+                    f"Expected event shape {self.event_shape}, but got {event_shape}"
                 )
             self._validate_sample(value)
         dim = int(self.concentration.size(-1))

--- a/pyro/distributions/sine_skewed.py
+++ b/pyro/distributions/sine_skewed.py
@@ -90,9 +90,9 @@ class SineSkewed(TorchDistribution):
     support = constraints.independent(constraints.real, 1)
 
     def __init__(self, base_dist: TorchDistribution, skewness, validate_args=None):
-        assert (
-            base_dist.event_shape == skewness.shape[-1:]
-        ), "Sine Skewing is only valid with a skewness parameter for each dimension of `base_dist.event_shape`."
+        assert base_dist.event_shape == skewness.shape[-1:], (
+            "Sine Skewing is only valid with a skewness parameter for each dimension of `base_dist.event_shape`."
+        )
 
         if (skewness.abs().sum(-1) > 1.0).any():
             warnings.warn("Total skewness weight shouldn't exceed one.", UserWarning)

--- a/pyro/distributions/transforms/householder.py
+++ b/pyro/distributions/transforms/householder.py
@@ -141,9 +141,7 @@ class Householder(ConditionedHouseholder, TransformModule):
         elif count_transforms > input_dim:
             warnings.warn(
                 "Number of Householder transforms, {}, is greater than input dimension {}, which is an \
-over-parametrization!".format(
-                    count_transforms, input_dim
-                )
+over-parametrization!".format(count_transforms, input_dim)
             )
         self.u_unnormed = nn.Parameter(torch.empty(count_transforms, input_dim))
         self.reset_parameters()
@@ -227,9 +225,7 @@ class ConditionalHouseholder(ConditionalTransformModule):
         elif count_transforms > input_dim:
             warnings.warn(
                 "Number of Householder transforms, {}, is greater than input dimension {}, which is an \
-over-parametrization!".format(
-                    count_transforms, input_dim
-                )
+over-parametrization!".format(count_transforms, input_dim)
             )
         self.count_transforms = count_transforms
 

--- a/pyro/distributions/transforms/lower_cholesky_affine.py
+++ b/pyro/distributions/transforms/lower_cholesky_affine.py
@@ -33,10 +33,10 @@ class LowerCholeskyAffine(Transform):
         super().__init__(cache_size=cache_size)
         self.loc = loc
         self.scale_tril = scale_tril
-        assert (
-            loc.size(-1) == scale_tril.size(-1) == scale_tril.size(-2)
-        ), "loc and scale_tril must be of size D and D x D, respectively (instead: {}, {})".format(
-            loc.shape, scale_tril.shape
+        assert loc.size(-1) == scale_tril.size(-1) == scale_tril.size(-2), (
+            "loc and scale_tril must be of size D and D x D, respectively (instead: {}, {})".format(
+                loc.shape, scale_tril.shape
+            )
         )
 
     def _call(self, x):

--- a/pyro/distributions/transforms/spline.py
+++ b/pyro/distributions/transforms/spline.py
@@ -191,9 +191,7 @@ def _monotonic_rational_spline(
                 inputs <= yc
             ).float() + (
                 (wc - input_lambdas * wb) * inputs + input_lambdas * wb * yb - wc * yc
-            ) * (
-                inputs > yc
-            ).float()
+            ) * (inputs > yc).float()
 
             denominator = ((wc - wa) * inputs + wa * ya - wc * yc) * (
                 inputs <= yc

--- a/pyro/distributions/zero_inflated.py
+++ b/pyro/distributions/zero_inflated.py
@@ -97,9 +97,9 @@ class ZeroInflatedDistribution(TorchDistribution):
 
     @lazy_property
     def variance(self):
-        return (1 - self.gate) * (
-            self.base_dist.mean**2 + self.base_dist.variance
-        ) - (self.mean) ** 2
+        return (1 - self.gate) * (self.base_dist.mean**2 + self.base_dist.variance) - (
+            self.mean
+        ) ** 2
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(type(self), _instance)

--- a/pyro/infer/abstract_infer.py
+++ b/pyro/infer/abstract_infer.py
@@ -31,9 +31,9 @@ class EmpiricalMarginal(Empirical):
     """
 
     def __init__(self, trace_posterior, sites=None, validate_args=None):
-        assert isinstance(
-            trace_posterior, TracePosterior
-        ), "trace_dist must be trace posterior distribution object"
+        assert isinstance(trace_posterior, TracePosterior), (
+            "trace_dist must be trace posterior distribution object"
+        )
         if sites is None:
             sites = "_RETURN"
         self._num_chains = 1
@@ -126,9 +126,9 @@ class Marginals:
     """
 
     def __init__(self, trace_posterior, sites=None, validate_args=None):
-        assert isinstance(
-            trace_posterior, TracePosterior
-        ), "trace_dist must be trace posterior distribution object"
+        assert isinstance(trace_posterior, TracePosterior), (
+            "trace_dist must be trace posterior distribution object"
+        )
         if sites is None:
             sites = ["_RETURN"]
         elif isinstance(sites, str):

--- a/pyro/infer/autoguide/guides.py
+++ b/pyro/infer/autoguide/guides.py
@@ -134,9 +134,9 @@ class AutoGuide(PyroModule):
                 plates = self.create_plates(*args, **kwargs)
                 if isinstance(plates, pyro.plate):
                     plates = [plates]
-                assert all(
-                    isinstance(p, pyro.plate) for p in plates
-                ), "create_plates() returned a non-plate"
+                assert all(isinstance(p, pyro.plate) for p in plates), (
+                    "create_plates() returned a non-plate"
+                )
                 self.plates = {p.name: p for p in plates}
             for name, frame in sorted(self._prototype_frames.items()):
                 if name not in self.plates:
@@ -145,9 +145,9 @@ class AutoGuide(PyroModule):
                         name, full_size, dim=frame.dim, subsample_size=frame.size
                     )
         else:
-            assert (
-                self.create_plates is None
-            ), "Cannot pass create_plates() to non-master guide"
+            assert self.create_plates is None, (
+                "Cannot pass create_plates() to non-master guide"
+            )
             self.plates = self.master().plates
         return self.plates
 

--- a/pyro/infer/mcmc/logger.py
+++ b/pyro/infer/mcmc/logger.py
@@ -267,7 +267,7 @@ def initialize_logger(logger, logger_id, progress_bar=None, log_queue=None):
         format = "%(levelname).1s \t %(message)s"
         handler = TqdmHandler()
     else:
-        raise ValueError("Logger cannot be initialized without a " "valid handler.")
+        raise ValueError("Logger cannot be initialized without a valid handler.")
     handler.setFormatter(logging.Formatter(format))
     logging_handler = MCMCLoggingHandler(handler, progress_bar)
     logging_handler.addFilter(MetadataFilter(logger_id))

--- a/pyro/infer/predictive.py
+++ b/pyro/infer/predictive.py
@@ -585,8 +585,9 @@ class MHResampler(torch.nn.Module):
                 idx = torch.rand(*prob.shape) <= prob
                 self.transition_count[idx] += 1
                 for field_desc in fields(self.samples):
-                    field, new_field = getattr(self.samples, field_desc.name), getattr(
-                        new_samples, field_desc.name
+                    field, new_field = (
+                        getattr(self.samples, field_desc.name),
+                        getattr(new_samples, field_desc.name),
                     )
                     if isinstance(field, dict):
                         for key in field:

--- a/pyro/infer/rws.py
+++ b/pyro/infer/rws.py
@@ -85,9 +85,9 @@ class ReweightedWakeSleep(ELBO):
         strict_enumeration_warning=True,
     ):
         # force K > 1 otherwise SNIS not possible
-        assert (
-            num_particles > 1
-        ), "Reweighted Wake Sleep needs to be run with more than one particle"
+        assert num_particles > 1, (
+            "Reweighted Wake Sleep needs to be run with more than one particle"
+        )
 
         super().__init__(
             num_particles=num_particles,

--- a/pyro/infer/svgd.py
+++ b/pyro/infer/svgd.py
@@ -236,9 +236,9 @@ class SVGD:
     ):
         assert callable(model)
         assert isinstance(kernel, SteinKernel), "Must provide a valid SteinKernel"
-        assert isinstance(
-            optim, pyro.optim.PyroOptim
-        ), "Must provide a valid Pyro optimizer"
+        assert isinstance(optim, pyro.optim.PyroOptim), (
+            "Must provide a valid Pyro optimizer"
+        )
         assert num_particles > 1, "Must use at least two particles"
         assert max_plate_nesting >= 0
         assert mode in [

--- a/pyro/infer/tracegraph_elbo.py
+++ b/pyro/infer/tracegraph_elbo.py
@@ -64,9 +64,9 @@ def _construct_baseline(node, guide_site, downstream_cost):
 
     use_baseline = use_nn_baseline or use_decaying_avg_baseline or use_baseline_value
 
-    assert not (
-        use_nn_baseline and use_baseline_value
-    ), "cannot use baseline_value and nn_baseline simultaneously"
+    assert not (use_nn_baseline and use_baseline_value), (
+        "cannot use baseline_value and nn_baseline simultaneously"
+    )
     if use_decaying_avg_baseline:
         dc_shape = downstream_cost.shape
         param_name = "__baseline_avg_downstream_cost_" + node

--- a/pyro/nn/module.py
+++ b/pyro/nn/module.py
@@ -515,9 +515,9 @@ class PyroModule(torch.nn.Module, metaclass=_PyroModuleMeta):
         self._pyro_context = context
         for key, value in self._modules.items():
             if isinstance(value, PyroModule):
-                assert (
-                    not value._pyro_context.used
-                ), "submodule {} has executed outside of supermodule".format(name)
+                assert not value._pyro_context.used, (
+                    "submodule {} has executed outside of supermodule".format(name)
+                )
                 value._pyro_set_supermodule(_make_name(name, key), context)
 
     def _pyro_get_fullname(self, name: str) -> str:

--- a/pyro/ops/packed.py
+++ b/pyro/ops/packed.py
@@ -17,9 +17,9 @@ def pack(value, dim_to_symbol):
     :param dim_to_symbol: a map from negative integers to characters
     """
     if isinstance(value, torch.Tensor):
-        assert not hasattr(
-            value, "_pyro_dims"
-        ), "tried to pack an already-packed tensor"
+        assert not hasattr(value, "_pyro_dims"), (
+            "tried to pack an already-packed tensor"
+        )
         shape = value.shape
         shift = len(shape)
         try:

--- a/pyro/ops/tensor_utils.py
+++ b/pyro/ops/tensor_utils.py
@@ -260,9 +260,9 @@ def repeated_matmul(M, n):
     :param int n: The order of the largest product :math:`M^n`
     :returns torch.Tensor: A batch of square tensors of shape (n, ..., N, N)
     """
-    assert M.size(-1) == M.size(
-        -2
-    ), "Input tensors must satisfy M.size(-1) == M.size(-2)."
+    assert M.size(-1) == M.size(-2), (
+        "Input tensors must satisfy M.size(-1) == M.size(-2)."
+    )
     assert n > 0, "argument n to repeated_matmul must be 1 or larger"
 
     doubling_rounds = 0 if n <= 2 else math.ceil(math.log(n, 2)) - 1

--- a/pyro/optim/optim.py
+++ b/pyro/optim/optim.py
@@ -89,17 +89,17 @@ class PyroOptim:
         self.pt_optim_constructor = optim_constructor
 
         # must be callable or dict
-        assert callable(optim_args) or isinstance(
-            optim_args, dict
-        ), "optim_args must be function that returns defaults or a defaults dictionary"
+        assert callable(optim_args) or isinstance(optim_args, dict), (
+            "optim_args must be function that returns defaults or a defaults dictionary"
+        )
 
         if clip_args is None:
             clip_args = {}
 
         # must be callable or dict
-        assert callable(clip_args) or isinstance(
-            clip_args, dict
-        ), "clip_args must be function that returns defaults or a defaults dictionary"
+        assert callable(clip_args) or isinstance(clip_args, dict), (
+            "clip_args must be function that returns defaults or a defaults dictionary"
+        )
 
         # hold our args to be called/used
         self.pt_optim_args = optim_args
@@ -217,9 +217,9 @@ class PyroOptim:
                 opt_dict = self.pt_optim_args(module_name, stripped_param_name)
 
             # must be dictionary
-            assert isinstance(
-                opt_dict, dict
-            ), "per-param optim arg must return defaults dictionary"
+            assert isinstance(opt_dict, dict), (
+                "per-param optim arg must return defaults dictionary"
+            )
             return opt_dict
         else:
             return self.pt_optim_args
@@ -248,9 +248,9 @@ class PyroOptim:
             clip_dict = self.pt_clip_args(module_name, stripped_param_name)
 
             # must be dictionary
-            assert isinstance(
-                clip_dict, dict
-            ), "per-param clip arg must return defaults dictionary"
+            assert isinstance(clip_dict, dict), (
+                "per-param clip arg must return defaults dictionary"
+            )
             return clip_dict
         else:
             return self.pt_clip_args

--- a/pyro/optim/pytorch_optimizers.py
+++ b/pyro/optim/pytorch_optimizers.py
@@ -20,8 +20,8 @@ for _name, _Optim in torch.optim.__dict__.items():
         continue
 
     _PyroOptim = (
-        lambda _Optim: lambda optim_args, clip_args=None: PyroOptim(
-            _Optim, optim_args, clip_args
+        lambda _Optim: (
+            lambda optim_args, clip_args=None: PyroOptim(_Optim, optim_args, clip_args)
         )
     )(_Optim)
     _PyroOptim.__name__ = _name
@@ -45,8 +45,10 @@ for _name, _Optim in torch.optim.lr_scheduler.__dict__.items():
         continue
 
     _PyroOptim = (
-        lambda _Optim: lambda optim_args, clip_args=None: PyroLRScheduler(
-            _Optim, optim_args, clip_args
+        lambda _Optim: (
+            lambda optim_args, clip_args=None: PyroLRScheduler(
+                _Optim, optim_args, clip_args
+            )
         )
     )(_Optim)
     _PyroOptim.__name__ = _name

--- a/pyro/params/param_store.py
+++ b/pyro/params/param_store.py
@@ -60,15 +60,15 @@ class ParamStoreDict:
         """
         initialize ParamStore data structures
         """
-        self._params: Dict[str, torch.Tensor] = (
-            {}
-        )  # dictionary from param name to param
-        self._param_to_name: Dict[torch.Tensor, str] = (
-            {}
-        )  # dictionary from unconstrained param to param name
-        self._constraints: Dict[str, constraints.Constraint] = (
-            {}
-        )  # dictionary from param name to constraint object
+        self._params: Dict[
+            str, torch.Tensor
+        ] = {}  # dictionary from param name to param
+        self._param_to_name: Dict[
+            torch.Tensor, str
+        ] = {}  # dictionary from unconstrained param to param name
+        self._constraints: Dict[
+            str, constraints.Constraint
+        ] = {}  # dictionary from param name to constraint object
 
     def clear(self) -> None:
         """
@@ -289,9 +289,9 @@ class ParamStoreDict:
         Set the ParamStore state using state from a previous :meth:`get_state` call
         """
         assert isinstance(state, dict), "malformed ParamStore state"
-        assert set(state.keys()) == set(
-            ["params", "constraints"]
-        ), "malformed ParamStore keys {}".format(state.keys())
+        assert set(state.keys()) == set(["params", "constraints"]), (
+            "malformed ParamStore keys {}".format(state.keys())
+        )
 
         for param_name, param in state["params"].items():
             self._params[param_name] = param

--- a/pyro/poutine/block_messenger.py
+++ b/pyro/poutine/block_messenger.py
@@ -48,9 +48,9 @@ def _make_default_hide_fn(
 ) -> Callable[["Message"], bool]:
     # first, some sanity checks:
     # hide_all and expose_all intersect?
-    assert (hide_all is False and expose_all is False) or (
-        hide_all != expose_all
-    ), "cannot hide and expose a site"
+    assert (hide_all is False and expose_all is False) or (hide_all != expose_all), (
+        "cannot hide and expose a site"
+    )
 
     # hide and expose intersect?
     if hide is None:
@@ -76,9 +76,9 @@ def _make_default_hide_fn(
     else:
         hide_all = True
 
-    assert set(hide_types).isdisjoint(
-        set(expose_types)
-    ), "cannot hide and expose a site type"
+    assert set(hide_types).isdisjoint(set(expose_types)), (
+        "cannot hide and expose a site type"
+    )
 
     return partial(_block_fn, expose, expose_types, hide, hide_types, hide_all)
 

--- a/pyro/poutine/enum_messenger.py
+++ b/pyro/poutine/enum_messenger.py
@@ -145,24 +145,24 @@ class EnumMessenger(Messenger):
     """
 
     def __init__(self, first_available_dim: Optional[int] = None) -> None:
-        assert (
-            first_available_dim is None or first_available_dim < 0
-        ), first_available_dim
+        assert first_available_dim is None or first_available_dim < 0, (
+            first_available_dim
+        )
         self.first_available_dim = first_available_dim
         super().__init__()
 
     def __enter__(self) -> Self:
         if self.first_available_dim is not None:
             _ENUM_ALLOCATOR.set_first_available_dim(self.first_available_dim)
-        self._markov_depths: Dict[str, int] = (
-            {}
-        )  # site name -> depth (nonnegative integer)
-        self._param_dims: Dict[str, Dict[int, int]] = (
-            {}
-        )  # site name -> (enum dim -> unique id)
-        self._value_dims: Dict[str, Dict[int, int]] = (
-            {}
-        )  # site name -> (enum dim -> unique id)
+        self._markov_depths: Dict[
+            str, int
+        ] = {}  # site name -> depth (nonnegative integer)
+        self._param_dims: Dict[
+            str, Dict[int, int]
+        ] = {}  # site name -> (enum dim -> unique id)
+        self._value_dims: Dict[
+            str, Dict[int, int]
+        ] = {}  # site name -> (enum dim -> unique id)
         return super().__enter__()
 
     @ignore_jit_warnings()
@@ -207,9 +207,9 @@ class EnumMessenger(Messenger):
             value = value.reshape(value.shape[:1] + (1,) * (-1 - target_dim))
             value._pyro_categorical_support = categorical_support  # type: ignore[attr-defined]
         elif actual_dim < target_dim:
-            assert (
-                value.size(target_dim - event_dim) == 1
-            ), "pyro.markov dim conflict at dim {}".format(actual_dim)
+            assert value.size(target_dim - event_dim) == 1, (
+                "pyro.markov dim conflict at dim {}".format(actual_dim)
+            )
             value = value.transpose(target_dim - event_dim, actual_dim - event_dim)
             while value.dim() and value.size(0) == 1:
                 value = value.squeeze(0)

--- a/pyro/poutine/handlers.py
+++ b/pyro/poutine/handlers.py
@@ -579,9 +579,9 @@ def queue(
     def wrapper(wrapped):
         def _fn(*args, **kwargs):
             for i in range(max_tries):
-                assert (
-                    not queue.empty()
-                ), "trying to get() from an empty queue will deadlock"
+                assert not queue.empty(), (
+                    "trying to get() from an empty queue will deadlock"
+                )
 
                 next_trace = queue.get()
                 try:

--- a/pyro/poutine/replay_messenger.py
+++ b/pyro/poutine/replay_messenger.py
@@ -83,8 +83,8 @@ class ReplayMessenger(Messenger):
     def _pyro_param(self, msg: "Message") -> None:
         name = msg["name"]
         if self.params is not None and name in self.params:
-            assert hasattr(
-                self.params[name], "unconstrained"
-            ), "param {} must be constrained value".format(name)
+            assert hasattr(self.params[name], "unconstrained"), (
+                "param {} must be constrained value".format(name)
+            )
             msg["done"] = True
             msg["value"] = self.params[name]

--- a/pyro/poutine/subsample_messenger.py
+++ b/pyro/poutine/subsample_messenger.py
@@ -166,7 +166,8 @@ class SubsampleMessenger(IndepMessenger):
         )
         msg["cond_indep_stack"] = (frame,) + msg["cond_indep_stack"]
         if isinstance(self.size, torch.Tensor) or isinstance(  # type: ignore[unreachable]
-            self.subsample_size, torch.Tensor  # type: ignore[unreachable]
+            self.subsample_size,  # type: ignore[unreachable]
+            torch.Tensor,
         ):
             if not isinstance(msg["scale"], torch.Tensor):  # type: ignore[unreachable]
                 with ignore_jit_warnings():

--- a/pyro/util.py
+++ b/pyro/util.py
@@ -627,8 +627,9 @@ def check_if_enumerated(guide_trace: "Trace") -> None:
         warnings.warn(
             "\n".join(
                 [
-                    "Found sample sites configured for enumeration:"
-                    ", ".join(enumerated_sites),
+                    "Found sample sites configured for enumeration:, ".join(
+                        enumerated_sites
+                    ),
                     "If you want to enumerate sites, you need to use TraceEnum_ELBO instead.",
                 ]
             )

--- a/tests/contrib/oed/test_finite_spaces_eig.py
+++ b/tests/contrib/oed/test_finite_spaces_eig.py
@@ -67,8 +67,9 @@ def make_lfire_classifier(n_theta_samples):
     def lfire_classifier(design, trace, observation_labels, target_labels):
         y_dict = {l: trace.nodes[l]["value"] for l in observation_labels}
         y = torch.cat(list(y_dict.values()), dim=-1)
-        a, b = pyro.param("a", torch.zeros(n_theta_samples)), pyro.param(
-            "b", torch.zeros(n_theta_samples)
+        a, b = (
+            pyro.param("a", torch.zeros(n_theta_samples)),
+            pyro.param("b", torch.zeros(n_theta_samples)),
         )
 
         return a + b * y

--- a/tests/contrib/tracking/test_dynamic_models.py
+++ b/tests/contrib/tracking/test_dynamic_models.py
@@ -21,9 +21,9 @@ def assert_cov_validity(cov, eigenvalue_lbnd=0.0, condition_number_ubnd=1e6):
       number. Must be greater or equal to 1.0.
     """
     assert eigenvalue_lbnd >= 0.0, "Covariance eigenvalue lower bound must be > 0.0!"
-    assert (
-        condition_number_ubnd >= 1.0
-    ), "Covariance condition number bound must be >= 1.0!"
+    assert condition_number_ubnd >= 1.0, (
+        "Covariance condition number bound must be >= 1.0!"
+    )
 
     # Symmetry
     assert (cov.t() == cov).all(), "Covariance must be symmetric!"
@@ -39,9 +39,9 @@ def assert_cov_validity(cov, eigenvalue_lbnd=0.0, condition_number_ubnd=1e6):
     assert w_min >= eigenvalue_lbnd, "Covariance eigenvalues must be >= lower bound!"
 
     # Condition number upper bound
-    assert (
-        w_max / w_min <= condition_number_ubnd
-    ), "Condition number must be <= upper bound!"
+    assert w_max / w_min <= condition_number_ubnd, (
+        "Condition number must be <= upper bound!"
+    )
 
 
 def test_NcpContinuous():

--- a/tests/distributions/test_one_one_matching.py
+++ b/tests/distributions/test_one_one_matching.py
@@ -82,9 +82,9 @@ def assert_grads_agree(logits):
     d2 = dist.OneOneMatching(logits, bp_iters=BP_ITERS)
     expected = torch.autograd.grad(d1.log_partition_function, [logits])[0]
     actual = torch.autograd.grad(d2.log_partition_function, [logits])[0]
-    assert torch.allclose(
-        actual, expected, atol=0.2, rtol=1e-3
-    ), f"Expected:\n{expected.numpy()}\nActual:\n{actual.numpy()}"
+    assert torch.allclose(actual, expected, atol=0.2, rtol=1e-3), (
+        f"Expected:\n{expected.numpy()}\nActual:\n{actual.numpy()}"
+    )
 
 
 @pytest.mark.parametrize("num_nodes", [2, 3, 4, 5])

--- a/tests/distributions/test_one_two_matching.py
+++ b/tests/distributions/test_one_two_matching.py
@@ -132,9 +132,9 @@ def assert_grads_agree(logits):
     d2 = dist.OneTwoMatching(logits, bp_iters=BP_ITERS)
     expected = torch.autograd.grad(d1.log_partition_function, [logits])[0]
     actual = torch.autograd.grad(d2.log_partition_function, [logits])[0]
-    assert torch.allclose(
-        actual, expected, atol=0.2, rtol=1e-3
-    ), f"Expected:\n{expected.numpy()}\nActual:\n{actual.numpy()}"
+    assert torch.allclose(actual, expected, atol=0.2, rtol=1e-3), (
+        f"Expected:\n{expected.numpy()}\nActual:\n{actual.numpy()}"
+    )
 
 
 @pytest.mark.parametrize("num_destins", [2, 3, 4, 5])

--- a/tests/infer/mcmc/test_nuts.py
+++ b/tests/infer/mcmc/test_nuts.py
@@ -359,8 +359,9 @@ def test_gaussian_hmm(num_steps):
         guide = AutoDelta(
             poutine.block(
                 model,
-                expose_fn=lambda msg: not msg["name"].startswith("x")
-                and not msg["name"].startswith("y"),
+                expose_fn=lambda msg: (
+                    not msg["name"].startswith("x") and not msg["name"].startswith("y")
+                ),
             )
         )
         elbo = TraceEnum_ELBO(max_plate_nesting=1)

--- a/tests/infer/test_autoguide.py
+++ b/tests/infer/test_autoguide.py
@@ -849,9 +849,9 @@ def test_nested_autoguide(Elbo):
     for _, m in guide.named_modules():
         if m is guide:
             continue
-        assert (
-            m.master is not None and m.master() is guide
-        ), "master ref wrong for {}".format(m._pyro_name)
+        assert m.master is not None and m.master() is guide, (
+            "master ref wrong for {}".format(m._pyro_name)
+        )
 
     infer = SVI(
         model, guide, Adam({"lr": 0.005}), Elbo(strict_enumeration_warning=False)

--- a/tests/infer/test_compute_downstream_costs.py
+++ b/tests/infer/test_compute_downstream_costs.py
@@ -18,7 +18,9 @@ from tests.common import assert_equal
 
 
 def _brute_force_compute_downstream_costs(
-    model_trace, guide_trace, non_reparam_nodes  #
+    model_trace,
+    guide_trace,
+    non_reparam_nodes,  #
 ):
     guide_nodes = [
         x for x in guide_trace.nodes if guide_trace.nodes[x]["type"] == "sample"

--- a/tests/infer/test_elbo_mapdata.py
+++ b/tests/infer/test_elbo_mapdata.py
@@ -70,18 +70,22 @@ def test_elbo_mapdata(map_type, batch_size, n_steps, lr):
         )
         if map_type == "iplate":
             for i in pyro.plate("aaa", len(data), batch_size):
-                pyro.sample(
-                    "obs_%d" % i,
-                    dist.Normal(loc_latent, torch.pow(lam, -0.5)).to_event(1),
-                    obs=data[i],
-                ),
+                (
+                    pyro.sample(
+                        "obs_%d" % i,
+                        dist.Normal(loc_latent, torch.pow(lam, -0.5)).to_event(1),
+                        obs=data[i],
+                    ),
+                )
         elif map_type == "plate":
             with pyro.plate("aaa", len(data), batch_size) as ind:
-                pyro.sample(
-                    "obs",
-                    dist.Normal(loc_latent, torch.pow(lam, -0.5)).to_event(1),
-                    obs=data[ind],
-                ),
+                (
+                    pyro.sample(
+                        "obs",
+                        dist.Normal(loc_latent, torch.pow(lam, -0.5)).to_event(1),
+                        obs=data[ind],
+                    ),
+                )
         else:
             for i, x in enumerate(data):
                 pyro.sample(

--- a/tests/nn/test_module.py
+++ b/tests/nn/test_module.py
@@ -417,9 +417,11 @@ def test_sample():
         def __init__(self, in_features, out_features):
             super().__init__(in_features, out_features)
             self.weight = PyroSample(
-                lambda self: dist.Normal(0, 1)
-                .expand([self.out_features, self.in_features])
-                .to_event(2)
+                lambda self: (
+                    dist.Normal(0, 1)
+                    .expand([self.out_features, self.in_features])
+                    .to_event(2)
+                )
             )
 
     class Guide(nn.Linear, PyroModule):
@@ -1069,7 +1071,6 @@ def test_module_list() -> None:
 def test_render_constrained_param(use_module_local_params):
 
     class Model(PyroModule):
-
         @PyroParam(constraint=constraints.positive)
         def x(self):
             return torch.tensor(1.234)

--- a/tests/ops/test_newton.py
+++ b/tests/ops/test_newton.py
@@ -108,9 +108,9 @@ def test_newton_step_trust(trust_radius, dims):
     if trust_radius is None:
         assert ((x - x_updated).pow(2).sum(-1) > 1.0).any(), "test is too weak"
     else:
-        assert (
-            (x - x_updated).pow(2).sum(-1) <= 1e-8 + trust_radius**2
-        ).all(), "trust region violated"
+        assert ((x - x_updated).pow(2).sum(-1) <= 1e-8 + trust_radius**2).all(), (
+            "trust region violated"
+        )
 
 
 @pytest.mark.parametrize("trust_radius", [None, 0.1, 1.0, 10.0])

--- a/tests/poutine/test_mapdata.py
+++ b/tests/poutine/test_mapdata.py
@@ -86,9 +86,9 @@ def test_cond_indep_stack(model, subsample_size):
     tr = poutine.trace(model).get_trace(subsample_size)
     for name, node in tr.nodes.items():
         if name.startswith("x"):
-            assert node[
-                "cond_indep_stack"
-            ], "missing cond_indep_stack at node {}".format(name)
+            assert node["cond_indep_stack"], (
+                "missing cond_indep_stack at node {}".format(name)
+            )
 
 
 @pytest.mark.parametrize("subsample_size", [5, 20])


### PR DESCRIPTION
## Summary

- Replace Black formatting commands and dependency with Ruff formatter.
- Configure Ruff formatting to 88 characters.
- Reformat the affected Python files and update contributor documentation.
- Preserve Black-compatible long comment/string behavior by ignoring E501.

## Validation

- `make lint`
- `pytest -q tests/test_settings.py`
- `git diff --check`